### PR TITLE
Fix or suppress some deprecation warnings

### DIFF
--- a/core/src/test/java/google/registry/export/ExportPremiumTermsActionTest.java
+++ b/core/src/test/java/google/registry/export/ExportPremiumTermsActionTest.java
@@ -48,7 +48,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 
 @RunWith(JUnit4.class)
 public class ExportPremiumTermsActionTest {
@@ -188,7 +188,8 @@ public class ExportPremiumTermsActionTest {
             EXPECTED_FILE_CONTENT.getBytes(UTF_8));
     verifyNoMoreInteractions(driveConnection);
     verify(response).setStatus(SC_INTERNAL_SERVER_ERROR);
-    verify(response).setPayload(Matchers.contains("Error exporting premium terms file to Drive."));
+    verify(response).setPayload(
+        ArgumentMatchers.contains("Error exporting premium terms file to Drive."));
     verify(response).setContentType(PLAIN_TEXT_UTF_8);
     verifyNoMoreInteractions(response);
   }

--- a/core/src/test/java/google/registry/testing/FakeHttpSession.java
+++ b/core/src/test/java/google/registry/testing/FakeHttpSession.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpSession;
-import javax.servlet.http.HttpSessionContext;
 
 /** A fake {@link HttpSession} that only provides support for getting/setting attributes. */
 @SuppressWarnings("deprecation")
@@ -63,7 +62,7 @@ public class FakeHttpSession implements HttpSession {
   }
 
   @Override
-  public HttpSessionContext getSessionContext() {
+  public javax.servlet.http.HttpSessionContext getSessionContext() {
     throw new UnsupportedOperationException();
   }
 

--- a/core/src/test/java/google/registry/webdriver/RegistrarConsoleWebTest.java
+++ b/core/src/test/java/google/registry/webdriver/RegistrarConsoleWebTest.java
@@ -29,6 +29,7 @@ import google.registry.model.registrar.RegistrarContact;
 import google.registry.module.frontend.FrontendServlet;
 import google.registry.server.RegistryTestServer;
 import google.registry.testing.AppEngineRule;
+import java.util.concurrent.TimeUnit;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -60,7 +61,7 @@ public class RegistrarConsoleWebTest extends WebDriverTestCase {
 
 
 
-  @Rule public final Timeout deathClock = new Timeout(60000);
+  @Rule public final Timeout deathClock = new Timeout(60000, TimeUnit.MILLISECONDS);
 
   /** Checks the identified element has the given text content. */
   void assertEltText(String eltId, String eltValue) {

--- a/core/src/test/java/google/registry/webdriver/WebDriverPlusScreenDifferRule.java
+++ b/core/src/test/java/google/registry/webdriver/WebDriverPlusScreenDifferRule.java
@@ -39,17 +39,19 @@ import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.HasInputDevices;
-import org.openqa.selenium.interactions.Keyboard;
-import org.openqa.selenium.interactions.Mouse;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 /**
  * WebDriver delegate JUnit Rule that exposes most {@link WebDriver} API plus {@link ScreenDiffer}
  * API.
  */
+@SuppressWarnings("deprecation")
 public final class WebDriverPlusScreenDifferRule extends ExternalResource
-    implements WebDriver, HasInputDevices, TakesScreenshot, JavascriptExecutor, HasCapabilities {
+    implements WebDriver,
+        org.openqa.selenium.interactions.HasInputDevices,
+        TakesScreenshot,
+        JavascriptExecutor,
+        HasCapabilities {
 
   private static final int WAIT_FOR_ELEMENTS_POLLING_INTERVAL_MS = 10;
   private static final int WAIT_FOR_ELEMENTS_BONUS_DELAY_MS = 150;
@@ -274,13 +276,13 @@ public final class WebDriverPlusScreenDifferRule extends ExternalResource
   }
 
   @Override
-  public Keyboard getKeyboard() {
-    return ((HasInputDevices) driver).getKeyboard();
+  public org.openqa.selenium.interactions.Keyboard getKeyboard() {
+    return ((org.openqa.selenium.interactions.HasInputDevices) driver).getKeyboard();
   }
 
   @Override
-  public Mouse getMouse() {
-    return ((HasInputDevices) driver).getMouse();
+  public org.openqa.selenium.interactions.Mouse getMouse() {
+    return ((org.openqa.selenium.interactions.HasInputDevices) driver).getMouse();
   }
 
   @Override

--- a/proxy/src/test/java/google/registry/proxy/CertificateModuleTest.java
+++ b/proxy/src/test/java/google/registry/proxy/CertificateModuleTest.java
@@ -33,7 +33,7 @@ import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import org.bouncycastle.openssl.PEMWriter;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -50,8 +50,8 @@ public class CertificateModuleTest {
 
   private static byte[] getPemBytes(Object... objects) throws Exception {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    try (PEMWriter pemWriter =
-        new PEMWriter(new OutputStreamWriter(byteArrayOutputStream, UTF_8))) {
+    try (JcaPEMWriter pemWriter =
+        new JcaPEMWriter(new OutputStreamWriter(byteArrayOutputStream, UTF_8))) {
       for (Object object : objects) {
         pemWriter.writeObject(object);
       }

--- a/proxy/src/test/java/google/registry/proxy/handler/SslInitializerTestUtils.java
+++ b/proxy/src/test/java/google/registry/proxy/handler/SslInitializerTestUtils.java
@@ -31,12 +31,12 @@ import java.util.Date;
 import javax.net.ssl.SSLSession;
 import javax.security.auth.x500.X500Principal;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.x509.X509V3CertificateGenerator;
 
 /**
  * Utility class that provides methods used by {@link SslClientInitializerTest} and {@link
  * SslServerInitializerTest}.
  */
+@SuppressWarnings("deprecation")
 public class SslInitializerTestUtils {
 
   static {
@@ -56,7 +56,8 @@ public class SslInitializerTestUtils {
    */
   public static X509Certificate signKeyPair(
       SelfSignedCertificate ssc, KeyPair keyPair, String hostname) throws Exception {
-    X509V3CertificateGenerator certGen = new X509V3CertificateGenerator();
+    org.bouncycastle.x509.X509V3CertificateGenerator certGen =
+        new org.bouncycastle.x509.X509V3CertificateGenerator();
     X500Principal dnName = new X500Principal("CN=" + hostname);
     certGen.setSerialNumber(BigInteger.valueOf(System.currentTimeMillis()));
     certGen.setSubjectDN(dnName);


### PR DESCRIPTION
Fix or suppress deprecation warnings except those about GoogleCredential,
which is being handled separately.

The @SuppressWarnings("deprecation") annotation does not cover imports
even when it is at the class level. We removed imports of deprecated
classes and use their fully qualified names in class body.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/121)
<!-- Reviewable:end -->
