### PR TITLE
Make additional targets publicly visible

### DIFF
--- a/java/com/google/domain/registry/tools/params/BUILD
+++ b/java/com/google/domain/registry/tools/params/BUILD
@@ -5,6 +5,7 @@ package(
 
 java_library(
     name = "params",
+    visibility = ["//visibility:public"],
     srcs = glob(["*.java"]),
     deps = [
         "//java/com/google/common/annotations",

--- a/java/com/google/domain/registry/whois/BUILD
+++ b/java/com/google/domain/registry/whois/BUILD
@@ -7,6 +7,7 @@ java_library(
     name = "whois",
     srcs = glob(["*.java"]),
     resources = ["disclaimer.txt"],
+    visibility = ["//visibility:public"],
     deps = [
         "//java/com/google/common/annotations",
         "//java/com/google/common/base",

--- a/javatests/com/google/domain/registry/server/BUILD
+++ b/javatests/com/google/domain/registry/server/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//java/com/google/domain/registry:registry_projec
 
 java_library(
     name = "TestServer",
+    visibility = ["//visibility:public"],
     srcs = [
         "HealthzServlet.java",
         "Route.java",


### PR DESCRIPTION
The admin console needs public visibility for additional targets.

//java/com/google/domain/registry/tools/params
- Needed for the Whois test server
  //java/com/google/domain/registry/whois
- Needed for reusing WhoisHttpServer in the whois appengine module
  //javatests/com/google/domain/registry/server
- Needed for the Whois test server
