### PR TITLE
Update GCB beam deployment pipeline

### DIFF
--- a/release/cloudbuild-beam.yaml
+++ b/release/cloudbuild-beam.yaml
@@ -1,17 +1,14 @@
 # To run the build locally, install cloud-build-local first.
 # Then run:
 # cloud-build-local --config=cloudbuild-deploy-beam.yaml --dryrun=false \
-# --substitutions=TAG_NAME=[TAG],_CREDENTIAL_JSON=[CREDENTIAL_JSON],\
-# _CREDENTIAL_KEYRING=[CREDENTIAL_KEYRING],_CREDENTIAL_KEY=[CREDENTIAL_KEY],\
-# _ENV=[ENV] ..
+# --substitutions=TAG_NAME=[TAG],_ENV=[ENV] ..
 #
 # This will deploy Beam pipelines to GCS for the PROJECT_ID defined in gcloud
 # tool.
 #
 # To manually trigger a build on GCB, run:
-# gcloud builds submit --config=cloudbuild-deploy-beam.yaml --substitutions=TAG_NAME=[TAG],\
-# _CREDENTIAL_JSON=[CREDENTIAL_JSON],_CREDENTIAL_KEYRING=[CREDENTIAL_KEYRING],\
-# _CREDENTIAL_KEY=[CREDENTIAL_KEY],_ENV=[ENV] ..
+# gcloud builds submit --config=cloudbuild-deploy-beam.yaml \
+# --substitutions=TAG_NAME=[TAG],_ENV=[ENV] ..
 #
 # To trigger a build automatically, follow the instructions below and add a trigger:
 # https://cloud.google.com/cloud-build/docs/running-builds/automate-builds
@@ -28,27 +25,26 @@ steps:
   args:
   - gsutil
   - cp
-  - gs://${PROJECT_ID}-deploy/nomulus-credential/${_CREDENTIAL_JSON}
+  - gs://${PROJECT_ID}-deploy/secrets/tool-credential.json.enc
   - .
 # Decrypt the credential
-- name: 'gcr.io/cloud-builders/gcloud'
+- name: 'gcr.io/${PROJECT_ID}/builder:latest'
+  entrypoint: /bin/bash
   args:
-  - kms
-  - decrypt
-  - --ciphertext-file=${_CREDENTIAL_JSON}
-  - --plaintext-file=nomulus-credential.json
-  - --location=global
-  - --keyring=${_CREDENTIAL_KEYRING}
-  - --key=${_CREDENTIAL_KEY}
+  - -c
+  - |
+    cat tool-credential.json.enc | base64 -d | gcloud kms decrypt \
+      --ciphertext-file=- --plaintext-file=tool-credential.json \
+      --location=global --keyring=nomulus-tool-keyring --key=nomulus-tool-key
 # Deploy spec11 and invoicing pipeline to GCS
 - name: 'gcr.io/${PROJECT_ID}/builder:latest'
   entrypoint: /bin/bash
   args:
   - -c
   - |
-    java -jar nomulus.jar -e ${_ENV} --credential nomulus-credential.json \
+    java -jar nomulus.jar -e ${_ENV} --credential tool-credential.json \
     deploy_spec11_pipeline
-    java -jar nomulus.jar -e ${_ENV} --credential nomulus-credential.json \
+    java -jar nomulus.jar -e ${_ENV} --credential tool-credential.json \
     deploy_invoicing_pipeline
 timeout: 3600s
 options:

--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -45,6 +45,7 @@ artifacts:
     - 'output/*.tar'
     - 'output/nomulus.jar'
     - 'release/cloudbuild-sync.yaml'
+    - 'release/cloudbuild-beam.yaml'
 timeout: 3600s
 options:
   machineType: 'N1_HIGHCPU_8'

--- a/release/cloudbuild-release.yaml
+++ b/release/cloudbuild-release.yaml
@@ -75,8 +75,11 @@ steps:
     sed -i s%distroless/java%${PROJECT_ID}/base@$base_digest% proxy/Dockerfile
     sed -i s/builder:latest/builder@$builder_digest/g release/cloudbuild-proxy.yaml
     sed -i s/builder:latest/builder@$builder_digest/g release/cloudbuild-nomulus.yaml
+    sed -i s/builder:latest/builder@$builder_digest/g release/cloudbuild-beam.yaml
     sed -i s/GCP_PROJECT/${PROJECT_ID}/ proxy/kubernetes/proxy-*.yaml
     sed -i s/'$${TAG_NAME}'/${TAG_NAME}/g release/cloudbuild-sync.yaml
+    sed -i s/'$${TAG_NAME}'/${TAG_NAME}/g release/cloudbuild-beam.yaml
+    sed -i s/'$${_ENV}'/production/g release/cloudbuild-beam.yaml
 # Upload the gradle binary to GCS if it does not exist and point URL in gradle wrapper to it.
 - name: 'gcr.io/cloud-builders/gsutil'
   entrypoint: /bin/bash


### PR DESCRIPTION
Some of the texts are not really secerts because they are per-project.
Also changed the location of the credential file to `secerts` so that in
the future we may add more secerts in that folder.

The encrypted file is base64 encoded, consistent with how the proxy
certificates are encoded. Also made some changes to the other pipelines
to facilitate automation with Spinnaker

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/134)
<!-- Reviewable:end -->
