### PR TITLE
Remove unnecessary provider method

### DIFF
--- a/core/src/main/java/google/registry/tools/AuthModule.java
+++ b/core/src/main/java/google/registry/tools/AuthModule.java
@@ -17,7 +17,6 @@ package google.registry.tools;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.api.client.auth.oauth2.Credential;
-import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
 import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
@@ -115,12 +114,6 @@ public class AuthModule {
     } catch (IOException ex) {
       throw new RuntimeException(ex);
     }
-  }
-
-  @Provides
-  public static AuthorizationCodeInstalledApp provideAuthorizationCodeInstalledApp(
-      GoogleAuthorizationCodeFlow flow) {
-    return new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver());
   }
 
   @Provides

--- a/core/src/main/java/google/registry/tools/AuthModule.java
+++ b/core/src/main/java/google/registry/tools/AuthModule.java
@@ -17,7 +17,6 @@ package google.registry.tools;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.api.client.auth.oauth2.Credential;
-import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow;
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets;
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets.Details;


### PR DESCRIPTION
This provider is not used. Instead, depending on if the login is performed on
[a remote machine or not](https://github.com/google/nomulus/blob/8bdc77501fcbb4053bf7742ac112b3a0551b44e0/core/src/main/java/google/registry/tools/LoginCommand.java#L43),
the instance is created directly in the command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/113)
<!-- Reviewable:end -->
