### PR TITLE
Make postgres dependency runtime

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -250,7 +250,7 @@ dependencies {
   compile deps['org.hibernate:hibernate-core']
   testCompile deps['junit:junit']
   testCompile deps['org.mockito:mockito-core']
-  compile deps['org.postgresql:postgresql']
+  runtime deps['org.postgresql:postgresql']
 
   // Indirect dependency found by undeclared-dependency check. Such
   // dependencies should go after all other compile and testCompile


### PR DESCRIPTION
Labeling it 'compile' unnecessarily makes psql-dependency a
public contract.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/225)
<!-- Reviewable:end -->
