### PR TITLE
Add tasks used in release as dependencies of the build task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ env:
     - TERM=dumb
     # Do not prompt for user input when using any SDK methods.
     - CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
 install:
   - |
     if [ ! -d $HOME/google-cloud-sdk/bin ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@
 # usage (usually just wrapping it in single quotes should suffice).
 
 language: java
-install: true
 jdk:
   # Our builds fail against Oracle Java for reasons yet unknown.
   - openjdk8
@@ -39,15 +38,35 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+    - $HOME/google-cloud-sdk/
 
 # WebDriver tests need Chrome and ChromeDriver provisioned by the docker image
 services:
   - docker
 
 env:
-  # Disable fancy status information (looks bad on travis and exceeds logfile
-  # quota)
-  TERM=dumb
+  global:
+    # Disable fancy status information (looks bad on travis and exceeds logfile
+    # quota)
+    - TERM=dumb
+    # Do not prompt for user input when using any SDK methods.
+    - CLOUDSDK_CORE_DISABLE_PROMPTS=1
+install:
+  - |
+    if [ ! -d $HOME/google-cloud-sdk/bin ]
+    then
+      # The install script errors if this directory already exists,
+      # but Travis already creates it when we mark it as cached.
+      rm -rf $HOME/google-cloud-sdk
+      # The install script is overly verbose, which sometimes causes
+      # problems on Travis, so ignore stdout.
+      curl https://sdk.cloud.google.com | bash
+    fi
+  # This line is critical. We setup the SDK to take precedence in our
+  # environment over the old SDK that is already on the machine.
+  - source $HOME/google-cloud-sdk/path.bash.inc
+  - gcloud components install app-engine-java
+  - gcloud version
 
 # Specialize gradle build to use an up-to-date gradle and the /gradle
 # directory.

--- a/appengine_war.gradle
+++ b/appengine_war.gradle
@@ -8,7 +8,7 @@ def projects = ['production': 'domain-registry',
 
 def environment = rootProject.findProperty("environment")
 if (environment == null) {
-    environment = 'alpha'
+    environment = 'production'
 }
 def gcpProject = projects[environment]
 if (gcpProject == null) {

--- a/appengine_war.gradle
+++ b/appengine_war.gradle
@@ -71,3 +71,4 @@ dependencies {
 
 rootProject.deploy.dependsOn appengineDeploy
 rootProject.stage.dependsOn appengineStage
+appengineDeploy.dependsOn rootProject.verifyDeployment

--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,9 @@ ext.projectRootDir = "${rootDir}"
 task deploy {
   group = 'deployment'
   description = 'Deploys all services to App Engine.'
+  if (rootProject.findProperty("environment") != 'alpha') {
+    throw new GradleException("Can only deploy to alpha.");
+  }
 }
 
 task stage {

--- a/build.gradle
+++ b/build.gradle
@@ -74,8 +74,15 @@ ext.projectRootDir = "${rootDir}"
 task deploy {
   group = 'deployment'
   description = 'Deploys all services to App Engine.'
-  if (rootProject.findProperty("environment") != 'alpha') {
-    throw new GradleException("Can only deploy to alpha.");
+}
+
+task verifyDeployment {
+  group = 'deployment'
+  description = 'Ensure that one can only deploy to alpha.'
+  doFirst {
+    if (rootProject.findProperty("environment") != 'alpha') {
+      throw new GradleException("Can only deploy to alpha.");
+    }
   }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -677,3 +677,7 @@ createUberJar('nomulus', 'nomulus', 'google.registry.tools.RegistryTool')
 createUberJar('gtechTool', 'gtech_tool', 'google.registry.tools.GtechTool')
 project.nomulus.dependsOn project(':third_party').jar
 project.gtechTool.dependsOn project(':third_party').jar
+
+project.build.dependsOn nomulus
+project.build.dependsOn gtechTool
+project.build.dependsOn ':stage'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Jun 18 15:57:55 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/package-lock.json
+++ b/package-lock.json
@@ -944,7 +944,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -965,12 +966,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -985,17 +988,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1112,7 +1118,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1124,6 +1131,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1138,6 +1146,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1145,12 +1154,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1169,6 +1180,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1249,7 +1261,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1261,6 +1274,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1346,7 +1360,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1382,6 +1397,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1401,6 +1417,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1444,12 +1461,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -11,6 +11,8 @@ sourceSets {
 
 createUberJar('deployJar', 'proxy_server', 'google.registry.proxy.ProxyServer')
 
+project.build.dependsOn deployJar
+
 dependencies {
   def deps = rootProject.dependencyMap
 


### PR DESCRIPTION
Our CI (Travis & Kokoro) runs "gradle build", so we need to make
sure that all tasks used in the release process are called during
the build so that breakage can be caught earlier.

In order to stage the GAE folder we need gcloud to be present.
Therefore the Travis config is changed to install gcloud.

See: https://gist.github.com/mjackson/5887963e7d8b8fb0615416c510ae8857

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/108)
<!-- Reviewable:end -->
