### PR TITLE
Use base64-encoded SQL credentials

### DIFF
--- a/db/build.gradle
+++ b/db/build.gradle
@@ -94,6 +94,7 @@ ext {
     def command =
         """gsutil cp \
            gs://domain-registry${env}-cloudsql-credentials/${role}_credential.enc - | \
+           base64 -d | \
            gcloud kms decrypt --location global --keyring nomulus \
            --key sql-credentials-on-gcs-key --plaintext-file=- \
            --ciphertext-file=- \
@@ -118,11 +119,11 @@ artifacts {
 publishing {
   repositories {
     maven {
-      url project.schema_jar_repo
+      url project.schema_publish_repo
     }
   }
   publications {
-    schemaOrmPublication(MavenPublication) {
+    sqlSchemaPublication(MavenPublication) {
       groupId 'google.registry'
       artifactId 'schema'
       version project.schema_version

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,5 +24,5 @@ dbPassword=
 
 # Maven repository of the Cloud SQL schema jar, which contains the
 # SQL DDL scripts.
-schema_jar_repo=
+schema_publish_repo=
 schema_version=


### PR DESCRIPTION
Encode Cloud SQL credential files on gcs with base64,
to be consistent with our Cloud Build practices.

Also renamed a property that specifies where to publish
the schema jar. New name is schema_publish_repo.

Manually tested relevant Flyway tasks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/314)
<!-- Reviewable:end -->
