### PR TITLE
Add a link to kokoro

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | Internal | Open Source |
 |-------|--------|
-|![Build Status for Google Registry internal build](https://storage.googleapis.com/domain-registry-kokoro/build.svg)|[![Build Status for the open source build](https://travis-ci.org/google/nomulus.svg?branch=master)](https://travis-ci.org/google/nomulus)|
+|[![Build Status for Google Registry internal build](https://storage.googleapis.com/domain-registry-kokoro/build.svg)](https://storage.googleapis.com/domain-registry-kokoro/index.html)|[![Build Status for the open source build](https://travis-ci.org/google/nomulus.svg?branch=master)](https://travis-ci.org/google/nomulus)|
 
 ![Nomulus logo](./nomulus-logo.png)
 


### PR DESCRIPTION
This allows us to click on the build badge to visit kokoro and find out build status. The link is only accessible for Googlers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/101)
<!-- Reviewable:end -->
