### PR TITLE
Allow switching off the -Werror javac option

### DIFF
--- a/java_common.gradle
+++ b/java_common.gradle
@@ -15,6 +15,12 @@ dependencies {
 }
 
 tasks.withType(JavaCompile).configureEach {
+    // The -Werror flag causes Intellij to fail on deprecated api use.
+    // Allow IDE user to turn off this flag by specifying a Gradle VM
+    // option from inside the IDE.
+    if (System.getProperty('no_werror') != 'true') {
+        options.compilerArgs << "-Werror"
+    }
     options.compilerArgs << "-Werror"
     options.errorprone.disableWarningsInGeneratedCode = true
     options.errorprone.errorproneArgumentProviders.add([


### PR DESCRIPTION
This option causes Intellij build to fail if the
'Delegate IDE build/run actions to gradle' box is checked.
We do not know of anyway to change the Intellij behavior.

This change allows an IDE user to prevent -Werror to be passed
to javac by adding a Gradle VM option: -Dno_werror=true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/115)
<!-- Reviewable:end -->
