### PR TITLE
Allow @RequestScope on methods

### DIFF
--- a/java/com/google/domain/registry/request/RequestScope.java
+++ b/java/com/google/domain/registry/request/RequestScope.java
@@ -25,6 +25,6 @@ import javax.inject.Scope;
 /** Dagger annotation for request-scoped components that depend on a global component. */
 @Scope
 @Documented
-@Target({ElementType.TYPE})
+@Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface RequestScope {}


### PR DESCRIPTION
By default, a provider method is invoked each time a
provided object is injected. This allows provider methods
in dagger modules to provide request-scoped objects.
For more details see:
https://guides.codepath.com/android/Dependency-Injection-with-Dagger-2#scopes
