### PR TITLE
Add RegistryLockGetActionTest to SQL testclasses

### DIFF
--- a/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
+++ b/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
@@ -24,6 +24,7 @@ import google.registry.persistence.CurrencyUnitConverterTest;
 import google.registry.persistence.UpdateAutoTimestampConverterTest;
 import google.registry.persistence.ZonedDateTimeConverterTest;
 import google.registry.schema.tld.PremiumListDaoTest;
+import google.registry.ui.server.registrar.RegistryLockGetActionTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -48,6 +49,7 @@ import org.junit.runners.Suite.SuiteClasses;
   JpaTransactionManagerRuleTest.class,
   PremiumListDaoTest.class,
   RegistryLockDaoTest.class,
+  RegistryLockGetActionTest.class,
   UpdateAutoTimestampConverterTest.class,
   ZonedDateTimeConverterTest.class
 })


### PR DESCRIPTION
This should have been there before but there was a semantic merge conflict (the branch didn't have this test running)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/347)
<!-- Reviewable:end -->
