### PR TITLE
Generate code coverage report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ plugins {
 
   id 'idea'
   id 'com.diffplug.gradle.spotless' version '3.18.0'
-  
+
   id 'jacoco'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ plugins {
 
   id 'idea'
   id 'com.diffplug.gradle.spotless' version '3.18.0'
+  
+  id 'jacoco'
 }
 
 wrapper {

--- a/build.gradle
+++ b/build.gradle
@@ -236,9 +236,7 @@ subprojects {
     }
   }
 
-  if (project.name == 'util') return
-  if (project.name == 'proxy') return
-  if (project.name == 'core') return
+  if (['util', 'proxy', 'core', 'prober'].contains(project.name)) return
 
   test {
     testLogging.showStandardStreams = Boolean.parseBoolean(showAllOutput)

--- a/config/dependency-license/allowed_licenses.json
+++ b/config/dependency-license/allowed_licenses.json
@@ -109,6 +109,9 @@
       "moduleLicense": "Eclipse Public License 1.0"
     },
     {
+      "moduleLicense": "Eclipse Public License v1.0"
+    },
+    {
       "moduleLicense": "Google App Engine Terms of Service"
     },
     {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,5 @@ uploaderCredentialsFile=
 uploaderMultithreadedUpload=
 flowDocsFile=
 enableDependencyLocking=true
+# TODO(b/138857168): Swtich back to Google JDK8 when the fix is released.
+org.gradle.java.home=/usr/lib/jvm/java-8-openjdk-amd64

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -94,9 +94,10 @@ spotless {
   }
 }
 
-// Set coverage minimums for each sub project.
-// We use the current instruction-level coverage ratios.
+// Initialize for coverage minimum determination for each sub project.
 task initCoverageMinimums {
+  // Use current coverage ratio of each subproject as placeholder value.
+  // Long-term plan is to calculate incremental coverage on the fly.
   rootProject.ext.coverageMinimums = [
      'core'    : 0.6,
      'proxy'   : 0.52,

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -17,10 +17,13 @@ apply plugin: 'nebula.lint'
 apply plugin: 'net.ltgt.apt'
 apply plugin: 'net.ltgt.errorprone'
 apply plugin: 'checkstyle'
+apply plugin: 'jacoco'
 
 // Checkstyle should run as part of the testing task
 tasks.test.dependsOn tasks.checkstyleMain
 tasks.test.dependsOn tasks.checkstyleTest
+
+tasks.test.finalizedBy jacocoTestReport
 
 dependencies {
     // compatibility with Java 8

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -23,6 +23,9 @@ apply plugin: 'jacoco'
 tasks.test.dependsOn tasks.checkstyleMain
 tasks.test.dependsOn tasks.checkstyleTest
 
+// Generate per-subproject reports in build/reports/jacoco directory.
+// TODO(weiminyu): publish periodical reports to well known location.
+// TODO(weiminyu): investigate incremental coverage change calculation and alert.
 tasks.test.finalizedBy jacocoTestReport
 
 dependencies {
@@ -88,5 +91,44 @@ spotless {
     trimTrailingWhitespace()
     indentWithSpaces(2)
     endWithNewline()
+  }
+}
+
+// Set coverage minimums for each sub project.
+// We use the current instruction-level coverage ratios.
+task initCoverageMinimums {
+  rootProject.ext.coverageMinimums = [
+     'core'    : 0.6,
+     'proxy'   : 0.52,
+     'util'    : 0.57
+  ].asImmutable()
+
+  rootProject.ext.getMinCoverage = { key ->
+    if (rootProject.ext.coverageMinimums.containsKey(key)) {
+      return rootProject.ext.coverageMinimums.get(key)
+    }
+    return 0.0
+  }
+}
+
+// Alerts for coverage violation. Note that,
+// - This task is FYI only and needs to be invoked explicitly. We will consider
+// - This task does not address incremental coverage.
+jacocoTestCoverageVerification {
+
+  dependsOn initCoverageMinimums
+
+  violationRules {
+    rule {
+      // Each limit consists of the following properties:
+      // - An 'element' type: BUNDLE (default), PACKAGE, CLASS, SOURCEFILE, or METHOD.
+      // - A 'counter' type: INSTRUCTION (default), LINE, BRANCH, COMPLEXITY, METHOD, or CLASS
+      // - A 'value' type: TOTALCOUNT, COVEREDCOUNT, MISSEDCOUNT, COVEREDRATIO (default),
+      //   or MISSEDRATIO
+      // - The 'minimum' threshold, given as a fraction or a percentage (including '%')
+      limit {
+        minimum = rootProject.ext.getMinCoverage(project.getName())
+      }
+    }
   }
 }

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -112,7 +112,7 @@ task initCoverageMinimums {
 }
 
 // Alerts for coverage violation. Note that,
-// - This task is FYI only and needs to be invoked explicitly. We will consider
+// - This task is FYI only and needs to be invoked explicitly.
 // - This task does not address incremental coverage.
 jacocoTestCoverageVerification {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1007,8 +1007,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1029,14 +1028,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1051,20 +1048,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1181,8 +1175,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1194,7 +1187,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1209,7 +1201,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1217,14 +1208,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1243,7 +1232,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1324,8 +1312,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1337,7 +1324,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1423,8 +1409,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1460,7 +1445,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1480,7 +1464,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1524,14 +1507,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1007,7 +1007,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1028,12 +1029,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1048,17 +1051,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1175,7 +1181,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1187,6 +1194,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1201,6 +1209,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1208,12 +1217,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1232,6 +1243,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1312,7 +1324,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1324,6 +1337,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1409,7 +1423,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1445,6 +1460,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1464,6 +1480,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1507,12 +1524,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/prober/build.gradle
+++ b/prober/build.gradle
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,38 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-apply plugin: 'java'
-
 createUberJar('deployJar', 'prober', 'google.registry.monitoring.blackbox.Prober')
 
 dependencies {
-    def deps = rootProject.dependencyMap
+  def deps = rootProject.dependencyMap
 
-    compile deps['com.google.auto.value:auto-value-annotations']
-    compile deps['com.google.dagger:dagger']
-    compile deps['com.google.flogger:flogger']
-    compile deps['com.google.guava:guava']
-    compile deps['io.netty:netty-buffer']
-    compile deps['io.netty:netty-codec-http']
-    compile deps['io.netty:netty-codec']
-    compile deps['io.netty:netty-common']
-    compile deps['io.netty:netty-handler']
-    compile deps['io.netty:netty-transport']
-    compile deps['javax.inject:javax.inject']
+  compile deps['com.google.auto.value:auto-value-annotations']
+  compile deps['com.google.dagger:dagger']
+  compile deps['com.google.flogger:flogger']
+  compile deps['com.google.guava:guava']
+  compile deps['io.netty:netty-buffer']
+  compile deps['io.netty:netty-codec-http']
+  compile deps['io.netty:netty-codec']
+  compile deps['io.netty:netty-common']
+  compile deps['io.netty:netty-handler']
+  compile deps['io.netty:netty-transport']
+  compile deps['javax.inject:javax.inject']
 
-    runtime deps['com.google.flogger:flogger-system-backend']
-    runtime deps['com.google.auto.value:auto-value']
-    runtime deps['io.netty:netty-tcnative-boringssl-static']
+  runtime deps['com.google.flogger:flogger-system-backend']
+  runtime deps['com.google.auto.value:auto-value']
+  runtime deps['io.netty:netty-tcnative-boringssl-static']
 
-    testCompile deps['com.google.truth:truth']
-    testCompile deps['junit:junit']
-    testCompile deps['org.mockito:mockito-core']
-    testCompile project(':third_party')
+  testCompile deps['com.google.truth:truth']
+  testCompile deps['junit:junit']
+  testCompile deps['org.mockito:mockito-core']
+  testCompile project(':third_party')
 
-    // Include auto-value in compile until nebula-lint understands
-    // annotationProcessor
-    annotationProcessor deps['com.google.auto.value:auto-value']
-    testAnnotationProcessor deps['com.google.auto.value:auto-value']
-    annotationProcessor deps['com.google.dagger:dagger-compiler']
-    testAnnotationProcessor deps['com.google.dagger:dagger-compiler']
+  // Include auto-value in compile until nebula-lint understands
+  // annotationProcessor
+  annotationProcessor deps['com.google.auto.value:auto-value']
+  testAnnotationProcessor deps['com.google.auto.value:auto-value']
+  annotationProcessor deps['com.google.dagger:dagger-compiler']
+  testAnnotationProcessor deps['com.google.dagger:dagger-compiler']
 }

--- a/prober/src/main/java/google/registry/monitoring/blackbox/Protocol.java
+++ b/prober/src/main/java/google/registry/monitoring/blackbox/Protocol.java
@@ -41,14 +41,16 @@ public abstract class Protocol {
     return new AutoValue_Protocol.Builder();
   }
 
+  /** Builder for {@link Protocol}. */
   @AutoValue.Builder
-  public static abstract class Builder {
+  public abstract static class Builder {
 
     public abstract Builder name(String value);
 
     public abstract Builder port(int num);
 
-    public abstract Builder handlerProviders(ImmutableList<Provider<? extends ChannelHandler>> providers);
+    public abstract Builder handlerProviders(
+        ImmutableList<Provider<? extends ChannelHandler>> providers);
 
     public abstract Builder persistentConnection(boolean value);
 

--- a/prober/src/main/java/google/registry/monitoring/blackbox/handlers/ActionHandler.java
+++ b/prober/src/main/java/google/registry/monitoring/blackbox/handlers/ActionHandler.java
@@ -17,22 +17,23 @@ package google.registry.monitoring.blackbox.handlers;
 import com.google.common.flogger.FluentLogger;
 import google.registry.monitoring.blackbox.messages.InboundMessageType;
 import google.registry.monitoring.blackbox.messages.OutboundMessageType;
-import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.SimpleChannelInboundHandler;
 
 /**
- *Superclass of all {@link ChannelHandler}s placed at end of channel pipeline
+ * Superclass of all {@link ChannelHandler}s placed at end of channel pipeline
  *
- * <p> {@code ActionHandler} inherits from {@link SimpleChannelInboundHandler< InboundMessageType >}, as it should only be passed in
- * messages that implement the {@link InboundMessageType} interface. </p>
+ * <p>{@code ActionHandler} inherits from {@link SimpleChannelInboundHandler< InboundMessageType >},
+ * as it should only be passed in messages that implement the {@link InboundMessageType} interface.
  *
- * <p> The {@code ActionHandler} skeleton exists for a few main purposes. First, it returns a {@link ChannelPromise},
- * which informs the {@link ProbingAction} in charge that a response has been read. Second, it stores the {@link OutboundMessageType}
- * passed down the pipeline, so that subclasses can use that information for their own processes. Lastly, with any exception
- * thrown, the connection is closed, and the ProbingAction governing this channel is informed of the error. Subclasses
- * specify further work to be done for specific kinds of channel pipelines. </p>
+ * <p>The {@code ActionHandler} skeleton exists for a few main purposes. First, it returns a {@link
+ * ChannelPromise}, which informs the {@link ProbingAction} in charge that a response has been read.
+ * Second, it stores the {@link OutboundMessageType} passed down the pipeline, so that subclasses
+ * can use that information for their own processes. Lastly, with any exception thrown, the
+ * connection is closed, and the ProbingAction governing this channel is informed of the error.
+ * Subclasses specify further work to be done for specific kinds of channel pipelines.
  */
 public abstract class ActionHandler extends SimpleChannelInboundHandler<InboundMessageType> {
 
@@ -40,7 +41,10 @@ public abstract class ActionHandler extends SimpleChannelInboundHandler<InboundM
 
   protected ChannelPromise finished;
 
-  /** Takes in {@link OutboundMessageType} type and saves for subclasses. Then returns initialized {@link ChannelPromise}*/
+  /**
+   * Takes in {@link OutboundMessageType} type and saves for subclasses. Then returns initialized
+   * {@link ChannelPromise}
+   */
   public ChannelFuture getFuture() {
     return finished;
   }
@@ -48,27 +52,30 @@ public abstract class ActionHandler extends SimpleChannelInboundHandler<InboundM
   /** Initializes new {@link ChannelPromise} */
   @Override
   public void handlerAdded(ChannelHandlerContext ctx) {
-    //Once handler is added to channel pipeline, initialize channel and future for this handler
+    // Once handler is added to channel pipeline, initialize channel and future for this handler
     finished = ctx.newPromise();
   }
 
   @Override
-  public void channelRead0(ChannelHandlerContext ctx, InboundMessageType inboundMessage) throws Exception {
-    //simply marks finished as success
-    finished.setSuccess();
+  public void channelRead0(ChannelHandlerContext ctx, InboundMessageType inboundMessage)
+      throws Exception {
+    // simply marks finished as success
+    finished = finished.setSuccess();
   }
 
-  /** Logs the channel and pipeline that caused error, closes channel, then informs {@link ProbingAction} listeners of error */
+  /**
+   * Logs the channel and pipeline that caused error, closes channel, then informs {@link
+   * ProbingAction} listeners of error
+   */
   @Override
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-    logger.atSevere().withCause(cause).log(String.format(
-        "Attempted Action was unsuccessful with channel: %s, having pipeline: %s",
-        ctx.channel().toString(),
-        ctx.channel().pipeline().toString()));
+    logger.atSevere().withCause(cause).log(
+        String.format(
+            "Attempted Action was unsuccessful with channel: %s, having pipeline: %s",
+            ctx.channel().toString(), ctx.channel().pipeline().toString()));
 
-    finished.setFailure(cause);
+    finished = finished.setFailure(cause);
     ChannelFuture closedFuture = ctx.channel().close();
     closedFuture.addListener(f -> logger.atInfo().log("Unsuccessful channel connection closed"));
   }
 }
-

--- a/prober/src/main/java/google/registry/monitoring/blackbox/messages/InboundMessageType.java
+++ b/prober/src/main/java/google/registry/monitoring/blackbox/messages/InboundMessageType.java
@@ -15,7 +15,7 @@
 package google.registry.monitoring.blackbox.messages;
 
 /**
- * Marker Interface that is implemented by all classes that serve as {@code inboundMessages} in channel pipeline
+ * Marker Interface that is implemented by all classes that serve as {@code inboundMessages} in
+ * channel pipeline
  */
 public interface InboundMessageType {}
-

--- a/prober/src/main/java/google/registry/monitoring/blackbox/messages/OutboundMessageType.java
+++ b/prober/src/main/java/google/registry/monitoring/blackbox/messages/OutboundMessageType.java
@@ -15,7 +15,7 @@
 package google.registry.monitoring.blackbox.messages;
 
 /**
- * Marker Interface that is implemented by all classes that serve as {@code outboundMessages} in channel pipeline
+ * Marker Interface that is implemented by all classes that serve as {@code outboundMessages} in
+ * channel pipeline
  */
 public interface OutboundMessageType {}
-

--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-apply plugin: 'java'
-
 createUberJar('deployJar', 'proxy_server', 'google.registry.proxy.ProxyServer')
 
 task buildProxyImage(dependsOn: deployJar, type: Exec) {

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-apply plugin: 'java'
-
 dependencies {
   def deps = rootProject.dependencyMap
   compile deps['com.google.api-client:google-api-client']


### PR DESCRIPTION
Enable jacoco, the official Gradle code coverage plugin.
    
    The 'build' task will write a code coverage report to
    build/reports/jacoco for each subproject that has tests.
    We should consider publish periodical reports to a well known
    location.
    
    This change also defines a minimum coverage verification task.
    The task is for experiment only, and is not added to the build
    process yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/211)
<!-- Reviewable:end -->
