### PR TITLE
Add tasks used in release as dependencies of the build task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+      #    - $HOME/google-cloud-sdk/
 
 # WebDriver tests need Chrome and ChromeDriver provisioned by the docker image
 services:
@@ -48,6 +49,16 @@ env:
   # Disable fancy status information (looks bad on travis and exceeds logfile
   # quota)
   TERM=dumb
+  global:
+    # Do not prompt for user input when using any SDK methods.
+    - CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+before_install:
+  - if [ ! -d $HOME/google-cloud-sdk/bin ]; then rm -rf $HOME/google-cloud-sdk; curl https://sdk.cloud.google.com | bash ; fi
+  # This line is critical. We setup the SDK to take precedence in our
+  # environment over the old SDK that is already on the machine.
+  #  - source $HOME/google-cloud-sdk/path.bash.inc
+  #  - gcloud version
 
 # Specialize gradle build to use an up-to-date gradle and the /gradle
 # directory.

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -671,4 +671,7 @@ createUberJar('gtechTool', 'gtech_tool', 'google.registry.tools.GtechTool')
 project.nomulus.dependsOn project(':third_party').jar
 project.gtechTool.dependsOn project(':third_party').jar
 
+project.build.dependsOn nomulus
+project.build.dependsOn gtechTool
+project.build.dependsOn ':stage'
 

--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -11,6 +11,8 @@ sourceSets {
 
 createUberJar('deployJar', 'proxy_server', 'google.registry.proxy.ProxyServer')
 
+project.build.dependsOn deployJar
+
 dependencies {
   def deps = rootProject.dependencyMap
 


### PR DESCRIPTION
Our CI (Travis & Kokoro) runs "gradle build", so we need to make
sure that all tasks used in the release process are called during
the build so that breakage can be caught earlier.

In order to stage the GAE folder we need gcloud to be present.
Therefore the Travis config is changed to install gcloud.

See: https://gist.github.com/mjackson/5887963e7d8b8fb0615416c510ae8857

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/106)
<!-- Reviewable:end -->
