### PR TITLE
Remove jdbcUrl config for nomulus tool

### DIFF
--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -1297,12 +1297,6 @@ public final class RegistryConfig {
     }
 
     @Provides
-    @Config("toolsCloudSqlJdbcUrl")
-    public static String providesToolsCloudSqlJdbcUrl(RegistryConfigSettings config) {
-      return config.registryTool.jdbcUrl;
-    }
-
-    @Provides
     @Config("toolsCloudSqlUsername")
     public static String providesToolsCloudSqlUsername(RegistryConfigSettings config) {
       return config.registryTool.username;

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -213,7 +213,6 @@ public class RegistryConfigSettings {
   public static class RegistryTool {
     public String clientId;
     public String clientSecret;
-    public String jdbcUrl;
     public String username;
   }
 }

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -422,6 +422,4 @@ registryTool:
   clientId: YOUR_CLIENT_ID
   # OAuth client secret used by the tool.
   clientSecret: YOUR_CLIENT_SECRET
-  # Nomulus tool uses a different jdbc url and user to connect to Cloud SQL
-  jdbcUrl: jdbc:postgresql://localhost/tool
   username: toolusername


### PR DESCRIPTION
This is because the nomulus tool has been changed to use the same JDBC url as the App Engine application in #321 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/330)
<!-- Reviewable:end -->
