### PR TITLE
Clean up Karma config file

### DIFF
--- a/core/karma.conf.js
+++ b/core/karma.conf.js
@@ -43,10 +43,6 @@ module.exports = function(config) {
         included: false
       },
       {
-        pattern: 'node_modules/soyutils_usegoog.js',
-        included: false
-      },
-      {
         pattern: 'node_modules/google-closure-library/closure/goog/deps.js',
         included: false,
         served: false
@@ -70,7 +66,6 @@ module.exports = function(config) {
       'node_modules/google-closure-library/closure/**/*.js': ['closure'],
       'core/src/*/javascript/**/*.js': ['closure'],
       'core/build/generated/source/custom/main/**/*.soy.js': ['closure'],
-      'node_modules/soyutils_usegoog.js': ['closure']
     },
     proxies: {
       "/assets/": "/base/core/build/resources/main/google/registry/ui/assets/"


### PR DESCRIPTION
soyutils_usegoog.js (the dependency) has been moved into core/src/main/javascript/ so it's covered by the other rules in the file -- this was a special-cased rule that we had before that is no longer necessary 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/345)
<!-- Reviewable:end -->
