### PR TITLE
Add tasks used in release as dependencies of the build task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+    - $HOME/google-cloud-sdk
 
 # WebDriver tests need Chrome and ChromeDriver provisioned by the docker image
 services:
@@ -48,6 +49,20 @@ env:
   # Disable fancy status information (looks bad on travis and exceeds logfile
   # quota)
   TERM=dumb
+
+before_install:
+- if [ ! -d $HOME/google-cloud-sdk/bin ]; then
+    # The install script errors if this directory already exists,
+    # but Travis already creates it when we mark it as cached.
+    rm -rf $HOME/google-cloud-sdk;
+    # The install script is overly verbose, which sometimes causes
+    # problems on Travis, so ignore stdout.
+    curl https://sdk.cloud.google.com | bash > /dev/null;
+  fi
+# This line is critical. We setup the SDK to take precedence in our
+# environment over the old SDK that is already on the machine.
+- source $HOME/google-cloud-sdk/path.bash.inc
+- gcloud version
 
 # Specialize gradle build to use an up-to-date gradle and the /gradle
 # directory.

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -671,4 +671,7 @@ createUberJar('gtechTool', 'gtech_tool', 'google.registry.tools.GtechTool')
 project.nomulus.dependsOn project(':third_party').jar
 project.gtechTool.dependsOn project(':third_party').jar
 
+project.build.dependsOn nomulus
+project.build.dependsOn gtechTool
+project.build.dependsOn ':stage'
 

--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -11,6 +11,8 @@ sourceSets {
 
 createUberJar('deployJar', 'proxy_server', 'google.registry.proxy.ProxyServer')
 
+project.build.dependsOn deployJar
+
 dependencies {
   def deps = rootProject.dependencyMap
 


### PR DESCRIPTION
Our CI (Travis & Kokoro) runs "gradle build", so we need to make
sure that all tasks used in the release process are called during
the build so that breakage can be caught earlier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/104)
<!-- Reviewable:end -->
