### PR TITLE
Make ui/server/registrar and flows targets public

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -22,3 +22,4 @@ Pablo Mayrgundter <pmy@google.com>
 Daisuke Yabuki <dxy@google.com>
 Tim Boring <tjb@google.com>
 Hans Ridder <hans.ridder@gmail.com>
+Wolfgang Meyers <wolfgang@donuts.co>

--- a/java/com/google/domain/registry/flows/BUILD
+++ b/java/com/google/domain/registry/flows/BUILD
@@ -45,4 +45,5 @@ java_library(
         "//third_party/java/objectify:objectify-v4_1",
         "//third_party/java/servlet/servlet_api",
     ],
+    visibility = ["//visibility:public"],
 )

--- a/java/com/google/domain/registry/ui/server/registrar/BUILD
+++ b/java/com/google/domain/registry/ui/server/registrar/BUILD
@@ -37,4 +37,5 @@ java_library(
 
         "//third_party/closure/templates",
     ],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This change is necessary in order to directly use the Epp flows
from another project.
