### PR TITLE
Make RDE SSH key identity injectable

### DIFF
--- a/java/google/registry/config/ConfigModule.java
+++ b/java/google/registry/config/ConfigModule.java
@@ -406,6 +406,18 @@ public final class ConfigModule {
   }
 
   /**
+   * Returns the identity used for the SSH keys used in RDE SFTP uploads.
+   *
+   * @see Keyring#getRdeSshClientPublicKey()
+   * @see Keyring#getRdeSshClientPrivateKey()
+   */
+  @Provides
+  @Config("rdeSshIdentity")
+  public static String provideSshIdentity() {
+    return "rde@charlestonroadregistry.com";
+  }
+
+  /**
    * Returns SFTP URL containing a username, hostname, port (optional), and directory (optional) to
    * which cloud storage files are uploaded. The password should not be included, as it's better to
    * use public key authentication.

--- a/java/google/registry/rde/JSchModule.java
+++ b/java/google/registry/rde/JSchModule.java
@@ -21,6 +21,7 @@ import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import dagger.Module;
 import dagger.Provides;
+import google.registry.config.ConfigModule.Config;
 import google.registry.keyring.api.KeyModule.Key;
 
 /** Dagger module for {@link JSch} which provides SSH/SFTP connectivity. */
@@ -29,13 +30,14 @@ public final class JSchModule {
 
   @Provides
   static JSch provideJSch(
+      @Config("rdeSshIdentity") String identity,
       @Key("rdeSshClientPrivateKey") String privateKey,
       @Key("rdeSshClientPublicKey") String publicKey) {
     applyAppEngineKludge();
     JSch jsch = new JSch();
     try {
       jsch.addIdentity(
-          "rde@charlestonroadregistry.com",
+          identity,
           privateKey.getBytes(UTF_8),
           publicKey.getBytes(UTF_8),
           null);

--- a/javatests/google/registry/rde/RdeUploadActionTest.java
+++ b/javatests/google/registry/rde/RdeUploadActionTest.java
@@ -181,6 +181,7 @@ public class RdeUploadActionTest {
       action.ghostryde = new Ghostryde(BUFFER_SIZE);
       action.jsch =
           JSchModule.provideJSch(
+              "user@ignored",
               keyring.getRdeSshClientPrivateKey(), keyring.getRdeSshClientPublicKey());
       action.jschSshSessionFactory = new JSchSshSessionFactory(standardSeconds(3));
       action.response = response;


### PR DESCRIPTION
The SSH identity in `JSchModule` is hardcoded to `rde@charlestonroadregistry.com`. This seems Google specific, and caused runtime errors when it didn't match the identity used to create keys here for testing. I don't understand why `RdeUploadActionTest` doesn't have a similar problem, so I put a placeholder value there to simply make the compiler happy.

The provider method is added to `ConfigModule` under the belief that it is preferred over `RegistryConfig`.
