### PR TITLE
Disable Javadoc and tests in Java 12

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -58,12 +58,24 @@ sourceSets {
   main {
     java {
       srcDirs += generatedDir
+      // Javadoc API is deprecated and removed in Java 12.
+      // TODO(jianglai): re-enable after migrating to the new Javadoc API
+      if ((JavaVersion.current().majorVersion as Integer) > 11) {
+        exclude 'google/registry/documentation/**'
+      }
     }
     resources {
       exclude '**/*.xjb'
     }
   }
   test {
+    java {
+      // Javadoc API is deprecated and removed in Java 12.
+      // TODO(jianglai): re-enable after migrating to the new Javadoc API
+      if ((JavaVersion.current().majorVersion as Integer) > 11) {
+        exclude 'google/registry/documentation/**'
+      }
+    }
     resources {
       exclude '**/*.xjb', '**/*.xsd'
     }


### PR DESCRIPTION
The API is deprecated and removed in Java 12. Do not build these
classes when using Java 12, till we migrate to the new API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/135)
<!-- Reviewable:end -->
