### PR TITLE
Restrict "Public Domain" license acceptance

### DIFF
--- a/config/dependency-license/README.md
+++ b/config/dependency-license/README.md
@@ -1,0 +1,16 @@
+## Summary
+
+This folder contains configuration files for the gradle-license-report plugin:
+
+*   allowed_licenses.json declares the acceptable licenses. A license may have
+    multiple entries in this file, since the 'moduleLicense' property value must
+    match exactly the phrases found in pom or manifest files.
+*   license_normalizer_bundle.json configures normalization rules for license
+    reporting.
+
+## Notes About Adding New Licenses
+
+*   The WTFPL license is not allowed.
+
+*   Each 'Public Domain' license entry must include a specific 'moduleName'. Do
+    not omit moduleName or use wildcards.

--- a/config/dependency-license/allowed_licenses.json
+++ b/config/dependency-license/allowed_licenses.json
@@ -4,6 +4,9 @@
       "moduleLicense": "Apache Software License, Version 1.1"
     },
     {
+      "moduleLicense": "Apache Software License, version 1.1"
+    },
+    {
       "moduleLicense": "Apache 2"
     },
     {
@@ -205,10 +208,12 @@
       "moduleLicense": "Mozilla Public License Version 2.0"
     },
     {
-      "moduleLicense": "Public Domain"
+      "moduleLicense": "Public Domain",
+      "moduleName": "aopalliance:aopalliance"
     },
     {
-      "moduleLicense": "PUBLIC DOMAIN"
+      "moduleLicense": "Public Domain",
+      "moduleName": "org.tukaani:xz"
     },
     {
       "moduleLicense": "The W3C Software License"


### PR DESCRIPTION
"Public Domain" license must be reviewed case by case.
Removed blanket acceptance and named accepted dependencies
individually.

Also added a README file to warn about this license and WTFPL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/329)
<!-- Reviewable:end -->
