### PR TITLE
Use the correct HTTP status code constant in NotModifiedException

### DIFF
--- a/java/google/registry/request/HttpException.java
+++ b/java/google/registry/request/HttpException.java
@@ -84,7 +84,7 @@ public abstract class HttpException extends RuntimeException {
     }
 
     public NotModifiedException(String message) {
-      super(HttpServletResponse.SC_NOT_FOUND, message, null);
+      super(HttpServletResponse.SC_NOT_MODIFIED, message, null);
     }
 
     @Override


### PR DESCRIPTION
`NotModifiedException` was using `HttpServletResponse.SC_NOT_FOUND` instead of `SC_NOT_MODIFIED` (likely an autocomplete typo).