### PR TITLE
Check dependencies' open-source licenses

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,19 @@ reportUploader {
 
 apply from: 'dependencies.gradle'
 
+apply from: 'dependency_license.gradle'
+
+// Custom task to run checkLicense in buildSrc, which is not triggered
+// by root project tasks. A shell task is used because buildSrc tasks
+// cannot be referenced in the same way as tasks from a regular included
+// build.
+task checkBuildSrcLicense(type:Exec) {
+  workingDir "${rootDir}/buildSrc"
+  commandLine '../gradlew', 'checkLicense'
+}
+tasks.checkLicense.dependsOn(tasks.checkBuildSrcLicense)
+tasks.build.dependsOn(tasks.checkLicense)
+
 // Provide defaults for all of the project properties.
 
 // showAllOutput: boolean.  If true, dump all test output during the build.
@@ -159,9 +172,10 @@ subprojects {
         resolutionStrategy.activateDependencyLocking()
       }
     }
-    // Lock application dependencies.
-    dependencyLocking {
-      lockAllConfigurations()
+    // Lock application dependencies except for the gradle-license-report
+    // plugin. See dependency_license.gradle for more information.
+    configurations.findAll { it.name != 'dependencyLicenseReport' }.each {
+      it.resolutionStrategy.activateDependencyLocking()
     }
   }
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -52,6 +52,7 @@ repositories {
 }
 
 apply from: '../dependencies.gradle'
+apply from: '../dependency_license.gradle'
 apply from: '../java_common.gradle'
 
 sourceSets {

--- a/config/dependency-license/allowed_licenses.json
+++ b/config/dependency-license/allowed_licenses.json
@@ -1,0 +1,172 @@
+{
+  "allowedLicenses": [
+    {
+      "moduleLicense": "Apache Software License, Version 1.1"
+    },
+    {
+      "moduleLicense": "Apache 2"
+    },
+    {
+      "moduleLicense": "Apache 2.0"
+    },
+    {
+      "moduleLicense": "Apache-2.0"
+    },
+    {
+      "moduleLicense": "Apache License 2.0"
+    },
+    {
+      "moduleLicense": "Apache License v2.0"
+    },
+    {
+      "moduleLicense": "Apache License, Version 2.0"
+    },
+    {
+      "moduleLicense": "Apache Software License - Version 2.0"
+    },
+    {
+      "moduleLicense": "The Apache License, Version 2.0"
+    },
+    {
+      "moduleLicense": "The Apache Software License, Version 2.0"
+    },
+    {
+      "moduleLicense": "The Apache Software License, version 2.0"
+    },
+    {
+      "moduleLicense": "Bouncy Castle Licence"
+    },
+    {
+      "moduleLicense": "BSD"
+    },
+    {
+      "moduleLicense": "BSD 2-Clause License"
+    },
+    {
+      "moduleLicense": "BSD 2-Clause license"
+    },
+    {
+      "moduleLicense": "BSD 3-clause"
+    },
+    {
+      "moduleLicense": "BSD 3-Clause"
+    },
+    {
+      "moduleLicense": "BSD 3-Clause License"
+    },
+    {
+      "moduleLicense": "The 3-Clause BSD License"
+    },
+    {
+      "moduleLicense": "BSD License"
+    },
+    {
+      "moduleLicense": "BSD New License"
+    },
+    {
+      "moduleLicense": "BSD New license"
+    },
+    {
+      "moduleLicense": "BSD style"
+    },
+    {
+      "moduleLicense": "New BSD License"
+    },
+    {
+      "moduleLicense": "Revised BSD"
+    },
+    {
+      "moduleLicense": "The BSD License"
+    },
+    {
+      "moduleLicense": "CC0 1.0 Universal License"
+    },
+    {
+      "moduleLicense": "CDDL 1.1"
+    },
+    {
+      "moduleLicense": "CDDL + GPLv2 with classpath exception"
+    },
+    {
+      "moduleLicense": "COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0"
+    },
+    {
+      "moduleLicense": "https://glassfish.java.net/public/CDDL+GPL_1_1.html, https://glassfish.java.net/public/CDDL+GPL_1_1.html"
+    },
+    {
+      "moduleLicense": "CDDL+GPL License"
+    },
+    {
+      "moduleLicense": "\\n                Dual license consisting of the CDDL v1.1 and GPL v2\\n            "
+    },
+    {
+      "moduleLicense": "Eclipse Public License - Version 1.0"
+    },
+    {
+      "moduleLicense": "Eclipse Public License - v 1.0"
+    },
+    {
+      "moduleLicense": "Eclipse Public License 1.0"
+    },
+    {
+      "moduleLicense": "Google App Engine Terms of Service"
+    },
+    {
+      "moduleLicense": "GNU General Public License, version 2, with the Classpath Exception"
+    },
+    {
+      "moduleLicense": "GNU GENERAL PUBLIC LICENSE, Version 2 + Classpath Exception"
+    },
+    {
+      "moduleLicense": "GPL2 w/ CPE"
+    },
+    {
+      "moduleLicense": "GNU Lesser Public License"
+    },
+    {
+      "moduleLicense": "The Go license"
+    },
+    {
+      "moduleLicense": "GWT Terms"
+    },
+    {
+      "moduleLicense": "ICU License"
+    },
+    {
+      "moduleLicense": "The JSON License"
+    },
+    {
+      "moduleLicense": "LGPL-2.1+"
+    },
+    {
+      "moduleLicense": "LGPL, version 2.1"
+    },
+    {
+      "moduleLicense": "MIT"
+    },
+    {
+      "moduleLicense": "MIT License"
+    },
+    {
+      "moduleLicense": "MIT license"
+    },
+    {
+      "moduleLicense": "The MIT License"
+    },
+    {
+      "moduleLicense": "The MIT license"
+    },
+    {
+      "moduleLicense": "Mozilla Public License Version 2.0"
+    },
+    {
+      "moduleLicense": "Public Domain"
+    },
+    {
+      "moduleLicense": "PUBLIC DOMAIN"
+    },
+    {
+      "moduleLicense": "The W3C Software License"
+    }
+  ]
+}

--- a/config/dependency-license/license_normalizer_bundle.json
+++ b/config/dependency-license/license_normalizer_bundle.json
@@ -1,0 +1,32 @@
+{
+  "bundles" : [
+    {
+      "bundleName" : "Apache 2.0",
+      "licenseName" : "Apache 2.0",
+      "licenseUrl" : "http://www.apache.org/licenses/LICENSE-2.0"
+    },
+    {
+      "bundleName" : "MIT License",
+      "licenseName" : "MIT License",
+      "licenseUrl" : "http://www.opensource.org/licenses/mit-license.php"
+    }
+  ],
+  "transformationRules" : [
+    {
+      "bundleName" : "Apache 2.0",
+      "licenseUrlPattern" : "http://www.apache.org/licenses/LICENSE-2.0"
+    },
+    {
+      "bundleName" : "Apache 2.0",
+      "licenseUrlPattern" : "http://www.apache.org/licenses/LICENSE-2.0.txt"
+    },
+    {
+      "bundleName" : "MIT License",
+      "licenseUrlPattern" : "http://www.opensource.org/licenses/mit-license.php"
+    },
+    {
+      "bundleName" : "MIT License",
+      "licenseUrlPattern" : "http://www.opensource.org/licenses/MIT"
+    }
+  ]
+}

--- a/dependency_license.gradle
+++ b/dependency_license.gradle
@@ -1,0 +1,87 @@
+// Copyright 2019 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Legacy-style declaration of the gradle-license-report plugin, which is necessary
+// in shared scripts.
+// Note that the 'apply plugin' line does not use string literal. It references directly the
+// main class of the plugin.
+buildscript {
+  repositories {
+    maven {
+      url 'https://plugins.gradle.org/m2/'
+    }
+  }
+  dependencies {
+    classpath 'com.github.jk1:gradle-license-report:1.8'
+  }
+}
+apply plugin: com.github.jk1.license.LicenseReportPlugin
+
+// Configures the checkLicense task.
+//
+// This task discovers license information for each dependency including a
+// name phrase and possibly additional details, such as an http link or relative
+// path of a file in the jar. This information is saved in json format under
+// build/reports/dependency-license. It is not used right now, but may be useful
+// if we want to check the content of the licenses.
+//
+// The required 'allowedLicensesFile' contains the acceptable license name phrases.
+// If a phrase not in this file is found, the checkLicense task will fail. Exact
+// string match is used, so they are case-sensitive and preceding/trailing whitespaces are important.
+//
+// This plugin also generates an html report under build/reports/dependency-license.
+// The optional 'filters' parameter accepts custom name-normalization rules. This
+// report is not currently in use.
+//
+// Note that this task needs to be explicitly invoked on buildSrc.
+//
+// Also note that dependencies of buildscript classpath and 'official' Gradle plugins are
+// not checked.
+//
+// Due to a bug/feature of this plugin, the Nomulus project can not lock all dependencies.
+// The 'dependencyLicenseReport' configuration must be excluded from locking.
+// TODO(weiminyu): add github issue number after reporting to author.
+licenseReport {
+  ext.toFullFilePath = { relativePath ->
+    if (rootDir.path.endsWith('buildSrc')) {
+      return "${rootDir.path}/../${relativePath}"
+    }
+    return "${rootDir.path}/${relativePath}"
+  }
+
+  // Check licenses dependencies in all configurations. This does not include
+  // buildscript-classpath.
+  configurations = ALL
+
+  def configFolder = 'config/dependency-license'
+
+  allowedLicensesFile = file(toFullFilePath("${configFolder}/allowed_licenses.json"))
+
+  filters = new com.github.jk1.license.filter.LicenseBundleNormalizer(
+      bundlePath: toFullFilePath("${configFolder}/license_normalizer_bundle.json"),
+      createDefaultTransformationRules: false)
+
+  // The following dependency jars do not contain license info.
+  // Investigation results are documented inline.
+  excludes = [
+      // BSD: https://github.com/javacc/javacc/blob/master/LICENSE
+      'javacc:javacc',
+      // CDDL+GPL2.0 according to Maven Central:
+      // https://mvnrepository.com/artifact/javax.servlet/servlet-api/2.5
+      'javax.servlet:servlet-api',
+      // Presumed free since this is from Apache:
+      // http://www.apache.org/licenses/
+      'xerces:xmlParserAPIs'
+  ]
+}


### PR DESCRIPTION
Use jk1/Gradle-License-Report to verify that all
dependencies have open-source licenses.

Note that the following dependencies are not checked:

Dependencies of official Gradle plugins
Dependencies declared in buildscript block
Dependencies of jk1/Gradle-License-Report itself

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/165)
<!-- Reviewable:end -->
