### PR TITLE
Update IAM binding to restrict proxy service account's access to GCS

### DIFF
--- a/proxy/terraform/modules/gcs.tf
+++ b/proxy/terraform/modules/gcs.tf
@@ -3,8 +3,14 @@ resource "google_storage_bucket" "proxy_certificate" {
   storage_class = "MULTI_REGIONAL"
 }
 
-resource "google_storage_bucket_iam_member" "member" {
+resource "google_storage_bucket_iam_member" "certificate_viewer" {
   bucket = "${google_storage_bucket.proxy_certificate.name}"
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.proxy_service_account.email}"
+}
+
+resource "google_storage_bucket_iam_member" "gcr_viewer" {
+  bucket = "artifacts.${var.gcr_project_name}.appspot.com"
   role   = "roles/storage.objectViewer"
   member = "serviceAccount:${google_service_account.proxy_service_account.email}"
 }

--- a/proxy/terraform/modules/iam.tf
+++ b/proxy/terraform/modules/iam.tf
@@ -3,12 +3,6 @@ resource "google_service_account" "proxy_service_account" {
   display_name = "Nomulus proxy service account"
 }
 
-resource "google_project_iam_member" "gcr_storage_viewer" {
-  project = "${var.gcr_project_name}"
-  role    = "roles/storage.objectViewer"
-  member  = "serviceAccount:${google_service_account.proxy_service_account.email}"
-}
-
 resource "google_project_iam_member" "metric_writer" {
   role   = "roles/monitoring.metricWriter"
   member = "serviceAccount:${google_service_account.proxy_service_account.email}"


### PR DESCRIPTION
Per
https://cloud.google.com/container-registry/docs/access-control#granting_users_and_other_projects_access_to_a_registry,
for a service account to access GCR, it does not need reader access to *all*
buckets in a project, but just the specific one.

This is duped from cl/254092941.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/125)
<!-- Reviewable:end -->
