### PR TITLE
Remove a reference to sun.security.provider.certpath

### DIFF
--- a/javatests/google/registry/proxy/handler/SslClientInitializerTest.java
+++ b/javatests/google/registry/proxy/handler/SslClientInitializerTest.java
@@ -37,6 +37,7 @@ import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import java.security.KeyPair;
 import java.security.PrivateKey;
+import java.security.cert.CertPathBuilderException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import javax.net.ssl.SSLException;
@@ -46,7 +47,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
-import sun.security.provider.certpath.SunCertPathBuilderException;
 
 /**
  * Unit tests for {@link SslClientInitializer}.
@@ -142,7 +142,7 @@ public class SslClientInitializerTest {
     nettyRule.setUpClient(localAddress, PROTOCOL, sslClientInitializer);
     // The connection is now terminated, both the client side and the server side should get
     // exceptions.
-    nettyRule.assertThatClientRootCause().isInstanceOf(SunCertPathBuilderException.class);
+    nettyRule.assertThatClientRootCause().isInstanceOf(CertPathBuilderException.class);
     nettyRule.assertThatServerRootCause().isInstanceOf(SSLException.class);
     assertThat(nettyRule.getChannel().isActive()).isFalse();
   }


### PR DESCRIPTION
`sun.security.provider.certpath.SunCertPathBuilderException` is not visible in JDK 9,
see: https://github.com/bazelbuild/bazel/issues/6154