### PR TITLE
Fixes "Insufficient permission" error in export-snapshot task

### DIFF
--- a/java/com/google/domain/registry/export/DatastoreBackupService.java
+++ b/java/com/google/domain/registry/export/DatastoreBackupService.java
@@ -72,8 +72,7 @@ public class DatastoreBackupService {
         .param("name", name + "_")  // Add underscore since the name will be used as a prefix.
         .param("filesystem", "gs")
         .param("gs_bucket_name", gcsBucket)
-        .param("queue", queue)
-        .param("run_as_a_service", String.valueOf(true));
+        .param("queue", queue);
     for (String kind : kinds) {
       options.param("kind", kind);
     }

--- a/javatests/com/google/domain/registry/export/DatastoreBackupServiceTest.java
+++ b/javatests/com/google/domain/registry/export/DatastoreBackupServiceTest.java
@@ -96,7 +96,6 @@ public class DatastoreBackupServiceTest {
             .param("filesystem", "gs")
             .param("gs_bucket_name", "somebucket")
             .param("queue", "default")
-            .param("run_as_a_service", "true")
             .param("kind", "foo")
             .param("kind", "bar"));
   }


### PR DESCRIPTION
Removed "run_as_a_service" parameter from backup.create command in DatastoreBackupService.
This parameter can't be used externally, and is apparently no longer needed. @nfelt should know what this is about.

`Executed 316 out of 330 tests: 330 tests pass.`
