### PR TITLE
Fix command tests that set stdout/stderr

### DIFF
--- a/core/src/test/java/google/registry/tools/CreateTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateTldCommandTest.java
@@ -34,8 +34,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
 import com.googlecode.objectify.Key;
 import google.registry.model.registry.Registry;
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.math.BigDecimal;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
@@ -472,14 +470,11 @@ public class CreateTldCommandTest extends CommandTestCase<CreateTldCommand> {
 
   @Test
   public void testSuccess_setCommonAndReservedListFromOtherTld_withOverride() throws Exception {
-    ByteArrayOutputStream errContent = new ByteArrayOutputStream();
-    System.setErr(new PrintStream(errContent));
     runReservedListsTestOverride("common_abuse,tld_banned");
     String errMsg =
         "Error overridden: The reserved list(s) tld_banned "
             + "cannot be applied to the tld xn--q9jyb4c";
-    assertThat(errContent.toString()).contains(errMsg);
-    System.setOut(null);
+    assertThat(getStderrAsString()).contains(errMsg);
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/UpdateTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateTldCommandTest.java
@@ -38,8 +38,6 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.googlecode.objectify.Key;
 import google.registry.model.registry.Registry;
 import google.registry.model.registry.label.PremiumList;
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
@@ -898,14 +896,11 @@ public class UpdateTldCommandTest extends CommandTestCase<UpdateTldCommand> {
 
   @Test
   public void testSuccess_setCommonAndReservedListFromOtherTld_withOverride() throws Exception {
-    ByteArrayOutputStream errContent = new ByteArrayOutputStream();
-    System.setErr(new PrintStream(errContent));
     runReservedListsTestOverride("common_abuse,tld_banned");
     String errMsg =
         "Error overridden: The reserved list(s) tld_banned "
             + "cannot be applied to the tld xn--q9jyb4c";
-    assertThat(errContent.toString()).contains(errMsg);
-    System.setOut(null);
+    assertThat(getStderrAsString()).contains(errMsg);
   }
 
   @Test


### PR DESCRIPTION
CommandTestCase already wraps stdout stderr, just use the provided methods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/258)
<!-- Reviewable:end -->
