### PR TITLE
Adds otherClientId to HistoryEntry

### DIFF
--- a/java/google/registry/flows/domain/DomainTransferApproveFlow.java
+++ b/java/google/registry/flows/domain/DomainTransferApproveFlow.java
@@ -102,13 +102,14 @@ public final class DomainTransferApproveFlow implements TransactionalFlow {
     verifyResourceOwnership(clientId, existingDomain);
     String tld = existingDomain.getTld();
     checkAllowedAccessToTld(clientId, tld);
+    TransferData transferData = existingDomain.getTransferData();
+    String gainingClientId = transferData.getGainingClientId();
     HistoryEntry historyEntry = historyBuilder
         .setType(HistoryEntry.Type.DOMAIN_TRANSFER_APPROVE)
         .setModificationTime(now)
+        .setOtherClientId(gainingClientId)
         .setParent(Key.create(existingDomain))
         .build();
-    TransferData transferData = existingDomain.getTransferData();
-    String gainingClientId = transferData.getGainingClientId();
     int extraYears = transferData.getExtendedRegistrationYears();
     // Bill for the transfer.
     BillingEvent.OneTime billingEvent = new BillingEvent.OneTime.Builder()

--- a/java/google/registry/flows/domain/DomainTransferCancelFlow.java
+++ b/java/google/registry/flows/domain/DomainTransferCancelFlow.java
@@ -87,6 +87,7 @@ public final class DomainTransferCancelFlow implements TransactionalFlow {
     checkAllowedAccessToTld(clientId, existingDomain.getTld());
     HistoryEntry historyEntry = historyBuilder
         .setType(HistoryEntry.Type.DOMAIN_TRANSFER_CANCEL)
+        .setOtherClientId(clientId)
         .setModificationTime(now)
         .setParent(Key.create(existingDomain))
         .build();

--- a/java/google/registry/flows/domain/DomainTransferRejectFlow.java
+++ b/java/google/registry/flows/domain/DomainTransferRejectFlow.java
@@ -82,6 +82,7 @@ public final class DomainTransferRejectFlow implements TransactionalFlow {
     HistoryEntry historyEntry = historyBuilder
         .setType(HistoryEntry.Type.DOMAIN_TRANSFER_REJECT)
         .setModificationTime(now)
+        .setOtherClientId(existingDomain.getTransferData().getGainingClientId())
         .setParent(Key.create(existingDomain))
         .build();
     verifyOptionalAuthInfo(authInfo, existingDomain);

--- a/java/google/registry/flows/domain/DomainTransferRequestFlow.java
+++ b/java/google/registry/flows/domain/DomainTransferRequestFlow.java
@@ -213,6 +213,7 @@ public final class DomainTransferRequestFlow implements TransactionalFlow {
   private HistoryEntry buildHistory(Period period, DomainResource existingResource, DateTime now) {
     return historyBuilder
         .setType(HistoryEntry.Type.DOMAIN_TRANSFER_REQUEST)
+        .setOtherClientId(existingResource.getCurrentSponsorClientId())
         .setPeriod(period)
         .setModificationTime(now)
         .setParent(Key.create(existingResource))

--- a/java/google/registry/model/reporting/HistoryEntry.java
+++ b/java/google/registry/model/reporting/HistoryEntry.java
@@ -103,7 +103,11 @@ public class HistoryEntry extends ImmutableObject implements Buildable {
   @Index
   String clientId;
 
-  /** The id of the registrar that is being acted upon. */
+  /**
+   * The id of the registrar that is being acted upon in a domain transfer type. Every transfer is
+   * triggered by the registrar making the EPP transfer command; the other registrar involved is
+   * stored here in the otherClientId.
+   */
   String otherClientId;
 
   /** Transaction id that made this change. */

--- a/java/google/registry/model/reporting/HistoryEntry.java
+++ b/java/google/registry/model/reporting/HistoryEntry.java
@@ -103,6 +103,9 @@ public class HistoryEntry extends ImmutableObject implements Buildable {
   @Index
   String clientId;
 
+  /** The id of the registrar that is being acted upon. */
+  String otherClientId;
+
   /** Transaction id that made this change. */
   Trid trid;
 
@@ -137,6 +140,10 @@ public class HistoryEntry extends ImmutableObject implements Buildable {
 
   public String getClientId() {
     return clientId;
+  }
+
+  public String getOtherClientId() {
+    return otherClientId;
   }
 
   public Trid getTrid() {
@@ -200,6 +207,11 @@ public class HistoryEntry extends ImmutableObject implements Buildable {
 
     public Builder setClientId(String clientId) {
       getInstance().clientId = clientId;
+      return this;
+    }
+
+    public Builder setOtherClientId(String otherClientId) {
+      getInstance().otherClientId = otherClientId;
       return this;
     }
 

--- a/javatests/google/registry/flows/domain/DomainTransferApproveFlowTest.java
+++ b/javatests/google/registry/flows/domain/DomainTransferApproveFlowTest.java
@@ -26,6 +26,7 @@ import static google.registry.testing.DatastoreHelper.getOnlyPollMessage;
 import static google.registry.testing.DatastoreHelper.getPollMessages;
 import static google.registry.testing.DatastoreHelper.persistResource;
 import static google.registry.testing.DomainResourceSubject.assertAboutDomains;
+import static google.registry.testing.HistoryEntrySubject.assertAboutHistoryEntries;
 import static google.registry.testing.HostResourceSubject.assertAboutHosts;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static java.util.Arrays.asList;
@@ -155,6 +156,8 @@ public class DomainTransferApproveFlowTest
         HistoryEntry.Type.DOMAIN_TRANSFER_APPROVE);
     final HistoryEntry historyEntryTransferApproved =
         getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_TRANSFER_APPROVE);
+    assertAboutHistoryEntries().that(historyEntryTransferApproved)
+        .hasOtherClientId("NewRegistrar");
     assertTransferApproved(domain);
     assertAboutDomains().that(domain).hasRegistrationExpirationTime(expectedExpirationTime);
     assertThat(ofy().load().key(domain.getAutorenewBillingEvent()).now().getEventTime())

--- a/javatests/google/registry/flows/domain/DomainTransferCancelFlowTest.java
+++ b/javatests/google/registry/flows/domain/DomainTransferCancelFlowTest.java
@@ -22,6 +22,7 @@ import static google.registry.testing.DatastoreHelper.getOnlyHistoryEntryOfType;
 import static google.registry.testing.DatastoreHelper.getPollMessages;
 import static google.registry.testing.DatastoreHelper.persistResource;
 import static google.registry.testing.DomainResourceSubject.assertAboutDomains;
+import static google.registry.testing.HistoryEntrySubject.assertAboutHistoryEntries;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 
 import com.google.common.collect.ImmutableList;
@@ -117,6 +118,9 @@ public class DomainTransferCancelFlowTest
         HistoryEntry.Type.DOMAIN_CREATE,
         HistoryEntry.Type.DOMAIN_TRANSFER_REQUEST,
         HistoryEntry.Type.DOMAIN_TRANSFER_CANCEL);
+    final HistoryEntry historyEntryTransferCancel =
+        getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_TRANSFER_CANCEL);
+    assertAboutHistoryEntries().that(historyEntryTransferCancel).hasOtherClientId("NewRegistrar");
     // The only billing event left should be the original autorenew event, now reopened.
     assertBillingEvents(
         getLosingClientAutorenewEvent().asBuilder().setRecurrenceEndTime(END_OF_TIME).build());

--- a/javatests/google/registry/flows/domain/DomainTransferRejectFlowTest.java
+++ b/javatests/google/registry/flows/domain/DomainTransferRejectFlowTest.java
@@ -17,10 +17,12 @@ package google.registry.flows.domain;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.testing.DatastoreHelper.assertBillingEvents;
 import static google.registry.testing.DatastoreHelper.deleteResource;
+import static google.registry.testing.DatastoreHelper.getOnlyHistoryEntryOfType;
 import static google.registry.testing.DatastoreHelper.getOnlyPollMessage;
 import static google.registry.testing.DatastoreHelper.getPollMessages;
 import static google.registry.testing.DatastoreHelper.persistResource;
 import static google.registry.testing.DomainResourceSubject.assertAboutDomains;
+import static google.registry.testing.HistoryEntrySubject.assertAboutHistoryEntries;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 
 import com.google.common.collect.FluentIterable;
@@ -90,6 +92,11 @@ public class DomainTransferRejectFlowTest
             HistoryEntry.Type.DOMAIN_CREATE,
             HistoryEntry.Type.DOMAIN_TRANSFER_REQUEST,
             HistoryEntry.Type.DOMAIN_TRANSFER_REJECT);
+    final HistoryEntry historyEntryTransferRejected =
+        getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_TRANSFER_REJECT);
+    assertAboutHistoryEntries()
+        .that(historyEntryTransferRejected)
+        .hasOtherClientId("NewRegistrar");
     // The only billing event left should be the original autorenew event, now reopened.
     assertBillingEvents(
         getLosingClientAutorenewEvent().asBuilder().setRecurrenceEndTime(END_OF_TIME).build());

--- a/javatests/google/registry/flows/domain/DomainTransferRequestFlowTest.java
+++ b/javatests/google/registry/flows/domain/DomainTransferRequestFlowTest.java
@@ -190,7 +190,11 @@ public class DomainTransferRequestFlowTest
         .hasOneHistoryEntryEachOfTypes(
             HistoryEntry.Type.DOMAIN_CREATE,
             HistoryEntry.Type.DOMAIN_TRANSFER_REQUEST);
-    assertAboutHistoryEntries().that(historyEntryTransferRequest).hasPeriodYears(registrationYears);
+    assertAboutHistoryEntries()
+        .that(historyEntryTransferRequest)
+        .hasPeriodYears(registrationYears)
+        .and()
+        .hasOtherClientId("TheRegistrar");
     assertAboutHosts().that(subordinateHost).hasNoHistoryEntries();
     assertThat(getPollMessages("TheRegistrar", clock.nowUtc())).hasSize(1);
 

--- a/javatests/google/registry/model/reporting/HistoryEntryTest.java
+++ b/javatests/google/registry/model/reporting/HistoryEntryTest.java
@@ -43,6 +43,7 @@ public class HistoryEntryTest extends EntityTestCase {
       .setXmlBytes("<xml></xml>".getBytes(UTF_8))
       .setModificationTime(clock.nowUtc())
       .setClientId("foo")
+      .setOtherClientId("otherClient")
       .setTrid(Trid.create("ABC-123"))
       .setBySuperuser(false)
       .setReason("reason")

--- a/javatests/google/registry/model/schema.txt
+++ b/javatests/google/registry/model/schema.txt
@@ -776,6 +776,7 @@ class google.registry.model.reporting.HistoryEntry {
   google.registry.model.reporting.HistoryEntry$Type type;
   java.lang.Boolean requestedByRegistrar;
   java.lang.String clientId;
+  java.lang.String otherClientId;
   java.lang.String reason;
   org.joda.time.DateTime modificationTime;
 }

--- a/javatests/google/registry/testing/HistoryEntrySubject.java
+++ b/javatests/google/registry/testing/HistoryEntrySubject.java
@@ -56,6 +56,10 @@ public class HistoryEntrySubject extends Subject<HistoryEntrySubject, HistoryEnt
     return hasValue(clientId, actual().getClientId(), "has client ID");
   }
 
+  public And<HistoryEntrySubject> hasOtherClientId(String otherClientId) {
+    return hasValue(otherClientId, actual().getOtherClientId(), "has other client ID");
+  }
+
   public And<HistoryEntrySubject> hasPeriod() {
     if (actual().getPeriod() == null) {
       fail("has a period");


### PR DESCRIPTION
This adds an otherClientId field to be populated on domain transfers
with the losing client id. This will be used for reporting in compliance
with specification 3 of the ICANN registry agreement.