### PR TITLE
Enable the updateRegistrarRdapBaseUrls endpoint

### DIFF
--- a/core/src/main/java/google/registry/env/production/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/production/default/WEB-INF/cron.xml
@@ -112,8 +112,6 @@
     <target>backend</target>
   </cron>
 
-  <!--
-    TODO(b/134576418) enable this cron job once we're sure the Action works
   <cron>
     <url><![CDATA[/_dr/task/updateRegistrarRdapBaseUrls]]></url>
     <description>
@@ -122,7 +120,6 @@
     <schedule>every day 02:34</schedule>
     <target>backend</target>
   </cron>
-  -->
 
   <cron>
     <url><![CDATA[/_dr/task/deleteOldCommitLogs]]></url>

--- a/core/src/main/java/google/registry/env/production/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/production/default/WEB-INF/cron.xml
@@ -113,7 +113,7 @@
   </cron>
 
   <cron>
-    <url><![CDATA[/_dr/task/updateRegistrarRdapBaseUrls]]></url>
+    <url><![CDATA[/_dr/task/updateRegistrarRdapBaseUrls?tld=app]]></url>
     <description>
       This job reloads all registrar RDAP base URLs from ICANN.
     </description>

--- a/core/src/main/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsAction.java
+++ b/core/src/main/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsAction.java
@@ -61,13 +61,13 @@ import javax.inject.Inject;
  * <p>For clarity, this is how one would contact this endpoint "manually", from a whitelisted IP
  * server:
  *
- * <p>curl [base]/login -I --user [tld]_ry:[password]
+ * <p>$ curl [base]/login -I --user [tld]_ry:[password]
  *
  * <p>get the id=xxx value from the reply
  *
- * <p>curl [base]/registrarRdapBaseUrl/list -b 'id=xxx'
+ * <p>$ curl [base]/registrarRdapBaseUrl/list -b 'id=xxx'
  *
- * <p>curl [base]/logout -b 'id=xxx'
+ * <p>$ curl [base]/logout -b 'id=xxx'
  *
  * <p>where [base] is https://mosapi.icann.org/mosapi/v1/[tld]
  */

--- a/core/src/main/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsAction.java
+++ b/core/src/main/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsAction.java
@@ -57,6 +57,19 @@ import javax.inject.Inject;
  * a cookie you then send to get the list and finally logout.
  *
  * <p>The username is [TLD]_ry. It could be any "real" TLD.
+ *
+ * <p>For clarity, this is how one would contact this endpoint "manually", from a whitelisted IP
+ * server:
+ *
+ * <p>curl [base]/login -I --user [tld]_ry:[password]
+ *
+ * <p>get the id=xxx value from the reply
+ *
+ * <p>curl [base]/registrarRdapBaseUrl/list -b 'id=xxx'
+ *
+ * <p>curl [base]/logout -b 'id=xxx'
+ *
+ * <p>where [base] is https://mosapi.icann.org/mosapi/v1/[tld]
  */
 @Action(
     service = Action.Service.BACKEND,


### PR DESCRIPTION
This endpoint will update the Registrar RDAP Base URLs from ICANN once a day.
    
Note that the endpoint needs a TLD to use for the query, since the ICANN MoSAPI endpoint we use needs a TLD to authenticate (even though the results don't depend on the TLD)
    
This is unfortunate in an open source project, and we might need to change it to a configured value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/139)
<!-- Reviewable:end -->
