### PR TITLE
Don't destroy existing registry lock passwords in contacts

### DIFF
--- a/core/src/main/java/google/registry/ui/server/RegistrarFormFields.java
+++ b/core/src/main/java/google/registry/ui/server/RegistrarFormFields.java
@@ -372,24 +372,20 @@ public final class RegistrarFormFields {
 
   private static void applyRegistrarContactArgs(
       RegistrarContact.Builder builder, Map<String, ?> args) {
-    CONTACT_NAME_FIELD.extractUntyped(args).ifPresent(builder::setName);
-    CONTACT_EMAIL_ADDRESS_FIELD.extractUntyped(args).ifPresent(builder::setEmailAddress);
-    CONTACT_VISIBLE_IN_WHOIS_AS_ADMIN_FIELD
-        .extractUntyped(args)
-        .ifPresent(builder::setVisibleInWhoisAsAdmin);
-    CONTACT_VISIBLE_IN_WHOIS_AS_TECH_FIELD
-        .extractUntyped(args)
-        .ifPresent(builder::setVisibleInWhoisAsTech);
-    PHONE_AND_EMAIL_VISIBLE_IN_DOMAIN_WHOIS_AS_ABUSE_FIELD
-        .extractUntyped(args)
-        .ifPresent(builder::setVisibleInDomainWhoisAsAbuse);
-    CONTACT_PHONE_NUMBER_FIELD.extractUntyped(args).ifPresent(builder::setPhoneNumber);
-    CONTACT_FAX_NUMBER_FIELD.extractUntyped(args).ifPresent(builder::setFaxNumber);
-    CONTACT_TYPES.extractUntyped(args).ifPresent(builder::setTypes);
-    CONTACT_GAE_USER_ID_FIELD.extractUntyped(args).ifPresent(builder::setGaeUserId);
-    CONTACT_ALLOWED_TO_SET_REGISTRY_LOCK_PASSWORD
-        .extractUntyped(args)
-        .ifPresent(builder::setAllowedToSetRegistryLockPassword);
+    builder.setName(CONTACT_NAME_FIELD.extractUntyped(args).orElse(null));
+    builder.setEmailAddress(CONTACT_EMAIL_ADDRESS_FIELD.extractUntyped(args).orElse(null));
+    builder.setVisibleInWhoisAsAdmin(
+        CONTACT_VISIBLE_IN_WHOIS_AS_ADMIN_FIELD.extractUntyped(args).orElse(false));
+    builder.setVisibleInWhoisAsTech(
+        CONTACT_VISIBLE_IN_WHOIS_AS_TECH_FIELD.extractUntyped(args).orElse(false));
+    builder.setVisibleInDomainWhoisAsAbuse(
+        PHONE_AND_EMAIL_VISIBLE_IN_DOMAIN_WHOIS_AS_ABUSE_FIELD.extractUntyped(args).orElse(false));
+    builder.setPhoneNumber(CONTACT_PHONE_NUMBER_FIELD.extractUntyped(args).orElse(null));
+    builder.setFaxNumber(CONTACT_FAX_NUMBER_FIELD.extractUntyped(args).orElse(null));
+    builder.setTypes(CONTACT_TYPES.extractUntyped(args).orElse(ImmutableSet.of()));
+    builder.setGaeUserId(CONTACT_GAE_USER_ID_FIELD.extractUntyped(args).orElse(null));
+    builder.setAllowedToSetRegistryLockPassword(
+        CONTACT_ALLOWED_TO_SET_REGISTRY_LOCK_PASSWORD.extractUntyped(args).orElse(false));
 
     // Registry lock password does not need to be set every time
     CONTACT_REGISTRY_LOCK_PASSWORD_FIELD

--- a/core/src/main/java/google/registry/ui/server/RegistrarFormFields.java
+++ b/core/src/main/java/google/registry/ui/server/RegistrarFormFields.java
@@ -14,6 +14,7 @@
 
 package google.registry.ui.server;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Range.atLeast;
 import static com.google.common.collect.Range.atMost;
 import static com.google.common.collect.Range.closed;
@@ -21,7 +22,9 @@ import static google.registry.util.DomainNameUtils.canonicalizeDomainName;
 
 import com.google.common.base.Ascii;
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.net.InternetDomainName;
 import com.google.re2j.Pattern;
 import google.registry.model.registrar.Registrar;
@@ -194,12 +197,10 @@ public final class RegistrarFormFields {
           FormField.named("visibleInDomainWhoisAsAbuse", Boolean.class).build();
 
   public static final FormField<String, String> CONTACT_PHONE_NUMBER_FIELD =
-      FormFields.PHONE_NUMBER.asBuilder()
-          .build();
+      FormFields.PHONE_NUMBER.asBuilder().build();
 
   public static final FormField<String, String> CONTACT_FAX_NUMBER_FIELD =
-      FormFields.PHONE_NUMBER.asBuilderNamed("faxNumber")
-          .build();
+      FormFields.PHONE_NUMBER.asBuilderNamed("faxNumber").build();
 
   public static final FormField<String, String> CONTACT_GAE_USER_ID_FIELD =
       FormFields.NAME.asBuilderNamed("gaeUserId").build();
@@ -217,11 +218,8 @@ public final class RegistrarFormFields {
           .asSet(Splitter.on(',').omitEmptyStrings().trimResults())
           .build();
 
-  public static final FormField<List<Map<String, ?>>, List<RegistrarContact.Builder>>
-      CONTACTS_FIELD = FormField.mapNamed("contacts")
-          .transform(RegistrarContact.Builder.class, RegistrarFormFields::toRegistrarContactBuilder)
-          .asList()
-          .build();
+  public static final FormField<List<Map<String, ?>>, List<Map<String, ?>>> CONTACTS_AS_MAPS =
+      FormField.mapNamed("contacts").asList().build();
 
   public static final FormField<List<String>, List<String>> I18N_STREET_FIELD =
       FormFields.XS_NORMALIZED_STRING.asBuilderNamed("street")
@@ -344,33 +342,63 @@ public final class RegistrarFormFields {
     }
   }
 
-  private static @Nullable RegistrarContact.Builder toRegistrarContactBuilder(
-      @Nullable Map<String, ?> args) {
+  public static Optional<ImmutableList<RegistrarContact.Builder>> getRegistrarContactBuilders(
+      ImmutableSet<RegistrarContact> existingContacts, @Nullable Map<String, ?> args) {
     if (args == null) {
-      return null;
+      return Optional.empty();
     }
-    RegistrarContact.Builder builder = new RegistrarContact.Builder();
-    CONTACT_NAME_FIELD.extractUntyped(args).ifPresent(builder::setName);
-    CONTACT_EMAIL_ADDRESS_FIELD.extractUntyped(args).ifPresent(builder::setEmailAddress);
-    CONTACT_VISIBLE_IN_WHOIS_AS_ADMIN_FIELD
+    return CONTACTS_AS_MAPS
         .extractUntyped(args)
-        .ifPresent(builder::setVisibleInWhoisAsAdmin);
-    CONTACT_VISIBLE_IN_WHOIS_AS_TECH_FIELD
-        .extractUntyped(args)
-        .ifPresent(builder::setVisibleInWhoisAsTech);
-    PHONE_AND_EMAIL_VISIBLE_IN_DOMAIN_WHOIS_AS_ABUSE_FIELD
-        .extractUntyped(args)
-        .ifPresent(builder::setVisibleInDomainWhoisAsAbuse);
-    CONTACT_PHONE_NUMBER_FIELD.extractUntyped(args).ifPresent(builder::setPhoneNumber);
-    CONTACT_FAX_NUMBER_FIELD.extractUntyped(args).ifPresent(builder::setFaxNumber);
-    CONTACT_TYPES.extractUntyped(args).ifPresent(builder::setTypes);
-    CONTACT_GAE_USER_ID_FIELD.extractUntyped(args).ifPresent(builder::setGaeUserId);
-    CONTACT_ALLOWED_TO_SET_REGISTRY_LOCK_PASSWORD
-        .extractUntyped(args)
-        .ifPresent(builder::setAllowedToSetRegistryLockPassword);
+        .map(
+            l ->
+                l.stream()
+                    .map(
+                        contactAsMap -> {
+                          String emailAddress =
+                              CONTACT_EMAIL_ADDRESS_FIELD
+                                  .extractUntyped(contactAsMap)
+                                  .orElseThrow(
+                                      () ->
+                                          new IllegalArgumentException(
+                                              "Contacts from UI must have email addresses"));
+                          // Start with a new builder if the contact didn't previously exist
+                          RegistrarContact.Builder contactBuilder =
+                              existingContacts.stream()
+                                  .filter(rc -> rc.getEmailAddress().equals(emailAddress))
+                                  .findFirst()
+                                  .map(RegistrarContact::asBuilder)
+                                  .orElse(new RegistrarContact.Builder());
+                          applyRegistrarContactArgs(contactBuilder, contactAsMap);
+                          return contactBuilder;
+                        })
+                    .collect(toImmutableList()));
+  }
+
+  private static void applyRegistrarContactArgs(
+      RegistrarContact.Builder builder, Map<String, ?> args) {
+    builder.setName(CONTACT_NAME_FIELD.extractUntyped(args).orElse(null));
+    builder.setEmailAddress(CONTACT_EMAIL_ADDRESS_FIELD.extractUntyped(args).orElse(null));
+    builder.setVisibleInWhoisAsAdmin(
+        CONTACT_VISIBLE_IN_WHOIS_AS_ADMIN_FIELD.extractUntyped(args).orElse(false));
+    builder.setVisibleInWhoisAsTech(
+        CONTACT_VISIBLE_IN_WHOIS_AS_TECH_FIELD.extractUntyped(args).orElse(false));
+    builder.setVisibleInDomainWhoisAsAbuse(
+        PHONE_AND_EMAIL_VISIBLE_IN_DOMAIN_WHOIS_AS_ABUSE_FIELD.extractUntyped(args).orElse(false));
+    builder.setPhoneNumber(CONTACT_PHONE_NUMBER_FIELD.extractUntyped(args).orElse(null));
+    builder.setFaxNumber(CONTACT_FAX_NUMBER_FIELD.extractUntyped(args).orElse(null));
+    builder.setTypes(CONTACT_TYPES.extractUntyped(args).orElse(ImmutableSet.of()));
+    builder.setGaeUserId(CONTACT_GAE_USER_ID_FIELD.extractUntyped(args).orElse(null));
+    builder.setAllowedToSetRegistryLockPassword(
+        CONTACT_ALLOWED_TO_SET_REGISTRY_LOCK_PASSWORD.extractUntyped(args).orElse(false));
+
+    // Registry lock password does not need to be set every time
     CONTACT_REGISTRY_LOCK_PASSWORD_FIELD
         .extractUntyped(args)
-        .ifPresent(builder::setRegistryLockPassword);
-    return builder;
+        .ifPresent(
+            password -> {
+              if (!Strings.isNullOrEmpty(password)) {
+                builder.setRegistryLockPassword(password);
+              }
+            });
   }
 }

--- a/core/src/main/java/google/registry/ui/server/RegistrarFormFields.java
+++ b/core/src/main/java/google/registry/ui/server/RegistrarFormFields.java
@@ -341,14 +341,14 @@ public final class RegistrarFormFields {
     }
   }
 
-  public static Optional<ImmutableList<RegistrarContact.Builder>> getRegistrarContactBuilders(
+  public static ImmutableList<RegistrarContact.Builder> getRegistrarContactBuilders(
       ImmutableSet<RegistrarContact> existingContacts, @Nullable Map<String, ?> args) {
     if (args == null) {
-      return Optional.empty();
+      return ImmutableList.of();
     }
     Optional<List<Map<String, ?>>> contactsAsMaps = CONTACTS_AS_MAPS.extractUntyped(args);
     if (!contactsAsMaps.isPresent()) {
-      return Optional.empty();
+      return ImmutableList.of();
     }
     ImmutableList.Builder<RegistrarContact.Builder> result = new ImmutableList.Builder<>();
     for (Map<String, ?> contactAsMap : contactsAsMaps.get()) {
@@ -367,7 +367,7 @@ public final class RegistrarFormFields {
       applyRegistrarContactArgs(contactBuilder, contactAsMap);
       result.add(contactBuilder);
     }
-    return Optional.of(result.build());
+    return result.build();
   }
 
   private static void applyRegistrarContactArgs(

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
@@ -377,13 +377,9 @@ public class RegistrarSettingsAction implements Runnable, JsonActionRunner.JsonA
   /** Reads the contacts from the supplied args. */
   public static ImmutableSet<RegistrarContact> readContacts(
       Registrar registrar, ImmutableSet<RegistrarContact> existingContacts, Map<String, ?> args) {
-
-    ImmutableSet.Builder<RegistrarContact> contacts = new ImmutableSet.Builder<>();
-    ImmutableList<RegistrarContact.Builder> builders =
-        RegistrarFormFields.getRegistrarContactBuilders(existingContacts, args);
-    builders.forEach(c -> contacts.add(c.setParent(registrar).build()));
-
-    return contacts.build();
+    return RegistrarFormFields.getRegistrarContactBuilders(existingContacts, args).stream()
+        .map(builder -> builder.setParent(registrar).build())
+        .collect(toImmutableSet());
   }
 
   /**

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
@@ -379,10 +379,9 @@ public class RegistrarSettingsAction implements Runnable, JsonActionRunner.JsonA
       Registrar registrar, ImmutableSet<RegistrarContact> existingContacts, Map<String, ?> args) {
 
     ImmutableSet.Builder<RegistrarContact> contacts = new ImmutableSet.Builder<>();
-    Optional<ImmutableList<RegistrarContact.Builder>> builders =
+    ImmutableList<RegistrarContact.Builder> builders =
         RegistrarFormFields.getRegistrarContactBuilders(existingContacts, args);
-    builders.ifPresent(
-        buildersList -> buildersList.forEach(c -> contacts.add(c.setParent(registrar).build())));
+    builders.forEach(c -> contacts.add(c.setParent(registrar).build()));
 
     return contacts.build();
   }

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
@@ -60,7 +60,6 @@ import google.registry.util.CollectionUtils;
 import google.registry.util.DiffUtils;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -175,8 +174,7 @@ public class RegistrarSettingsAction implements Runnable, JsonActionRunner.JsonA
   }
 
   private RegistrarResult update(final Map<String, ?> args, String clientId) {
-    return tm()
-        .transact(
+    return tm().transact(
             () -> {
               // We load the registrar here rather than outside of the transaction - to make
               // sure we have the latest version. This one is loaded inside the transaction, so it's
@@ -215,7 +213,8 @@ public class RegistrarSettingsAction implements Runnable, JsonActionRunner.JsonA
               updatedRegistrar = checkAndUpdateAdminControlledFields(updatedRegistrar, args);
 
               // read the contacts from the request.
-              ImmutableSet<RegistrarContact> updatedContacts = readContacts(registrar, args);
+              ImmutableSet<RegistrarContact> updatedContacts =
+                  readContacts(registrar, contacts, args);
 
               // Save the updated contacts
               if (!updatedContacts.equals(contacts)) {
@@ -377,14 +376,13 @@ public class RegistrarSettingsAction implements Runnable, JsonActionRunner.JsonA
 
   /** Reads the contacts from the supplied args. */
   public static ImmutableSet<RegistrarContact> readContacts(
-      Registrar registrar, Map<String, ?> args) {
+      Registrar registrar, ImmutableSet<RegistrarContact> existingContacts, Map<String, ?> args) {
 
     ImmutableSet.Builder<RegistrarContact> contacts = new ImmutableSet.Builder<>();
-    Optional<List<RegistrarContact.Builder>> builders =
-        RegistrarFormFields.CONTACTS_FIELD.extractUntyped(args);
-    if (builders.isPresent()) {
-      builders.get().forEach(c -> contacts.add(c.setParent(registrar).build()));
-    }
+    Optional<ImmutableList<RegistrarContact.Builder>> builders =
+        RegistrarFormFields.getRegistrarContactBuilders(existingContacts, args);
+    builders.ifPresent(
+        buildersList -> buildersList.forEach(c -> contacts.add(c.setParent(registrar).build())));
 
     return contacts.build();
   }
@@ -452,8 +450,17 @@ public class RegistrarSettingsAction implements Runnable, JsonActionRunner.JsonA
                     () ->
                         new FormException(
                             "Not allowed to set registry lock password directly on new contact"));
-        if (!existingContact.isAllowedToSetRegistryLockPassword()) {
-          throw new FormException("Registrar contact not allowed to set registry lock password");
+        if (updatedContact.isRegistryLockAllowed()) {
+          // the password must have been set before or the user was allowed to set it now
+          if (!existingContact.isAllowedToSetRegistryLockPassword()
+              && !existingContact.isRegistryLockAllowed()) {
+            throw new FormException("Registrar contact not allowed to set registry lock password");
+          }
+        }
+        if (updatedContact.isAllowedToSetRegistryLockPassword()) {
+          if (!existingContact.isAllowedToSetRegistryLockPassword()) {
+            throw new FormException("Cannot set isAllowedToSetRegistryLockPassword through UI");
+          }
         }
       }
     }


### PR DESCRIPTION
The existing code assumes that the "contacts" segment of the form
contains an exact representation of the registrar contacts. This breaks
when we have a contact with an existing registry lock password because
we don't want to keep passing around that password in plain text (we
never store it in plain text)

This PR changes the code so that instead of assuming the contact is
provided in its entirety, we load the contact from storage first
(matching by email address) if it exists. We then set the required
fields from the JSON object, and set the password optionally if it was
provided.

Alternatives:
- Create a separate RegistrarContactPassword object with a
RegistrarContact parent. This increases complexity significantly since
we'd be adding a parent-child relationship and adding more objects to
Datastore during the transition to SQL. It also doesn't completely solve
the problem of "When should we set the password?" because the password
field still must be part of the same form.
- Rearrange the UI so that the password is set as part of a completely
separate form with a separate submit action. This would be possible but
is sub-optimal for two reasons. First, we are trying to not re-engineer
the web console as much as possible since we're likely starting it from
scratch before too long anyway. Second, we want the
lock-password-setting to be part of the standard contact modification
workflow.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/317)
<!-- Reviewable:end -->
