### PR TITLE
Update extension parameters

### DIFF
--- a/java/google/registry/flows/custom/DomainCreateFlowCustomLogic.java
+++ b/java/google/registry/flows/custom/DomainCreateFlowCustomLogic.java
@@ -103,9 +103,6 @@ public class DomainCreateFlowCustomLogic extends BaseFlowCustomLogic {
     @Nullable
     public abstract String signedMarkId();
 
-    /** The time at which this flow was executed */
-    public abstract DateTime transactionTime();
-
     public static Builder newBuilder() {
       return new AutoValue_DomainCreateFlowCustomLogic_AfterValidationParameters.Builder();
     }
@@ -119,8 +116,6 @@ public class DomainCreateFlowCustomLogic extends BaseFlowCustomLogic {
       public abstract Builder setYears(int years);
 
       public abstract Builder setSignedMarkId(String signedMarkId);
-
-      public abstract Builder setTransactionTime(DateTime transactionTime);
 
       public abstract AfterValidationParameters build();
     }

--- a/java/google/registry/flows/custom/DomainCreateFlowCustomLogic.java
+++ b/java/google/registry/flows/custom/DomainCreateFlowCustomLogic.java
@@ -26,6 +26,9 @@ import google.registry.model.eppinput.EppInput;
 import google.registry.model.eppoutput.EppResponse.ResponseData;
 import google.registry.model.eppoutput.EppResponse.ResponseExtension;
 import google.registry.model.reporting.HistoryEntry;
+import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
 
 /**
  * A no-op base class for {@link DomainCreateFlow} custom logic.
@@ -92,6 +95,17 @@ public class DomainCreateFlowCustomLogic extends BaseFlowCustomLogic {
      */
     public abstract int years();
 
+    /**
+     * The ID of the validated signed mark.
+     *
+     * <p>If a signed mark was not supplied this value will be null</p>
+     */
+    @Nullable
+    public abstract String signedMarkId();
+
+    /** The time at which this flow was executed */
+    public abstract DateTime transactionTime();
+
     public static Builder newBuilder() {
       return new AutoValue_DomainCreateFlowCustomLogic_AfterValidationParameters.Builder();
     }
@@ -103,6 +117,10 @@ public class DomainCreateFlowCustomLogic extends BaseFlowCustomLogic {
       public abstract Builder setDomainName(InternetDomainName domainName);
 
       public abstract Builder setYears(int years);
+
+      public abstract Builder setSignedMarkId(String signedMarkId);
+
+      public abstract Builder setTransactionTime(DateTime transactionTime);
 
       public abstract AfterValidationParameters build();
     }

--- a/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -202,16 +202,6 @@ public class DomainCreateFlow implements TransactionalFlow {
       validateLaunchCreateNotice(launchCreate.getNotice(), domainLabel, isSuperuser, now);
     }
     boolean isSunriseCreate = hasSignedMarks && SUNRISE_STATES.contains(tldState);
-    customLogic.afterValidation(
-        DomainCreateFlowCustomLogic.AfterValidationParameters.newBuilder()
-            .setDomainName(domainName)
-            .setYears(years)
-            .build());
-
-    FeeCreateCommandExtension feeCreate =
-        eppInput.getSingleExtension(FeeCreateCommandExtension.class);
-    FeesAndCredits feesAndCredits = pricingLogic.getCreatePrice(registry, targetId, now, years);
-    validateFeeChallenge(targetId, registry.getTldStr(), now, feeCreate, feesAndCredits);
     // Superusers can create reserved domains, force creations on domains that require a claims
     // notice without specifying a claims key, ignore the registry phase, and override blocks on
     // registering premium domains.
@@ -233,6 +223,19 @@ public class DomainCreateFlow implements TransactionalFlow {
       verifyNoOpenApplications(now);
       verifyIsGaOrIsSpecialCase(tldState, isAnchorTenant);
     }
+    String signedMarkId = hasSignedMarks
+        // If a signed mark was provided, then it must match the desired domain label.
+        ? verifySignedMarks(launchCreate.getSignedMarks(), domainLabel, now).getId()
+        : null;
+    customLogic.afterValidation(
+        DomainCreateFlowCustomLogic.AfterValidationParameters.newBuilder()
+            .setDomainName(domainName)
+            .setYears(years)
+            .build());
+    FeeCreateCommandExtension feeCreate =
+        eppInput.getSingleExtension(FeeCreateCommandExtension.class);
+    FeesAndCredits feesAndCredits = pricingLogic.getCreatePrice(registry, targetId, now, years);
+    validateFeeChallenge(targetId, registry.getTldStr(), now, feeCreate, feesAndCredits);
     SecDnsCreateExtension secDnsCreate =
         validateSecDnsExtension(eppInput.getSingleExtension(SecDnsCreateExtension.class));
     String repoId = createDomainRoid(ObjectifyService.allocateId(), registry.getTldStr());
@@ -266,10 +269,7 @@ public class DomainCreateFlow implements TransactionalFlow {
         .setAutorenewBillingEvent(Key.create(autorenewBillingEvent))
         .setAutorenewPollMessage(Key.create(autorenewPollMessage))
         .setLaunchNotice(hasClaimsNotice ? launchCreate.getNotice() : null)
-        .setSmdId(hasSignedMarks
-            // If a signed mark was provided, then it must match the desired domain label.
-            ? verifySignedMarks(launchCreate.getSignedMarks(), domainLabel, now).getId()
-            : null)
+        .setSmdId(signedMarkId)
         .setDsData(secDnsCreate == null ? null : secDnsCreate.getDsData())
         .setRegistrant(command.getRegistrant())
         .setAuthInfo(command.getAuthInfo())

--- a/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -230,6 +230,8 @@ public class DomainCreateFlow implements TransactionalFlow {
     customLogic.afterValidation(
         DomainCreateFlowCustomLogic.AfterValidationParameters.newBuilder()
             .setDomainName(domainName)
+            .setSignedMarkId(signedMarkId)
+            .setTransactionTime(now)
             .setYears(years)
             .build());
     FeeCreateCommandExtension feeCreate =

--- a/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -231,7 +231,6 @@ public class DomainCreateFlow implements TransactionalFlow {
         DomainCreateFlowCustomLogic.AfterValidationParameters.newBuilder()
             .setDomainName(domainName)
             .setSignedMarkId(signedMarkId)
-            .setTransactionTime(now)
             .setYears(years)
             .build());
     FeeCreateCommandExtension feeCreate =


### PR DESCRIPTION
This is the follow up PR for https://github.com/google/nomulus/pull/49. It adds two additional parameters to `DomainCreateFlowCustomLogic.AfterValidationParameters`. A nullable signed mark id and the transaction time.