### PR TITLE
Make parameter names in generate_sql_schema command consistent

### DIFF
--- a/core/src/main/java/google/registry/tools/GenerateSqlSchemaCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateSqlSchemaCommand.java
@@ -28,19 +28,19 @@ import org.hibernate.tool.schema.TargetType;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 /**
- * Generates a schema for JPA annotated classes using hibernate.
+ * Generates a schema for JPA annotated classes using Hibernate.
  *
  * <p>Note that this isn't complete yet, as all of the persistent classes have not yet been
  * converted. After converting a class, a call to "addAnnotatedClass()" for the new class must be
  * added to the code below.
  */
-@Parameters(separators = " =", commandDescription = "Generate postgresql schema.")
+@Parameters(separators = " =", commandDescription = "Generate PostgreSQL schema.")
 public class GenerateSqlSchemaCommand implements Command {
 
   @VisibleForTesting
   public static final String DB_OPTIONS_CLASH =
-      "Database host and port may not be spcified along with the option to start a "
-          + "postgresql container.";
+      "Database host and port may not be specified along with the option to start a "
+          + "PostgreSQL container.";
 
   @VisibleForTesting
   public static final int POSTGRESQL_PORT = 5432;
@@ -48,31 +48,31 @@ public class GenerateSqlSchemaCommand implements Command {
   private PostgreSQLContainer postgresContainer = null;
 
   @Parameter(
-      names = {"-o", "--out-file"},
+      names = {"-o", "--out_file"},
       description = "Name of the output file.",
       required = true)
   String outFile;
 
   @Parameter(
-      names = {"-s", "--start-postgresql"},
-      description = "If specified, start postgresql in a docker container.")
+      names = {"-s", "--start_postgresql"},
+      description = "If specified, start PostgreSQL in a Docker container.")
   boolean startPostgresql = false;
 
   @Parameter(
-      names = {"-a", "--db-host"},
+      names = {"-a", "--db_host"},
       description = "Database host name.")
   String databaseHost;
 
   @Parameter(
-      names = {"-p", "--db-port"},
-      description = "Database port number.  This defaults to the postgresql default port.")
+      names = {"-p", "--db_port"},
+      description = "Database port number.  This defaults to the PostgreSQL default port.")
   Integer databasePort;
 
   @Override
   public void run() {
-    // Start postgres if requested.
+    // Start PostgreSQL if requested.
     if (startPostgresql) {
-      // Complain if the user has also specified either --db-host or --db-port.
+      // Complain if the user has also specified either --db_host or --db_port.
       if (databaseHost != null || databasePort != null) {
         System.err.println(DB_OPTIONS_CLASH);
         // TODO: it would be nice to exit(1) here, but this breaks testability.
@@ -89,8 +89,8 @@ public class GenerateSqlSchemaCommand implements Command {
       databasePort = postgresContainer.getMappedPort(POSTGRESQL_PORT);
     } else if (databaseHost == null) {
       System.err.println(
-          "You must specify either --start-postgresql to start a PostgreSQL database in a\n"
-              + "docker instance, or specify --db-host (and, optionally, --db-port) to identify\n"
+          "You must specify either --start_postgresql to start a PostgreSQL database in a\n"
+              + "docker instance, or specify --db_host (and, optionally, --db_port) to identify\n"
               + "the location of a running instance.  To start a long-lived instance (suitable\n"
               + "for running this command multiple times) run this:\n\n"
               + "  docker run --rm --name some-postgres -e POSTGRES_PASSWORD=domain-registry \\\n"
@@ -99,7 +99,7 @@ public class GenerateSqlSchemaCommand implements Command {
               + "  docker inspect <container-id> | grep IPAddress\n\n"
               + "To obtain the value for --db-host.\n"
               );
-      // TODO: need exit(1), see above.
+      // TODO(mmuller): need exit(1), see above.
       return;
     }
 
@@ -109,7 +109,7 @@ public class GenerateSqlSchemaCommand implements Command {
     }
 
     try {
-      // Configure hibernate settings.
+      // Configure Hibernate settings.
       Map<String, String> settings = new HashMap<>();
       settings.put("hibernate.dialect", "org.hibernate.dialect.PostgreSQL9Dialect");
       settings.put(

--- a/core/src/test/java/google/registry/tools/GenerateSqlSchemaCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateSqlSchemaCommandTest.java
@@ -28,6 +28,7 @@ import org.junit.runners.JUnit4;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 
+/** Unit tests for {@link google.registry.tools.GenerateSqlSchemaCommand}. */
 @RunWith(JUnit4.class)
 public class GenerateSqlSchemaCommandTest extends CommandTestCase<GenerateSqlSchemaCommand> {
 
@@ -53,9 +54,9 @@ public class GenerateSqlSchemaCommandTest extends CommandTestCase<GenerateSqlSch
   @Test
   public void testSchemaGeneration() throws Exception {
     runCommand(
-        "--out-file=" + tmp.getRoot() + File.separatorChar + "schema.sql",
-        "--db-host=" + containerHostName,
-        "--db-port=" + containerPort);
+        "--out_file=" + tmp.getRoot() + File.separatorChar + "schema.sql",
+        "--db_host=" + containerHostName,
+        "--db_port=" + containerPort);
 
     // We're just interested in verifying that there is a schema file generated, we don't do any
     // checks on the contents, this would make the test too brittle and serves no real purpose.
@@ -66,18 +67,18 @@ public class GenerateSqlSchemaCommandTest extends CommandTestCase<GenerateSqlSch
   @Test
   public void testIncompatibleFlags() throws Exception {
     runCommand(
-        "--out-file=" + tmp.getRoot() + File.separatorChar + "schema.sql",
-        "--db-host=" + containerHostName,
-        "--db-port=" + containerPort,
-        "--start-postgresql");
+        "--out_file=" + tmp.getRoot() + File.separatorChar + "schema.sql",
+        "--db_host=" + containerHostName,
+        "--db_port=" + containerPort,
+        "--start_postgresql");
     assertInStderr(GenerateSqlSchemaCommand.DB_OPTIONS_CLASH);
   }
 
   @Test
   public void testDockerPostgresql() throws Exception {
     runCommand(
-        "--start-postgresql",
-        "--out-file=" + tmp.getRoot() + File.separatorChar + "schema.sql");
+        "--start_postgresql",
+        "--out_file=" + tmp.getRoot() + File.separatorChar + "schema.sql");
     assertThat(new File(tmp.getRoot(), "schema.sql").exists()).isTrue();
   }
 }


### PR DESCRIPTION
The rest of the nomulus commands use underscores for delimiting words in
parameter names, so this should too.

Also fixed capitalization of some proper nouns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/250)
<!-- Reviewable:end -->
