### PR TITLE
Change test to large to fix timeout on ci server

### DIFF
--- a/javatests/google/registry/rde/BUILD
+++ b/javatests/google/registry/rde/BUILD
@@ -53,7 +53,7 @@ java_library(
 
 GenTestRules(
     name = "GeneratedTestRules",
-    default_test_size = "medium",
+    default_test_size = "large",
     test_files = glob(["*Test.java"]),
     deps = [":rde"],
 )


### PR DESCRIPTION
This fixes a ci test issue we are seeing on our jenkins server as previously discussed https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/nomulus-discuss/b_gBmsQ5gHc