### PR TITLE
Refactor environment -> project map out of build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,13 +119,9 @@ task stage {
 
 def environments = ['production', 'sandbox', 'alpha', 'crash']
 
-// TODO(mmuller): Move this into internal specialization code.
-def projects = ['production': 'domain-registry',
-                'sandbox'   : 'domain-registry-sandbox',
-                'alpha'     : 'domain-registry-alpha',
-                'crash'     : 'domain-registry-crash']
-
 def gcpProject = null
+
+apply from: "${rootDir.path}/projects.gradle"
 
 if (environment == '') {
     // Keep the project null, this will prevent deployment.  Set the
@@ -135,7 +131,8 @@ if (environment == '') {
 } else if (environment != 'production' && environment != 'sandbox') {
     gcpProject = projects[environment]
     if (gcpProject == null) {
-        throw new GradleException("-Penvironment must be one of ${environments}.")
+        throw new GradleException("-Penvironment must be one of " +
+                                  "${projects.keySet()}.")
     }
 }
 

--- a/projects.gradle
+++ b/projects.gradle
@@ -1,0 +1,21 @@
+// Copyright 2019 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Mapping from environment names to GCP projects.
+// Replace the values with the names of your deployment environments.
+
+rootProject.ext.projects = ['production': 'your-production-project',
+                            'sandbox'   : 'your-sandbox-project',
+                            'alpha'     : 'your-alpha-project',
+                            'crash'     : 'your-crash-project']


### PR DESCRIPTION
Move the project mapping into its own file so that it can be more easily
overriden.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/300)
<!-- Reviewable:end -->
