### PR TITLE
Throw a more useful error message on attempted domain restore reports

### DIFF
--- a/core/src/main/java/google/registry/flows/EppException.java
+++ b/core/src/main/java/google/registry/flows/EppException.java
@@ -209,6 +209,7 @@ public abstract class EppException extends Exception {
   /** Specified command is not implemented. */
   @EppResultCode(Code.UNIMPLEMENTED_COMMAND)
   public static class UnimplementedCommandException extends EppException {
+
     public UnimplementedCommandException(InnerCommand command) {
       super(String.format(
           "No flow found for %s with extension %s",
@@ -216,6 +217,10 @@ public abstract class EppException extends Exception {
           command instanceof ResourceCommandWrapper
               ? ((ResourceCommandWrapper) command).getResourceCommand().getClass().getSimpleName()
               : null));
+    }
+
+    public UnimplementedCommandException(String message) {
+      super(message);
     }
   }
 

--- a/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
@@ -632,4 +632,16 @@ public class DomainRestoreRequestFlowTest
                 TransactionReportField.RESTORED_DOMAINS,
                 1));
   }
+
+  @Test
+  public void testFailure_restoreReportsAreNotSupported() {
+    setEppInput("domain_update_restore_report.xml");
+    // This exception is referred to by its fully qualified path (rather than being imported) so
+    // that it is not included in the list of exceptions thrown by DomainRestoreRequestFlow, as this
+    // test EPP won't trigger the request flow at all.
+    EppException thrown = assertThrows(
+        google.registry.flows.EppException.UnimplementedCommandException.class, this::runFlow);
+    assertThat(thrown).hasMessageThat().contains("domain restore reports are not supported");
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
+  }
 }

--- a/core/src/test/java/google/registry/flows/domain/testdata/domain_update_restore_report.xml
+++ b/core/src/test/java/google/registry/flows/domain/testdata/domain_update_restore_report.xml
@@ -1,0 +1,46 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="urn:ietf:params:xml:ns:epp-1.0
+     epp-1.0.xsd">
+  <command>
+    <update>
+      <domain:update
+       xmlns:domain="urn:ietf:params:xml:ns:domain-1.0"
+       xsi:schemaLocation="urn:ietf:params:xml:ns:domain-1.0
+       domain-1.0.xsd">
+        <domain:name>example.com</domain:name>
+        <domain:chg/>
+      </domain:update>
+    </update>
+    <extension>
+      <rgp:update xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0"
+       xsi:schemaLocation="urn:ietf:params:xml:ns:rgp-1.0
+       rgp-1.0.xsd">
+        <rgp:restore op="report">
+          <rgp:report>
+            <rgp:preData>Pre-delete registration data goes here.
+            Both XML and free text are allowed.</rgp:preData>
+            <rgp:postData>Post-restore registration data goes here.
+            Both XML and free text are allowed.</rgp:postData>
+            <rgp:delTime>2003-07-10T22:00:00.0Z</rgp:delTime>
+            <rgp:resTime>2003-07-20T22:00:00.0Z</rgp:resTime>
+            <rgp:resReason>Registrant error.</rgp:resReason>
+            <rgp:statement>This registrar has not restored the
+            Registered Name in order to assume the rights to use
+            or sell the Registered Name for itself or for any
+            third party.</rgp:statement>
+            <rgp:statement>The information in this report is
+            true to best of this registrar's knowledge, and this
+            registrar acknowledges that intentionally supplying
+            false information in this report shall constitute an
+            incurable material breach of the
+            Registry-Registrar Agreement.</rgp:statement>
+            <rgp:other>Supporting information goes
+            here.</rgp:other>
+          </rgp:report>
+        </rgp:restore>
+      </rgp:update>
+    </extension>
+    <clTRID>ABC-12345</clTRID>
+  </command>
+</epp>


### PR DESCRIPTION
Per DomainRestoreRequestFlow's Javadoc, we automatically approve and instantly
enact all domain restore requests, thus we don't use or support restore
reports. This improves the registrar-visible error message to help make this
more clear.

BUG=b/136493385

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/145)
<!-- Reviewable:end -->
