### PR TITLE
Updated the ordering of the DomainCreateFlow

### DIFF
--- a/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -202,16 +202,6 @@ public class DomainCreateFlow implements TransactionalFlow {
       validateLaunchCreateNotice(launchCreate.getNotice(), domainLabel, isSuperuser, now);
     }
     boolean isSunriseCreate = hasSignedMarks && SUNRISE_STATES.contains(tldState);
-    customLogic.afterValidation(
-        DomainCreateFlowCustomLogic.AfterValidationParameters.newBuilder()
-            .setDomainName(domainName)
-            .setYears(years)
-            .build());
-
-    FeeCreateCommandExtension feeCreate =
-        eppInput.getSingleExtension(FeeCreateCommandExtension.class);
-    FeesAndCredits feesAndCredits = pricingLogic.getCreatePrice(registry, targetId, now, years);
-    validateFeeChallenge(targetId, registry.getTldStr(), now, feeCreate, feesAndCredits);
     // Superusers can create reserved domains, force creations on domains that require a claims
     // notice without specifying a claims key, ignore the registry phase, and override blocks on
     // registering premium domains.
@@ -233,6 +223,19 @@ public class DomainCreateFlow implements TransactionalFlow {
       verifyNoOpenApplications(now);
       verifyIsGaOrIsSpecialCase(tldState, isAnchorTenant);
     }
+    String signedMarkId = hasSignedMarks
+        // If a signed mark was provided, then it must match the desired domain label.
+        ? verifySignedMarks(launchCreate.getSignedMarks(), domainLabel, now).getId()
+        : null;
+    customLogic.afterValidation(
+        DomainCreateFlowCustomLogic.AfterValidationParameters.newBuilder()
+            .setDomainName(domainName)
+            .setYears(years)
+            .build());
+    FeeCreateCommandExtension feeCreate =
+        eppInput.getSingleExtension(FeeCreateCommandExtension.class);
+    FeesAndCredits feesAndCredits = pricingLogic.getCreatePrice(registry, targetId, now, years);
+    validateFeeChallenge(targetId, registry.getTldStr(), now, feeCreate, feesAndCredits);
     SecDnsCreateExtension secDnsCreate =
         validateSecDnsExtension(eppInput.getSingleExtension(SecDnsCreateExtension.class));
     String repoId = createDomainRoid(ObjectifyService.allocateId(), registry.getTldStr());
@@ -266,10 +269,7 @@ public class DomainCreateFlow implements TransactionalFlow {
         .setAutorenewBillingEvent(Key.create(autorenewBillingEvent))
         .setAutorenewPollMessage(Key.create(autorenewPollMessage))
         .setLaunchNotice(hasClaimsNotice ? launchCreate.getNotice() : null)
-        .setSmdId(hasSignedMarks
-            // If a signed mark was provided, then it must match the desired domain label.
-            ? verifySignedMarks(launchCreate.getSignedMarks(), domainLabel, now).getId()
-            : null)
+        .setSmdId(signedMarkId)
         .setDsData(secDnsCreate == null ? null : secDnsCreate.getDsData())
         .setRegistrant(command.getRegistrant())
         .setAuthInfo(command.getAuthInfo())


### PR DESCRIPTION
Hey guys, while implementing the DPML fee logic it came to my attention that the current injection points will not work for our use case. I'm adding this PR more as a proposal to get feedback than a requested change (yet). 

Currently our DPML logic exists in 'Before Save'. At this point the default flow has already validated the SMD, premium, and reserved for us. It's only after that can we determine if we should block the label. The issue I ran into while implementing the fee logic is during a standard create, if the label happens to be within DPML, a generic fee error is thrown stating the fee extension must be present. In this case we  would rather state the label is blocked by DPML. Then if the SMD is present we override the block, validate the fee is present and of the correct price, and allow the domain create.

In the current DomainCreateFlow the fee validation within 'Create Fee' happens well before we know the SMD is valid (during 'Create'):

NOTE:  `* = injection point`
```
*Before Validation
1st Validation
*After Validation
Create Fee (verify fee) - *Customize Create Price
2nd Validation
Create [Billing, Entities] (verify signed marks)
*Before Save
Save
*Before Response
Return
```

This PR reorders the flow into the following:

```
*Before Validation
1st & 2nd Validation (verify signed marks)
*After Validation
Create [Billing, Entities, Fee] (verify fee) - *Customize Create Price
*Before Save
Save
*Before Response
Return
```

With this the signed marks are verified during the validation phase and the 'After Validation' injection point is truly after validation. It also allows us to move our DPML validation up into the 'After Validation' point before the creation of our fee.

I've verified all the tests are still passing but I'm unsure if there are other cases I may have not thought of. 

It's worth noting additional work still needs to be done to allow this new structure to function in our use case. For example: 'After Validation' is not supplied enough data to support our DPML logic.

