### PR TITLE
Implement ZonedDateTimeConverter

### DIFF
--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -61,6 +61,8 @@ public class PersistenceModule {
     // SessionFactory is created. Setting it to 'none' to turn off the feature.
     properties.put(Environment.HBM2DDL_AUTO, "none");
 
+    // Hibernate converts any date to this timezone when writing to the database.
+    properties.put(Environment.JDBC_TIME_ZONE, "UTC");
     properties.put(
         Environment.PHYSICAL_NAMING_STRATEGY, NomulusNamingStrategy.class.getCanonicalName());
 

--- a/core/src/main/java/google/registry/persistence/ZonedDateTimeConverter.java
+++ b/core/src/main/java/google/registry/persistence/ZonedDateTimeConverter.java
@@ -1,0 +1,48 @@
+// Copyright 2019 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.persistence;
+
+import java.sql.Timestamp;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import javax.annotation.Nullable;
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+/**
+ * JPA converter to for storing/retrieving {@link ZonedDateTime} objects.
+ *
+ * <p>Hibernate provides a default converter for {@link ZonedDateTime}, but it converts timestamp to
+ * a non-normalized format, e.g., 2019-09-01T01:01:01Z will be converted to
+ * 2019-09-01T01:01:01Z[UTC]. This converter solves that problem by explicitly calling {@link
+ * ZoneId#normalized()} to normalize the zone id.
+ */
+@Converter(autoApply = true)
+public class ZonedDateTimeConverter implements AttributeConverter<ZonedDateTime, Timestamp> {
+
+  @Override
+  @Nullable
+  public Timestamp convertToDatabaseColumn(@Nullable ZonedDateTime attribute) {
+    return attribute == null ? null : Timestamp.from(attribute.toInstant());
+  }
+
+  @Override
+  @Nullable
+  public ZonedDateTime convertToEntityAttribute(@Nullable Timestamp dbData) {
+    return dbData == null
+        ? null
+        : ZonedDateTime.ofInstant(dbData.toInstant(), ZoneId.of("UTC").normalized());
+  }
+}

--- a/core/src/main/java/google/registry/tools/GenerateSqlSchemaCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateSqlSchemaCommand.java
@@ -31,6 +31,7 @@ import google.registry.persistence.CreateAutoTimestampConverter;
 import google.registry.persistence.NomulusNamingStrategy;
 import google.registry.persistence.NomulusPostgreSQLDialect;
 import google.registry.persistence.UpdateAutoTimestampConverter;
+import google.registry.persistence.ZonedDateTimeConverter;
 import google.registry.schema.domain.RegistryLock;
 import google.registry.schema.tld.PremiumList;
 import google.registry.schema.tmch.ClaimsList;
@@ -74,7 +75,8 @@ public class GenerateSqlSchemaCommand implements Command {
           RegistryLock.class,
           TransferData.class,
           Trid.class,
-          UpdateAutoTimestampConverter.class);
+          UpdateAutoTimestampConverter.class,
+          ZonedDateTimeConverter.class);
 
   @VisibleForTesting
   public static final String DB_OPTIONS_CLASH =

--- a/core/src/main/resources/META-INF/persistence.xml
+++ b/core/src/main/resources/META-INF/persistence.xml
@@ -35,6 +35,7 @@
     <!-- Customized type converters -->
     <class>google.registry.persistence.CreateAutoTimestampConverter</class>
     <class>google.registry.persistence.UpdateAutoTimestampConverter</class>
+    <class>google.registry.persistence.ZonedDateTimeConverter</class>
 
     <!-- TODO(weiminyu): check out application-layer validation. -->
     <validation-mode>NONE</validation-mode>

--- a/core/src/test/java/google/registry/persistence/ZonedDateTimeConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/ZonedDateTimeConverterTest.java
@@ -1,0 +1,104 @@
+// Copyright 2019 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.persistence;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.model.transaction.TransactionManagerFactory.jpaTm;
+
+import com.google.common.collect.ImmutableMap;
+import google.registry.model.transaction.JpaTransactionManagerRule;
+import google.registry.schema.tmch.ClaimsList;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link ZonedDateTimeConverter}. */
+@RunWith(JUnit4.class)
+public class ZonedDateTimeConverterTest {
+
+  @Rule
+  public final JpaTransactionManagerRule jpaTmRule =
+      new JpaTransactionManagerRule.Builder().build();
+
+  private final ZonedDateTimeConverter converter = new ZonedDateTimeConverter();
+
+  @Test
+  public void convertToDatabaseColumn_returnsNullIfInputIsNull() {
+    assertThat(converter.convertToDatabaseColumn(null)).isNull();
+  }
+
+  @Test
+  public void convertToDatabaseColumn_convertsCorrectly() {
+    ZonedDateTime zonedDateTime = ZonedDateTime.parse("2019-09-01T01:01:01Z");
+    assertThat(converter.convertToDatabaseColumn(zonedDateTime).toInstant())
+        .isEqualTo(zonedDateTime.toInstant());
+  }
+
+  @Test
+  public void convertToEntityAttribute_returnsNullIfInputIsNull() {
+    assertThat(converter.convertToEntityAttribute(null)).isNull();
+  }
+
+  @Test
+  public void convertToEntityAttribute_convertsCorrectly() {
+    ZonedDateTime zonedDateTime = ZonedDateTime.parse("2019-09-01T01:01:01Z");
+    Instant instant = zonedDateTime.toInstant();
+    assertThat(converter.convertToEntityAttribute(Timestamp.from(instant)))
+        .isEqualTo(zonedDateTime);
+  }
+
+  @Test
+  public void converter_generatesTimestampWithNormalizedZone() {
+    ClaimsList claimsList =
+        ClaimsList.create(
+            ZonedDateTime.parse("2019-09-01T01:01:01Z"), ImmutableMap.of("label1", "key1"));
+    jpaTm().transact(() -> jpaTm().getEntityManager().persist(claimsList));
+    long revisionId = claimsList.getRevisionId();
+    ClaimsList retrievedClaimsList =
+        jpaTm().transact(() -> jpaTm().getEntityManager().find(ClaimsList.class, revisionId));
+    assertThat(retrievedClaimsList.getCreationTimestamp().toString())
+        .isEqualTo("2019-09-01T01:01:01Z");
+  }
+
+  @Test
+  public void converter_convertsNonNormalizedZoneCorrectly() {
+    ClaimsList claimsList =
+        ClaimsList.create(
+            ZonedDateTime.parse("2019-09-01T01:01:01Z[UTC]"), ImmutableMap.of("label1", "key1"));
+    jpaTm().transact(() -> jpaTm().getEntityManager().persist(claimsList));
+    long revisionId = claimsList.getRevisionId();
+    ClaimsList retrievedClaimsList =
+        jpaTm().transact(() -> jpaTm().getEntityManager().find(ClaimsList.class, revisionId));
+    assertThat(retrievedClaimsList.getCreationTimestamp().toString())
+        .isEqualTo("2019-09-01T01:01:01Z");
+  }
+
+  @Test
+  public void converter_convertsNonUtcZoneCorrectly() {
+    ClaimsList claimsList =
+        ClaimsList.create(
+            ZonedDateTime.parse("2019-09-01T01:01:01+05:00"), ImmutableMap.of("label1", "key1"));
+    jpaTm().transact(() -> jpaTm().getEntityManager().persist(claimsList));
+    long revisionId = claimsList.getRevisionId();
+    ClaimsList retrievedClaimsList =
+        jpaTm().transact(() -> jpaTm().getEntityManager().find(ClaimsList.class, revisionId));
+    assertThat(retrievedClaimsList.getCreationTimestamp().toString())
+        .isEqualTo("2019-08-31T20:01:01Z");
+  }
+}

--- a/core/src/test/java/google/registry/rde/EscrowTaskRunnerTest.java
+++ b/core/src/test/java/google/registry/rde/EscrowTaskRunnerTest.java
@@ -35,6 +35,7 @@ import google.registry.testing.FakeClock;
 import google.registry.testing.FakeLockHandler;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -54,8 +55,10 @@ public class EscrowTaskRunnerTest {
   private final EscrowTask task = mock(EscrowTask.class);
   private final FakeClock clock = new FakeClock(DateTime.parse("2000-01-01TZ"));
 
+  private DateTimeZone previousDateTimeZone;
   private EscrowTaskRunner runner;
   private Registry registry;
+
 
   @Before
   public void before() {
@@ -64,7 +67,13 @@ public class EscrowTaskRunnerTest {
     runner = new EscrowTaskRunner();
     runner.clock = clock;
     runner.lockHandler = new FakeLockHandler(true);
+    previousDateTimeZone = DateTimeZone.getDefault();
     DateTimeZone.setDefault(DateTimeZone.forID("America/New_York"));  // Make sure UTC stuff works.
+  }
+
+  @After
+  public void after() {
+    DateTimeZone.setDefault(previousDateTimeZone);
   }
 
   @Test


### PR DESCRIPTION
Hibernate provides a default converter for ZonedDateTime, but it converts timestamp to a non-normalized format, e.g., 2019-09-01T01:01:01Z will be converted to 2019-09-01T01:01:01Z[UTC]. This converter solves that problem by explicitly calling ZoneId.normalized() to normalize the zone id.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/287)
<!-- Reviewable:end -->
