### PR TITLE
Moved BigQueryStreamingMetricsQueue into a Dagger Provider

### DIFF
--- a/java/google/registry/module/backend/BackendComponent.java
+++ b/java/google/registry/module/backend/BackendComponent.java
@@ -31,6 +31,7 @@ import google.registry.monitoring.metrics.MetricReporter;
 import google.registry.monitoring.whitebox.StackdriverModule;
 import google.registry.rde.JSchModule;
 import google.registry.request.Modules.AppIdentityCredentialModule;
+import google.registry.request.Modules.BigQueryStreamingMetricsModule;
 import google.registry.request.Modules.DatastoreServiceModule;
 import google.registry.request.Modules.GoogleCredentialModule;
 import google.registry.request.Modules.Jackson2Module;
@@ -49,6 +50,7 @@ import javax.inject.Singleton;
     modules = {
         AppIdentityCredentialModule.class,
         BackendRequestComponentModule.class,
+        BigQueryStreamingMetricsModule.class,
         BigqueryModule.class,
         ConfigModule.class,
         DatastoreServiceModule.class,

--- a/java/google/registry/module/frontend/FrontendComponent.java
+++ b/java/google/registry/module/frontend/FrontendComponent.java
@@ -24,6 +24,7 @@ import google.registry.module.frontend.FrontendRequestComponent.FrontendRequestC
 import google.registry.monitoring.metrics.MetricReporter;
 import google.registry.monitoring.whitebox.StackdriverModule;
 import google.registry.request.Modules.AppIdentityCredentialModule;
+import google.registry.request.Modules.BigQueryStreamingMetricsModule;
 import google.registry.request.Modules.Jackson2Module;
 import google.registry.request.Modules.ModulesServiceModule;
 import google.registry.request.Modules.UrlFetchTransportModule;
@@ -39,6 +40,7 @@ import javax.inject.Singleton;
 @Component(
     modules = {
         AppIdentityCredentialModule.class,
+        BigQueryStreamingMetricsModule.class,
         BraintreeModule.class,
         ConfigModule.class,
         ConsoleConfigModule.class,

--- a/java/google/registry/module/tools/ToolsComponent.java
+++ b/java/google/registry/module/tools/ToolsComponent.java
@@ -26,6 +26,7 @@ import google.registry.keyring.api.DummyKeyringModule;
 import google.registry.keyring.api.KeyModule;
 import google.registry.module.tools.ToolsRequestComponent.ToolsRequestComponentModule;
 import google.registry.request.Modules.AppIdentityCredentialModule;
+import google.registry.request.Modules.BigQueryStreamingMetricsModule;
 import google.registry.request.Modules.DatastoreServiceModule;
 import google.registry.request.Modules.GoogleCredentialModule;
 import google.registry.request.Modules.Jackson2Module;
@@ -42,6 +43,7 @@ import javax.inject.Singleton;
 @Component(
     modules = {
         AppIdentityCredentialModule.class,
+        BigQueryStreamingMetricsModule.class,
         ConfigModule.class,
         CustomLogicFactoryModule.class,
         DatastoreServiceModule.class,

--- a/java/google/registry/monitoring/whitebox/BigQueryMetricsEnqueuer.java
+++ b/java/google/registry/monitoring/whitebox/BigQueryMetricsEnqueuer.java
@@ -14,10 +14,10 @@
 
 package google.registry.monitoring.whitebox;
 
-import static com.google.appengine.api.taskqueue.QueueFactory.getQueue;
 import static com.google.appengine.api.taskqueue.TaskOptions.Builder.withUrl;
 
 import com.google.appengine.api.modules.ModulesService;
+import com.google.appengine.api.taskqueue.Queue;
 import com.google.appengine.api.taskqueue.TaskOptions;
 import com.google.appengine.api.taskqueue.TransientFailureException;
 import com.google.common.base.Supplier;
@@ -39,6 +39,7 @@ public class BigQueryMetricsEnqueuer {
   public static final String QUEUE = "bigquery-streaming-metrics";
 
   @Inject ModulesService modulesService;
+  @Inject @Named(QUEUE) Queue bigQueryStreamingMetricsQueue;
   @Inject @Named("insertIdGenerator") Supplier<String> idGenerator;
 
   @Inject BigQueryMetricsEnqueuer() {}
@@ -54,7 +55,7 @@ public class BigQueryMetricsEnqueuer {
         opts.param(entry.getKey(), entry.getValue());
       }
       opts.param("tableId", metric.getTableId());
-      getQueue(QUEUE).add(opts);
+      bigQueryStreamingMetricsQueue.add(opts);
     } catch (TransientFailureException e) {
       // Log and swallow. We may drop some metrics here but this should be rare.
       logger.info(e, e.getMessage());

--- a/java/google/registry/request/BUILD
+++ b/java/google/registry/request/BUILD
@@ -11,8 +11,6 @@ java_library(
         exclude = ["Modules.java"],
     ),
     deps = [
-        "//java/google/registry/security",
-        "//java/google/registry/util",
         "@com_google_appengine_api_1_0_sdk",
         "@com_google_auto_value",
         "@com_google_code_findbugs_jsr305",
@@ -21,6 +19,8 @@ java_library(
         "@com_googlecode_json_simple",
         "@javax_servlet_api",
         "@joda_time",
+        "//java/google/registry/security",
+        "//java/google/registry/util",
     ],
 )
 
@@ -28,8 +28,6 @@ java_library(
     name = "modules",
     srcs = ["Modules.java"],
     deps = [
-        "//java/google/registry/config",
-        "//java/google/registry/keyring/api",
         "@com_google_api_client",
         "@com_google_api_client_appengine",
         "@com_google_appengine_api_1_0_sdk",
@@ -38,5 +36,8 @@ java_library(
         "@com_google_http_client",
         "@com_google_http_client_appengine",
         "@com_google_http_client_jackson2",
+        "//java/google/registry/config",
+        "//java/google/registry/keyring/api",
+        "//java/google/registry/monitoring/whitebox",
     ],
 )

--- a/java/google/registry/request/Modules.java
+++ b/java/google/registry/request/Modules.java
@@ -15,6 +15,7 @@
 package google.registry.request;
 
 import static com.google.appengine.api.datastore.DatastoreServiceFactory.getDatastoreService;
+import static com.google.appengine.api.taskqueue.QueueFactory.getQueue;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.api.client.extensions.appengine.http.UrlFetchTransport;
@@ -27,6 +28,7 @@ import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.modules.ModulesService;
 import com.google.appengine.api.modules.ModulesServiceFactory;
+import com.google.appengine.api.taskqueue.Queue;
 import com.google.appengine.api.urlfetch.URLFetchService;
 import com.google.appengine.api.urlfetch.URLFetchServiceFactory;
 import com.google.appengine.api.users.UserService;
@@ -38,12 +40,14 @@ import dagger.Module;
 import dagger.Provides;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.keyring.api.KeyModule.Key;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.Set;
+import google.registry.monitoring.whitebox.BigQueryMetricsEnqueuer;
+
 import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Set;
 
 /** Dagger modules for App Engine services and other vendor classes. */
 public final class Modules {
@@ -67,6 +71,16 @@ public final class Modules {
     @Provides
     static ModulesService provideModulesService() {
       return modulesService;
+    }
+  }
+
+  /** Dagger module for {@link BigQueryMetricsEnqueuer} queue */
+  @Module
+  public static final class BigQueryStreamingMetricsModule {
+    @Provides
+    @Named(BigQueryMetricsEnqueuer.QUEUE)
+    static Queue provideBigQueryStreamingMetricsQueue() {
+      return getQueue(BigQueryMetricsEnqueuer.QUEUE);
     }
   }
 

--- a/javatests/google/registry/monitoring/whitebox/BigQueryMetricsEnqueuerTest.java
+++ b/javatests/google/registry/monitoring/whitebox/BigQueryMetricsEnqueuerTest.java
@@ -14,6 +14,7 @@
 
 package google.registry.monitoring.whitebox;
 
+import static com.google.appengine.api.taskqueue.QueueFactory.getQueue;
 import static google.registry.bigquery.BigqueryUtils.toBigqueryTimestamp;
 import static google.registry.testing.TaskQueueHelper.assertTasksEnqueued;
 import static org.mockito.Mockito.when;
@@ -59,6 +60,7 @@ public class BigQueryMetricsEnqueuerTest {
     enqueuer = new BigQueryMetricsEnqueuer();
     enqueuer.idGenerator = Suppliers.ofInstance("laffo");
     enqueuer.modulesService = modulesService;
+    enqueuer.bigQueryStreamingMetricsQueue = getQueue(BigQueryMetricsEnqueuer.QUEUE);
     when(modulesService.getVersionHostname(Matchers.anyString(), Matchers.anyString()))
         .thenReturn("1.backend.test.localhost");
   }


### PR DESCRIPTION
This PR moves the BigQueryStreamingMetricsQueue call into a Dagger Provider method allowing us to inject stubs during our UI development. 

As it is now when we are working on our custom UI we are frequently debugging locally. This involves making calls to the flows running locally. This works great however when the EppController goes to return the EppOutput it currently tries to [make a call](https://github.com/google/nomulus/blob/master/java/google/registry/flows/EppController.java#L109) to the BigQueryMetricsEnqueuer (which is not running locally). This then throws an Exception instead of returning the response. By moving the queue into a provider we can inject a stub within our development module.