### PR TITLE
Add work-around for our "explode war" failure

### DIFF
--- a/appengine_war.gradle
+++ b/appengine_war.gradle
@@ -76,6 +76,20 @@ dependencies {
     compile project(':core')
 }
 
+// The tools.jar file gets pulled in from the java environment and for some
+// reason gets exploded "readonly", causing subsequent builds to fail when
+// they can't overwrite it.  The hack below makes the file writable after
+// we're done exploding it.
+//
+// Fun fact: We only use this jar for documentation generation and as such we
+// don't need it in our warfile, as it is not used by the application at
+// runtime.  But it's not clear how to exclude it, as we seem to be
+// constructing the jar from the entire WEB-INF directory and per-file
+// exclude rules don't seem to work on it.  Better solutions are welcome :-)
+explodeWar.doLast {
+    file("${it.explodedAppDirectory}/WEB-INF/lib/tools.jar").setWritable(true)
+}
+
 rootProject.deploy.dependsOn appengineDeployAll
 rootProject.stage.dependsOn appengineStage
 appengineDeployAll.dependsOn rootProject.verifyDeployment


### PR DESCRIPTION
For some reason tools.jar (which we don't need in the runtime in the first
place) gets exploded readonly, causing subsequent builds to fail since they
can't overwrite it.  This hack makes it writable at the end of explodeWar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/279)
<!-- Reviewable:end -->
