### PR TITLE
Fix beam pipeline deployment issue

### DIFF
--- a/core/src/main/java/google/registry/beam/invoicing/InvoicingPipeline.java
+++ b/core/src/main/java/google/registry/beam/invoicing/InvoicingPipeline.java
@@ -85,7 +85,7 @@ public class InvoicingPipeline implements Serializable {
   }
 
   /** Custom options for running the invoicing pipeline. */
-  interface InvoicingPipelineOptions extends DataflowPipelineOptions {
+  public interface InvoicingPipelineOptions extends DataflowPipelineOptions {
     /** Returns the yearMonth we're generating invoices for, in yyyy-MM format. */
     @Description("The yearMonth we generate invoices for, in yyyy-MM format.")
     ValueProvider<String> getYearMonth();

--- a/core/src/main/java/google/registry/beam/spec11/Spec11Pipeline.java
+++ b/core/src/main/java/google/registry/beam/spec11/Spec11Pipeline.java
@@ -105,7 +105,7 @@ public class Spec11Pipeline implements Serializable {
   }
 
   /** Custom options for running the spec11 pipeline. */
-  interface Spec11PipelineOptions extends DataflowPipelineOptions {
+  public interface Spec11PipelineOptions extends DataflowPipelineOptions {
     /** Returns the local date we're generating the report for, in yyyy-MM-dd format. */
     @Description("The local date we generate the report for, in yyyy-MM-dd format.")
     ValueProvider<String> getDate();


### PR DESCRIPTION
Fixed the issue by just marking the nested interface public per the error log. Tested the deployment
in alpha and manually kicked off the spec11 and invoicing pipeline. The spec11 pipeline
succeeded without any issue. The invoicing pipeline failed due to missing some data in BigQuery as the alpha environment just doesn't have those data, but it should be not related to this fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/360)
<!-- Reviewable:end -->
