### PR TITLE
Add cursors for tracking ICANN report uploads to Cursor.java

### DIFF
--- a/core/src/main/java/google/registry/model/common/Cursor.java
+++ b/core/src/main/java/google/registry/model/common/Cursor.java
@@ -79,7 +79,16 @@ public class Cursor extends ImmutableObject {
      * stored is the last time that registrar changes were successfully synced to the sheet. If
      * there were no changes since the last time the action run, the cursor is not updated.
      */
-    SYNC_REGISTRAR_SHEET(EntityGroupRoot.class);
+    SYNC_REGISTRAR_SHEET(EntityGroupRoot.class),
+
+    /** Cursor for tracking monthly uploads of ICANN transaction reports. */
+    ICANN_UPLOAD_TX(Registry.class),
+
+    /** Cursor for tracking monthly uploads of ICANN activity reports. */
+    ICANN_UPLOAD_ACTIVITY(Registry.class),
+
+    /** Cursor for tracking monthly upload of MANIFEST.txt to ICANN. */
+    ICANN_UPLOAD_MANIFEST(EntityGroupRoot.class);
 
     /** See the definition of scope on {@link #getScopeClass}. */
     private final Class<? extends ImmutableObject> scope;


### PR DESCRIPTION
This PR only adds the new cursor types to Cursor.java. Once these are added, the nomulus update_cursor tool can be used to add the cursors for each tld with a cursorTime of the 1st of next month. This is a necessary first step before #343 can be deployed.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/349)
<!-- Reviewable:end -->
