### PR TITLE
Remove unique ROID suffixes requirement

### DIFF
--- a/java/google/registry/config/RegistryConfig.java
+++ b/java/google/registry/config/RegistryConfig.java
@@ -1077,6 +1077,15 @@ public final class RegistryConfig {
               .build())
           .build();
     }
+
+    /**
+     * Returns {@code true} if the roid suffix of each tld is required to be unique.
+     */
+    @Provides
+    @Config("requireUniqueRoidSuffix")
+    public static boolean provideRequireUniqueRoidSuffix() {
+      return true;
+    }
   }
 
   /**

--- a/java/google/registry/flows/domain/DomainAllocateFlow.java
+++ b/java/google/registry/flows/domain/DomainAllocateFlow.java
@@ -16,6 +16,7 @@ package google.registry.flows.domain;
 
 import static com.google.common.collect.Iterables.filter;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static google.registry.config.RegistryConfig.Config;
 import static google.registry.flows.FlowUtils.validateClientIsLoggedIn;
 import static google.registry.flows.ResourceFlowUtils.verifyResourceDoesNotExist;
 import static google.registry.flows.domain.DomainFlowUtils.cloneAndLinkReferences;
@@ -111,6 +112,7 @@ public class DomainAllocateFlow implements TransactionalFlow {
   @Inject EppInput eppInput;
   @Inject EppResponse.Builder responseBuilder;
   @Inject DomainPricingLogic pricingLogic;
+  @Inject @Config("requireUniqueRoidSuffix") boolean requireUniqueRoidSuffix;
   @Inject DomainAllocateFlow() {}
 
   @Override
@@ -140,7 +142,9 @@ public class DomainAllocateFlow implements TransactionalFlow {
         eppInput.getSingleExtension(AllocateCreateExtension.class);
     DomainApplication application =
         loadAndValidateApplication(allocateCreate.getApplicationRoid(), now);
-    String repoId = createDomainRepoId(ObjectifyService.allocateId(), registry.getTldStr());
+    String repoId =
+        createDomainRepoId(
+            ObjectifyService.allocateId(), registry.getTldStr(), requireUniqueRoidSuffix);
     ImmutableSet.Builder<ImmutableObject> entitiesToSave = new ImmutableSet.Builder<>();
     HistoryEntry historyEntry = buildHistory(repoId, period, now);
     entitiesToSave.add(historyEntry);

--- a/java/google/registry/flows/domain/DomainApplicationCreateFlow.java
+++ b/java/google/registry/flows/domain/DomainApplicationCreateFlow.java
@@ -48,6 +48,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.InternetDomainName;
 import com.googlecode.objectify.Key;
+import google.registry.config.RegistryConfig.Config;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.CommandUseErrorException;
 import google.registry.flows.EppException.ObjectAlreadyExistsException;
@@ -172,6 +173,7 @@ public final class DomainApplicationCreateFlow implements TransactionalFlow {
   @Inject DomainApplicationCreateFlowCustomLogic customLogic;
   @Inject DomainFlowTmchUtils tmchUtils;
   @Inject DomainPricingLogic pricingLogic;
+  @Inject @Config("requireUniqueRoidSuffix") boolean requireUniqueRoidSuffix;
   @Inject DomainApplicationCreateFlow() {}
 
   @Override
@@ -232,7 +234,7 @@ public final class DomainApplicationCreateFlow implements TransactionalFlow {
         .setCreationTrid(trid)
         .setCreationClientId(clientId)
         .setCurrentSponsorClientId(clientId)
-        .setRepoId(createDomainRepoId(ObjectifyService.allocateId(), tld))
+        .setRepoId(createDomainRepoId(ObjectifyService.allocateId(), tld, requireUniqueRoidSuffix))
         .setLaunchNotice(launchCreate == null ? null : launchCreate.getNotice())
         .setIdnTableName(idnTableName)
         .setPhase(launchCreate.getPhase())

--- a/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -48,6 +48,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.net.InternetDomainName;
 import com.googlecode.objectify.Key;
+import google.registry.config.RegistryConfig.Config;
 import google.registry.dns.DnsQueue;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.CommandUseErrorException;
@@ -167,6 +168,7 @@ public class DomainCreateFlow implements TransactionalFlow {
   @Inject DomainFlowTmchUtils tmchUtils;
   @Inject DomainPricingLogic pricingLogic;
   @Inject DnsQueue dnsQueue;
+  @Inject @Config("requireUniqueRoidSuffix") boolean requireUniqueRoidSuffix;
   @Inject DomainCreateFlow() {}
 
   @Override
@@ -239,7 +241,9 @@ public class DomainCreateFlow implements TransactionalFlow {
     validateFeeChallenge(targetId, registry.getTldStr(), now, feeCreate, feesAndCredits);
     SecDnsCreateExtension secDnsCreate =
         validateSecDnsExtension(eppInput.getSingleExtension(SecDnsCreateExtension.class));
-    String repoId = createDomainRepoId(ObjectifyService.allocateId(), registry.getTldStr());
+    String repoId =
+        createDomainRepoId(
+            ObjectifyService.allocateId(), registry.getTldStr(), requireUniqueRoidSuffix);
     DateTime registrationExpirationTime = leapSafeAddYears(now, years);
     HistoryEntry historyEntry = buildHistory(repoId, period, now);
     // Bill for the create.

--- a/java/google/registry/model/EppResourceUtils.java
+++ b/java/google/registry/model/EppResourceUtils.java
@@ -55,8 +55,8 @@ public final class EppResourceUtils {
   private static final FormattingLogger logger = FormattingLogger.getLoggerForCallerClass();
 
   /** Returns the full domain repoId in the format HEX-TLD for the specified long id and tld. */
-  public static String createDomainRepoId(long repoId, String tld) {
-    return createRepoId(repoId, getRoidSuffixForTld(tld));
+  public static String createDomainRepoId(long repoId, String tld, boolean requireUniqueRoidSuffix) {
+    return createRepoId(repoId, getRoidSuffixForTld(tld, requireUniqueRoidSuffix));
   }
 
   /** Returns the full repoId in the format HEX-TLD for the specified long id and ROID suffix. */

--- a/java/google/registry/model/RoidSuffixes.java
+++ b/java/google/registry/model/RoidSuffixes.java
@@ -51,8 +51,13 @@ public final class RoidSuffixes {
    * @throws IllegalStateException if there is no such tld, or the tld does not have a roid suffix
    * configured on it
    */
-  public static String getRoidSuffixForTld(String tld) {
-    String roidSuffix = roidSuffixMapCache.get().get(tld);
+  public static String getRoidSuffixForTld(String tld, boolean requireUniqueRoidSuffix) {
+    String roidSuffix;
+    if (requireUniqueRoidSuffix) {
+      roidSuffix = roidSuffixMapCache.get().get(tld);
+    } else {
+      roidSuffix = Registry.get(tld).getRoidSuffix();
+    }
     checkState(roidSuffix != null, "Could not find ROID suffix for TLD %s", tld);
     return roidSuffix;
   }

--- a/javatests/google/registry/model/RoidSuffixesTest.java
+++ b/javatests/google/registry/model/RoidSuffixesTest.java
@@ -37,6 +37,24 @@ public class RoidSuffixesTest {
   @Test
   public void test_newlyCreatedRegistry_isAddedToRoidSuffixesList() {
     persistResource(newRegistry("tld", "MEOW"));
-    assertThat(getRoidSuffixForTld("tld")).isEqualTo("MEOW");
+    assertThat(getRoidSuffixForTld("tld", true)).isEqualTo("MEOW");
+  }
+
+  @Test
+  public void test_shouldAllowTldsWithSameRoidSuffix_whenNotRequiredUnique() {
+    persistResource(newRegistry("wtf", "donuts"));
+    persistResource(newRegistry("ltd", "donuts"));
+
+    assertThat(getRoidSuffixForTld("wtf", false)).isEqualTo("donuts");
+    assertThat(getRoidSuffixForTld("ltd", false)).isEqualTo("donuts");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void test_shouldNotAllowTldsWithSameRoidSuffix_whenRequiredUnique() {
+    persistResource(newRegistry("wtf", "donuts"));
+    persistResource(newRegistry("ltd", "donuts"));
+
+    assertThat(getRoidSuffixForTld("wtf", true)).isEqualTo("donuts");
+    assertThat(getRoidSuffixForTld("ltd", true)).isEqualTo("donuts");
   }
 }

--- a/javatests/google/registry/testing/DatastoreHelper.java
+++ b/javatests/google/registry/testing/DatastoreHelper.java
@@ -737,7 +737,7 @@ public class DatastoreHelper {
 
   /** Returns a newly allocated, globally unique domain repoId of the format HEX-TLD. */
   public static String generateNewDomainRoid(String tld) {
-    return createDomainRepoId(ObjectifyService.allocateId(), tld);
+    return createDomainRepoId(ObjectifyService.allocateId(), tld, true);
   }
 
   /**


### PR DESCRIPTION
This makes the requirement of having a unique Roid suffix per tld
optional. A new parameter has been added added to config module called
"requireUniqueRoidSuffixes" which will allow setting this feature.

Possible todo: This has not been added to the CreateOrUpdateCommand
as Donuts doesn't use this feature.