### PR TITLE
Start postgresql container in generate_sql_schema

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -226,7 +226,7 @@ dependencies {
   testCompile deps['org.seleniumhq.selenium:selenium-chrome-driver']
   testCompile deps['org.seleniumhq.selenium:selenium-java']
   testCompile deps['org.seleniumhq.selenium:selenium-remote-driver']
-  testCompile deps['org.testcontainers:postgresql']
+  compile deps['org.testcontainers:postgresql']
   testCompile deps['org.testcontainers:selenium']
   compile deps['xerces:xmlParserAPIs']
   compile deps['xpp3:xpp3']

--- a/core/src/main/java/google/registry/tools/GenerateSqlSchemaCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateSqlSchemaCommand.java
@@ -16,6 +16,7 @@ package google.registry.tools;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.google.common.annotations.VisibleForTesting;
 import google.registry.model.domain.DomainBase;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -24,6 +25,7 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.schema.TargetType;
+import org.testcontainers.containers.PostgreSQLContainer;
 
 /**
  * Generates a schema for JPA annotated classes using hibernate.
@@ -35,12 +37,25 @@ import org.hibernate.tool.schema.TargetType;
 @Parameters(separators = " =", commandDescription = "Generate postgresql schema.")
 public class GenerateSqlSchemaCommand implements Command {
 
+  @VisibleForTesting
+  public static final String DB_OPTIONS_CLASH =
+      "Database host and port may not be spcified along with the option to start a "
+          + "postgresql container.";
+
+  @VisibleForTesting
   public static final int POSTGRESQL_PORT = 5432;
+
+  private PostgreSQLContainer postgresContainer = null;
 
   @Parameter(
       names = {"-o", "--out-file"},
-      description = "")
+      description = "Name of the output file.")
   String outFile;
+
+  @Parameter(
+      names = {"-s", "--start-postgresql"},
+      description = "If specified, start postgresql in a docker container.")
+  boolean startPostgresql = false;
 
   @Parameter(
       names = {"-a", "--db-host"},
@@ -50,30 +65,64 @@ public class GenerateSqlSchemaCommand implements Command {
   @Parameter(
       names = {"-p", "--db-port"},
       description = "Database port number.  This defaults to the postgresql default port.")
-  int databasePort = POSTGRESQL_PORT;
+  Integer databasePort;
 
   @Override
   public void run() {
-    // TODO(mmuller): Optionally (and perhaps by default) start a postgresql instance container
-    // rather than relying on the user to have one to connect to.
-    Map<String, String> settings = new HashMap<>();
-    settings.put("hibernate.dialect", "org.hibernate.dialect.PostgreSQL9Dialect");
-    settings.put(
-        "hibernate.connection.url",
-        "jdbc:postgresql://" + databaseHost + ":" + databasePort + "/postgres?useSSL=false");
-    settings.put("hibernate.connection.username", "postgres");
-    settings.put("hibernate.connection.password", "domain-registry");
-    settings.put("hibernate.hbm2ddl.auto", "none");
-    settings.put("show_sql", "true");
+    // Start postgres if requested.
+    if (startPostgresql) {
+      // Complain if the user has also specified either --db-host or --db-port.
+      if (databaseHost != null || databasePort != null) {
+        System.err.println(DB_OPTIONS_CLASH);
+        // TODO: it would be nice to exit(1) here, but this breaks testability.
+        return;
+      }
 
-    MetadataSources metadata =
-        new MetadataSources(new StandardServiceRegistryBuilder().applySettings(settings).build());
-    metadata.addAnnotatedClass(DomainBase.class);
-    SchemaExport schemaExport = new SchemaExport();
-    schemaExport.setHaltOnError(true);
-    schemaExport.setFormat(true);
-    schemaExport.setDelimiter(";");
-    schemaExport.setOutputFile(outFile);
-    schemaExport.createOnly(EnumSet.of(TargetType.SCRIPT), metadata.buildMetadata());
+      // Start the container and store the address information.
+      postgresContainer = new PostgreSQLContainer()
+          .withDatabaseName("postgres")
+          .withUsername("postgres")
+          .withPassword("domain-registry");
+      postgresContainer.start();
+      databaseHost = postgresContainer.getContainerIpAddress();
+      databasePort = postgresContainer.getMappedPort(POSTGRESQL_PORT);
+    } else {
+      // Make sure that both database host and port have values, assume localhost:5432.  Note that
+      // we can't specify the default in the definitions, we wouldn't be able to distinguish that
+      // from a user provided value which would be incompatible with --start-postgresql.
+      if (databaseHost == null) {
+        databaseHost = "localhost";
+      }
+      if (databasePort == null) {
+        databasePort = POSTGRESQL_PORT;
+      }
+    }
+
+    try {
+      // Configure hibernate settings.
+      Map<String, String> settings = new HashMap<>();
+      settings.put("hibernate.dialect", "org.hibernate.dialect.PostgreSQL9Dialect");
+      settings.put(
+          "hibernate.connection.url",
+          "jdbc:postgresql://" + databaseHost + ":" + databasePort + "/postgres?useSSL=false");
+      settings.put("hibernate.connection.username", "postgres");
+      settings.put("hibernate.connection.password", "domain-registry");
+      settings.put("hibernate.hbm2ddl.auto", "none");
+      settings.put("show_sql", "true");
+
+      MetadataSources metadata =
+          new MetadataSources(new StandardServiceRegistryBuilder().applySettings(settings).build());
+      metadata.addAnnotatedClass(DomainBase.class);
+      SchemaExport schemaExport = new SchemaExport();
+      schemaExport.setHaltOnError(true);
+      schemaExport.setFormat(true);
+      schemaExport.setDelimiter(";");
+      schemaExport.setOutputFile(outFile);
+      schemaExport.createOnly(EnumSet.of(TargetType.SCRIPT), metadata.buildMetadata());
+    } finally {
+      if (postgresContainer != null) {
+        postgresContainer.stop();
+      }
+    }
   }
 }

--- a/core/src/test/java/google/registry/tools/GenerateSqlSchemaCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateSqlSchemaCommandTest.java
@@ -19,6 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import java.io.File;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -35,7 +36,7 @@ public class GenerateSqlSchemaCommandTest extends CommandTestCase<GenerateSqlSch
 
   @Rule public TemporaryFolder tmp = new TemporaryFolder();
 
-  @Rule public PostgreSQLContainer postgres =
+  @ClassRule public static PostgreSQLContainer postgres =
       new PostgreSQLContainer()
           .withDatabaseName("postgres")
           .withUsername("postgres")
@@ -59,6 +60,24 @@ public class GenerateSqlSchemaCommandTest extends CommandTestCase<GenerateSqlSch
     // We're just interested in verifying that there is a schema file generated, we don't do any
     // checks on the contents, this would make the test too brittle and serves no real purpose.
     // TODO: try running the schema against the test database.
+    assertThat(new File(tmp.getRoot(), "schema.sql").exists()).isTrue();
+  }
+
+  @Test
+  public void testIncompatibleFlags() throws Exception {
+    runCommand(
+        "--out-file=" + tmp.getRoot() + File.separatorChar + "schema.sql",
+        "--db-host=" + containerHostName,
+        "--db-port=" + containerPort,
+        "--start-postgresql");
+    assertInStderr(GenerateSqlSchemaCommand.DB_OPTIONS_CLASH);
+  }
+
+  @Test
+  public void testDockerPostgresql() throws Exception {
+    runCommand(
+        "--start-postgresql",
+        "--out-file=" + tmp.getRoot() + File.separatorChar + "schema.sql");
     assertThat(new File(tmp.getRoot(), "schema.sql").exists()).isTrue();
   }
 }


### PR DESCRIPTION
Add a --start-postgresql option to the nomulus generate_sql_schema command so
that users don't have to start their own docker container to run it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/249)
<!-- Reviewable:end -->
