### PR TITLE
Add a 30s timeout for all webdriver tests

### DIFF
--- a/core/src/test/java/google/registry/webdriver/WebDriverTestCase.java
+++ b/core/src/test/java/google/registry/webdriver/WebDriverTestCase.java
@@ -17,6 +17,7 @@ package google.registry.webdriver;
 import google.registry.webdriver.RepeatableRunner.AttemptNumber;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.rules.Timeout;
 
 /** Base class for tests that needs a {@link WebDriverPlusScreenDifferRule}. */
 public class WebDriverTestCase {
@@ -27,4 +28,7 @@ public class WebDriverTestCase {
   @Rule
   public final WebDriverPlusScreenDifferRule driver =
       new WebDriverPlusScreenDifferRule(webDriverProvider::getWebDriver, attemptNumber);
+
+  @Rule
+  public final Timeout timeout = Timeout.seconds(30);
 }


### PR DESCRIPTION
Sometimes, the webdriver tests get stuck forever for no reason. It could
be some issue in the test container but it is hard to root cause it. So,
adding a 30s timeout can either trigger the retry earlier or let the
test just fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/161)
<!-- Reviewable:end -->
