### PR TITLE
Fail gracefully when copying detailed reports

### DIFF
--- a/core/src/main/java/google/registry/storage/drive/DriveConnection.java
+++ b/core/src/main/java/google/registry/storage/drive/DriveConnection.java
@@ -54,6 +54,10 @@ public class DriveConnection {
   /**
    * Creates a file with the given parent.
    *
+   * <p>If a file with the same path already exists, a duplicate is created. If overwriting the
+   * existing file is the desired behavior, use {@link #createOrUpdateFile(String, MediaType,
+   * String, byte[])} instead.
+   *
    * @returns the file id.
    */
   public String createFile(String title, MediaType mimeType, String parentFolderId, byte[] bytes)


### PR DESCRIPTION
When the detailed reports are copied from GCS to registrars' Drive
folders, do not fail the entire copy operation when a single registrar
fails. Instead, send an alert email about the failure, and continue to copy the
rest of the reports.

Also, instead of creating duplicates, overwrite the existing files on
Drive.

BUG=127690361

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/181)
<!-- Reviewable:end -->
