### PR TITLE
Allow IDE user to switch off the -Werror javac option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ running system:
 *   [Install
     guide](https://github.com/google/nomulus/blob/master/docs/install.md)
 *   View the source code in
-    [java/google/registry/](https://github.com/google/nomulus/tree/master/java/google/registry)
+    [java/google/registry/](https://github.com/google/nomulus/tree/master/core/src/main/java/google/registry)
 *   [Other docs](https://github.com/google/nomulus/tree/master/docs)
 *   [Javadoc](https://nomulus.foo/javadoc/latest/)
 *   [Nomulus discussion

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -15,7 +15,12 @@ dependencies {
 }
 
 tasks.withType(JavaCompile).configureEach {
-    options.compilerArgs << "-Werror"
+    // The -Werror flag causes Intellij to fail on deprecated api use.
+    // Allow IDE user to turn off this flag by specifying a Gradle VM
+    // option from inside the IDE.
+    if (System.getProperty('no_werror') != 'true') {
+        options.compilerArgs << "-Werror"
+    }
     options.errorprone.disableWarningsInGeneratedCode = true
     options.errorprone.errorproneArgumentProviders.add([
             asArguments: {


### PR DESCRIPTION
This option causes Intellij build to fail if the 'Delegate
IDE build/run actions to gradle' box is checked. We do not
know of anyway to change the Intellij behavior.

This change allows an IDE user to prevent -Werror from
being passed to javac by adding a Gradle VM option: -Dno_werror=true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/110)
<!-- Reviewable:end -->
