### PR TITLE
Stop provisioning RegistryEnvironment from Dagger

### DIFF
--- a/core/src/main/java/google/registry/batch/DeleteLoadTestDataAction.java
+++ b/core/src/main/java/google/registry/batch/DeleteLoadTestDataAction.java
@@ -73,7 +73,6 @@ public class DeleteLoadTestDataAction implements Runnable {
 
   @Inject MapreduceRunner mrRunner;
   @Inject Response response;
-  @Inject RegistryEnvironment registryEnvironment;
 
   @Inject
   DeleteLoadTestDataAction() {}
@@ -84,7 +83,8 @@ public class DeleteLoadTestDataAction implements Runnable {
     // run on production. On other environments, data is fully wiped out occasionally anyway, so
     // having some broken data that isn't referred to isn't the end of the world.
     checkState(
-        registryEnvironment != PRODUCTION, "This mapreduce is not safe to run on PRODUCTION.");
+        !RegistryEnvironment.get().equals(PRODUCTION),
+        "This mapreduce is not safe to run on PRODUCTION.");
 
     mrRunner
         .setJobName("Delete load test data")

--- a/core/src/main/java/google/registry/batch/DeleteProberDataAction.java
+++ b/core/src/main/java/google/registry/batch/DeleteProberDataAction.java
@@ -17,6 +17,7 @@ package google.registry.batch;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static google.registry.config.RegistryEnvironment.PRODUCTION;
 import static google.registry.mapreduce.MapreduceRunner.PARAM_DRY_RUN;
 import static google.registry.model.ResourceTransferUtils.updateForeignKeyIndexDeletionTime;
 import static google.registry.model.ofy.ObjectifyService.ofy;
@@ -77,7 +78,6 @@ public class DeleteProberDataAction implements Runnable {
   @Inject @Config("registryAdminClientId") String registryAdminClientId;
   @Inject MapreduceRunner mrRunner;
   @Inject Response response;
-  @Inject RegistryEnvironment registryEnvironment;
   @Inject DeleteProberDataAction() {}
 
   @Override
@@ -96,7 +96,7 @@ public class DeleteProberDataAction implements Runnable {
 
   private ImmutableSet<String> getProberRoidSuffixes() {
     checkArgument(
-        !RegistryEnvironment.PRODUCTION.equals(registryEnvironment)
+        !PRODUCTION.equals(RegistryEnvironment.get())
             || tlds.stream().allMatch(tld -> tld.endsWith(".test")),
         "On production, can only work on TLDs that end with .test");
     ImmutableSet<String> deletableTlds =

--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -94,13 +94,6 @@ public final class RegistryConfig {
   @Module
   public static final class ConfigModule {
 
-    private static final RegistryEnvironment REGISTRY_ENVIRONMENT = RegistryEnvironment.get();
-
-    @Provides
-    public static RegistryEnvironment provideRegistryEnvironment() {
-      return REGISTRY_ENVIRONMENT;
-    }
-
     @Provides
     @Config("projectId")
     public static String provideProjectId(RegistryConfigSettings config) {

--- a/core/src/main/java/google/registry/dns/DnsMetrics.java
+++ b/core/src/main/java/google/registry/dns/DnsMetrics.java
@@ -14,6 +14,8 @@
 
 package google.registry.dns;
 
+import static google.registry.config.RegistryEnvironment.PRODUCTION;
+
 import com.google.common.collect.ImmutableSet;
 import com.google.monitoring.metrics.DistributionFitter;
 import com.google.monitoring.metrics.EventMetric;
@@ -180,8 +182,6 @@ public class DnsMetrics {
               LABEL_DESCRIPTORS_FOR_LATENCY,
               EXPONENTIAL_FITTER);
 
-  @Inject RegistryEnvironment registryEnvironment;
-
   @Inject
   DnsMetrics() {}
 
@@ -225,7 +225,7 @@ public class DnsMetrics {
     hostsCommittedCount.incrementBy(numberOfHosts, tld, status.name(), dnsWriter);
 
     // We don't want to record the following metrics in production, as they are quite expensive
-    if (registryEnvironment == RegistryEnvironment.PRODUCTION) {
+    if (RegistryEnvironment.get().equals(PRODUCTION)) {
       return;
     }
 

--- a/core/src/main/java/google/registry/ui/server/registrar/ConsoleRegistrarCreatorAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/ConsoleRegistrarCreatorAction.java
@@ -107,7 +107,6 @@ public final class ConsoleRegistrarCreatorAction implements Runnable {
   @Inject UserService userService;
   @Inject XsrfTokenManager xsrfTokenManager;
   @Inject AuthResult authResult;
-  @Inject RegistryEnvironment registryEnvironment;
   @Inject SendEmailUtils sendEmailUtils;
   @Inject @Config("logoFilename") String logoFilename;
   @Inject @Config("productName") String productName;
@@ -354,7 +353,7 @@ public final class ConsoleRegistrarCreatorAction implements Runnable {
     if (!sendEmailUtils.hasRecipients()) {
       return;
     }
-    String environment = Ascii.toLowerCase(String.valueOf(registryEnvironment));
+    String environment = Ascii.toLowerCase(String.valueOf(RegistryEnvironment.get()));
     String body =
         String.format(
                 "The following registrar was created in %s by %s:\n",

--- a/core/src/main/java/google/registry/ui/server/registrar/ConsoleUiAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/ConsoleUiAction.java
@@ -66,7 +66,7 @@ public final class ConsoleUiAction implements Runnable {
           google.registry.ui.soy.registrar.ConsoleSoyInfo.getInstance(),
           google.registry.ui.soy.AnalyticsSoyInfo.getInstance());
 
-  @VisibleForTesting  // webdriver and screenshot tests need this
+  @VisibleForTesting // webdriver and screenshot tests need this
   public static final Supplier<SoyCssRenamingMap> CSS_RENAMING_MAP_SUPPLIER =
       SoyTemplateUtils.createCssRenamingMapSupplier(
           Resources.getResource("google/registry/ui/css/registrar_bin.css.js"),
@@ -79,18 +79,49 @@ public final class ConsoleUiAction implements Runnable {
   @Inject UserService userService;
   @Inject XsrfTokenManager xsrfTokenManager;
   @Inject AuthResult authResult;
-  @Inject RegistryEnvironment environment;
-  @Inject @Config("logoFilename") String logoFilename;
-  @Inject @Config("productName") String productName;
-  @Inject @Config("integrationEmail") String integrationEmail;
-  @Inject @Config("supportEmail") String supportEmail;
-  @Inject @Config("announcementsEmail") String announcementsEmail;
-  @Inject @Config("supportPhoneNumber") String supportPhoneNumber;
-  @Inject @Config("technicalDocsUrl") String technicalDocsUrl;
-  @Inject @Config("registrarConsoleEnabled") boolean enabled;
-  @Inject @Config("analyticsConfig") Map<String, Object> analyticsConfig;
-  @Inject @Parameter(PARAM_CLIENT_ID) Optional<String> paramClientId;
-  @Inject ConsoleUiAction() {}
+
+  @Inject
+  @Config("logoFilename")
+  String logoFilename;
+
+  @Inject
+  @Config("productName")
+  String productName;
+
+  @Inject
+  @Config("integrationEmail")
+  String integrationEmail;
+
+  @Inject
+  @Config("supportEmail")
+  String supportEmail;
+
+  @Inject
+  @Config("announcementsEmail")
+  String announcementsEmail;
+
+  @Inject
+  @Config("supportPhoneNumber")
+  String supportPhoneNumber;
+
+  @Inject
+  @Config("technicalDocsUrl")
+  String technicalDocsUrl;
+
+  @Inject
+  @Config("registrarConsoleEnabled")
+  boolean enabled;
+
+  @Inject
+  @Config("analyticsConfig")
+  Map<String, Object> analyticsConfig;
+
+  @Inject
+  @Parameter(PARAM_CLIENT_ID)
+  Optional<String> paramClientId;
+
+  @Inject
+  ConsoleUiAction() {}
 
   @Override
   public void run() {
@@ -113,8 +144,8 @@ public final class ConsoleUiAction implements Runnable {
     }
     User user = authResult.userAuthInfo().get().user();
     response.setContentType(MediaType.HTML_UTF_8);
-    response.setHeader(X_FRAME_OPTIONS, "SAMEORIGIN");  // Disallow iframing.
-    response.setHeader("X-Ui-Compatible", "IE=edge");  // Ask IE not to be silly.
+    response.setHeader(X_FRAME_OPTIONS, "SAMEORIGIN"); // Disallow iframing.
+    response.setHeader("X-Ui-Compatible", "IE=edge"); // Ask IE not to be silly.
     SoyMapData data = new SoyMapData();
     data.put("logoFilename", logoFilename);
     data.put("productName", productName);
@@ -127,7 +158,8 @@ public final class ConsoleUiAction implements Runnable {
     if (!enabled) {
       response.setStatus(SC_SERVICE_UNAVAILABLE);
       response.setPayload(
-          TOFU_SUPPLIER.get()
+          TOFU_SUPPLIER
+              .get()
               .newRenderer(ConsoleSoyInfo.DISABLED)
               .setCssRenamingMap(CSS_RENAMING_MAP_SUPPLIER.get())
               .setData(data)
@@ -139,7 +171,7 @@ public final class ConsoleUiAction implements Runnable {
     data.put("xsrfToken", xsrfTokenManager.generateToken(user.getEmail()));
     ImmutableSetMultimap<String, Role> roleMap = registrarAccessor.getAllClientIdWithRoles();
     data.put("allClientIds", roleMap.keySet());
-    data.put("environment", environment.toString());
+    data.put("environment", RegistryEnvironment.get().toString());
     // We set the initial value to the value that will show if guessClientId throws.
     String clientId = "<null>";
     try {
@@ -161,7 +193,8 @@ public final class ConsoleUiAction implements Runnable {
           "User %s doesn't have access to registrar console.", authResult.userIdForLogging());
       response.setStatus(SC_FORBIDDEN);
       response.setPayload(
-          TOFU_SUPPLIER.get()
+          TOFU_SUPPLIER
+              .get()
               .newRenderer(ConsoleSoyInfo.WHOAREYOU)
               .setCssRenamingMap(CSS_RENAMING_MAP_SUPPLIER.get())
               .setData(data)
@@ -175,7 +208,9 @@ public final class ConsoleUiAction implements Runnable {
       throw e;
     }
 
-    String payload = TOFU_SUPPLIER.get()
+    String payload =
+        TOFU_SUPPLIER
+            .get()
             .newRenderer(ConsoleSoyInfo.MAIN)
             .setCssRenamingMap(CSS_RENAMING_MAP_SUPPLIER.get())
             .setData(data)

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Sets.difference;
+import static google.registry.config.RegistryEnvironment.PRODUCTION;
 import static google.registry.export.sheet.SyncRegistrarsSheetAction.enqueueRegistrarSheetSync;
 import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.security.JsonResponseHelper.Status.ERROR;
@@ -92,7 +93,6 @@ public class RegistrarSettingsAction implements Runnable, JsonActionRunner.JsonA
   @Inject SendEmailUtils sendEmailUtils;
   @Inject AuthenticatedRegistrarAccessor registrarAccessor;
   @Inject AuthResult authResult;
-  @Inject RegistryEnvironment registryEnvironment;
 
   @Inject RegistrarSettingsAction() {}
 
@@ -334,7 +334,7 @@ public class RegistrarSettingsAction implements Runnable, JsonActionRunner.JsonA
       // If a REAL registrar isn't in compliance with regards to having an abuse contact set,
       // prevent addition of allowed TLDs until that's fixed.
       if (Registrar.Type.REAL.equals(initialRegistrar.getType())
-          && RegistryEnvironment.PRODUCTION.equals(registryEnvironment)) {
+          && PRODUCTION.equals(RegistryEnvironment.get())) {
         checkArgumentPresent(
             initialRegistrar.getWhoisAbuseContact(),
             "Cannot add allowed TLDs if there is no WHOIS abuse contact set.");
@@ -496,7 +496,7 @@ public class RegistrarSettingsAction implements Runnable, JsonActionRunner.JsonA
       return;
     }
     enqueueRegistrarSheetSync(appEngineServiceUtils.getCurrentVersionHostname("backend"));
-    String environment = Ascii.toLowerCase(String.valueOf(registryEnvironment));
+    String environment = Ascii.toLowerCase(String.valueOf(RegistryEnvironment.get()));
     sendEmailUtils.sendEmail(
         String.format(
             "Registrar %s (%s) updated in registry %s environment",

--- a/core/src/test/java/google/registry/batch/DeleteProberDataActionTest.java
+++ b/core/src/test/java/google/registry/batch/DeleteProberDataActionTest.java
@@ -46,12 +46,14 @@ import google.registry.model.registry.Registry;
 import google.registry.model.registry.Registry.TldType;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.testing.FakeResponse;
+import google.registry.testing.SystemPropertyRule;
 import google.registry.testing.mapreduce.MapreduceTestCase;
 import java.util.Optional;
 import java.util.Set;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -61,6 +63,9 @@ import org.junit.runners.JUnit4;
 public class DeleteProberDataActionTest extends MapreduceTestCase<DeleteProberDataAction> {
 
   private static final DateTime DELETION_TIME = DateTime.parse("2010-01-01T00:00:00.000Z");
+
+  @Rule
+  public final SystemPropertyRule systemPropertyRule = new SystemPropertyRule();
 
   @Before
   public void init() {
@@ -90,8 +95,8 @@ public class DeleteProberDataActionTest extends MapreduceTestCase<DeleteProberDa
     action.response = new FakeResponse();
     action.isDryRun = false;
     action.tlds = ImmutableSet.of();
-    action.registryEnvironment = RegistryEnvironment.SANDBOX;
     action.registryAdminClientId = "TheRegistrar";
+    RegistryEnvironment.SANDBOX.setup(systemPropertyRule);
   }
 
   private void runMapreduce() throws Exception {
@@ -153,7 +158,7 @@ public class DeleteProberDataActionTest extends MapreduceTestCase<DeleteProberDa
   @Test
   public void testFail_givenNonDotTestTldOnProd() {
     action.tlds = ImmutableSet.of("example");
-    action.registryEnvironment = RegistryEnvironment.PRODUCTION;
+    RegistryEnvironment.PRODUCTION.setup(systemPropertyRule);
     IllegalArgumentException thrown =
         assertThrows(IllegalArgumentException.class, this::runMapreduce);
     assertThat(thrown)

--- a/core/src/test/java/google/registry/ui/server/registrar/ConsoleOteSetupActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/ConsoleOteSetupActionTest.java
@@ -41,6 +41,7 @@ import google.registry.testing.AppEngineRule;
 import google.registry.testing.DeterministicStringGenerator;
 import google.registry.testing.FakeClock;
 import google.registry.testing.FakeResponse;
+import google.registry.testing.SystemPropertyRule;
 import google.registry.ui.server.SendEmailUtils;
 import google.registry.util.EmailMessage;
 import google.registry.util.SendEmailService;
@@ -67,6 +68,9 @@ public final class ConsoleOteSetupActionTest {
 
   @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
+  @Rule
+  public final SystemPropertyRule systemPropertyRule = new SystemPropertyRule();
+
   private final FakeResponse response = new FakeResponse();
   private final ConsoleOteSetupAction action = new ConsoleOteSetupAction();
   private final User user = new User("marla.singer@example.com", "gmail.com", "12345");
@@ -87,7 +91,6 @@ public final class ConsoleOteSetupActionTest {
     action.userService = UserServiceFactory.getUserService();
     action.xsrfTokenManager = new XsrfTokenManager(new FakeClock(), action.userService);
     action.authResult = AuthResult.create(AuthLevel.USER, UserAuthInfo.create(user, false));
-    action.registryEnvironment = RegistryEnvironment.UNITTEST;
     action.sendEmailUtils =
         new SendEmailUtils(
             new InternetAddress("outgoing@registry.example"),
@@ -122,7 +125,7 @@ public final class ConsoleOteSetupActionTest {
 
   @Test
   public void testGet_authorized_onProduction() {
-    action.registryEnvironment = RegistryEnvironment.PRODUCTION;
+    RegistryEnvironment.PRODUCTION.setup(systemPropertyRule);
     assertThrows(IllegalStateException.class, action::run);
   }
 

--- a/core/src/test/java/google/registry/ui/server/registrar/ConsoleRegistrarCreatorActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/ConsoleRegistrarCreatorActionTest.java
@@ -42,6 +42,7 @@ import google.registry.testing.AppEngineRule;
 import google.registry.testing.DeterministicStringGenerator;
 import google.registry.testing.FakeClock;
 import google.registry.testing.FakeResponse;
+import google.registry.testing.SystemPropertyRule;
 import google.registry.ui.server.SendEmailUtils;
 import google.registry.util.EmailMessage;
 import google.registry.util.SendEmailService;
@@ -69,6 +70,9 @@ public final class ConsoleRegistrarCreatorActionTest {
 
   @Rule public final MockitoRule mocks = MockitoJUnit.rule();
 
+  @Rule
+  public final SystemPropertyRule systemPropertyRule = new SystemPropertyRule();
+
   private final FakeResponse response = new FakeResponse();
   private final ConsoleRegistrarCreatorAction action = new ConsoleRegistrarCreatorAction();
   private final User user = new User("marla.singer@example.com", "gmail.com", "12345");
@@ -89,7 +93,6 @@ public final class ConsoleRegistrarCreatorActionTest {
     action.userService = UserServiceFactory.getUserService();
     action.xsrfTokenManager = new XsrfTokenManager(new FakeClock(), action.userService);
     action.authResult = AuthResult.create(AuthLevel.USER, UserAuthInfo.create(user, false));
-    action.registryEnvironment = RegistryEnvironment.UNITTEST;
     action.sendEmailUtils =
         new SendEmailUtils(
             new InternetAddress("outgoing@registry.example"),
@@ -142,7 +145,7 @@ public final class ConsoleRegistrarCreatorActionTest {
 
   @Test
   public void testGet_authorized_onProduction() {
-    action.registryEnvironment = RegistryEnvironment.PRODUCTION;
+    RegistryEnvironment.PRODUCTION.setup(systemPropertyRule);
     action.run();
     assertThat(response.getPayload()).contains("<h1>Create Registrar</h1>");
     assertThat(response.getPayload()).contains("gtag('config', 'sampleId')");

--- a/core/src/test/java/google/registry/ui/server/registrar/ConsoleUiActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/ConsoleUiActionTest.java
@@ -28,7 +28,6 @@ import com.google.appengine.api.users.UserServiceFactory;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.net.MediaType;
-import google.registry.config.RegistryEnvironment;
 import google.registry.request.auth.AuthLevel;
 import google.registry.request.auth.AuthResult;
 import google.registry.request.auth.AuthenticatedRegistrarAccessor;
@@ -52,10 +51,11 @@ import org.junit.runners.JUnit4;
 public class ConsoleUiActionTest {
 
   @Rule
-  public final AppEngineRule appEngineRule = AppEngineRule.builder()
-      .withDatastore()
-      .withUserService(UserInfo.create("marla.singer@example.com", "12345"))
-      .build();
+  public final AppEngineRule appEngineRule =
+      AppEngineRule.builder()
+          .withDatastore()
+          .withUserService(UserInfo.create("marla.singer@example.com", "12345"))
+          .build();
 
   private final HttpServletRequest request = mock(HttpServletRequest.class);
   private final FakeResponse response = new FakeResponse();
@@ -79,7 +79,6 @@ public class ConsoleUiActionTest {
     action.xsrfTokenManager = new XsrfTokenManager(new FakeClock(), action.userService);
     action.paramClientId = Optional.empty();
     action.authResult = AuthResult.create(AuthLevel.USER, UserAuthInfo.create(user, false));
-    action.environment = RegistryEnvironment.UNITTEST;
     action.analyticsConfig = ImmutableMap.of("googleAnalyticsId", "sampleId");
 
     action.registrarAccessor =

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistrarSettingsActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistrarSettingsActionTest.java
@@ -36,6 +36,7 @@ import google.registry.model.registrar.Registrar;
 import google.registry.request.auth.AuthenticatedRegistrarAccessor;
 import google.registry.request.auth.AuthenticatedRegistrarAccessor.Role;
 import google.registry.testing.CertificateSamples;
+import google.registry.testing.SystemPropertyRule;
 import google.registry.testing.TaskQueueHelper.TaskMatcher;
 import google.registry.util.CidrAddressBlock;
 import google.registry.util.EmailMessage;
@@ -44,6 +45,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.json.simple.JSONValue;
 import org.json.simple.parser.ParseException;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -52,6 +54,9 @@ import org.mockito.ArgumentCaptor;
 /** Tests for {@link RegistrarSettingsAction}. */
 @RunWith(JUnit4.class)
 public class RegistrarSettingsActionTest extends RegistrarSettingsActionTestCase {
+
+  @Rule
+  public final SystemPropertyRule systemPropertyRule = new SystemPropertyRule();
 
   @Test
   public void testSuccess_updateRegistrarInfo_andSendsNotificationEmail() throws Exception {
@@ -393,7 +398,7 @@ public class RegistrarSettingsActionTest extends RegistrarSettingsActionTestCase
   @Test
   public void testUpdate_allowedTlds_failedWhenNoWhoisAbuseContactExists() {
     setUserAdmin();
-    action.registryEnvironment = RegistryEnvironment.PRODUCTION;
+    RegistryEnvironment.PRODUCTION.setup(systemPropertyRule);
     Map<String, Object> args = Maps.newHashMap(loadRegistrar(CLIENT_ID).toJsonMap());
     args.put("allowedTlds", ImmutableList.of("newtld", "currenttld"));
 

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistrarSettingsActionTestCase.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistrarSettingsActionTestCase.java
@@ -33,7 +33,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.truth.Truth;
-import google.registry.config.RegistryEnvironment;
 import google.registry.model.ofy.Ofy;
 import google.registry.model.registrar.RegistrarContact;
 import google.registry.request.JsonActionRunner;
@@ -116,7 +115,6 @@ public abstract class RegistrarSettingsActionTestCase {
             getGSuiteOutgoingEmailDisplayName(),
             ImmutableList.of("notification@test.example", "notification2@test.example"),
             emailService);
-    action.registryEnvironment = RegistryEnvironment.get();
     action.registrarConsoleMetrics = new RegistrarConsoleMetrics();
     action.authResult =
         AuthResult.create(


### PR DESCRIPTION
We found that some webdriver tests failed because RegistryEnvironment
was set to 'production' by other test and was carried over to the
webdriver test, and it was nontrivial to fix them because the instance
of RegistryEnvironment was injected into the testing web server.

Also, to eliminate this problem from potential victims, we stopped
provisioning RegistryEnvironment from Dagger. Instead, we just use
RegistryEnvironment.get() function to get the instance, which indeed
retrives the value from system property every time. If any test case
needs to run the test with other environment, it can just simply use
the existing SystemPropertyRule and RegistryEnvironment.${ENV}.setup
to change it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/140)
<!-- Reviewable:end -->
