### PR TITLE
Jacoco redo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ plugins {
 
   id 'idea'
   id 'com.diffplug.gradle.spotless' version '3.18.0'
-  
+
   id 'jacoco'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ plugins {
 
   id 'idea'
   id 'com.diffplug.gradle.spotless' version '3.18.0'
+  
+  id 'jacoco'
 }
 
 wrapper {

--- a/config/dependency-license/allowed_licenses.json
+++ b/config/dependency-license/allowed_licenses.json
@@ -109,6 +109,9 @@
       "moduleLicense": "Eclipse Public License 1.0"
     },
     {
+      "moduleLicense": "Eclipse Public License v1.0"
+    },
+    {
       "moduleLicense": "Google App Engine Terms of Service"
     },
     {

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -94,9 +94,10 @@ spotless {
   }
 }
 
-// Set coverage minimums for each sub project.
-// We use the current instruction-level coverage ratios.
+// Initialize for coverage minimum determination for each sub project.
 task initCoverageMinimums {
+  // Use current coverage ratio of each subproject as placeholder value.
+  // Long-term plan is to calculate incremental coverage on the fly.
   rootProject.ext.coverageMinimums = [
      'core'    : 0.6,
      'proxy'   : 0.52,

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -17,10 +17,13 @@ apply plugin: 'nebula.lint'
 apply plugin: 'net.ltgt.apt'
 apply plugin: 'net.ltgt.errorprone'
 apply plugin: 'checkstyle'
+apply plugin: 'jacoco'
 
 // Checkstyle should run as part of the testing task
 tasks.test.dependsOn tasks.checkstyleMain
 tasks.test.dependsOn tasks.checkstyleTest
+
+tasks.test.finalizedBy jacocoTestReport
 
 dependencies {
     // compatibility with Java 8

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -23,6 +23,9 @@ apply plugin: 'jacoco'
 tasks.test.dependsOn tasks.checkstyleMain
 tasks.test.dependsOn tasks.checkstyleTest
 
+// Generate per-subproject reports in build/reports/jacoco directory.
+// TODO(weiminyu): publish periodical reports to well known location.
+// TODO(weiminyu): investigate incremental coverage change calculation and alert.
 tasks.test.finalizedBy jacocoTestReport
 
 dependencies {
@@ -88,5 +91,44 @@ spotless {
     trimTrailingWhitespace()
     indentWithSpaces(2)
     endWithNewline()
+  }
+}
+
+// Set coverage minimums for each sub project.
+// We use the current instruction-level coverage ratios.
+task initCoverageMinimums {
+  rootProject.ext.coverageMinimums = [
+     'core'    : 0.6,
+     'proxy'   : 0.52,
+     'util'    : 0.57
+  ].asImmutable()
+
+  rootProject.ext.getMinCoverage = { key ->
+    if (rootProject.ext.coverageMinimums.containsKey(key)) {
+      return rootProject.ext.coverageMinimums.get(key)
+    }
+    return 0.0
+  }
+}
+
+// Alerts for coverage violation. Note that,
+// - This task is FYI only and needs to be invoked explicitly. We will consider
+// - This task does not address incremental coverage.
+jacocoTestCoverageVerification {
+
+  dependsOn initCoverageMinimums
+
+  violationRules {
+    rule {
+      // Each limit consists of the following properties:
+      // - An 'element' type: BUNDLE (default), PACKAGE, CLASS, SOURCEFILE, or METHOD.
+      // - A 'counter' type: INSTRUCTION (default), LINE, BRANCH, COMPLEXITY, METHOD, or CLASS
+      // - A 'value' type: TOTALCOUNT, COVEREDCOUNT, MISSEDCOUNT, COVEREDRATIO (default),
+      //   or MISSEDRATIO
+      // - The 'minimum' threshold, given as a fraction or a percentage (including '%')
+      limit {
+        minimum = rootProject.ext.getMinCoverage(project.getName())
+      }
+    }
   }
 }

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -112,7 +112,7 @@ task initCoverageMinimums {
 }
 
 // Alerts for coverage violation. Note that,
-// - This task is FYI only and needs to be invoked explicitly. We will consider
+// - This task is FYI only and needs to be invoked explicitly.
 // - This task does not address incremental coverage.
 jacocoTestCoverageVerification {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1007,8 +1007,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1029,14 +1028,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1051,20 +1048,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1181,8 +1175,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1194,7 +1187,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1209,7 +1201,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1217,14 +1208,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1243,7 +1232,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1324,8 +1312,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1337,7 +1324,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1423,8 +1409,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1460,7 +1445,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1480,7 +1464,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1524,14 +1507,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1007,7 +1007,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1028,12 +1029,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1048,17 +1051,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1175,7 +1181,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1187,6 +1194,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1201,6 +1209,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1208,12 +1217,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1232,6 +1243,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1312,7 +1324,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1324,6 +1337,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1409,7 +1423,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1445,6 +1460,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -1464,6 +1480,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1507,12 +1524,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
Generate code coverage report
 
 Enable jacoco, the official Gradle code coverage plugin.
    
 The 'build' task will write a code coverage report to
 build/reports/jacoco for each subproject that has tests.
 We should consider publish periodical reports to a well known
 location.
    
 This change also defines a minimum coverage verification task.
 The task is for experiment only, and is not added to the build
 process yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/215)
<!-- Reviewable:end -->
