### PR TITLE
Fix issues related to Cloud SQL connection

### DIFF
--- a/core/src/main/java/google/registry/model/transaction/TransactionManagerFactory.java
+++ b/core/src/main/java/google/registry/model/transaction/TransactionManagerFactory.java
@@ -14,8 +14,15 @@
 
 package google.registry.model.transaction;
 
+import static google.registry.config.RegistryEnvironment.ALPHA;
+import static google.registry.config.RegistryEnvironment.CRASH;
+
+import com.google.appengine.api.utils.SystemProperty;
+import com.google.appengine.api.utils.SystemProperty.Environment.Value;
 import com.google.common.annotations.VisibleForTesting;
+import google.registry.config.RegistryEnvironment;
 import google.registry.model.ofy.DatastoreTransactionManager;
+import google.registry.persistence.DaggerPersistenceComponent;
 
 /** Factory class to create {@link TransactionManager} instance. */
 // TODO: Rename this to PersistenceFactory and move to persistence package.
@@ -27,19 +34,11 @@ public class TransactionManagerFactory {
   private TransactionManagerFactory() {}
 
   private static JpaTransactionManager createJpaTransactionManager() {
-    // TODO(shicong): There is currently no environment where we want to create a real JPA
-    // transaction manager here.  The unit tests that require one are all set up using
-    // JpaTransactionManagerRule which launches its own PostgreSQL instance.  When we actually have
-    // PostgreSQL tables in production, ensure that all of the test environments are set up
-    // correctly and restore the code that creates a JpaTransactionManager when
-    // RegistryEnvironment.get() != UNITTEST.
-    //
-    // We removed the original code because it didn't work in sandbox (due to the absence of the
-    // persistence.xml file, which has since been added), and then (after adding this) didn't work
-    // in crash because the postgresql password hadn't been set up.  Prior to restoring, we'll need
-    // to do setup in all environments, and we probably only want to do this once we're actually
-    // using Cloud SQL for one of the new tables.
-    return DummyJpaTransactionManager.create();
+    if (shouldEnableJpaTm() && SystemProperty.environment.value() == Value.Production) {
+      return DaggerPersistenceComponent.create().appEngineJpaTransactionManager();
+    } else {
+      return DummyJpaTransactionManager.create();
+    }
   }
 
   private static TransactionManager createTransactionManager() {
@@ -54,8 +53,14 @@ public class TransactionManagerFactory {
    * {@link google.registry.tools.RegistryCli} to initialize jpaTm.
    */
   public static void initForTool() {
-    // TODO(shicong): Uncomment the line below when we set up Cloud SQL instance in all environments
-    // jpaTm = DaggerPersistenceComponent.create().nomulusToolJpaTransactionManager();
+    if (shouldEnableJpaTm()) {
+      jpaTm = DaggerPersistenceComponent.create().nomulusToolJpaTransactionManager();
+    }
+  }
+
+  // TODO(shicong): Enable JpaTm for all environments and remove this function
+  private static boolean shouldEnableJpaTm() {
+    return RegistryEnvironment.get() == ALPHA || RegistryEnvironment.get() == CRASH;
   }
 
   /** Returns {@link TransactionManager} instance. */

--- a/core/src/main/java/google/registry/model/transaction/TransactionManagerFactory.java
+++ b/core/src/main/java/google/registry/model/transaction/TransactionManagerFactory.java
@@ -34,7 +34,7 @@ public class TransactionManagerFactory {
   private TransactionManagerFactory() {}
 
   private static JpaTransactionManager createJpaTransactionManager() {
-    if (shouldEnableJpaTm() && SystemProperty.environment.value() == Value.Production) {
+    if (shouldEnableJpaTm() && isInAppEngine()) {
       return DaggerPersistenceComponent.create().appEngineJpaTransactionManager();
     } else {
       return DummyJpaTransactionManager.create();
@@ -61,6 +61,19 @@ public class TransactionManagerFactory {
   // TODO(shicong): Enable JpaTm for all environments and remove this function
   private static boolean shouldEnableJpaTm() {
     return RegistryEnvironment.get() == ALPHA || RegistryEnvironment.get() == CRASH;
+  }
+
+  /**
+   * This function uses App Engine API to determine if the current runtime environment is App
+   * Engine.
+   *
+   * @see <a
+   *     href="https://cloud.google.com/appengine/docs/standard/java/javadoc/com/google/appengine/api/utils/SystemProperty">App
+   *     Engine API public doc</a>
+   */
+  private static boolean isInAppEngine() {
+    // SystemProperty.environment.value() returns null if the current runtime is local JVM
+    return SystemProperty.environment.value() == Value.Production;
   }
 
   /** Returns {@link TransactionManager} instance. */

--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -122,7 +122,7 @@ public class PersistenceModule {
             .append("?cloudSqlInstance=" + instanceConnectionName)
             .append("&socketFactory=com.google.cloud.sql.postgres.SocketFactory")
             .append("&user=" + username)
-            .append("&password=" + kmsKeyring.getCloudSqlPassword())
+            .append("&password=" + kmsKeyring.getToolsCloudSqlPassword())
             .toString();
 
     HashMap<String, String> overrides = Maps.newHashMap(defaultConfigs);

--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -51,6 +51,10 @@ public class PersistenceModule {
   public static final String HIKARI_MAXIMUM_POOL_SIZE = "hibernate.hikari.maximumPoolSize";
   public static final String HIKARI_IDLE_TIMEOUT = "hibernate.hikari.idleTimeout";
 
+  public static final String HIKARI_DS_SOCKET_FACTORY = "hibernate.hikari.dataSource.socketFactory";
+  public static final String HIKARI_DS_CLOUD_SQL_INSTANCE =
+      "hibernate.hikari.dataSource.cloudSqlInstance";
+
   @Provides
   @DefaultHibernateConfigs
   public static ImmutableMap<String, String> providesDefaultDatabaseConfigs() {
@@ -81,20 +85,29 @@ public class PersistenceModule {
 
   @Provides
   @Singleton
+  @PartialCloudSqlConfigs
+  public static ImmutableMap<String, String> providesPartialCloudSqlConfigs(
+      @Config("cloudSqlJdbcUrl") String jdbcUrl,
+      @Config("cloudSqlInstanceConnectionName") String instanceConnectionName,
+      @DefaultHibernateConfigs ImmutableMap<String, String> defaultConfigs) {
+    HashMap<String, String> overrides = Maps.newHashMap(defaultConfigs);
+    overrides.put(Environment.URL, jdbcUrl);
+    overrides.put(HIKARI_DS_SOCKET_FACTORY, "com.google.cloud.sql.postgres.SocketFactory");
+    overrides.put(HIKARI_DS_CLOUD_SQL_INSTANCE, instanceConnectionName);
+    return ImmutableMap.copyOf(overrides);
+  }
+
+  @Provides
+  @Singleton
   @AppEngineJpaTm
   public static JpaTransactionManager providesAppEngineJpaTm(
-      @Config("cloudSqlJdbcUrl") String jdbcUrl,
       @Config("cloudSqlUsername") String username,
-      @Config("cloudSqlInstanceConnectionName") String instanceConnectionName,
       KmsKeyring kmsKeyring,
-      @DefaultHibernateConfigs ImmutableMap<String, String> defaultConfigs,
+      @PartialCloudSqlConfigs ImmutableMap<String, String> cloudSqlConfigs,
       Clock clock) {
-    HashMap<String, String> overrides = Maps.newHashMap(defaultConfigs);
-    overrides.put(
-        Environment.URL,
-        getFullJdbcUrl(
-            jdbcUrl, instanceConnectionName, username, kmsKeyring.getCloudSqlPassword()));
-
+    HashMap<String, String> overrides = Maps.newHashMap(cloudSqlConfigs);
+    overrides.put(Environment.USER, username);
+    overrides.put(Environment.PASS, kmsKeyring.getCloudSqlPassword());
     return new JpaTransactionManagerImpl(create(overrides), clock);
   }
 
@@ -102,34 +115,14 @@ public class PersistenceModule {
   @Singleton
   @NomulusToolJpaTm
   public static JpaTransactionManager providesNomulusToolJpaTm(
-      @Config("cloudSqlJdbcUrl") String jdbcUrl,
       @Config("toolsCloudSqlUsername") String username,
-      @Config("cloudSqlInstanceConnectionName") String instanceConnectionName,
       KmsKeyring kmsKeyring,
-      @DefaultHibernateConfigs ImmutableMap<String, String> defaultConfigs,
+      @PartialCloudSqlConfigs ImmutableMap<String, String> cloudSqlConfigs,
       Clock clock) {
-    HashMap<String, String> overrides = Maps.newHashMap(defaultConfigs);
-    overrides.put(
-        Environment.URL,
-        getFullJdbcUrl(
-            jdbcUrl, instanceConnectionName, username, kmsKeyring.getToolsCloudSqlPassword()));
-
+    HashMap<String, String> overrides = Maps.newHashMap(cloudSqlConfigs);
+    overrides.put(Environment.USER, username);
+    overrides.put(Environment.PASS, kmsKeyring.getToolsCloudSqlPassword());
     return new JpaTransactionManagerImpl(create(overrides), clock);
-  }
-
-  /**
-   * Cloud SQL JDBC Socket Factory library requires the jdbc url to include all connection
-   * information, otherwise the connection initialization will fail. See here for more details:
-   * https://github.com/GoogleCloudPlatform/cloud-sql-jdbc-socket-factory
-   */
-  private static String getFullJdbcUrl(
-      String jdbcUrl, String instanceConnectionName, String username, String password) {
-    return new StringBuilder(jdbcUrl)
-        .append("?cloudSqlInstance=" + instanceConnectionName)
-        .append("&socketFactory=com.google.cloud.sql.postgres.SocketFactory")
-        .append("&user=" + username)
-        .append("&password=" + password)
-        .toString();
   }
 
   /** Constructs the {@link EntityManagerFactory} instance. */
@@ -166,6 +159,11 @@ public class PersistenceModule {
   @Qualifier
   @Documented
   @interface NomulusToolJpaTm {}
+
+  /** Dagger qualifier for the partial Cloud SQL configs. */
+  @Qualifier
+  @Documented
+  @interface PartialCloudSqlConfigs {}
 
   /** Dagger qualifier for the default Hibernate configurations. */
   // TODO(shicong): Change annotations in this class to none public or put them in a top level

--- a/core/src/main/java/google/registry/tools/UploadClaimsListCommand.java
+++ b/core/src/main/java/google/registry/tools/UploadClaimsListCommand.java
@@ -32,7 +32,7 @@ import java.util.List;
 
 /** A command to upload a {@link ClaimsListShard}. */
 @Parameters(separators = " =", commandDescription = "Manually upload a new claims list file")
-final class UploadClaimsListCommand extends ConfirmingCommand implements CommandWithRemoteApi {
+final class UploadClaimsListCommand extends ConfirmingCommand implements CommandWithCloudSql {
 
   @Parameter(description = "Claims list filename")
   private List<String> mainParameters = new ArrayList<>();


### PR DESCRIPTION
This PR made the following changes:
1. Make `UploadClaimsListCommand` implement `CommandWithCloudSql` so that the command
can get Cloud SQL environment installed. See #303 for more details.
2. Change to use Cloud SQL JDBC Socket Factory library to connect to Cloud SQL for App Engine application. The previous setup was derived from the public Cloud SQL [doc](https://cloud.google.com/sql/docs/postgres/connect-app-engine) but it just didn't work.

The following tests have been done to verify the current setup:
1. Tested the connection from Nomulus tool by running the `upload_claims_list` command:
    * `java -jar ./nomulus.jar -e alpha upload_claims_list --also_cloud_sql /tmp/test_cloud_sql/claims_list.txt`
2. Tested the connection from App Engine application by running the `create_premium_list` command:
    * `java -jar ./nomulus.jar -e alpha create_premium_list --name test --input /tmp/list/premium_list.txt --also_cloud_sql`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/321)
<!-- Reviewable:end -->
