### PR TITLE
Fix permission issue in Beam pipeline deployment

### DIFF
--- a/core/src/main/java/google/registry/tools/AuthModule.java
+++ b/core/src/main/java/google/registry/tools/AuthModule.java
@@ -100,7 +100,7 @@ public class AuthModule {
       AbstractDataStoreFactory dataStoreFactory) {
     try {
       return new GoogleAuthorizationCodeFlow.Builder(
-              new NetHttpTransport(), jsonFactory, clientSecrets, requiredOauthScopes)
+          new NetHttpTransport(), jsonFactory, clientSecrets, requiredOauthScopes)
           .setDataStoreFactory(dataStoreFactory)
           .build();
     } catch (IOException ex) {

--- a/core/src/test/java/google/registry/beam/invoicing/InvoicingPipelineTest.java
+++ b/core/src/test/java/google/registry/beam/invoicing/InvoicingPipelineTest.java
@@ -16,8 +16,10 @@ package google.registry.beam.invoicing;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import google.registry.util.GoogleCredentialsBundle;
 import google.registry.util.ResourceUtils;
 import java.io.File;
 import java.io.IOException;
@@ -58,15 +60,17 @@ public class InvoicingPipelineTest {
 
   @Before
   public void initializePipeline() throws IOException {
-    invoicingPipeline = new InvoicingPipeline();
-    invoicingPipeline.projectId = "test-project";
     File beamTempFolder = tempFolder.newFolder();
-    invoicingPipeline.beamBucketUrl = beamTempFolder.getAbsolutePath();
-    invoicingPipeline.invoiceFilePrefix = "REG-INV";
-    invoicingPipeline.beamStagingUrl = beamTempFolder.getAbsolutePath() + "/staging";
-    invoicingPipeline.invoiceTemplateUrl =
-        beamTempFolder.getAbsolutePath() + "/templates/invoicing";
-    invoicingPipeline.billingBucketUrl = tempFolder.getRoot().getAbsolutePath();
+    String beamTempFolderPath = beamTempFolder.getAbsolutePath();
+    invoicingPipeline = new InvoicingPipeline(
+        "test-project",
+        beamTempFolderPath,
+        beamTempFolderPath + "/templates/invoicing",
+        beamTempFolderPath + "/staging",
+        tempFolder.getRoot().getAbsolutePath(),
+        "REG-INV",
+        GoogleCredentialsBundle.create(GoogleCredentials.create(null))
+    );
   }
 
   private ImmutableList<BillingEvent> getInputEvents() {


### PR DESCRIPTION
This will fix #167.

TESTED=Deploy the pipelines successfully locally without seeing any warning(see https://paste.googleplex.com/4664621635993600). Deploy the pipelines from alpha's Cloud Build to crash's GCS successfully(see https://pantheon.corp.google.com/cloud-build/builds/c19daf88-8223-4a9c-9bb9-b9382db8afb7?project=domain-registry-alpha).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/170)
<!-- Reviewable:end -->
