### PR TITLE
Protect KMS-secured data against destruction in upcoming google provi…

### DIFF
--- a/proxy/terraform/modules/kms.tf
+++ b/proxy/terraform/modules/kms.tf
@@ -5,11 +5,16 @@ resource "google_kms_key_ring" "proxy_key_ring" {
 
 resource "google_kms_crypto_key" "proxy_key" {
   name     = "${var.proxy_key}"
-  key_ring = "${google_kms_key_ring.proxy_key_ring.id}"
+  key_ring = google_kms_key_ring.proxy_key_ring.self_link
+
+  lifecycle {
+    # If a crypto key gets destroyed, all data encrypted with it is lost.
+    prevent_destroy = true
+  }
 }
 
 resource "google_kms_crypto_key_iam_member" "ssl_key_decrypter" {
-  crypto_key_id = "${google_kms_crypto_key.proxy_key.id}"
+  crypto_key_id = google_kms_crypto_key.proxy_key.self_link
   role          = "roles/cloudkms.cryptoKeyDecrypter"
   member        = "serviceAccount:${google_service_account.proxy_service_account.email}"
 }


### PR DESCRIPTION
…der update.

Export of cl/270900150.

To refer to a KMS key or key ring, we should use the stable `.self_link`. Using `.id` instead provides an unstable identifier which may change (and it will change in the upcoming update of the google provider to 2.9.1). A change in the identifier will cause Terraform to destroy and recreate the key. Destroying the key means all data associated with it is lost; the key cannot be recreated.

This CL replaces `.id` with `.self_link`, so all of those problems will not happen. In addition, `prevent_destroy` protects the key against delete-and-recreate in general.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/284)
<!-- Reviewable:end -->
