### PR TITLE
Bucket RDAP metrics by type

### DIFF
--- a/core/src/main/java/google/registry/request/RequestMetrics.java
+++ b/core/src/main/java/google/registry/request/RequestMetrics.java
@@ -18,6 +18,8 @@ import static com.google.monitoring.metrics.EventMetric.DEFAULT_FITTER;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Streams;
 import com.google.common.flogger.FluentLogger;
 import com.google.monitoring.metrics.EventMetric;
 import com.google.monitoring.metrics.LabelDescriptor;
@@ -67,8 +69,7 @@ class RequestMetrics {
     // e.g. "/rdap/domains" rather than "/rdap/domains/foo.tld"
     if (path.startsWith("/rdap")) {
       List<String> splitPath = Splitter.on("/").omitEmptyStrings().splitToList(path);
-      splitPath = splitPath.subList(0, Math.min(2, splitPath.size()));
-      return splitPath.stream().collect(Collectors.joining("/", "/", "/"));
+      return Streams.stream(Iterables.limit(splitPath, 2)).collect(Collectors.joining("/", "/", "/")));
     }
     return path;
   }

--- a/core/src/main/java/google/registry/request/RequestMetrics.java
+++ b/core/src/main/java/google/registry/request/RequestMetrics.java
@@ -69,7 +69,8 @@ class RequestMetrics {
     // e.g. "/rdap/domains" rather than "/rdap/domains/foo.tld"
     if (path.startsWith("/rdap")) {
       List<String> splitPath = Splitter.on("/").omitEmptyStrings().splitToList(path);
-      return Streams.stream(Iterables.limit(splitPath, 2)).collect(Collectors.joining("/", "/", "/"));
+      return Streams.stream(Iterables.limit(splitPath, 2))
+          .collect(Collectors.joining("/", "/", "/"));
     }
     return path;
   }

--- a/core/src/main/java/google/registry/request/RequestMetrics.java
+++ b/core/src/main/java/google/registry/request/RequestMetrics.java
@@ -16,13 +16,15 @@ package google.registry.request;
 
 import static com.google.monitoring.metrics.EventMetric.DEFAULT_FITTER;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.FluentLogger;
 import com.google.monitoring.metrics.EventMetric;
 import com.google.monitoring.metrics.LabelDescriptor;
 import com.google.monitoring.metrics.MetricRegistryImpl;
 import google.registry.request.auth.AuthLevel;
-import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.joda.time.Duration;
 
 class RequestMetrics {
@@ -64,10 +66,9 @@ class RequestMetrics {
     // We want to bucket RDAP requests by type to use less metric space,
     // e.g. "/rdap/domains" rather than "/rdap/domains/foo.tld"
     if (path.startsWith("/rdap")) {
-      String[] splitPath = path.split("/");
-      // First element of the split path is the empty string, so grab that + rdap + the request type
-      String[] rdapBucket = Arrays.copyOfRange(splitPath, 0, Math.max(3, splitPath.length));
-      return String.join("/", rdapBucket);
+      List<String> splitPath = Splitter.on("/").omitEmptyStrings().splitToList(path);
+      splitPath = splitPath.subList(0, Math.min(2, splitPath.size()));
+      return splitPath.stream().collect(Collectors.joining("/", "/", "/"));
     }
     return path;
   }

--- a/core/src/main/java/google/registry/request/RequestMetrics.java
+++ b/core/src/main/java/google/registry/request/RequestMetrics.java
@@ -51,7 +51,7 @@ class RequestMetrics {
       Duration duration, String path, Action.Method method, AuthLevel authLevel, boolean success) {
     requestDurationMetric.record(
         duration.getMillis(),
-        transformPath(path),
+        truncatePath(path),
         String.valueOf(method),
         String.valueOf(authLevel),
         String.valueOf(success));
@@ -60,7 +60,7 @@ class RequestMetrics {
         path, method, authLevel, success, duration.getMillis() / 1000d);
   }
 
-  private String transformPath(String path) {
+  private static String truncatePath(String path) {
     // We want to bucket RDAP requests by type to use less metric space,
     // e.g. "/rdap/domains" rather than "/rdap/domains/foo.tld"
     if (path.startsWith("/rdap")) {

--- a/core/src/main/java/google/registry/request/RequestMetrics.java
+++ b/core/src/main/java/google/registry/request/RequestMetrics.java
@@ -69,7 +69,7 @@ class RequestMetrics {
     // e.g. "/rdap/domains" rather than "/rdap/domains/foo.tld"
     if (path.startsWith("/rdap")) {
       List<String> splitPath = Splitter.on("/").omitEmptyStrings().splitToList(path);
-      return Streams.stream(Iterables.limit(splitPath, 2)).collect(Collectors.joining("/", "/", "/")));
+      return Streams.stream(Iterables.limit(splitPath, 2)).collect(Collectors.joining("/", "/", "/"));
     }
     return path;
   }


### PR DESCRIPTION
Metric usage scales linearly with the number of paths (basically) so we should bucket these

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/220)
<!-- Reviewable:end -->
