### PR TITLE
Make ForeignKeyIndex java 7 compatible

### DIFF
--- a/java/com/google/domain/registry/model/index/ForeignKeyIndex.java
+++ b/java/com/google/domain/registry/model/index/ForeignKeyIndex.java
@@ -114,7 +114,7 @@ public abstract class ForeignKeyIndex<E extends EppResource> extends BackupGroup
 
   /** Create a {@link ForeignKeyIndex} key for a resource. */
   public static Key<ForeignKeyIndex<?>> createKey(EppResource resource) {
-    return Key.create(
+    return Key.<ForeignKeyIndex<?>>create(
         RESOURCE_CLASS_TO_FKI_CLASS.get(resource.getClass()), resource.getForeignKey());
   }
 


### PR DESCRIPTION
ForeignKeyIndex.java would not compile when building with bazel
and targeting 1.7. This change fixes the build issue.
