### PR TITLE
Enable JpaTransactionManager in all environment

### DIFF
--- a/core/src/main/java/google/registry/model/transaction/TransactionManagerFactory.java
+++ b/core/src/main/java/google/registry/model/transaction/TransactionManagerFactory.java
@@ -14,14 +14,10 @@
 
 package google.registry.model.transaction;
 
-import static google.registry.config.RegistryEnvironment.ALPHA;
-import static google.registry.config.RegistryEnvironment.CRASH;
-import static google.registry.config.RegistryEnvironment.SANDBOX;
 
 import com.google.appengine.api.utils.SystemProperty;
 import com.google.appengine.api.utils.SystemProperty.Environment.Value;
 import com.google.common.annotations.VisibleForTesting;
-import google.registry.config.RegistryEnvironment;
 import google.registry.model.ofy.DatastoreTransactionManager;
 import google.registry.persistence.DaggerPersistenceComponent;
 
@@ -35,7 +31,7 @@ public class TransactionManagerFactory {
   private TransactionManagerFactory() {}
 
   private static JpaTransactionManager createJpaTransactionManager() {
-    if (shouldEnableJpaTm() && isInAppEngine()) {
+    if (isInAppEngine()) {
       return DaggerPersistenceComponent.create().appEngineJpaTransactionManager();
     } else {
       return DummyJpaTransactionManager.create();
@@ -54,16 +50,7 @@ public class TransactionManagerFactory {
    * {@link google.registry.tools.RegistryCli} to initialize jpaTm.
    */
   public static void initForTool() {
-    if (shouldEnableJpaTm()) {
-      jpaTm = DaggerPersistenceComponent.create().nomulusToolJpaTransactionManager();
-    }
-  }
-
-  // TODO(shicong): Enable JpaTm for all environments and remove this function
-  private static boolean shouldEnableJpaTm() {
-    return RegistryEnvironment.get() == ALPHA
-        || RegistryEnvironment.get() == CRASH
-        || RegistryEnvironment.get() == SANDBOX;
+    jpaTm = DaggerPersistenceComponent.create().nomulusToolJpaTransactionManager();
   }
 
   /**

--- a/core/src/main/java/google/registry/model/transaction/TransactionManagerFactory.java
+++ b/core/src/main/java/google/registry/model/transaction/TransactionManagerFactory.java
@@ -20,6 +20,7 @@ import com.google.appengine.api.utils.SystemProperty.Environment.Value;
 import com.google.common.annotations.VisibleForTesting;
 import google.registry.model.ofy.DatastoreTransactionManager;
 import google.registry.persistence.DaggerPersistenceComponent;
+import google.registry.tools.RegistryToolEnvironment;
 
 /** Factory class to create {@link TransactionManager} instance. */
 // TODO: Rename this to PersistenceFactory and move to persistence package.
@@ -33,6 +34,9 @@ public class TransactionManagerFactory {
   private static JpaTransactionManager createJpaTransactionManager() {
     if (isInAppEngine()) {
       return DaggerPersistenceComponent.create().appEngineJpaTransactionManager();
+    } else if (RegistryToolEnvironment.isInRegistryTool()
+        && RegistryToolEnvironment.isJpaTmEnabled()) {
+      return DaggerPersistenceComponent.create().nomulusToolJpaTransactionManager();
     } else {
       return DummyJpaTransactionManager.create();
     }
@@ -43,14 +47,6 @@ public class TransactionManagerFactory {
     // dual-write transitional phase, we need the TransactionManager for both Datastore and Cloud
     // SQL, and this method returns the one for Datastore.
     return new DatastoreTransactionManager(null);
-  }
-
-  /**
-   * Sets jpaTm to the implementation for Nomulus tool. Note that this method should be only used by
-   * {@link google.registry.tools.RegistryCli} to initialize jpaTm.
-   */
-  public static void initForTool() {
-    jpaTm = DaggerPersistenceComponent.create().nomulusToolJpaTransactionManager();
   }
 
   /**

--- a/core/src/main/java/google/registry/tools/RegistryCli.java
+++ b/core/src/main/java/google/registry/tools/RegistryCli.java
@@ -31,7 +31,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import google.registry.config.RegistryConfig;
 import google.registry.model.ofy.ObjectifyService;
-import google.registry.model.transaction.TransactionManagerFactory;
 import google.registry.tools.AuthModule.LoginRequiredException;
 import google.registry.tools.params.ParameterFactory;
 import java.io.ByteArrayInputStream;
@@ -237,7 +236,7 @@ final class RegistryCli implements AutoCloseable, CommandRunner {
     }
 
     if (command instanceof CommandWithCloudSql) {
-      TransactionManagerFactory.initForTool();
+      RegistryToolEnvironment.get().enableJpaTm();
     }
 
     command.run();

--- a/core/src/main/java/google/registry/tools/RegistryToolEnvironment.java
+++ b/core/src/main/java/google/registry/tools/RegistryToolEnvironment.java
@@ -25,7 +25,7 @@ import google.registry.config.RegistryEnvironment;
 import google.registry.config.SystemPropertySetter;
 
 /** Enum of production environments, used for the {@code --environment} flag. */
-enum RegistryToolEnvironment {
+public enum RegistryToolEnvironment {
   PRODUCTION(RegistryEnvironment.PRODUCTION),
   ALPHA(RegistryEnvironment.ALPHA),
   CRASH(RegistryEnvironment.CRASH),
@@ -39,6 +39,7 @@ enum RegistryToolEnvironment {
 
   private static final ImmutableList<String> FLAGS = ImmutableList.of("-e", "--environment");
   private static RegistryToolEnvironment instance;
+  private static boolean isJpaTmEnabled = false;
   private final RegistryEnvironment actualEnvironment;
   private final ImmutableMap<String, String> extraProperties;
 
@@ -72,7 +73,7 @@ enum RegistryToolEnvironment {
    *
    * <p>This should be called after {@link #parseFromArgs(String[])}.
    */
-  static RegistryToolEnvironment get() {
+  public static RegistryToolEnvironment get() {
     checkState(instance != null, "No RegistryToolEnvironment has been set up");
     return instance;
   }
@@ -96,6 +97,26 @@ enum RegistryToolEnvironment {
     for (ImmutableMap.Entry<String, String> entry : extraProperties.entrySet()) {
       systemPropertySetter.setProperty(entry.getKey(), entry.getValue());
     }
+  }
+
+  /** Returns true if the RegistryToolEnvironment is set up. */
+  public static boolean isInRegistryTool() {
+    return instance != null;
+  }
+
+  /**
+   * Sets the flag to indicate that the running command needs JpaTransactionManager to be enabled.
+   */
+  public static void enableJpaTm() {
+    isJpaTmEnabled = true;
+  }
+
+  /**
+   * Returns true if the JpaTransactionManager is enabled. Note that JpaTm is actually enabled in
+   * {@link google.registry.model.transaction.TransactionManagerFactory} by reading this flag.
+   */
+  public static boolean isJpaTmEnabled() {
+    return isJpaTmEnabled;
   }
 
   /** Extracts value from command-line arguments associated with any {@code flags}. */


### PR DESCRIPTION
JpaTransactionManager has been enabled in sandbox since 11/6 and I verified that
the claims list has been generated successfully in Cloud SQL. Also, there is no any
JpaTransactionManager related errors in the stackdriver. So, it should be fine to
enable it in all environments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/352)
<!-- Reviewable:end -->
