### PR TITLE
Read golden images from src folder directly

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -97,6 +97,10 @@ sourceSets {
   }
 }
 
+processTestResources {
+  exclude '**/webdriver/*'
+}
+
 configurations {
   css
   jaxb
@@ -139,6 +143,8 @@ dependencies {
   implementation files(
       "${rootDir}/third_party/objectify/v4_1/objectify-4.1.3.jar")
   testImplementation project(':third_party')
+
+  testRuntime files(sourceSets.test.resources.srcDirs)
 
   compile deps['com.beust:jcommander']
   compile deps['com.google.api-client:google-api-client']

--- a/core/src/test/java/google/registry/webdriver/RepeatableRunner.java
+++ b/core/src/test/java/google/registry/webdriver/RepeatableRunner.java
@@ -141,7 +141,15 @@ public class RepeatableRunner extends BlockJUnit4ClassRunner {
       int numSuccess = 0, numFailure = 0;
       Throwable lastException = null;
       for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-        attemptNumber.set(attempt);
+        // attemptNumber would be null if any exception happens during the
+        // instantiation of test class object(including test rules). However,
+        // those exceptions would not be actually thrown until statement.evaluate()
+        // is invoked. So, we should just skip the setter and let the statement
+        // be evaluated. Then we should be able to find the stack trace of
+        // root cause in the test reports.
+        if (attemptNumber != null) {
+          attemptNumber.set(attempt);
+        }
         try {
           statement.evaluate();
           numSuccess++;


### PR DESCRIPTION
This PR prevents Gradle from copying the golden images
to build/resources/test, so the screenshot test would
read golden images from src/test/resources directly and
display the path in test log if the test fails. Because
the path pointing to the actual file in src/ folder,
the engineer can easily find it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/159)
<!-- Reviewable:end -->
