### PR TITLE
Improve FilteringTest so it works in all cases

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -578,13 +578,42 @@ artifacts {
  */
 class FilteringTest extends Test {
 
-  void setTests(List<String> tests) {
-    // Common exclude pattern. See README in parent directory for explanation.
-    exclude "**/*TestCase.*", "**/*TestSuite.*"
-    include tests
+  private void applyTestFilter() {
     if (project.testFilter) {
       testNameIncludePatterns = project.testFilter.split(',')
+
+      // By default, gradle test tasks will produce a failure if no tests
+      // match the include/exclude/filter rules.  Since test filtering allows us
+      // to select a set of tests from a particular task, we don't want this
+      // behavior.
+      filter.failOnNoMatchingTests = false
     }
+  }
+
+  /**
+   * Set to false if you also want to include TestCase classes.
+   *
+   * <p>Must be defined before "test", if at all.
+   */
+  boolean excludeTestCases = true
+
+  void setTests(List<String> tests) {
+    // Common exclude pattern. See README in parent directory for explanation.
+    if (excludeTestCases) {
+      exclude "**/*TestCase.*", "**/*TestSuite.*"
+    }
+    include tests
+    applyTestFilter()
+  }
+
+  /**
+   * Include all of the tests (except Test{Case,TestSuite}).  This actually
+   * doesn't explicitly "include" anything, in which cast the Test class tries
+   * to include everything that is not explicitly excluded.
+   */
+  void includeAllTests() {
+    exclude "**/*TestCase.*", "**/*TestSuite.*"
+    applyTestFilter()
   }
 }
 
@@ -608,12 +637,9 @@ task outcastTest(type: FilteringTest) {
 }
 
 // Dedicated test suite for schema-dependent tests.
-task sqlIntegrationTest(type: Test) {
-  include 'google/registry/schema/integration/SqlIntegrationTestSuite.*'
-  // Copied from FilteringTest. Not inheriting b/c it excludes TestSuites.
-  if (project.testFilter) {
-    testNameIncludePatterns = project.testFilter.split(',')
-  }
+task sqlIntegrationTest(type: FilteringTest) {
+  excludeTestCases = false
+  tests = ['google/registry/schema/integration/SqlIntegrationTestSuite.*']
 }
 
 task findGoldenImages(type: JavaExec) {
@@ -698,9 +724,8 @@ task flowDocsTool(type: JavaExec) {
   args arguments
 }
 
-test {
-  // Common exclude pattern. See README in parent directory for explanation.
-  exclude "**/*TestCase.*", "**/*TestSuite.*"
+task standardTest(type: FilteringTest) {
+  includeAllTests()
   exclude fragileTestPatterns
   exclude outcastTestPatterns
 
@@ -722,7 +747,13 @@ test {
   doFirst {
     new File(screenshotsDir).deleteDir()
   }
-}.dependsOn(fragileTest, outcastTest)
+}
+
+test {
+  // Don't run any tests from this task, all testing gets done in the
+  // FilteringTest tasks.
+  exclude "**"
+}.dependsOn(fragileTest, outcastTest, standardTest)
 
 createUberJar('nomulus', 'nomulus', 'google.registry.tools.RegistryTool')
 project.nomulus.dependsOn project(':third_party').jar

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -591,7 +591,7 @@ class FilteringTest extends Test {
   }
 
   /**
-   * Set to false if you also want to include TestCase classes.
+   * Set to false if you also want to include TestCase and TestSuite classes.
    *
    * <p>Must be defined before "test", if at all.
    */


### PR DESCRIPTION
- Disable failOnMatchingTests so we don't fail if we filter out all of the
  tests for any given task.
- Add excludeTestCases flag so that we can turn this behavior off for test
  tasks that need to run TestCas/TestSuite classes.
- Add includeAllTests() function for test tasks where we don't explicitly
  include our required tests.

This makes all test tasks in core FilteringTest, with the exception of the
default test task which now does nothing (it just depends on the other test
tasks).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/339)
<!-- Reviewable:end -->
