### PR TITLE
Throw an EPP exception when using discount on premium domains

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -187,6 +187,7 @@ import org.joda.time.Duration;
  * @error {@link DomainFlowUtils.UnexpectedClaimsNoticeException}
  * @error {@link DomainFlowUtils.UnsupportedFeeAttributeException}
  * @error {@link DomainFlowUtils.UnsupportedMarkTypeException}
+ * @error {@link DomainPricingLogic.AllocationTokenInvalidForPremiumNameException}
  */
 @ReportingSpec(ActivityReportField.DOMAIN_CREATE)
 public class DomainCreateFlow implements TransactionalFlow {

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -129,6 +129,7 @@ import google.registry.flows.domain.DomainFlowUtils.TrailingDashException;
 import google.registry.flows.domain.DomainFlowUtils.UnexpectedClaimsNoticeException;
 import google.registry.flows.domain.DomainFlowUtils.UnsupportedFeeAttributeException;
 import google.registry.flows.domain.DomainFlowUtils.UnsupportedMarkTypeException;
+import google.registry.flows.domain.DomainPricingLogic.AllocationTokenInvalidForPremiumNameException;
 import google.registry.flows.domain.token.AllocationTokenFlowUtils.AllocationTokenNotInPromotionException;
 import google.registry.flows.domain.token.AllocationTokenFlowUtils.AllocationTokenNotValidForRegistrarException;
 import google.registry.flows.domain.token.AllocationTokenFlowUtils.AllocationTokenNotValidForTldException;
@@ -1227,9 +1228,9 @@ public class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow,
             .build());
     clock.advanceOneMilli();
     setEppInput("domain_create_premium_allocationtoken.xml");
-    assertThat(assertThrows(IllegalArgumentException.class, this::runFlow))
-        .hasMessageThat()
-        .isEqualTo("A nonzero discount code cannot be applied to premium domains");
+    assertAboutEppExceptions()
+        .that(assertThrows(AllocationTokenInvalidForPremiumNameException.class, this::runFlow))
+        .marshalsToXml();
   }
 
   @Test

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -302,6 +302,7 @@ An EPP flow that creates a new domain resource.
     *   The current registry phase allows registrations only with signed marks.
     *   The current registry phase does not allow for general registrations.
     *   Signed marks are only allowed during sunrise.
+    *   An allocation token was provided that is invalid for premium domains.
 *   2003
     *   The provided mark does not match the desired domain label.
     *   Fees must be explicitly acknowledged when creating domains during the


### PR DESCRIPTION
We should communicate to the users why this command failed, that they are not allowed to use discounted allocation tokens on premium domains. Currently it still fails, but we don't yet tell them why.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/351)
<!-- Reviewable:end -->
