### PR TITLE
Fix deploying to alpha from workstation

### DIFF
--- a/appengine_war.gradle
+++ b/appengine_war.gradle
@@ -75,6 +75,12 @@ if (project.path == ":services:default") {
 
 appengine {
     deploy {
+        // appengineDeployAll task requires the version to be set. So,
+        // this config lets gcloud select a version name when deploying
+        // to alpha from our workstation.
+        if (environment != 'production' && environment != 'sandbox') {
+            version = 'GCLOUD_CONFIG'
+        }
         projectId = gcpProject
     }
 }


### PR DESCRIPTION
appengineDeployAll requires appengine.deploy.version to be set
otherwiese the deployment would fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/198)
<!-- Reviewable:end -->
