### PR TITLE
Don't use @RunWith JUnit annotations on classes with no @tests

### DIFF
--- a/core/src/test/java/google/registry/model/EntityTestCase.java
+++ b/core/src/test/java/google/registry/model/EntityTestCase.java
@@ -48,7 +48,7 @@ import org.junit.runners.JUnit4;
 
 /** Base class of all unit tests for entities which are persisted to Datastore via Objectify. */
 @RunWith(JUnit4.class)
-public class EntityTestCase {
+public abstract class EntityTestCase {
 
   @Rule
   public final AppEngineRule appEngine = AppEngineRule.builder()

--- a/core/src/test/java/google/registry/model/ResourceCommandTestCase.java
+++ b/core/src/test/java/google/registry/model/ResourceCommandTestCase.java
@@ -23,6 +23,7 @@ import google.registry.testing.EppLoader;
 
 /** Unit tests for {@code ResourceCommand}. */
 public abstract class ResourceCommandTestCase extends EntityTestCase {
+
   protected void doXmlRoundtripTest(String inputFilename, String... ignoredPaths)
       throws Exception {
     EppLoader eppLoader = new EppLoader(this, inputFilename);

--- a/core/src/test/java/google/registry/model/host/HostCommandTest.java
+++ b/core/src/test/java/google/registry/model/host/HostCommandTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 
 /** Test xml roundtripping of commands. */
 public class HostCommandTest extends ResourceCommandTestCase {
+
   @Test
   public void testCreate() throws Exception {
     doXmlRoundtripTest("host_create.xml");

--- a/core/src/test/java/google/registry/model/registrar/RegistrarTest.java
+++ b/core/src/test/java/google/registry/model/registrar/RegistrarTest.java
@@ -46,7 +46,7 @@ import org.joda.money.CurrencyUnit;
 import org.junit.Before;
 import org.junit.Test;
 
-/** Unit tests for {@link Registrar}. */
+ /** Unit tests for {@link Registrar}. */
 public class RegistrarTest extends EntityTestCase {
   private Registrar registrar;
   private RegistrarContact abuseAdminContact;

--- a/core/src/test/java/google/registry/rdap/RdapActionBaseTestCase.java
+++ b/core/src/test/java/google/registry/rdap/RdapActionBaseTestCase.java
@@ -41,12 +41,9 @@ import java.util.Optional;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
 /** Common unit test code for actions inheriting {@link RdapActionBase}. */
-@RunWith(JUnit4.class)
-public class RdapActionBaseTestCase<A extends RdapActionBase> {
+public abstract class RdapActionBaseTestCase<A extends RdapActionBase> {
 
   @Rule
   public final AppEngineRule appEngine = AppEngineRule.builder()

--- a/core/src/test/java/google/registry/rdap/RdapHelpActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapHelpActionTest.java
@@ -24,8 +24,11 @@ import google.registry.rdap.RdapMetrics.WildcardType;
 import google.registry.rdap.RdapSearchResults.IncompletenessWarningType;
 import google.registry.request.Action;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link RdapHelpAction}. */
+@RunWith(JUnit4.class)
 public class RdapHelpActionTest extends RdapActionBaseTestCase<RdapHelpAction> {
 
   public RdapHelpActionTest() {

--- a/core/src/test/java/google/registry/rdap/RdapSearchActionTestCase.java
+++ b/core/src/test/java/google/registry/rdap/RdapSearchActionTestCase.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 import org.junit.Before;
 
 /** Common unit test code for actions inheriting {@link RdapSearchActionBase}. */
-public class RdapSearchActionTestCase<A extends RdapSearchActionBase>
+public abstract class RdapSearchActionTestCase<A extends RdapSearchActionBase>
     extends RdapActionBaseTestCase<A> {
 
   protected RdapSearchActionTestCase(Class<A> rdapActionClass) {

--- a/core/src/test/java/google/registry/tmch/TmchActionTestCase.java
+++ b/core/src/test/java/google/registry/tmch/TmchActionTestCase.java
@@ -36,7 +36,7 @@ import org.mockito.junit.MockitoRule;
 
 /** Common code for unit tests of classes that extend {@link Marksdb}. */
 @RunWith(JUnit4.class)
-public class TmchActionTestCase {
+public abstract class TmchActionTestCase {
 
   static final String MARKSDB_LOGIN_AND_PASSWORD = "lolcat:attack";
   static final String MARKSDB_URL = "http://127.0.0.1/love";

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistrarSettingsActionTestCase.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistrarSettingsActionTestCase.java
@@ -59,16 +59,13 @@ import org.joda.time.DateTime;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 /** Base class for tests using {@link RegistrarSettingsAction}. */
-@RunWith(JUnit4.class)
-public class RegistrarSettingsActionTestCase {
+public abstract class RegistrarSettingsActionTestCase {
 
   static final String CLIENT_ID = "TheRegistrar";
 


### PR DESCRIPTION
IntelliJ is complaining when this annotation is used on a base class that has no
actual runnable tests itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/107)
<!-- Reviewable:end -->
