### PR TITLE
Add PersistenceXmlUtility and refactor related code

### DIFF
--- a/core/src/main/java/google/registry/persistence/HibernateSchemaExporter.java
+++ b/core/src/main/java/google/registry/persistence/HibernateSchemaExporter.java
@@ -21,15 +21,12 @@ import com.google.common.collect.Maps;
 import java.io.File;
 import java.util.EnumSet;
 import java.util.Map;
-import java.util.Properties;
 import java.util.stream.Stream;
 import javax.persistence.AttributeConverter;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Environment;
-import org.hibernate.jpa.boot.internal.ParsedPersistenceXmlDescriptor;
-import org.hibernate.jpa.boot.internal.PersistenceXmlParser;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.schema.TargetType;
 
@@ -82,25 +79,7 @@ public class HibernateSchemaExporter {
   }
 
   private ImmutableList<Class> findAllConverters() {
-    ParsedPersistenceXmlDescriptor descriptor =
-        PersistenceXmlParser.locatePersistenceUnits(new Properties()).stream()
-            .filter(unit -> PersistenceModule.PERSISTENCE_UNIT_NAME.equals(unit.getName()))
-            .findFirst()
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        String.format(
-                            "Could not find persistence unit with name %s",
-                            PersistenceModule.PERSISTENCE_UNIT_NAME)));
-    return descriptor.getManagedClassNames().stream()
-        .map(
-            className -> {
-              try {
-                return Class.forName(className);
-              } catch (ClassNotFoundException e) {
-                throw new RuntimeException(e);
-              }
-            })
+    return PersistenceXmlUtility.getManagedClasses().stream()
         .filter(AttributeConverter.class::isAssignableFrom)
         .collect(toImmutableList());
   }

--- a/core/src/main/java/google/registry/persistence/PersistenceXmlUtility.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceXmlUtility.java
@@ -48,7 +48,10 @@ public class PersistenceXmlUtility {
               try {
                 return Class.forName(className);
               } catch (ClassNotFoundException e) {
-                throw new RuntimeException(e);
+                throw new IllegalArgumentException(
+                    String.format(
+                        "Could not load class with name %s present in persistence.xml", className),
+                    e);
               }
             })
         .collect(toImmutableList());

--- a/core/src/main/java/google/registry/persistence/PersistenceXmlUtility.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceXmlUtility.java
@@ -1,0 +1,56 @@
+// Copyright 2019 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.persistence;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Properties;
+import org.hibernate.jpa.boot.internal.ParsedPersistenceXmlDescriptor;
+import org.hibernate.jpa.boot.internal.PersistenceXmlParser;
+
+/** Utility class that provides methods to manipulate persistence.xml file. */
+public class PersistenceXmlUtility {
+  private PersistenceXmlUtility() {}
+
+  /**
+   * Returns the {@link ParsedPersistenceXmlDescriptor} instance constructed from persistence.xml.
+   */
+  public static ParsedPersistenceXmlDescriptor getParsedPersistenceXmlDescriptor() {
+    return PersistenceXmlParser.locatePersistenceUnits(new Properties()).stream()
+        .filter(unit -> PersistenceModule.PERSISTENCE_UNIT_NAME.equals(unit.getName()))
+        .findFirst()
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    String.format(
+                        "Could not find persistence unit with name %s",
+                        PersistenceModule.PERSISTENCE_UNIT_NAME)));
+  }
+
+  /** Returns all managed classes defined in persistence.xml. */
+  public static ImmutableList<Class> getManagedClasses() {
+    return getParsedPersistenceXmlDescriptor().getManagedClassNames().stream()
+        .map(
+            className -> {
+              try {
+                return Class.forName(className);
+              } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .collect(toImmutableList());
+  }
+}

--- a/core/src/test/java/google/registry/model/transaction/JpaTransactionManagerRule.java
+++ b/core/src/test/java/google/registry/model/transaction/JpaTransactionManagerRule.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
 import google.registry.persistence.HibernateSchemaExporter;
 import google.registry.persistence.PersistenceModule;
+import google.registry.persistence.PersistenceXmlUtility;
 import google.registry.testing.FakeClock;
 import java.io.File;
 import java.io.IOException;
@@ -45,7 +46,6 @@ import java.util.Properties;
 import javax.persistence.EntityManagerFactory;
 import org.hibernate.cfg.Environment;
 import org.hibernate.jpa.boot.internal.ParsedPersistenceXmlDescriptor;
-import org.hibernate.jpa.boot.internal.PersistenceXmlParser;
 import org.hibernate.jpa.boot.spi.Bootstrap;
 import org.joda.time.DateTime;
 import org.junit.rules.ExternalResource;
@@ -214,15 +214,7 @@ public class JpaTransactionManagerRule extends ExternalResource {
     properties.put(Environment.PASS, password);
 
     ParsedPersistenceXmlDescriptor descriptor =
-        PersistenceXmlParser.locatePersistenceUnits(properties).stream()
-            .filter(unit -> PersistenceModule.PERSISTENCE_UNIT_NAME.equals(unit.getName()))
-            .findFirst()
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        String.format(
-                            "Could not find persistence unit with name %s",
-                            PersistenceModule.PERSISTENCE_UNIT_NAME)));
+        PersistenceXmlUtility.getParsedPersistenceXmlDescriptor();
 
     extraEntityClasses.stream().map(Class::getName).forEach(descriptor::addClasses);
     return Bootstrap.getEntityManagerFactoryBuilder(descriptor, properties).build();


### PR DESCRIPTION
This PR added the `PersistenceXmlUtility` class which provides a few methods to help manipulate `persistence.xml` and refactored `HibernateSchemaExporter`, `GenerateSqlSchemaCommand` and `JpaTransactionManagerRule` by using the provided method to simply the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/357)
<!-- Reviewable:end -->
