### PR TITLE
Fix skipDockerIncompatibleTests

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -563,6 +563,10 @@ task fragileTest(type: Test) {
   exclude "**/*TestCase.*", "**/*TestSuite.*"
   include fragileTestPatterns
 
+  if (rootProject.findProperty("skipDockerIncompatibleTests") == "true") {
+    exclude dockerIncompatibleTestPatterns
+  }
+
   // Run every test class in a freshly started process.
   forkEvery 1
 


### PR DESCRIPTION
We have to add a check for the skipDockerIncompatibleTests property in the
fragileTest task, since that's where these tests now live.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/240)
<!-- Reviewable:end -->
