### PR TITLE
Add a metric for EPP processing time regardless of ID/TLD

### DIFF
--- a/core/src/main/java/google/registry/flows/EppMetrics.java
+++ b/core/src/main/java/google/registry/flows/EppMetrics.java
@@ -43,7 +43,7 @@ public class EppMetrics {
       ImmutableSet.of(
           LabelDescriptor.create("command", "The name of the command."),
           LabelDescriptor.create("traffic_type",
-              "The traffic type of the command, one of CANARY, PROBER, or REAL."),
+              "The traffic type of the command; one of CANARY, PROBER, or REAL."),
           LabelDescriptor.create("status", "The return status of the command."));
 
   private static final IncrementableMetric eppRequestsByRegistrar =

--- a/core/src/main/java/google/registry/flows/EppMetrics.java
+++ b/core/src/main/java/google/registry/flows/EppMetrics.java
@@ -39,6 +39,11 @@ public class EppMetrics {
           LabelDescriptor.create("tld", "The TLD acted on by the command (if applicable)."),
           LabelDescriptor.create("status", "The return status of the command."));
 
+  private static final ImmutableSet<LabelDescriptor> LABEL_DESCRIPTORS =
+      ImmutableSet.of(
+          LabelDescriptor.create("command", "The name of the command."),
+          LabelDescriptor.create("status", "The return status of the command."));
+
   private static final IncrementableMetric eppRequestsByRegistrar =
       MetricRegistryImpl.getDefault()
           .newIncrementableMetric(
@@ -71,6 +76,15 @@ public class EppMetrics {
               "EPP Processing Time By TLD",
               "milliseconds",
               LABEL_DESCRIPTORS_BY_TLD,
+              DEFAULT_FITTER);
+
+  private static final EventMetric eppProcessingTime =
+      MetricRegistryImpl.getDefault()
+          .newEventMetric(
+              "/epp/total_processing_time",
+              "EPP Processing Time",
+              "milliseconds",
+              LABEL_DESCRIPTORS,
               DEFAULT_FITTER);
 
   @Inject
@@ -107,5 +121,6 @@ public class EppMetrics {
         metric.getCommandName().orElse(""),
         metric.getTld().orElse(""),
         eppStatusCode);
+    eppProcessingTime.record(processingTime, metric.getCommandName().orElse(""), eppStatusCode);
   }
 }

--- a/core/src/main/java/google/registry/flows/EppMetrics.java
+++ b/core/src/main/java/google/registry/flows/EppMetrics.java
@@ -43,7 +43,7 @@ public class EppMetrics {
       ImmutableSet.of(
           LabelDescriptor.create("command", "The name of the command."),
           LabelDescriptor.create("traffic_type",
-              "The traffic type of the command, either CANARY, PROBER, or REAL."),
+              "The traffic type of the command, one of CANARY, PROBER, or REAL."),
           LabelDescriptor.create("status", "The return status of the command."));
 
   private static final IncrementableMetric eppRequestsByRegistrar =
@@ -84,7 +84,7 @@ public class EppMetrics {
       MetricRegistryImpl.getDefault()
           .newEventMetric(
               "/epp/processing_time_by_traffic_type",
-              "EPP Request Time",
+              "EPP Request Time By Traffic Type",
               "milliseconds",
               LABEL_DESCRIPTORS_BY_TRAFFIC_TYPE,
               DEFAULT_FITTER);

--- a/core/src/main/java/google/registry/flows/EppMetrics.java
+++ b/core/src/main/java/google/registry/flows/EppMetrics.java
@@ -78,11 +78,11 @@ public class EppMetrics {
               LABEL_DESCRIPTORS_BY_TLD,
               DEFAULT_FITTER);
 
-  private static final EventMetric eppProcessingTime =
+  private static final EventMetric requestTime =
       MetricRegistryImpl.getDefault()
           .newEventMetric(
-              "/epp/total_processing_time",
-              "EPP Processing Time",
+              "/epp/request_time",
+              "EPP Request Time",
               "milliseconds",
               LABEL_DESCRIPTORS,
               DEFAULT_FITTER);
@@ -121,6 +121,6 @@ public class EppMetrics {
         metric.getCommandName().orElse(""),
         metric.getTld().orElse(""),
         eppStatusCode);
-    eppProcessingTime.record(processingTime, metric.getCommandName().orElse(""), eppStatusCode);
+    requestTime.record(processingTime, metric.getCommandName().orElse(""), eppStatusCode);
   }
 }

--- a/core/src/main/java/google/registry/flows/EppMetrics.java
+++ b/core/src/main/java/google/registry/flows/EppMetrics.java
@@ -39,7 +39,7 @@ public class EppMetrics {
           LabelDescriptor.create("tld", "The TLD acted on by the command (if applicable)."),
           LabelDescriptor.create("status", "The return status of the command."));
 
-  private static final ImmutableSet<LabelDescriptor> LABEL_DESCRIPTORS_BY_TRAFFIC_TYPE =
+  private static final ImmutableSet<LabelDescriptor> LABEL_DESCRIPTORS =
       ImmutableSet.of(
           LabelDescriptor.create("command", "The name of the command."),
           LabelDescriptor.create("traffic_type",
@@ -80,13 +80,13 @@ public class EppMetrics {
               LABEL_DESCRIPTORS_BY_TLD,
               DEFAULT_FITTER);
 
-  private static final EventMetric processingTimeByTrafficType =
+  private static final EventMetric requestTime =
       MetricRegistryImpl.getDefault()
           .newEventMetric(
-              "/epp/processing_time_by_traffic_type",
-              "EPP Request Time By Traffic Type",
+              "/epp/request_time",
+              "EPP Request Time",
               "milliseconds",
-              LABEL_DESCRIPTORS_BY_TRAFFIC_TYPE,
+              LABEL_DESCRIPTORS,
               DEFAULT_FITTER);
 
   private enum TrafficType {
@@ -122,8 +122,7 @@ public class EppMetrics {
         .record(processingTime, commandName, metric.getClientId().orElse(""), eppStatusCode);
     String tld = metric.getTld().orElse("");
     processingTimeByTld.record(processingTime, commandName, tld, eppStatusCode);
-    processingTimeByTrafficType
-        .record(processingTime, commandName, getTrafficType(tld).toString(), eppStatusCode);
+    requestTime.record(processingTime, commandName, getTrafficType(tld).toString(), eppStatusCode);
   }
 
   private static TrafficType getTrafficType(String tld) {


### PR DESCRIPTION
Assuming this all goes well, we can remove the by-tld and by-id metrics since they're taking up a significantly larger amount of space / cost.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/163)
<!-- Reviewable:end -->
