### PR TITLE
Add sql files to manage Cloud SQL user

### DIFF
--- a/db/src/main/resources/sql/user/create_table_readwrite_user.sql
+++ b/db/src/main/resources/sql/user/create_table_readwrite_user.sql
@@ -1,0 +1,21 @@
+-- Copyright 2019 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Script to create a user with read-write permission to all tables.
+
+CREATE USER :username ENCRYPTED PASSWORD :'password';
+GRANT CONNECT ON DATABASE postgres TO :username;
+GRANT USAGE ON SCHEMA public TO :username;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO :username;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO :username;

--- a/db/src/main/resources/sql/user/delete_user.sql
+++ b/db/src/main/resources/sql/user/delete_user.sql
@@ -1,0 +1,22 @@
+-- Copyright 2019 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Script to delete a user from the database.
+
+REVOKE ALL PRIVILEGES ON DATABASE postgres FROM :username;
+REVOKE ALL PRIVILEGES ON SCHEMA public FROM :username;
+REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM :username;
+REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM :username;
+REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public FROM :username;
+DROP USER :username;


### PR DESCRIPTION
Added sql files to create and delete the Cloud SQL user for the nomulus app engine services.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/274)
<!-- Reviewable:end -->
