### PR TITLE
Run both the AppEngineRule and JpaTransactionManagerRule in tests

### DIFF
--- a/core/src/test/java/google/registry/server/RegistryTestServerMain.java
+++ b/core/src/test/java/google/registry/server/RegistryTestServerMain.java
@@ -19,6 +19,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
+import google.registry.model.transaction.JpaTransactionManagerRule;
 import google.registry.testing.AppEngineRule;
 import google.registry.testing.UserInfo;
 import google.registry.tools.params.HostAndPortParameter;
@@ -134,36 +135,45 @@ public final class RegistryTestServerMain {
         LIGHT_PURPLE, ORANGE, PINK, RESET);
 
     final RegistryTestServer server = new RegistryTestServer(address);
-    Statement runner = new Statement() {
-      @Override
-      public void evaluate() throws InterruptedException {
-        System.out.printf("%sLoading Datastore fixtures...%s\n", BLUE, RESET);
-        for (Fixture fixture : fixtures) {
-          fixture.load();
-        }
-        System.out.printf("%sStarting Jetty6 HTTP Server...%s\n", BLUE, RESET);
-        server.start();
-        System.out.printf("%sListening on: %s%s\n", PURPLE, server.getUrl("/"), RESET);
-        try {
-          while (true) {
-            server.process();
+    Statement runner =
+        new Statement() {
+          @Override
+          public void evaluate() throws InterruptedException {
+            System.out.printf("%sLoading Datastore fixtures...%s\n", BLUE, RESET);
+            for (Fixture fixture : fixtures) {
+              fixture.load();
+            }
+            System.out.printf("%sStarting Jetty6 HTTP Server...%s\n", BLUE, RESET);
+            server.start();
+            System.out.printf("%sListening on: %s%s\n", PURPLE, server.getUrl("/"), RESET);
+            try {
+              while (true) {
+                server.process();
+              }
+            } finally {
+              server.stop();
+            }
           }
-        } finally {
-          server.stop();
-        }
-      }};
+        };
 
     System.out.printf("%sLoading AppEngineRule...%s\n", BLUE, RESET);
-    AppEngineRule.builder()
-        .withDatastore()
-        .withUrlFetch()
-        .withTaskQueue()
-        .withLocalModules()
-        .withUserService(loginIsAdmin
-            ? UserInfo.createAdmin(loginEmail, loginUserId)
-            : UserInfo.create(loginEmail, loginUserId))
+    Statement withAppEngine =
+        AppEngineRule.builder()
+            .withDatastore()
+            .withUrlFetch()
+            .withTaskQueue()
+            .withLocalModules()
+            .withUserService(
+                loginIsAdmin
+                    ? UserInfo.createAdmin(loginEmail, loginUserId)
+                    : UserInfo.create(loginEmail, loginUserId))
+            .build()
+            .apply(runner, Description.EMPTY);
+
+    System.out.printf("%sLoading SQL fixtures...%s\n", BLUE, RESET);
+    new JpaTransactionManagerRule.Builder()
         .build()
-        .apply(runner, Description.EMPTY)
+        .apply(withAppEngine, Description.EMPTY)
         .evaluate();
   }
 

--- a/core/src/test/java/google/registry/server/RegistryTestServerMain.java
+++ b/core/src/test/java/google/registry/server/RegistryTestServerMain.java
@@ -156,7 +156,6 @@ public final class RegistryTestServerMain {
           }
         };
 
-    System.out.printf("%sLoading AppEngineRule...%s\n", BLUE, RESET);
     Statement withAppEngine =
         AppEngineRule.builder()
             .withDatastore()
@@ -170,7 +169,7 @@ public final class RegistryTestServerMain {
             .build()
             .apply(runner, Description.EMPTY);
 
-    System.out.printf("%sLoading SQL fixtures...%s\n", BLUE, RESET);
+    System.out.printf("%sLoading SQL fixtures and AppEngineRule...%s\n", BLUE, RESET);
     new JpaTransactionManagerRule.Builder()
         .build()
         .apply(withAppEngine, Description.EMPTY)

--- a/core/src/test/java/google/registry/webdriver/TestServerRule.java
+++ b/core/src/test/java/google/registry/webdriver/TestServerRule.java
@@ -23,6 +23,7 @@ import static google.registry.util.NetworkUtils.pickUnusedPort;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
+import google.registry.model.transaction.JpaTransactionManagerRule;
 import google.registry.request.auth.AuthenticatedRegistrarAccessor;
 import google.registry.server.Fixture;
 import google.registry.server.Route;
@@ -53,6 +54,7 @@ public final class TestServerRule extends ExternalResource {
 
   private final ImmutableList<Fixture> fixtures;
   private final AppEngineRule appEngineRule;
+  private final JpaTransactionManagerRule jpaTransactionManagerRule;
   private final BlockingQueue<FutureTask<?>> jobs = new LinkedBlockingDeque<>();
   private final ImmutableMap<String, Path> runfiles;
   private final ImmutableList<Route> routes;
@@ -80,6 +82,7 @@ public final class TestServerRule extends ExternalResource {
         .withTaskQueue()
         .withUserService(UserInfo.createAdmin(email, THE_REGISTRAR_GAE_USER_ID))
         .build();
+    this.jpaTransactionManagerRule = new JpaTransactionManagerRule.Builder().build();
   }
 
   @Override
@@ -164,9 +167,8 @@ public final class TestServerRule extends ExternalResource {
     @Override
     public void run() {
       try {
-        appEngineRule
-            .apply(this, Description.EMPTY)
-            .evaluate();
+        Statement appEngineStatement = appEngineRule.apply(this, Description.EMPTY);
+        jpaTransactionManagerRule.apply(appEngineStatement, Description.EMPTY).evaluate();
       } catch (InterruptedException e) {
         // This is what we expect to happen.
       } catch (Throwable e) {


### PR DESCRIPTION
As previously written, the AppEngineRule wraps the infinite loop of the server handling requests. This changes the code so that we'll have a chain that does both the AppEngine management and the JPA transaction manager management so we can actually use SQL in tests and in the test server.

Tested with #336 to show that the verification page acted appropriately both in the test server and in the screenshot tests. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/356)
<!-- Reviewable:end -->
