### PR TITLE
Remove vestigial path for streaming EPP metrics

### DIFF
--- a/core/src/main/java/google/registry/env/common/backend/WEB-INF/web.xml
+++ b/core/src/main/java/google/registry/env/common/backend/WEB-INF/web.xml
@@ -13,11 +13,6 @@
     <load-on-startup>1</load-on-startup>
   </servlet>
 
-  <servlet-mapping>
-    <servlet-name>backend-servlet</servlet-name>
-    <url-pattern>/_dr/task/metrics</url-pattern>
-  </servlet-mapping>
-
   <!-- RDE -->
 
   <!--


### PR DESCRIPTION
The relevant action was deleted last year here: google@218c451

This removes the final hanging piece.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/184)
<!-- Reviewable:end -->
