### PR TITLE
Added phantomjs for Mac

### DIFF
--- a/java/com/google/domain/registry/repositories.bzl
+++ b/java/com/google/domain/registry/repositories.bzl
@@ -485,9 +485,15 @@ def domain_registry_repositories():
   # XXX: new_http_archive() doesn't maintain the executable bit.
   #      https://github.com/bazelbuild/bazel/issues/984
   native.http_file(
-      name = "phantomjs",
+      name = "phantomjs_linux",
       sha256 = "86dd9a4bf4aee45f1a84c9f61cf1947c1d6dce9b9e8d2a907105da7852460d2f",
       url = "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2",
+  )
+
+  native.http_file(
+      name = "phantomjs_mac",
+      sha256 = "538cf488219ab27e309eafc629e2bcee9976990fe90b1ec334f541779150f8c1",
+      url = "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-macosx.zip",
   )
 
   native.maven_jar(

--- a/third_party/phantomjs/BUILD
+++ b/third_party/phantomjs/BUILD
@@ -2,18 +2,38 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # BSD
 
+config_setting(
+    name = "darwin",
+    values = {"cpu": "darwin"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "darwin_x86_64",
+    values = {"cpu": "darwin_x86_64"},
+    visibility = ["//visibility:public"],
+)
+
 genrule(
     name = "phantomjs_bin",
-    srcs = ["@phantomjs//file"],
+    srcs = select({
+        ":darwin": ["@phantomjs_mac//file"],
+        ":darwin_x86_64": ["@phantomjs_mac//file"],
+        "//conditions:default": ["@phantomjs_linux//file"]
+    }),
     outs = ["phantomjs"],
     cmd = " && ".join([
-        "IN=$$(pwd)/$(SRCS)",
-        "OUT=$$(pwd)/$@",
-        "TMP=$$(mktemp -d $${TMPDIR:-/tmp}/phantomjs.XXXXXXXX)",
-        "cd $$TMP",
-        "tar -xjf $$IN",
-        "cd phantomjs-*",
-        "mv bin/phantomjs $$OUT",
-        "rm -rf $$TMP",
+            "IN=$$(pwd)/$(SRCS)",
+            "OUT=$$(pwd)/$@",
+            "TMP=$$(mktemp -d $${TMPDIR:-/tmp}/phantomjs.XXXXXXXX)",
+            "cd $$TMP"
+        ]) + select({
+            ":darwin": " && unzip $$IN && ",
+            ":darwin_x86_64": " && unzip $$IN && ",
+            "//conditions:default": " && tar -xjf $$IN && "
+        }) + " && ".join([
+            "cd phantomjs-*",
+            "mv bin/phantomjs $$OUT",
+            "rm -rf $$TMP",
     ]),
 )


### PR DESCRIPTION
Added dependency for mac executable for Phantomjs, with selection of appropriate src and extraction method based on the detected operating system.

Would be nice to have conditional dependency resolution in this situation to avoid downloading both versions of phantomjs. May be nice in the future to have a single location for config_settings as well.
