### PR TITLE
Add initial support for persisting premium lists to Cloud SQL

### DIFF
--- a/core/src/main/java/google/registry/persistence/CreateAutoTimestampConverter.java
+++ b/core/src/main/java/google/registry/persistence/CreateAutoTimestampConverter.java
@@ -33,8 +33,7 @@ public class CreateAutoTimestampConverter
 
   @Override
   public Timestamp convertToDatabaseColumn(CreateAutoTimestamp entity) {
-    DateTime dateTime =
-        firstNonNull(((CreateAutoTimestamp) entity).getTimestamp(), jpaTm().getTransactionTime());
+    DateTime dateTime = firstNonNull(entity.getTimestamp(), jpaTm().getTransactionTime());
     return Timestamp.from(DateTimeUtils.toZonedDateTime(dateTime).toInstant());
   }
 

--- a/core/src/main/java/google/registry/schema/tld/PremiumList.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumList.java
@@ -17,10 +17,12 @@ package google.registry.schema.tld;
 import static com.google.common.base.Preconditions.checkState;
 
 import google.registry.model.CreateAutoTimestamp;
+import google.registry.persistence.CreateAutoTimestampConverter;
 import java.math.BigDecimal;
 import java.util.Map;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -42,9 +44,7 @@ import org.joda.time.DateTime;
  * This is fine though, because we only use the list with the highest revisionId.
  */
 @Entity
-@Table(
-    name = "PremiumList",
-    indexes = {@Index(columnList = "name", name = "premiumlist_name_idx")})
+@Table(indexes = {@Index(columnList = "name", name = "premiumlist_name_idx")})
 public class PremiumList {
 
   @Column(nullable = false)
@@ -52,10 +52,11 @@ public class PremiumList {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(nullable = false)
+  @Column(name = "revision_id", nullable = false)
   private Long revisionId;
 
   @Column(nullable = false)
+  @Convert(converter = CreateAutoTimestampConverter.class)
   private CreateAutoTimestamp creationTimestamp = CreateAutoTimestamp.create(null);
 
   @Column(nullable = false)

--- a/core/src/main/java/google/registry/schema/tld/PremiumList.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumList.java
@@ -69,10 +69,7 @@ public class PremiumList {
   @Column(name = "price", nullable = false)
   private Map<String, BigDecimal> labelsToPrices;
 
-  private PremiumList(
-      String name,
-      CurrencyUnit currency,
-      Map<String, BigDecimal> labelsToPrices) {
+  private PremiumList(String name, CurrencyUnit currency, Map<String, BigDecimal> labelsToPrices) {
     // TODO(mcilwain): Generate the Bloom filter and set it here.
     this.name = name;
     this.currency = currency;
@@ -84,9 +81,7 @@ public class PremiumList {
 
   /** Constructs a {@link PremiumList} object. */
   public static PremiumList create(
-      String name,
-      CurrencyUnit currency,
-      Map<String, BigDecimal> labelsToPrices) {
+      String name, CurrencyUnit currency, Map<String, BigDecimal> labelsToPrices) {
     return new PremiumList(name, currency, labelsToPrices);
   }
 

--- a/core/src/main/java/google/registry/schema/tld/PremiumList.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumList.java
@@ -44,21 +44,21 @@ import org.joda.time.DateTime;
 @Entity
 @Table(
     name = "PremiumList",
-    indexes = {@Index(columnList = "name", name = "name_idx")})
+    indexes = {@Index(columnList = "name", name = "premiumlist_name_idx")})
 public class PremiumList {
 
-  @Column(name = "name", nullable = false)
+  @Column(nullable = false)
   private String name;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "revision_id", nullable = false)
+  @Column(nullable = false)
   private Long revisionId;
 
-  @Column(name = "creation_timestamp", nullable = false)
+  @Column(nullable = false)
   private CreateAutoTimestamp creationTimestamp = CreateAutoTimestamp.create(null);
 
-  @Column(name = "currency", nullable = false)
+  @Column(nullable = false)
   private CurrencyUnit currency;
 
   @ElementCollection

--- a/core/src/main/java/google/registry/schema/tld/PremiumList.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumList.java
@@ -15,11 +15,9 @@
 package google.registry.schema.tld;
 
 import static com.google.common.base.Preconditions.checkState;
-import static google.registry.util.DateTimeUtils.toJodaDateTime;
-import static google.registry.util.DateTimeUtils.toZonedDateTime;
 
+import google.registry.model.CreateAutoTimestamp;
 import java.math.BigDecimal;
-import java.time.ZonedDateTime;
 import java.util.Map;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -58,7 +56,7 @@ public class PremiumList {
   private Long revisionId;
 
   @Column(name = "creation_timestamp", nullable = false)
-  private ZonedDateTime creationTimestamp;
+  private CreateAutoTimestamp creationTimestamp = CreateAutoTimestamp.create(null);
 
   @Column(name = "currency", nullable = false)
   private CurrencyUnit currency;
@@ -73,11 +71,10 @@ public class PremiumList {
 
   private PremiumList(
       String name,
-      ZonedDateTime creationTimestamp,
       CurrencyUnit currency,
       Map<String, BigDecimal> labelsToPrices) {
+    // TODO(mcilwain): Generate the Bloom filter and set it here.
     this.name = name;
-    this.creationTimestamp = creationTimestamp;
     this.currency = currency;
     this.labelsToPrices = labelsToPrices;
   }
@@ -88,10 +85,9 @@ public class PremiumList {
   /** Constructs a {@link PremiumList} object. */
   public static PremiumList create(
       String name,
-      DateTime creationTimestamp,
       CurrencyUnit currency,
       Map<String, BigDecimal> labelsToPrices) {
-    return new PremiumList(name, toZonedDateTime(creationTimestamp), currency, labelsToPrices);
+    return new PremiumList(name, currency, labelsToPrices);
   }
 
   /** Returns the name of the premium list, which is usually also a TLD string. */
@@ -108,7 +104,7 @@ public class PremiumList {
 
   /** Returns the creation time of this revision of the premium list. */
   public DateTime getCreationTimestamp() {
-    return toJodaDateTime(creationTimestamp);
+    return creationTimestamp.getTimestamp();
   }
 
   /** Returns a {@link Map} of domain labels to prices. */

--- a/core/src/main/java/google/registry/schema/tld/PremiumList.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumList.java
@@ -52,7 +52,7 @@ public class PremiumList {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Column(name = "revision_id", nullable = false)
+  @Column(nullable = false)
   private Long revisionId;
 
   @Column(nullable = false)
@@ -65,8 +65,8 @@ public class PremiumList {
   @ElementCollection
   @CollectionTable(
       name = "PremiumEntry",
-      joinColumns = @JoinColumn(name = "revision_id", referencedColumnName = "revision_id"))
-  @MapKeyColumn(name = "domain_label")
+      joinColumns = @JoinColumn(name = "revisionId", referencedColumnName = "revisionId"))
+  @MapKeyColumn(name = "domainLabel")
   @Column(name = "price", nullable = false)
   private Map<String, BigDecimal> labelsToPrices;
 

--- a/core/src/main/java/google/registry/schema/tld/PremiumListDao.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumListDao.java
@@ -40,11 +40,14 @@ public class PremiumListDao {
    */
   public static boolean checkExists(String premiumListName) {
     return jpaTm()
-            .getEntityManager()
-            .createQuery("SELECT 1 FROM PremiumList WHERE name = :name", Long.class)
-            .setParameter("name", premiumListName)
-            .getSingleResult()
-        > 0;
+        .transact(
+            () ->
+                jpaTm()
+                        .getEntityManager()
+                        .createQuery("SELECT 1 FROM PremiumList WHERE name = :name", Long.class)
+                        .setParameter("name", premiumListName)
+                        .getSingleResult()
+                    > 0);
   }
 
   private PremiumListDao() {}

--- a/core/src/main/java/google/registry/schema/tld/PremiumListDao.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumListDao.java
@@ -1,0 +1,51 @@
+// Copyright 2019 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.schema.tld;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static google.registry.model.transaction.TransactionManagerFactory.jpaTm;
+
+/** Data access object class for {@link PremiumList}. */
+public class PremiumListDao {
+
+  /** Persist a new premium list to Cloud SQL. */
+  public static void saveNew(PremiumList premiumList) {
+    jpaTm()
+        .transact(
+            () -> {
+              checkArgument(
+                  !checkExists(premiumList.getName()),
+                  "A premium list of this name already exists: %s.",
+                  premiumList.getName());
+              jpaTm().getEntityManager().persist(premiumList);
+            });
+  }
+
+  /**
+   * Returns whether the premium list of the given name exists.
+   *
+   * <p>This means that at least one premium list revision must exist for the given name.
+   */
+  public static boolean checkExists(String premiumListName) {
+    return jpaTm()
+            .getEntityManager()
+            .createQuery("SELECT 1 FROM PremiumList WHERE name = :name", Long.class)
+            .setParameter("name", premiumListName)
+            .getSingleResult()
+        > 0;
+  }
+
+  private PremiumListDao() {}
+}

--- a/core/src/main/java/google/registry/schema/tld/PremiumListDao.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumListDao.java
@@ -44,7 +44,7 @@ public class PremiumListDao {
             () ->
                 jpaTm()
                         .getEntityManager()
-                        .createQuery("SELECT 1 FROM PremiumList WHERE name = :name", Long.class)
+                        .createQuery("SELECT 1 FROM PremiumList WHERE name = :name", Integer.class)
                         .setParameter("name", premiumListName)
                         .getSingleResult()
                     > 0);

--- a/core/src/main/java/google/registry/schema/tld/PremiumListDao.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumListDao.java
@@ -46,7 +46,9 @@ public class PremiumListDao {
                         .getEntityManager()
                         .createQuery("SELECT 1 FROM PremiumList WHERE name = :name", Integer.class)
                         .setParameter("name", premiumListName)
-                        .getSingleResult()
+                        .setMaxResults(1)
+                        .getResultList()
+                        .size()
                     > 0);
   }
 

--- a/core/src/main/java/google/registry/tools/CreateOrUpdatePremiumListCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdatePremiumListCommand.java
@@ -16,6 +16,7 @@ package google.registry.tools;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static google.registry.security.JsonHttp.JSON_SAFETY_PREFIX;
+import static google.registry.tools.server.CreateOrUpdatePremiumListAction.ALSO_CLOUD_SQL_PARAM;
 import static google.registry.tools.server.CreateOrUpdatePremiumListAction.INPUT_PARAM;
 import static google.registry.tools.server.CreateOrUpdatePremiumListAction.NAME_PARAM;
 import static google.registry.util.ListNamingUtils.convertFilePathToName;
@@ -57,6 +58,12 @@ abstract class CreateOrUpdatePremiumListCommand extends ConfirmingCommand
       required = true)
   Path inputFile;
 
+  @Parameter(
+      names = {"--also_cloud_sql"},
+      description =
+          "Persist premium list to Cloud SQL in addition to Datastore; defaults to false.")
+  boolean alsoCloudSql;
+
   protected AppEngineConnection connection;
   protected int inputLineCount;
 
@@ -90,6 +97,7 @@ abstract class CreateOrUpdatePremiumListCommand extends ConfirmingCommand
   public String execute() throws Exception {
     ImmutableMap.Builder<String, Object> params = new ImmutableMap.Builder<>();
     params.put(NAME_PARAM, name);
+    params.put(ALSO_CLOUD_SQL_PARAM, alsoCloudSql);
     String inputFileContents = new String(Files.readAllBytes(inputFile), UTF_8);
     String requestBody =
         Joiner.on('&').withKeyValueSeparator("=").join(
@@ -110,7 +118,7 @@ abstract class CreateOrUpdatePremiumListCommand extends ConfirmingCommand
 
   // TODO(user): refactor this behavior into a better general-purpose
   // response validation that can be re-used across the new client/server commands.
-  String extractServerResponse(String response) {
+  private String extractServerResponse(String response) {
     Map<String, Object> responseMap = toMap(JSONValue.parse(stripJsonPrefix(response)));
 
     // TODO(user): consider using jart's FormField Framework.
@@ -127,7 +135,7 @@ abstract class CreateOrUpdatePremiumListCommand extends ConfirmingCommand
   }
 
   // TODO(user): figure out better place to put this method to make it re-usable
-  static String stripJsonPrefix(String json) {
+  private static String stripJsonPrefix(String json) {
     Verify.verify(json.startsWith(JSON_SAFETY_PREFIX));
     return json.substring(JSON_SAFETY_PREFIX.length());
   }

--- a/core/src/main/java/google/registry/tools/CreateOrUpdatePremiumListCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdatePremiumListCommand.java
@@ -74,7 +74,7 @@ abstract class CreateOrUpdatePremiumListCommand extends ConfirmingCommand
 
   abstract String getCommandPath();
 
-  ImmutableMap<String, ?> getParameterMap() {
+  ImmutableMap<String, String> getParameterMap() {
     return ImmutableMap.of();
   }
 
@@ -95,15 +95,15 @@ abstract class CreateOrUpdatePremiumListCommand extends ConfirmingCommand
 
   @Override
   public String execute() throws Exception {
-    ImmutableMap.Builder<String, Object> params = new ImmutableMap.Builder<>();
+    ImmutableMap.Builder<String, String> params = new ImmutableMap.Builder<>();
     params.put(NAME_PARAM, name);
-    params.put(ALSO_CLOUD_SQL_PARAM, alsoCloudSql);
+    params.put(ALSO_CLOUD_SQL_PARAM, Boolean.toString(alsoCloudSql));
     String inputFileContents = new String(Files.readAllBytes(inputFile), UTF_8);
     String requestBody =
         Joiner.on('&').withKeyValueSeparator("=").join(
             ImmutableMap.of(INPUT_PARAM, URLEncoder.encode(inputFileContents, UTF_8.toString())));
 
-    ImmutableMap<String, ?> extraParams = getParameterMap();
+    ImmutableMap<String, String> extraParams = getParameterMap();
     if (extraParams != null) {
       params.putAll(extraParams);
     }

--- a/core/src/main/java/google/registry/tools/CreatePremiumListCommand.java
+++ b/core/src/main/java/google/registry/tools/CreatePremiumListCommand.java
@@ -36,12 +36,11 @@ public class CreatePremiumListCommand extends CreateOrUpdatePremiumListCommand {
   }
 
   @Override
-  ImmutableMap<String, ?> getParameterMap() {
+  ImmutableMap<String, String> getParameterMap() {
     if (override) {
-      return ImmutableMap.of("override", override);
+      return ImmutableMap.of("override", "true");
     } else {
       return ImmutableMap.of();
     }
   }
-
 }

--- a/core/src/main/java/google/registry/tools/server/CreateOrUpdatePremiumListAction.java
+++ b/core/src/main/java/google/registry/tools/server/CreateOrUpdatePremiumListAction.java
@@ -14,13 +14,25 @@
 
 package google.registry.tools.server;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.flogger.LazyArgs.lazy;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
 import com.google.common.flogger.FluentLogger;
+import google.registry.model.registry.label.PremiumList;
+import google.registry.model.registry.label.PremiumList.PremiumListEntry;
 import google.registry.request.JsonResponse;
 import google.registry.request.Parameter;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
 import javax.inject.Inject;
+import org.joda.money.CurrencyUnit;
 
 /**
  * Abstract base class for actions that update premium lists.
@@ -66,6 +78,28 @@ public abstract class CreateOrUpdatePremiumListAction implements Runnable {
         return;
       }
     }
+  }
+
+  google.registry.schema.tld.PremiumList parseInputToPremiumList() {
+    List<String> inputDataPreProcessed =
+        Splitter.on('\n').omitEmptyStrings().splitToList(inputData);
+
+    ImmutableMap<String, PremiumListEntry> prices =
+        new PremiumList.Builder().setName(name).build().parse(inputDataPreProcessed);
+    ImmutableSet<CurrencyUnit> currencies =
+        prices.values().stream()
+            .map(e -> e.getValue().getCurrencyUnit())
+            .distinct()
+            .collect(toImmutableSet());
+    checkArgument(
+        currencies.size() == 1,
+        "The Cloud SQL schema requires exactly one currency, but got: %s",
+        currencies);
+    CurrencyUnit currency = Iterables.getOnlyElement(currencies);
+
+    Map<String, BigDecimal> priceAmounts =
+        Maps.transformValues(prices, ple -> ple.getValue().getAmount());
+    return google.registry.schema.tld.PremiumList.create(name, currency, priceAmounts);
   }
 
   /** Logs the premium list data at INFO, truncated if too long. */

--- a/core/src/main/java/google/registry/tools/server/CreateOrUpdatePremiumListAction.java
+++ b/core/src/main/java/google/registry/tools/server/CreateOrUpdatePremiumListAction.java
@@ -21,6 +21,7 @@ import static com.google.common.flogger.LazyArgs.lazy;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.flogger.FluentLogger;
@@ -101,7 +102,7 @@ public abstract class CreateOrUpdatePremiumListAction implements Runnable {
     checkArgument(
         currencies.size() == 1,
         "The Cloud SQL schema requires exactly one currency, but got: %s",
-        currencies);
+        ImmutableSortedSet.copyOf(currencies));
     CurrencyUnit currency = Iterables.getOnlyElement(currencies);
 
     Map<String, BigDecimal> priceAmounts =

--- a/core/src/main/java/google/registry/tools/server/CreateOrUpdatePremiumListAction.java
+++ b/core/src/main/java/google/registry/tools/server/CreateOrUpdatePremiumListAction.java
@@ -34,9 +34,7 @@ import java.util.Map;
 import javax.inject.Inject;
 import org.joda.money.CurrencyUnit;
 
-/**
- * Abstract base class for actions that update premium lists.
- */
+/** Abstract base class for actions that update premium lists. */
 public abstract class CreateOrUpdatePremiumListAction implements Runnable {
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
@@ -48,9 +46,18 @@ public abstract class CreateOrUpdatePremiumListAction implements Runnable {
   public static final String ALSO_CLOUD_SQL_PARAM = "alsoCloudSql";
 
   @Inject JsonResponse response;
-  @Inject @Parameter("premiumListName") String name;
-  @Inject @Parameter(INPUT_PARAM) String inputData;
-  @Inject @Parameter(ALSO_CLOUD_SQL_PARAM) boolean alsoCloudSql;
+
+  @Inject
+  @Parameter("premiumListName")
+  String name;
+
+  @Inject
+  @Parameter(INPUT_PARAM)
+  String inputData;
+
+  @Inject
+  @Parameter(ALSO_CLOUD_SQL_PARAM)
+  boolean alsoCloudSql;
 
   @Override
   public void run() {

--- a/core/src/main/java/google/registry/tools/server/CreatePremiumListAction.java
+++ b/core/src/main/java/google/registry/tools/server/CreatePremiumListAction.java
@@ -15,20 +15,29 @@
 package google.registry.tools.server;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static google.registry.model.registry.Registries.assertTldExists;
 import static google.registry.model.registry.label.PremiumListUtils.doesPremiumListExist;
 import static google.registry.model.registry.label.PremiumListUtils.savePremiumListAndEntries;
+import static google.registry.model.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.request.Action.Method.POST;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
 import com.google.common.flogger.FluentLogger;
 import google.registry.model.registry.label.PremiumList;
+import google.registry.model.registry.label.PremiumList.PremiumListEntry;
 import google.registry.request.Action;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
+import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import javax.inject.Inject;
+import org.joda.money.CurrencyUnit;
 
 /**
  * An action that creates a premium list, for use by the {@code nomulus create_premium_list}
@@ -50,7 +59,7 @@ public class CreatePremiumListAction extends CreateOrUpdatePremiumListAction {
   @Inject CreatePremiumListAction() {}
 
   @Override
-  protected void savePremiumList() {
+  protected void saveToDatastore() {
     checkArgument(
         !doesPremiumListExist(name), "A premium list of this name already exists: %s.", name);
     if (!override) {
@@ -70,5 +79,56 @@ public class CreatePremiumListAction extends CreateOrUpdatePremiumListAction {
             premiumList.getName(), inputDataPreProcessed.size());
     logger.atInfo().log(message);
     response.setPayload(ImmutableMap.of("status", "success", "message", message));
+  }
+
+  @Override
+  protected void saveToCloudSql() {
+    if (!override) {
+      assertTldExists(name);
+    }
+    logger.atInfo().log("Saving premium list to Cloud SQL for TLD %s", name);
+    // TODO(mcilwain): Call logInputData() here once Datastore persistence is removed.
+    List<String> inputDataPreProcessed =
+        Splitter.on('\n').omitEmptyStrings().splitToList(inputData);
+
+    ImmutableMap<String, PremiumListEntry> prices =
+        new PremiumList.Builder().setName(name).build().parse(inputDataPreProcessed);
+    ImmutableSet<CurrencyUnit> currencies =
+        prices.values().stream()
+            .map(e -> e.getValue().getCurrencyUnit())
+            .distinct()
+            .collect(toImmutableSet());
+    checkArgument(
+        currencies.size() == 1,
+        "The Cloud SQL schema requires exactly one currency, but got: %s",
+        currencies);
+    CurrencyUnit currency = Iterables.getOnlyElement(currencies);
+
+    Map<String, BigDecimal> priceAmounts =
+        Maps.transformValues(prices, ple -> ple.getValue().getAmount());
+    // TODO(mcilwain): Generate the Bloom filter and write it to Cloud SQL.
+    jpaTm()
+        .transact(
+            () -> {
+              checkArgument(
+                  jpaTm()
+                          .getEntityManager()
+                          .createQuery("SELECT 1 FROM PremiumList WHERE name = :name", Long.class)
+                          .setParameter("name", name)
+                          .getSingleResult()
+                      == 0,
+                  "A premium list of this name already exists: %s.",
+                  name);
+              jpaTm()
+                  .getEntityManager()
+                  .persist(
+                      google.registry.schema.tld.PremiumList.create(
+                          name, jpaTm().getTransactionTime(), currency, priceAmounts));
+            });
+
+    String message =
+        String.format("Saved premium list %s with %d entries", name, inputDataPreProcessed.size());
+    logger.atInfo().log(message);
+    // TODO(mcilwain): Call response.setPayload(...) here once Datastore persistence is removed.
   }
 }

--- a/core/src/main/java/google/registry/tools/server/CreatePremiumListAction.java
+++ b/core/src/main/java/google/registry/tools/server/CreatePremiumListAction.java
@@ -15,29 +15,21 @@
 package google.registry.tools.server;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static google.registry.model.registry.Registries.assertTldExists;
 import static google.registry.model.registry.label.PremiumListUtils.doesPremiumListExist;
 import static google.registry.model.registry.label.PremiumListUtils.savePremiumListAndEntries;
-import static google.registry.model.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.request.Action.Method.POST;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
 import com.google.common.flogger.FluentLogger;
 import google.registry.model.registry.label.PremiumList;
-import google.registry.model.registry.label.PremiumList.PremiumListEntry;
 import google.registry.request.Action;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
-import java.math.BigDecimal;
+import google.registry.schema.tld.PremiumListDao;
 import java.util.List;
-import java.util.Map;
 import javax.inject.Inject;
-import org.joda.money.CurrencyUnit;
 
 /**
  * An action that creates a premium list, for use by the {@code nomulus create_premium_list}
@@ -88,46 +80,13 @@ public class CreatePremiumListAction extends CreateOrUpdatePremiumListAction {
     }
     logger.atInfo().log("Saving premium list to Cloud SQL for TLD %s", name);
     // TODO(mcilwain): Call logInputData() here once Datastore persistence is removed.
-    List<String> inputDataPreProcessed =
-        Splitter.on('\n').omitEmptyStrings().splitToList(inputData);
 
-    ImmutableMap<String, PremiumListEntry> prices =
-        new PremiumList.Builder().setName(name).build().parse(inputDataPreProcessed);
-    ImmutableSet<CurrencyUnit> currencies =
-        prices.values().stream()
-            .map(e -> e.getValue().getCurrencyUnit())
-            .distinct()
-            .collect(toImmutableSet());
-    checkArgument(
-        currencies.size() == 1,
-        "The Cloud SQL schema requires exactly one currency, but got: %s",
-        currencies);
-    CurrencyUnit currency = Iterables.getOnlyElement(currencies);
-
-    Map<String, BigDecimal> priceAmounts =
-        Maps.transformValues(prices, ple -> ple.getValue().getAmount());
-    // TODO(mcilwain): Generate the Bloom filter and write it to Cloud SQL.
-    jpaTm()
-        .transact(
-            () -> {
-              checkArgument(
-                  jpaTm()
-                          .getEntityManager()
-                          .createQuery("SELECT 1 FROM PremiumList WHERE name = :name", Long.class)
-                          .setParameter("name", name)
-                          .getSingleResult()
-                      == 0,
-                  "A premium list of this name already exists: %s.",
-                  name);
-              jpaTm()
-                  .getEntityManager()
-                  .persist(
-                      google.registry.schema.tld.PremiumList.create(
-                          name, jpaTm().getTransactionTime(), currency, priceAmounts));
-            });
+    google.registry.schema.tld.PremiumList premiumList = parseInputToPremiumList();
+    PremiumListDao.saveNew(premiumList);
 
     String message =
-        String.format("Saved premium list %s with %d entries", name, inputDataPreProcessed.size());
+        String.format(
+            "Saved premium list %s with %d entries", name, premiumList.getLabelsToPrices().size());
     logger.atInfo().log(message);
     // TODO(mcilwain): Call response.setPayload(...) here once Datastore persistence is removed.
   }

--- a/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
+++ b/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
@@ -61,6 +61,12 @@ public class ToolsServerModule {
   }
 
   @Provides
+  @Parameter("alsoCloudSql")
+  static boolean provideAlsoCloudSql(HttpServletRequest req) {
+    return extractBooleanParameter(req, CreatePremiumListAction.ALSO_CLOUD_SQL_PARAM);
+  }
+
+  @Provides
   @Parameter("premiumListName")
   static String provideName(HttpServletRequest req) {
     return extractRequiredParameter(req, CreatePremiumListAction.NAME_PARAM);

--- a/core/src/main/java/google/registry/tools/server/UpdatePremiumListAction.java
+++ b/core/src/main/java/google/registry/tools/server/UpdatePremiumListAction.java
@@ -46,7 +46,7 @@ public class UpdatePremiumListAction extends CreateOrUpdatePremiumListAction {
   @Inject UpdatePremiumListAction() {}
 
   @Override
-  protected void savePremiumList() {
+  protected void saveToDatastore() {
     Optional<PremiumList> existingPremiumList = PremiumList.getUncached(name);
     checkArgument(
         existingPremiumList.isPresent(),
@@ -66,5 +66,12 @@ public class UpdatePremiumListAction extends CreateOrUpdatePremiumListAction {
             newPremiumList.getName(), inputDataPreProcessed.size());
     logger.atInfo().log(message);
     response.setPayload(ImmutableMap.of("status", "success", "message", message));
+  }
+
+  // TODO(mcilwain): Implement this in a subsequent PR.
+  @Override
+  protected void saveToCloudSql() {
+    throw new UnsupportedOperationException(
+        "Updating of premium lists in Cloud SQL is not supported yet");
   }
 }

--- a/core/src/test/java/google/registry/schema/tld/PremiumListDaoTest.java
+++ b/core/src/test/java/google/registry/schema/tld/PremiumListDaoTest.java
@@ -1,0 +1,69 @@
+// Copyright 2019 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.schema.tld;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.model.transaction.TransactionManagerFactory.jpaTm;
+
+import com.google.common.collect.ImmutableMap;
+import google.registry.model.transaction.JpaTransactionManagerRule;
+import java.math.BigDecimal;
+import org.joda.money.CurrencyUnit;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link PremiumListDao}. */
+@RunWith(JUnit4.class)
+public class PremiumListDaoTest {
+
+  @Rule
+  public final JpaTransactionManagerRule jpaTmRule =
+      new JpaTransactionManagerRule.Builder().build();
+
+  private static final ImmutableMap<String, BigDecimal> TEST_PRICES =
+      ImmutableMap.of(
+          "silver",
+          BigDecimal.valueOf(10.23),
+          "gold",
+          BigDecimal.valueOf(1305.47),
+          "palladium",
+          BigDecimal.valueOf(1552.78));
+
+  @Test
+  public void saveNew_worksSuccessfully() {
+    DateTime beforeTest = DateTime.now(DateTimeZone.UTC);
+    PremiumList premiumList = PremiumList.create("testname", CurrencyUnit.USD, TEST_PRICES);
+    PremiumListDao.saveNew(premiumList);
+    PremiumList persistedList =
+        jpaTm()
+            .getEntityManager()
+            .createQuery("SELECT pl FROM PremiumList pl WHERE pl.name = :name", PremiumList.class)
+            .setParameter("name", "testname")
+            .getSingleResult();
+    assertThat(persistedList.getLabelsToPrices()).containsExactlyEntriesIn(TEST_PRICES);
+    assertThat(persistedList.getCreationTimestamp()).isGreaterThan(beforeTest);
+  }
+
+  @Test
+  public void checkExists_worksSuccessfully() {
+    assertThat(PremiumListDao.checkExists("testlist")).isFalse();
+    PremiumListDao.saveNew(PremiumList.create("testlist", CurrencyUnit.USD, TEST_PRICES));
+    assertThat(PremiumListDao.checkExists("testlist")).isTrue();
+  }
+}

--- a/core/src/test/java/google/registry/schema/tld/PremiumListDaoTest.java
+++ b/core/src/test/java/google/registry/schema/tld/PremiumListDaoTest.java
@@ -16,6 +16,7 @@ package google.registry.schema.tld;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.JUnitBackports.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.transaction.JpaTransactionManagerRule;
@@ -58,6 +59,18 @@ public class PremiumListDaoTest {
             .getSingleResult();
     assertThat(persistedList.getLabelsToPrices()).containsExactlyEntriesIn(TEST_PRICES);
     assertThat(persistedList.getCreationTimestamp()).isGreaterThan(beforeTest);
+  }
+
+  @Test
+  public void saveNew_throwsWhenPremiumListAlreadyExists() {
+    PremiumListDao.saveNew(PremiumList.create("testlist", CurrencyUnit.USD, TEST_PRICES));
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                PremiumListDao.saveNew(
+                    PremiumList.create("testlist", CurrencyUnit.USD, TEST_PRICES)));
+    assertThat(thrown).hasMessageThat().contains("A premium list of this name already exists");
   }
 
   @Test

--- a/core/src/test/java/google/registry/schema/tld/PremiumListDaoTest.java
+++ b/core/src/test/java/google/registry/schema/tld/PremiumListDaoTest.java
@@ -35,7 +35,7 @@ public class PremiumListDaoTest {
 
   @Rule
   public final JpaTransactionManagerRule jpaTmRule =
-      new JpaTransactionManagerRule.Builder().build();
+      new JpaTransactionManagerRule.Builder().withEntityClass(PremiumList.class).build();
 
   private static final ImmutableMap<String, BigDecimal> TEST_PRICES =
       ImmutableMap.of(

--- a/core/src/test/java/google/registry/tools/CreatePremiumListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreatePremiumListCommandTest.java
@@ -67,7 +67,13 @@ public class CreatePremiumListCommandTest<C extends CreatePremiumListCommand>
     verifySentParams(
         connection,
         servletPath,
-        ImmutableMap.of("name", "foo", "inputData", generateInputData(premiumTermsPath)));
+        ImmutableMap.of(
+            "name",
+            "foo",
+            "inputData",
+            generateInputData(premiumTermsPath),
+            "alsoCloudSql",
+            "false"));
   }
 
   @Test
@@ -78,7 +84,28 @@ public class CreatePremiumListCommandTest<C extends CreatePremiumListCommand>
         connection,
         servletPath,
         ImmutableMap.of(
-            "name", "example_premium_terms", "inputData", generateInputData(premiumTermsPath)));
+            "name",
+            "example_premium_terms",
+            "inputData",
+            generateInputData(premiumTermsPath),
+            "alsoCloudSql",
+            "false"));
+  }
+
+  @Test
+  public void testRun_alsoCloudSql() throws Exception {
+    runCommandForced("-i=" + premiumTermsPath, "-n=foo", "--also_cloud_sql");
+    assertInStdout("Successfully");
+    verifySentParams(
+        connection,
+        servletPath,
+        ImmutableMap.of(
+            "name",
+            "foo",
+            "inputData",
+            generateInputData(premiumTermsPath),
+            "alsoCloudSql",
+            "true"));
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/UpdatePremiumListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdatePremiumListCommandTest.java
@@ -57,7 +57,13 @@ public class UpdatePremiumListCommandTest<C extends UpdatePremiumListCommand>
     verifySentParams(
         connection,
         servletPath,
-        ImmutableMap.of("name", "foo", "inputData", generateInputData(premiumTermsPath)));
+        ImmutableMap.of(
+            "name",
+            "foo",
+            "inputData",
+            generateInputData(premiumTermsPath),
+            "alsoCloudSql",
+            "false"));
   }
 
   @Test
@@ -68,6 +74,11 @@ public class UpdatePremiumListCommandTest<C extends UpdatePremiumListCommand>
         connection,
         servletPath,
         ImmutableMap.of(
-            "name", "example_premium_terms", "inputData", generateInputData(premiumTermsPath)));
+            "name",
+            "example_premium_terms",
+            "inputData",
+            generateInputData(premiumTermsPath),
+            "alsoCloudSql",
+            "false"));
   }
 }

--- a/core/src/test/java/google/registry/tools/server/CreateOrUpdatePremiumListActionTest.java
+++ b/core/src/test/java/google/registry/tools/server/CreateOrUpdatePremiumListActionTest.java
@@ -1,0 +1,81 @@
+// Copyright 2017 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.tools.server;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+import static google.registry.model.registry.label.PremiumListUtils.deletePremiumList;
+import static google.registry.model.registry.label.PremiumListUtils.getPremiumPrice;
+import static google.registry.testing.DatastoreHelper.createTlds;
+import static google.registry.testing.DatastoreHelper.loadPremiumListEntries;
+import static google.registry.testing.JUnitBackports.assertThrows;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+
+import com.google.common.collect.ImmutableMap;
+import google.registry.model.registry.Registry;
+import google.registry.schema.tld.PremiumList;
+import google.registry.testing.AppEngineRule;
+import google.registry.testing.FakeJsonResponse;
+import java.math.BigDecimal;
+import org.joda.money.Money;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link CreateOrUpdatePremiumListAction}.
+ */
+@RunWith(JUnit4.class)
+public class CreateOrUpdatePremiumListActionTest {
+
+  @Rule public final AppEngineRule appEngine = AppEngineRule.builder().withDatastore().build();
+
+  private CreatePremiumListAction action;
+  private FakeJsonResponse response;
+
+  @Before
+  public void init() {
+    action = new CreatePremiumListAction();
+    response = new FakeJsonResponse();
+    action.response = response;
+    action.name = "testlist";
+  }
+
+  @Test
+  public void parseInputToPremiumList_works() {
+    action.inputData = "foo,USD 99.50\n" + "bar,USD 30\n" + "baz,USD 10\n";
+    PremiumList premiumList = action.parseInputToPremiumList();
+    assertThat(premiumList.getName()).isEqualTo("testlist");
+    assertThat(premiumList.getLabelsToPrices())
+        .containsExactlyEntriesIn(
+            ImmutableMap.of("foo", twoDigits(99.50), "bar", twoDigits(30), "baz", twoDigits(10)));
+  }
+
+  @Test
+  public void parseInputToPremiumList_throwsOnInconsistentCurrencies() {
+    action.inputData = "foo,USD 99.50\n" + "bar,USD 30\n" + "baz,JPY 990\n";
+    IllegalArgumentException thrown =
+        assertThrows(IllegalArgumentException.class, () -> action.parseInputToPremiumList());
+    assertThat(thrown)
+        .hasMessageThat()
+        .isEqualTo("The Cloud SQL schema requires exactly one currency, but got: [JPY, USD]");
+  }
+
+  private static BigDecimal twoDigits(double num) {
+    return BigDecimal.valueOf((long) (num * 100.0), 2);
+  }
+}

--- a/core/src/test/java/google/registry/tools/server/CreateOrUpdatePremiumListActionTest.java
+++ b/core/src/test/java/google/registry/tools/server/CreateOrUpdatePremiumListActionTest.java
@@ -61,8 +61,7 @@ public class CreateOrUpdatePremiumListActionTest {
     PremiumList premiumList = action.parseInputToPremiumList();
     assertThat(premiumList.getName()).isEqualTo("testlist");
     assertThat(premiumList.getLabelsToPrices())
-        .containsExactlyEntriesIn(
-            ImmutableMap.of("foo", twoDigits(99.50), "bar", twoDigits(30), "baz", twoDigits(10)));
+        .containsExactly("foo", twoDigits(99.50), "bar", twoDigits(30), "baz", twoDigits(10));
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/server/CreateOrUpdatePremiumListActionTest.java
+++ b/core/src/test/java/google/registry/tools/server/CreateOrUpdatePremiumListActionTest.java
@@ -16,29 +16,19 @@ package google.registry.tools.server;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
-import static google.registry.model.registry.label.PremiumListUtils.deletePremiumList;
-import static google.registry.model.registry.label.PremiumListUtils.getPremiumPrice;
-import static google.registry.testing.DatastoreHelper.createTlds;
-import static google.registry.testing.DatastoreHelper.loadPremiumListEntries;
 import static google.registry.testing.JUnitBackports.assertThrows;
-import static javax.servlet.http.HttpServletResponse.SC_OK;
 
-import com.google.common.collect.ImmutableMap;
-import google.registry.model.registry.Registry;
 import google.registry.schema.tld.PremiumList;
 import google.registry.testing.AppEngineRule;
 import google.registry.testing.FakeJsonResponse;
 import java.math.BigDecimal;
-import org.joda.money.Money;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Unit tests for {@link CreateOrUpdatePremiumListAction}.
- */
+/** Unit tests for {@link CreateOrUpdatePremiumListAction}. */
 @RunWith(JUnit4.class)
 public class CreateOrUpdatePremiumListActionTest {
 

--- a/db/src/main/resources/sql/flyway/V5__update_premium_list.sql
+++ b/db/src/main/resources/sql/flyway/V5__update_premium_list.sql
@@ -1,0 +1,17 @@
+-- Copyright 2019 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+alter table "PremiumList" add column if not exists name text not null;
+
+create index if not exists premiumlist_name_idx ON "PremiumList" (name);

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -132,6 +132,7 @@
        revision_id  bigserial not null,
         creation_timestamp timestamptz not null,
         currency bytea not null,
+        name text not null,
         primary key (revision_id)
     );
 
@@ -157,6 +158,7 @@
 
     alter table if exists "Domain_GracePeriod" 
        add constraint UK_4ps2u4y8i5r91wu2n1x2xea28 unique (grace_periods_id);
+create index premiumlist_name_idx on "PremiumList" (name);
 
     alter table if exists "RegistryLock" 
        add constraint idx_registry_lock_repo_id_revision_id unique (repo_id, revision_id);

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -91,7 +91,8 @@ CREATE TABLE public."PremiumEntry" (
 CREATE TABLE public."PremiumList" (
     revision_id bigint NOT NULL,
     creation_timestamp timestamp with time zone NOT NULL,
-    currency bytea NOT NULL
+    currency bytea NOT NULL,
+    name text NOT NULL
 );
 
 
@@ -225,6 +226,13 @@ ALTER TABLE ONLY public."RegistryLock"
 --
 
 CREATE INDEX idx_registry_lock_verification_code ON public."RegistryLock" USING btree (verification_code);
+
+
+--
+-- Name: premiumlist_name_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX premiumlist_name_idx ON public."PremiumList" USING btree (name);
 
 
 --


### PR DESCRIPTION
This adds support to the `nomulus create_premium_list` command only; support for
`nomulus update_premium_list` will be in a subsequent PR.

The design goals for this PR were:
1. Do not change the existing codepaths for premium lists at all, especially not
   on the read path.
2. Write premium lists to Cloud SQL only if requested (i.e. not by default), and
   write to Datastore first so as to not be blocked by errors with Cloud SQL.
3. Reuse existing codepaths to the maximum possible extent (e.g. don't yet
   re-implement premium list parsing; take advantage of the existing logic), but
   also ...
4. Some duplication is OK, since the existing Datastore path will be deleted
   once this migration is complete, leaving only the codepaths for Cloud SQL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/285)
<!-- Reviewable:end -->
