### PR TITLE
Remove the "showAllOutput" property from the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,11 +95,6 @@ tasks.build.dependsOn(tasks.checkLicense)
 
 // Provide defaults for all of the project properties.
 
-// showAllOutput: boolean.  If true, dump all test output during the build.
-if (!project.hasProperty('showAllOutput')) {
-  ext.showAllOutput = 'false'
-}
-
 // Only do linting if the build is successful.
 gradleLint.autoLintAfterFailure = false
 
@@ -242,10 +237,6 @@ subprojects {
   }
 
   if (['util', 'proxy', 'core', 'prober'].contains(project.name)) return
-
-  test {
-    testLogging.showStandardStreams = Boolean.parseBoolean(showAllOutput)
-  }
 
   ext.relativePath = "google/registry/${project.name}"
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -569,9 +569,6 @@ task fragileTest(type: Test) {
 
   // Run every test class in a freshly started process.
   forkEvery 1
-
-  // Uncomment to see test outputs in stdout.
-  //testLogging.showStandardStreams = true
 }
 
 task outcastTest(type: Test) {


### PR DESCRIPTION
It doesn't work very well and has been superseded by "verboseTestOutput",
which does the same thing and more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/247)
<!-- Reviewable:end -->
