### PR TITLE
Output command test output as well as consuming it

### DIFF
--- a/core/src/test/java/google/registry/tools/CommandTestCase.java
+++ b/core/src/test/java/google/registry/tools/CommandTestCase.java
@@ -84,7 +84,7 @@ public abstract class CommandTestCase<C extends Command> {
     RegistryToolEnvironment.UNITTEST.setup(systemPropertyRule);
     command = newCommandInstance();
 
-    // Capture standard output/error.  This is problematic because gradle tests run in parallel in
+    // Capture standard output/error. This is problematic because gradle tests run in parallel in
     // the same JVM.  So first lock out any other tests in this JVM that are trying to do this
     // trick.
     streamsLock.lock();


### PR DESCRIPTION
CommandTestCase currently consumes stdout & stderr for the command being
tested.  Unfortunately, this results in us not being able to see the command
output.  Add an output splitter so that output gets written to the original
stream in addition to being captured.

A simpler approach would be to print the captured data after command
completion.  However, this won't work for tests that become hung and also
won't display output in real-time.

Tested: Ran a command test with verboseTestOutput=true, verified that standard
output was visible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/248)
<!-- Reviewable:end -->
