### PR TITLE
Generate code coverage report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,8 @@ plugins {
 
   id 'idea'
   id 'com.diffplug.gradle.spotless' version '3.18.0'
+
+  id 'jacoco'
 }
 
 wrapper {

--- a/config/dependency-license/allowed_licenses.json
+++ b/config/dependency-license/allowed_licenses.json
@@ -109,6 +109,9 @@
       "moduleLicense": "Eclipse Public License 1.0"
     },
     {
+      "moduleLicense": "Eclipse Public License v1.0"
+    },
+    {
       "moduleLicense": "Google App Engine Terms of Service"
     },
     {

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -17,10 +17,16 @@ apply plugin: 'nebula.lint'
 apply plugin: 'net.ltgt.apt'
 apply plugin: 'net.ltgt.errorprone'
 apply plugin: 'checkstyle'
+apply plugin: 'jacoco'
 
 // Checkstyle should run as part of the testing task
 tasks.test.dependsOn tasks.checkstyleMain
 tasks.test.dependsOn tasks.checkstyleTest
+
+// Generate per-subproject reports in build/reports/jacoco directory.
+// TODO(weiminyu): publish periodical reports to well known location.
+// TODO(weiminyu): investigate incremental coverage change calculation and alert.
+tasks.test.finalizedBy jacocoTestReport
 
 dependencies {
     // compatibility with Java 8
@@ -85,5 +91,45 @@ spotless {
     trimTrailingWhitespace()
     indentWithSpaces(2)
     endWithNewline()
+  }
+}
+
+// Initialize for coverage minimum determination for each sub project.
+task initCoverageMinimums {
+  // Use current coverage ratio of each subproject as placeholder value.
+  // Long-term plan is to calculate incremental coverage on the fly.
+  rootProject.ext.coverageMinimums = [
+     'core'    : 0.6,
+     'proxy'   : 0.52,
+     'util'    : 0.57
+  ].asImmutable()
+
+  rootProject.ext.getMinCoverage = { key ->
+    if (rootProject.ext.coverageMinimums.containsKey(key)) {
+      return rootProject.ext.coverageMinimums.get(key)
+    }
+    return 0.0
+  }
+}
+
+// Alerts for coverage violation. Note that,
+// - This task is FYI only and needs to be invoked explicitly.
+// - This task does not address incremental coverage.
+jacocoTestCoverageVerification {
+
+  dependsOn initCoverageMinimums
+
+  violationRules {
+    rule {
+      // Each limit consists of the following properties:
+      // - An 'element' type: BUNDLE (default), PACKAGE, CLASS, SOURCEFILE, or METHOD.
+      // - A 'counter' type: INSTRUCTION (default), LINE, BRANCH, COMPLEXITY, METHOD, or CLASS
+      // - A 'value' type: TOTALCOUNT, COVEREDCOUNT, MISSEDCOUNT, COVEREDRATIO (default),
+      //   or MISSEDRATIO
+      // - The 'minimum' threshold, given as a fraction or a percentage (including '%')
+      limit {
+        minimum = rootProject.ext.getMinCoverage(project.getName())
+      }
+    }
   }
 }


### PR DESCRIPTION
Enable jacoco, the official Gradle code coverage plugin.

The 'build' task will write a code coverage report to
build/reports/jacoco for each subproject that has tests.
We should consider publish periodical reports to a well known
location.

This change also defines a minimum coverage verification task.
The task is for experiment only, and is not added to the build
process yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/216)
<!-- Reviewable:end -->
