### PR TITLE
Allow customized whois commands

### DIFF
--- a/java/google/registry/config/RegistryConfig.java
+++ b/java/google/registry/config/RegistryConfig.java
@@ -988,6 +988,13 @@ public final class RegistryConfig {
       return "google.registry.flows.custom.CustomLogicFactory";
     }
 
+    @Provides
+    @Config("whoisCommandFactoryClass")
+    public static String provideWhoisCommandFactoryClass() {
+      // TODO(b/32875427): This will be converted to YAML configuration in a future refactor.
+      return "google.registry.whois.WhoisCommandFactory";
+    }
+
     private static final String RESERVED_TERMS_EXPORT_DISCLAIMER = ""
         + "# This list contains reserve terms for the TLD. Other terms may be reserved\n"
         + "# but not included in this list, including terms EXAMPLE REGISTRY chooses not\n"

--- a/java/google/registry/tools/RegistryToolComponent.java
+++ b/java/google/registry/tools/RegistryToolComponent.java
@@ -26,6 +26,8 @@ import google.registry.request.Modules.Jackson2Module;
 import google.registry.request.Modules.URLFetchServiceModule;
 import google.registry.util.SystemClock.SystemClockModule;
 import google.registry.util.SystemSleeper.SystemSleeperModule;
+import google.registry.whois.WhoisModule;
+
 import javax.inject.Singleton;
 
 /**
@@ -50,6 +52,7 @@ import javax.inject.Singleton;
     SystemSleeperModule.class,
     URLFetchServiceModule.class,
     VoidDnsWriterModule.class,
+    WhoisModule.class,
   },
   dependencies = {
     HttpRequestFactoryComponent.class,

--- a/java/google/registry/whois/DomainLookupCommand.java
+++ b/java/google/registry/whois/DomainLookupCommand.java
@@ -14,13 +14,16 @@
 
 package google.registry.whois;
 
+import static google.registry.model.EppResourceUtils.loadByForeignKey;
+
+import com.google.common.base.Optional;
 import com.google.common.net.InternetDomainName;
 import google.registry.model.domain.DomainResource;
 import javax.annotation.Nullable;
 import org.joda.time.DateTime;
 
 /** Represents a WHOIS lookup on a domain name (i.e. SLD). */
-class DomainLookupCommand extends DomainOrHostLookupCommand<DomainResource> {
+public class DomainLookupCommand extends DomainOrHostLookupCommand {
 
   DomainLookupCommand(InternetDomainName domainName) {
     this(domainName, null);
@@ -31,7 +34,8 @@ class DomainLookupCommand extends DomainOrHostLookupCommand<DomainResource> {
   }
 
   @Override
-  WhoisResponse getSuccessResponse(DomainResource domain, DateTime now) {
-    return new DomainWhoisResponse(domain, now);
+  protected Optional<WhoisResponse> getResponse(InternetDomainName domainName, DateTime now) {
+    final DomainResource domainResource = loadByForeignKey(DomainResource.class, domainName.toString(), now);
+    return Optional.fromNullable(domainResource == null ? null : new DomainWhoisResponse(domainResource, now));
   }
 }

--- a/java/google/registry/whois/DomainLookupCommand.java
+++ b/java/google/registry/whois/DomainLookupCommand.java
@@ -19,8 +19,9 @@ import static google.registry.model.EppResourceUtils.loadByForeignKey;
 import com.google.common.base.Optional;
 import com.google.common.net.InternetDomainName;
 import google.registry.model.domain.DomainResource;
-import javax.annotation.Nullable;
 import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
 
 /** Represents a WHOIS lookup on a domain name (i.e. SLD). */
 public class DomainLookupCommand extends DomainOrHostLookupCommand {
@@ -35,7 +36,9 @@ public class DomainLookupCommand extends DomainOrHostLookupCommand {
 
   @Override
   protected Optional<WhoisResponse> getResponse(InternetDomainName domainName, DateTime now) {
-    final DomainResource domainResource = loadByForeignKey(DomainResource.class, domainName.toString(), now);
-    return Optional.fromNullable(domainResource == null ? null : new DomainWhoisResponse(domainResource, now));
+    final DomainResource domainResource =
+        loadByForeignKey(DomainResource.class, domainName.toString(), now);
+    return Optional.fromNullable(
+        domainResource == null ? null : new DomainWhoisResponse(domainResource, now));
   }
 }

--- a/java/google/registry/whois/DomainOrHostLookupCommand.java
+++ b/java/google/registry/whois/DomainOrHostLookupCommand.java
@@ -22,14 +22,14 @@ import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.net.InternetDomainName;
-import javax.annotation.Nullable;
 import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
 
 /** Represents a WHOIS lookup on a domain name (i.e. SLD) or a nameserver. */
 public abstract class DomainOrHostLookupCommand implements WhoisCommand {
 
-  @VisibleForTesting
-  final InternetDomainName domainOrHostName;
+  @VisibleForTesting final InternetDomainName domainOrHostName;
 
   private final String errorPrefix;
 
@@ -58,5 +58,6 @@ public abstract class DomainOrHostLookupCommand implements WhoisCommand {
   }
 
   /** Renders a response record, provided its successfully retrieved datastore entity. */
-  protected abstract Optional<WhoisResponse> getResponse(InternetDomainName domainName, DateTime now);
+  protected abstract Optional<WhoisResponse> getResponse(
+      InternetDomainName domainName, DateTime now);
 }

--- a/java/google/registry/whois/DomainOrHostLookupCommand.java
+++ b/java/google/registry/whois/DomainOrHostLookupCommand.java
@@ -15,7 +15,6 @@
 package google.registry.whois;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static google.registry.model.EppResourceUtils.loadByForeignKey;
 import static google.registry.model.registry.Registries.findTldForName;
 import static google.registry.model.registry.Registries.getTlds;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
@@ -23,13 +22,11 @@ import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.net.InternetDomainName;
-import google.registry.model.EppResource;
-import google.registry.util.TypeUtils.TypeInstantiator;
 import javax.annotation.Nullable;
 import org.joda.time.DateTime;
 
 /** Represents a WHOIS lookup on a domain name (i.e. SLD) or a nameserver. */
-abstract class DomainOrHostLookupCommand<T extends EppResource> implements WhoisCommand {
+public abstract class DomainOrHostLookupCommand implements WhoisCommand {
 
   @VisibleForTesting
   final InternetDomainName domainOrHostName;
@@ -52,17 +49,14 @@ abstract class DomainOrHostLookupCommand<T extends EppResource> implements Whois
     }
     // Google Policy: Do not return records under TLDs for which we're not authoritative.
     if (tld.isPresent() && getTlds().contains(tld.get().toString())) {
-      T domainOrHost = loadByForeignKey(
-          new TypeInstantiator<T>(getClass()){}.getExactType(),
-          domainOrHostName.toString(),
-          now);
-      if (domainOrHost != null) {
-        return getSuccessResponse(domainOrHost, now);
+      final Optional<WhoisResponse> response = getResponse(domainOrHostName, now);
+      if (response.isPresent()) {
+        return response.get();
       }
     }
     throw new WhoisException(now, SC_NOT_FOUND, errorPrefix + " not found.");
   }
 
   /** Renders a response record, provided its successfully retrieved datastore entity. */
-  abstract WhoisResponse getSuccessResponse(T domainOrHost, DateTime now);
+  protected abstract Optional<WhoisResponse> getResponse(InternetDomainName domainName, DateTime now);
 }

--- a/java/google/registry/whois/NameserverLookupByHostCommand.java
+++ b/java/google/registry/whois/NameserverLookupByHostCommand.java
@@ -19,8 +19,9 @@ import static google.registry.model.EppResourceUtils.loadByForeignKey;
 import com.google.common.base.Optional;
 import com.google.common.net.InternetDomainName;
 import google.registry.model.host.HostResource;
-import javax.annotation.Nullable;
 import org.joda.time.DateTime;
+
+import javax.annotation.Nullable;
 
 /** Represents a WHOIS lookup on a nameserver based on its hostname. */
 public class NameserverLookupByHostCommand extends DomainOrHostLookupCommand {
@@ -35,7 +36,9 @@ public class NameserverLookupByHostCommand extends DomainOrHostLookupCommand {
 
   @Override
   protected Optional<WhoisResponse> getResponse(InternetDomainName hostName, DateTime now) {
-    final HostResource hostResource = loadByForeignKey(HostResource.class, hostName.toString(), now);
-    return Optional.fromNullable(hostResource == null ? null : new NameserverWhoisResponse(hostResource, now));
+    final HostResource hostResource =
+        loadByForeignKey(HostResource.class, hostName.toString(), now);
+    return Optional.fromNullable(
+        hostResource == null ? null : new NameserverWhoisResponse(hostResource, now));
   }
 }

--- a/java/google/registry/whois/NameserverLookupByHostCommand.java
+++ b/java/google/registry/whois/NameserverLookupByHostCommand.java
@@ -14,13 +14,16 @@
 
 package google.registry.whois;
 
+import static google.registry.model.EppResourceUtils.loadByForeignKey;
+
+import com.google.common.base.Optional;
 import com.google.common.net.InternetDomainName;
 import google.registry.model.host.HostResource;
 import javax.annotation.Nullable;
 import org.joda.time.DateTime;
 
 /** Represents a WHOIS lookup on a nameserver based on its hostname. */
-final class NameserverLookupByHostCommand extends DomainOrHostLookupCommand<HostResource> {
+public class NameserverLookupByHostCommand extends DomainOrHostLookupCommand {
 
   NameserverLookupByHostCommand(InternetDomainName hostName) {
     this(hostName, null);
@@ -31,7 +34,8 @@ final class NameserverLookupByHostCommand extends DomainOrHostLookupCommand<Host
   }
 
   @Override
-  WhoisResponse getSuccessResponse(HostResource host, DateTime now) {
-    return new NameserverWhoisResponse(host, now);
+  protected Optional<WhoisResponse> getResponse(InternetDomainName hostName, DateTime now) {
+    final HostResource hostResource = loadByForeignKey(HostResource.class, hostName.toString(), now);
+    return Optional.fromNullable(hostResource == null ? null : new NameserverWhoisResponse(hostResource, now));
   }
 }

--- a/java/google/registry/whois/Whois.java
+++ b/java/google/registry/whois/Whois.java
@@ -26,18 +26,22 @@ public final class Whois {
 
   private final Clock clock;
   private final String disclaimer;
+  private final WhoisCommandFactory commandFactory;
 
   @Inject
-  public Whois(Clock clock, @Config("whoisDisclaimer") String disclaimer) {
+  public Whois(Clock clock,
+               @Config("whoisDisclaimer") String disclaimer,
+               @Config("whoisCommandFactory") WhoisCommandFactory commandFactory) {
     this.clock = clock;
     this.disclaimer = disclaimer;
+    this.commandFactory = commandFactory;
   }
 
   /** Performs a WHOIS lookup on a plaintext query string. */
   public String lookup(String query, boolean preferUnicode) {
     DateTime now = clock.nowUtc();
     try {
-      return new WhoisReader(new StringReader(query), now)
+      return new WhoisReader(new StringReader(query), commandFactory, now)
           .readCommand()
           .executeQuery(now)
           .getPlainTextOutput(preferUnicode, disclaimer);

--- a/java/google/registry/whois/Whois.java
+++ b/java/google/registry/whois/Whois.java
@@ -16,10 +16,11 @@ package google.registry.whois;
 
 import google.registry.config.RegistryConfig.Config;
 import google.registry.util.Clock;
+import org.joda.time.DateTime;
+
+import javax.inject.Inject;
 import java.io.IOException;
 import java.io.StringReader;
-import javax.inject.Inject;
-import org.joda.time.DateTime;
 
 /** High-level WHOIS API for other packages. */
 public final class Whois {
@@ -29,9 +30,10 @@ public final class Whois {
   private final WhoisCommandFactory commandFactory;
 
   @Inject
-  public Whois(Clock clock,
-               @Config("whoisDisclaimer") String disclaimer,
-               @Config("whoisCommandFactory") WhoisCommandFactory commandFactory) {
+  public Whois(
+      Clock clock,
+      @Config("whoisDisclaimer") String disclaimer,
+      @Config("whoisCommandFactory") WhoisCommandFactory commandFactory) {
     this.clock = clock;
     this.disclaimer = disclaimer;
     this.commandFactory = commandFactory;

--- a/java/google/registry/whois/WhoisCommand.java
+++ b/java/google/registry/whois/WhoisCommand.java
@@ -17,7 +17,7 @@ package google.registry.whois;
 import org.joda.time.DateTime;
 
 /** Represents a WHOIS command request from a client. */
-interface WhoisCommand {
+public interface WhoisCommand {
 
   /**
    * Executes a WHOIS query and returns the resultant data.

--- a/java/google/registry/whois/WhoisCommandFactory.java
+++ b/java/google/registry/whois/WhoisCommandFactory.java
@@ -1,0 +1,53 @@
+// Copyright 2016 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.whois;
+
+import com.google.common.net.InternetDomainName;
+import google.registry.config.RegistryConfig.ConfigModule;
+
+import javax.annotation.Nullable;
+import java.net.InetAddress;
+
+/**
+ * A class used to configure whois commands.
+ * <p>To add custom commands, extend this class, then configure it in
+ * {@link ConfigModule#provideWhoisCommandFactoryClass()}.
+ */
+public class WhoisCommandFactory {
+
+  public final WhoisCommand domainLookup(InternetDomainName domainName) {
+    return domainLookup(domainName, null);
+  }
+
+  public WhoisCommand domainLookup(InternetDomainName domainName, @Nullable InternetDomainName tld) {
+    return new DomainLookupCommand(domainName, tld);
+  }
+
+  public WhoisCommand nameserverLookupByIp(InetAddress inetAddress) {
+    return new NameserverLookupByIpCommand(inetAddress);
+  }
+
+  public final WhoisCommand nameserverLookupByHost(InternetDomainName hostName) {
+    return nameserverLookupByHost(hostName, null);
+  }
+
+  public WhoisCommand nameserverLookupByHost(InternetDomainName hostName, @Nullable InternetDomainName tld) {
+    return new NameserverLookupByHostCommand(hostName, tld);
+  }
+
+  public WhoisCommand registrarLookup(String registrar) {
+    return new RegistrarLookupCommand(registrar);
+  }
+}

--- a/java/google/registry/whois/WhoisCommandFactory.java
+++ b/java/google/registry/whois/WhoisCommandFactory.java
@@ -22,8 +22,9 @@ import java.net.InetAddress;
 
 /**
  * A class used to configure whois commands.
- * <p>To add custom commands, extend this class, then configure it in
- * {@link ConfigModule#provideWhoisCommandFactoryClass()}.
+ *
+ * <p>To add custom commands, extend this class, then configure it in {@link
+ * ConfigModule#provideWhoisCommandFactoryClass()}.
  */
 public class WhoisCommandFactory {
 
@@ -31,7 +32,8 @@ public class WhoisCommandFactory {
     return domainLookup(domainName, null);
   }
 
-  public WhoisCommand domainLookup(InternetDomainName domainName, @Nullable InternetDomainName tld) {
+  public WhoisCommand domainLookup(
+      InternetDomainName domainName, @Nullable InternetDomainName tld) {
     return new DomainLookupCommand(domainName, tld);
   }
 
@@ -43,7 +45,8 @@ public class WhoisCommandFactory {
     return nameserverLookupByHost(hostName, null);
   }
 
-  public WhoisCommand nameserverLookupByHost(InternetDomainName hostName, @Nullable InternetDomainName tld) {
+  public WhoisCommand nameserverLookupByHost(
+      InternetDomainName hostName, @Nullable InternetDomainName tld) {
     return new NameserverLookupByHostCommand(hostName, tld);
   }
 

--- a/java/google/registry/whois/WhoisHttpServer.java
+++ b/java/google/registry/whois/WhoisHttpServer.java
@@ -132,6 +132,7 @@ public final class WhoisHttpServer implements Runnable {
   @Inject Response response;
   @Inject @Config("whoisDisclaimer") String disclaimer;
   @Inject @Config("whoisHttpExpires") Duration expires;
+  @Inject @Config("whoisCommandFactory") WhoisCommandFactory commandFactory;
   @Inject @RequestPath String requestPath;
   @Inject WhoisHttpServer() {}
 
@@ -144,7 +145,7 @@ public final class WhoisHttpServer implements Runnable {
       String command = decode(JOINER.join(SLASHER.split(path.substring(PATH.length())))) + "\r\n";
       Reader reader = new StringReader(command);
       DateTime now = clock.nowUtc();
-      sendResponse(SC_OK, new WhoisReader(reader, now).readCommand().executeQuery(now));
+      sendResponse(SC_OK, new WhoisReader(reader, commandFactory, now).readCommand().executeQuery(now));
     } catch (WhoisException e) {
       sendResponse(e.getStatus(), e);
     } catch (IOException e) {

--- a/java/google/registry/whois/WhoisHttpServer.java
+++ b/java/google/registry/whois/WhoisHttpServer.java
@@ -104,15 +104,15 @@ public final class WhoisHttpServer implements Runnable {
    * Cross-origin resource sharing (CORS) allowed origins policy.
    *
    * <p>This field specifies the value of the {@code Access-Control-Allow-Origin} response header.
-   * Without this header, other domains such as charlestonroadregistry.com would not be able to
-   * send requests to our WHOIS interface.
+   * Without this header, other domains such as charlestonroadregistry.com would not be able to send
+   * requests to our WHOIS interface.
    *
-   * <p>Our policy shall be to allow requests from pretty much anywhere using a wildcard policy.
-   * The reason this is safe is because our WHOIS interface doesn't allow clients to modify data,
-   * nor does it allow them to fetch user data. Only publicly available information is returned.
+   * <p>Our policy shall be to allow requests from pretty much anywhere using a wildcard policy. The
+   * reason this is safe is because our WHOIS interface doesn't allow clients to modify data, nor
+   * does it allow them to fetch user data. Only publicly available information is returned.
    *
-   * @see <a href="http://www.w3.org/TR/cors/#access-control-allow-origin-response-header">
-   *        W3C CORS § 5.1 Access-Control-Allow-Origin Response Header</a>
+   * @see <a href="http://www.w3.org/TR/cors/#access-control-allow-origin-response-header">W3C CORS
+   *     § 5.1 Access-Control-Allow-Origin Response Header</a>
    */
   private static final String CORS_ALLOW_ORIGIN = "*";
 

--- a/java/google/registry/whois/WhoisModule.java
+++ b/java/google/registry/whois/WhoisModule.java
@@ -14,8 +14,13 @@
 
 package google.registry.whois;
 
+import static google.registry.util.TypeUtils.getClassFromString;
+import static google.registry.util.TypeUtils.instantiate;
+
 import dagger.Module;
 import dagger.Provides;
+import google.registry.config.RegistryConfig.Config;
+
 import java.io.IOException;
 import java.io.Reader;
 import javax.servlet.http.HttpServletRequest;
@@ -41,5 +46,12 @@ public final class WhoisModule {
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Provides
+  @Config("whoisCommandFactory")
+  static WhoisCommandFactory provideWhoisCommandFactory(
+    @Config("whoisCommandFactoryClass") String factoryClass) {
+    return instantiate(getClassFromString(factoryClass, WhoisCommandFactory.class));
   }
 }

--- a/java/google/registry/whois/WhoisModule.java
+++ b/java/google/registry/whois/WhoisModule.java
@@ -21,9 +21,9 @@ import dagger.Module;
 import dagger.Provides;
 import google.registry.config.RegistryConfig.Config;
 
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.Reader;
-import javax.servlet.http.HttpServletRequest;
 
 /**
  * Dagger module for the whois package.
@@ -51,7 +51,7 @@ public final class WhoisModule {
   @Provides
   @Config("whoisCommandFactory")
   static WhoisCommandFactory provideWhoisCommandFactory(
-    @Config("whoisCommandFactoryClass") String factoryClass) {
+      @Config("whoisCommandFactoryClass") String factoryClass) {
     return instantiate(getClassFromString(factoryClass, WhoisCommandFactory.class));
   }
 }

--- a/java/google/registry/whois/WhoisServer.java
+++ b/java/google/registry/whois/WhoisServer.java
@@ -58,9 +58,8 @@ public class WhoisServer implements Runnable {
   @Inject Clock clock;
   @Inject Reader input;
   @Inject Response response;
-  @Inject
-  @Config("whoisDisclaimer")
-  String disclaimer;
+  @Inject @Config("whoisCommandFactory") WhoisCommandFactory commandFactory;
+  @Inject @Config("whoisDisclaimer") String disclaimer;
   @Inject WhoisServer() {}
 
   @Override
@@ -69,7 +68,7 @@ public class WhoisServer implements Runnable {
     DateTime now = clock.nowUtc();
     try {
       responseText =
-          new WhoisReader(input, now)
+          new WhoisReader(input, commandFactory, now)
               .readCommand()
               .executeQuery(now)
               .getPlainTextOutput(PREFER_UNICODE, disclaimer);

--- a/javatests/google/registry/whois/WhoisHttpServerTest.java
+++ b/javatests/google/registry/whois/WhoisHttpServerTest.java
@@ -71,6 +71,7 @@ public class WhoisHttpServerTest {
     result.requestPath = WhoisHttpServer.PATH + pathInfo;
     result.response = response;
     result.disclaimer = "Doodle Disclaimer";
+    result.commandFactory = new WhoisCommandFactory();
     return result;
   }
 

--- a/javatests/google/registry/whois/WhoisReaderTest.java
+++ b/javatests/google/registry/whois/WhoisReaderTest.java
@@ -48,7 +48,7 @@ public class WhoisReaderTest {
 
   @SuppressWarnings("unchecked")  // XXX: Generic abuse ftw.
   <T> T readCommand(String commandStr) throws Exception {
-    return (T) new WhoisReader(new StringReader(commandStr), clock.nowUtc()).readCommand();
+    return (T) new WhoisReader(new StringReader(commandStr), new WhoisCommandFactory(), clock.nowUtc()).readCommand();
   }
 
   void assertLoadsExampleTld(String commandString) throws Exception {

--- a/javatests/google/registry/whois/WhoisServerTest.java
+++ b/javatests/google/registry/whois/WhoisServerTest.java
@@ -66,6 +66,7 @@ public class WhoisServerTest {
     result.input = new StringReader(input);
     result.response = response;
     result.disclaimer = "Doodle Disclaimer";
+    result.commandFactory = new WhoisCommandFactory();
     return result;
   }
 


### PR DESCRIPTION
@CydeWeys I looked at creating our own whois endpoint and the amount of code I was going to have to copy was pretty substantial. Creating a duplicate servlet is no problem, but the code to tell me if the request contains a domain lives inside the protected WhoisReader class. The workarounds included making it public, using reflection to get an instance, or copying its `parseCommand` logic (about a hundred lines). All of this felt very heavy handed when the logic change I need is four or five lines in total. After talking this over with @hridder we decided it would be much more flexible to create a factory that allows the whois commands to be overridden/changed. This way Google's code stays very much the same and we can add a lightweight WhoisCommand to handle our new logic.

This PR adds a Dagger injected WhoisCommandFactory very similar to the CustomLogicFactory class. With this factory we are able to inject our custom WhoisCommand.