### PR TITLE
Release SQL schema in Cloud Build

### DIFF
--- a/java_common.gradle
+++ b/java_common.gradle
@@ -54,7 +54,6 @@ tasks.withType(JavaCompile).configureEach {
     }
 }
 
-version = '1.0'
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'
 

--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -65,7 +65,22 @@ steps:
 # Build and package the deployment files for production.
 - name: 'gcr.io/${PROJECT_ID}/builder:latest'
   args: ['release/build_nomulus_for_env.sh', 'production', 'output']
-# The tarballs to upload to GCS.
+# Tentatively build and publish Cloud SQL schema jar here, before schema release
+# process is finalized.
+- name: 'gcr.io/${PROJECT_ID}/builder:latest'
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    ./gradlew \
+      :db:publish \
+      -PmavenUrl=https://storage.googleapis.com/domain-registry-maven-repository/maven \
+      -PpluginsUrl=https://storage.googleapis.com/domain-registry-maven-repository/plugins \
+      -Pschema_publish_repo=gcs://domain-registry-maven-repository/nomulus \
+      -Pschema_version=${TAG_NAME}
+    cp db/build/libs/schema.jar output/
+# The tarballs and jars to upload to GCS.
 artifacts:
   objects:
     location: 'gs://${PROJECT_ID}-deploy/${TAG_NAME}'
@@ -73,6 +88,7 @@ artifacts:
     - 'output/*.tar'
     - 'output/tag_name'
     - 'output/nomulus.jar'
+    - 'output/schema.jar'
     - 'release/cloudbuild-tag.yaml'
     - 'release/cloudbuild-sync.yaml'
     - 'release/cloudbuild-deploy-*.yaml'


### PR DESCRIPTION
Tentatively release SQL schema at the same time as the server release.
Publish schema jar to gs://domain-registry-maven-repository/nomulus
and also upload it with server artifacts.

Also removed the Gradle 'version' variable which is not used.

Tested=On cloud-build with a simplified version of
cloudbuild-nomulus.yaml.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/341)
<!-- Reviewable:end -->
