### PR TITLE
Add a POST action for registry locks

### DIFF
--- a/core/src/main/java/google/registry/env/common/default/WEB-INF/web.xml
+++ b/core/src/main/java/google/registry/env/common/default/WEB-INF/web.xml
@@ -61,6 +61,11 @@
     <url-pattern>/registry-lock-get</url-pattern>
   </servlet-mapping>
 
+  <servlet-mapping>
+    <servlet-name>frontend-servlet</servlet-name>
+    <url-pattern>/registry-lock-post</url-pattern>
+  </servlet-mapping>
+
   <!-- Security config -->
   <security-constraint>
     <web-resource-collection>

--- a/core/src/main/java/google/registry/schema/domain/RegistryLock.java
+++ b/core/src/main/java/google/registry/schema/domain/RegistryLock.java
@@ -178,12 +178,14 @@ public final class RegistryLock extends ImmutableObject implements Buildable {
     this.completionTimestamp = toZonedDateTime(dateTime);
   }
 
+  /** Returns true iff the lock has been verified and performed. */
   public boolean isVerified() {
     return completionTimestamp != null;
   }
 
+  /** Returns true iff the lock was requested >= 1 hour ago and has not been verified. */
   public boolean isExpired(Clock clock) {
-    return isBeforeOrAt(getCreationTimestamp(), clock.nowUtc().minusHours(1));
+    return !isVerified() && isBeforeOrAt(getCreationTimestamp(), clock.nowUtc().minusHours(1));
   }
 
   @Override

--- a/core/src/main/java/google/registry/schema/domain/RegistryLock.java
+++ b/core/src/main/java/google/registry/schema/domain/RegistryLock.java
@@ -15,12 +15,14 @@
 package google.registry.schema.domain;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static google.registry.util.DateTimeUtils.isBeforeOrAt;
 import static google.registry.util.DateTimeUtils.toZonedDateTime;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
 import google.registry.model.Buildable;
 import google.registry.model.CreateAutoTimestamp;
 import google.registry.model.ImmutableObject;
+import google.registry.util.Clock;
 import google.registry.util.DateTimeUtils;
 import java.time.ZonedDateTime;
 import java.util.Optional;
@@ -178,6 +180,10 @@ public final class RegistryLock extends ImmutableObject implements Buildable {
 
   public boolean isVerified() {
     return completionTimestamp != null;
+  }
+
+  public boolean isExpired(Clock clock) {
+    return isBeforeOrAt(getCreationTimestamp(), clock.nowUtc().minusHours(1));
   }
 
   @Override

--- a/core/src/main/java/google/registry/tools/LockOrUnlockDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/LockOrUnlockDomainCommand.java
@@ -31,7 +31,7 @@ import javax.inject.Inject;
 /** Shared base class for commands to registry lock or unlock a domain via EPP. */
 public abstract class LockOrUnlockDomainCommand extends MutatingEppToolCommand {
 
-  protected static final ImmutableSet<StatusValue> REGISTRY_LOCK_STATUSES =
+  public static final ImmutableSet<StatusValue> REGISTRY_LOCK_STATUSES =
       ImmutableSet.of(
           SERVER_DELETE_PROHIBITED, SERVER_TRANSFER_PROHIBITED, SERVER_UPDATE_PROHIBITED);
 

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistryLockPostAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistryLockPostAction.java
@@ -166,7 +166,13 @@ public final class RegistryLockPostAction implements Runnable, JsonActionRunner.
     // Unlock actions have restrictions (unless the user is admin)
     if (!postInput.isLock && !isAdmin) {
       RegistryLock previouslyVerifiedLock =
-          RegistryLockDao.getMostRecentVerifiedLockByRepoId(domainBase.getRepoId())
+          previousLock
+              .flatMap(
+                  lock ->
+                      lock.isVerified()
+                          ? Optional.of(lock)
+                          : RegistryLockDao.getMostRecentVerifiedLockByRepoId(
+                              domainBase.getRepoId()))
               .orElseThrow(
                   () ->
                       new IllegalArgumentException(

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistryLockPostAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistryLockPostAction.java
@@ -1,0 +1,221 @@
+// Copyright 2019 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ui.server.registrar;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static google.registry.model.EppResourceUtils.loadByForeignKeyCached;
+import static google.registry.security.JsonResponseHelper.Status.ERROR;
+import static google.registry.security.JsonResponseHelper.Status.SUCCESS;
+import static google.registry.ui.server.registrar.RegistrarConsoleModule.PARAM_CLIENT_ID;
+import static google.registry.util.DateTimeUtils.isBeforeOrAt;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.MoreCollectors;
+import com.google.common.flogger.FluentLogger;
+import google.registry.config.RegistryConfig;
+import google.registry.config.RegistryConfig.Config;
+import google.registry.model.domain.DomainBase;
+import google.registry.model.registrar.Registrar;
+import google.registry.model.registrar.RegistrarContact;
+import google.registry.model.registry.RegistryLockDao;
+import google.registry.request.Action;
+import google.registry.request.Action.Method;
+import google.registry.request.JsonActionRunner;
+import google.registry.request.auth.Auth;
+import google.registry.request.auth.AuthResult;
+import google.registry.request.auth.AuthenticatedRegistrarAccessor;
+import google.registry.request.auth.AuthenticatedRegistrarAccessor.RegistrarAccessDeniedException;
+import google.registry.request.auth.UserAuthInfo;
+import google.registry.schema.domain.RegistryLock;
+import google.registry.security.JsonResponseHelper;
+import google.registry.util.Clock;
+import google.registry.util.EmailMessage;
+import google.registry.util.SendEmailService;
+import java.net.URL;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import javax.inject.Inject;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+
+/**
+ * UI action that allows for updating registrar locks for a particular registrar. Locks /
+ * unlocks must be verified separately before they are written permanently.
+ *
+ * <p>Note: at the moment we have no mechanism for JSON GET/POSTs in the same class or at the same
+ * URL, which is why this is distinct from the {@link RegistryLockGetAction}.
+ */
+@Action(
+    service = Action.Service.DEFAULT,
+    path = RegistryLockPostAction.PATH,
+    method = Method.POST,
+    auth = Auth.AUTH_PUBLIC_LOGGED_IN)
+public final class RegistryLockPostAction implements Runnable, JsonActionRunner.JsonAction {
+
+  public static final String PATH = "/registry-lock-post";
+
+  private static final URL URL_BASE = RegistryConfig.getDefaultServer();
+  private static final String VERIFICATION_EMAIL_TEMPLATE =
+      "Please click the link below to perform the %s on domain %s. Note: this code will expire "
+          + "in one hour.\n\n%s";
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+  private static final String PARAM_FQDN = "fullyQualifiedDomainName";
+  private static final String PARAM_IS_LOCK = "isLock";
+  private static final String PARAM_PASSWORD = "password";
+
+  private final JsonActionRunner jsonActionRunner;
+  @VisibleForTesting AuthResult authResult;
+  private final AuthenticatedRegistrarAccessor registrarAccessor;
+  private final SendEmailService sendEmailService;
+  private final Clock clock;
+  private final InternetAddress gSuiteOutgoingEmailAddress;
+
+  @Inject
+  RegistryLockPostAction(
+      JsonActionRunner jsonActionRunner,
+      AuthResult authResult,
+      AuthenticatedRegistrarAccessor registrarAccessor,
+      SendEmailService sendEmailService,
+      Clock clock,
+      @Config("gSuiteOutgoingEmailAddress") InternetAddress gSuiteOutgoingEmailAddress) {
+    this.jsonActionRunner = jsonActionRunner;
+    this.authResult = authResult;
+    this.registrarAccessor = registrarAccessor;
+    this.sendEmailService = sendEmailService;
+    this.clock = clock;
+    this.gSuiteOutgoingEmailAddress = gSuiteOutgoingEmailAddress;
+  }
+
+  @Override
+  public void run() {
+    jsonActionRunner.run(this);
+  }
+
+  @Override
+  public Map<String, ?> handleJsonRequest(Map<String, ?> input) {
+    try {
+      checkArgument(input != null, "Malformed JSON");
+      String clientId = (String) input.get(PARAM_CLIENT_ID);
+      checkArgument(
+          !Strings.isNullOrEmpty(clientId), "Missing key for client: %s", PARAM_CLIENT_ID);
+
+      verifyRegistryLockPassword(clientId, (String) input.get(PARAM_PASSWORD));
+      RegistryLock registryLock = createLock(clientId, input);
+      RegistryLockDao.save(registryLock);
+      sendVerificationEmail(registryLock);
+      String action = registryLock.getAction().equals(RegistryLock.Action.LOCK) ? "lock" : "unlock";
+      return JsonResponseHelper.create(SUCCESS, String.format("Successful %s", action));
+    } catch (Throwable e) {
+      logger.atWarning().withCause(e).log("Failed to lock/unlock domain with input %s", input);
+      return JsonResponseHelper.create(
+          ERROR, Optional.ofNullable(e.getMessage()).orElse("Unspecified error"));
+    }
+  }
+
+  private RegistryLock createLock(String clientId, Map<String, ?> input) {
+    String domainName = (String) input.get(PARAM_FQDN);
+    checkArgument(!Strings.isNullOrEmpty(domainName), "Missing key for fqdn: %s", PARAM_FQDN);
+
+    DomainBase domainBase =
+        loadByForeignKeyCached(DomainBase.class, domainName, clock.nowUtc())
+            .orElseThrow(
+                () -> new IllegalArgumentException(String.format("Unknown domain %s", domainName)));
+
+    // Multiple pending actions are not allowed
+    Optional<RegistryLock> previousLock =
+        RegistryLockDao.getMostRecentByRepoId(domainBase.getRepoId());
+    previousLock.ifPresent(
+        lock ->
+            checkArgument(
+                lock.isVerified()
+                    || isBeforeOrAt(lock.getCreationTimestamp(), clock.nowUtc().minusHours(1)),
+                String.format("A pending action already exists for %s", domainName)));
+
+    checkArgument(input.containsKey(PARAM_IS_LOCK), "Missing key for isLock: %s", PARAM_IS_LOCK);
+    boolean lock = (Boolean) input.get(PARAM_IS_LOCK);
+    boolean isAdmin = authResult.userAuthInfo().get().isUserAdmin();
+
+    // Unlock actions have restrictions (unless the user is admin)
+    if (!lock && !isAdmin) {
+      RegistryLock previouslyVerifiedLock =
+          RegistryLockDao.getMostRecentVerifiedLockByRepoId(domainBase.getRepoId())
+              .orElseThrow(
+                  () ->
+                      new IllegalArgumentException(
+                          "Cannot unlock a domain without a previously-verified lock"));
+      checkArgument(
+          previouslyVerifiedLock.getAction().equals(RegistryLock.Action.LOCK),
+          "Cannot unlock a domain multiple times");
+      checkArgument(
+          !previouslyVerifiedLock.isSuperuser(),
+          "Non-admin user cannot unlock an admin-locked domain");
+    }
+    return new RegistryLock.Builder()
+        .isSuperuser(isAdmin)
+        .setVerificationCode(UUID.randomUUID().toString())
+        .setAction(lock ? RegistryLock.Action.LOCK : RegistryLock.Action.UNLOCK)
+        .setDomainName(domainName)
+        .setRegistrarId(clientId)
+        .setRepoId(domainBase.getRepoId())
+        .setRegistrarPocId(authResult.userAuthInfo().get().user().getEmail())
+        .build();
+  }
+
+  private void sendVerificationEmail(RegistryLock lock)
+      throws AddressException {
+    String url =
+        URL_BASE.toString()
+            + "/registry-lock-verify" // RegistryLockVerifyAction.PATH
+            + String.format("?lockVerificationCode=%s", lock.getVerificationCode());
+    String action = lock.getAction().equals(RegistryLock.Action.LOCK) ? "lock" : "unlock";
+    String body = String.format(VERIFICATION_EMAIL_TEMPLATE, action, lock.getDomainName(), url);
+    String subject = String.format("Registry %s verification", action);
+    ImmutableList<InternetAddress> recipients =
+        ImmutableList.of(
+            new InternetAddress(authResult.userAuthInfo().get().user().getEmail(), true));
+    sendEmailService.sendEmail(
+        EmailMessage.newBuilder()
+            .setBody(body)
+            .setSubject(subject)
+            .setRecipients(recipients)
+            .setFrom(gSuiteOutgoingEmailAddress)
+            .build());
+  }
+
+  private void verifyRegistryLockPassword(String clientId, String password)
+      throws RegistrarAccessDeniedException {
+    // Verify that the user can access the registrar and that the user is either an admin or has
+    // registry lock enabled and provided a correct password
+    checkArgument(authResult.userAuthInfo().isPresent(), "Auth result not present");
+    Registrar registrar = registrarAccessor.getRegistrar(clientId);
+    checkArgument(
+        registrar.isRegistryLockAllowed(), "Registry lock not allowed for this registrar");
+    UserAuthInfo userAuthInfo = authResult.userAuthInfo().get();
+    if (!userAuthInfo.isUserAdmin()) {
+      checkArgument(
+          !Strings.isNullOrEmpty(password), "Missing key for password: %s", PARAM_PASSWORD);
+      RegistrarContact registrarContact =
+          registrar.getContacts().stream()
+              .filter(contact -> contact.getEmailAddress().equals(userAuthInfo.user().getEmail()))
+              .collect(MoreCollectors.onlyElement());
+      checkArgument(
+          registrarContact.verifyRegistryLockPassword(password),
+          "Incorrect registry lock password for contact");
+    }
+  }
+}

--- a/core/src/test/java/google/registry/model/registry/RegistryLockDaoTest.java
+++ b/core/src/test/java/google/registry/model/registry/RegistryLockDaoTest.java
@@ -136,6 +136,21 @@ public final class RegistryLockDaoTest {
   }
 
   @Test
+  public void testLoad_verified_byRepoId() {
+    RegistryLock completedLock =
+        createLock().asBuilder().setCompletionTimestamp(jpaTmRule.getTxnClock().nowUtc()).build();
+    RegistryLockDao.save(completedLock);
+
+    jpaTmRule.getTxnClock().advanceOneMilli();
+    RegistryLock inProgressLock = createLock();
+    RegistryLockDao.save(inProgressLock);
+
+    Optional<RegistryLock> mostRecent = RegistryLockDao.getMostRecentVerifiedLockByRepoId("repoId");
+    assertThat(mostRecent.isPresent()).isTrue();
+    assertThat(mostRecent.get().isVerified()).isTrue();
+  }
+
+  @Test
   public void testLoad_byRepoId_empty() {
     assertThat(RegistryLockDao.getMostRecentByRepoId("nonexistent").isPresent()).isFalse();
   }

--- a/core/src/test/java/google/registry/model/registry/RegistryLockDaoTest.java
+++ b/core/src/test/java/google/registry/model/registry/RegistryLockDaoTest.java
@@ -151,6 +151,13 @@ public final class RegistryLockDaoTest {
   }
 
   @Test
+  public void testLoad_verified_byRepoId_empty() {
+    RegistryLockDao.save(createLock());
+    Optional<RegistryLock> mostRecent = RegistryLockDao.getMostRecentVerifiedLockByRepoId("repoId");
+    assertThat(mostRecent.isPresent()).isFalse();
+  }
+
+  @Test
   public void testLoad_byRepoId_empty() {
     assertThat(RegistryLockDao.getMostRecentByRepoId("nonexistent").isPresent()).isFalse();
   }

--- a/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
+++ b/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
@@ -27,6 +27,7 @@ import google.registry.persistence.UpdateAutoTimestampConverterTest;
 import google.registry.persistence.ZonedDateTimeConverterTest;
 import google.registry.schema.tld.PremiumListDaoTest;
 import google.registry.ui.server.registrar.RegistryLockGetActionTest;
+import google.registry.ui.server.registrar.RegistryLockPostActionTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
@@ -54,6 +55,7 @@ import org.junit.runners.Suite.SuiteClasses;
   PremiumListDaoTest.class,
   RegistryLockDaoTest.class,
   RegistryLockGetActionTest.class,
+  RegistryLockPostActionTest.class,
   UpdateAutoTimestampConverterTest.class,
   ZonedDateTimeConverterTest.class
 })

--- a/core/src/test/java/google/registry/server/RegistryTestServer.java
+++ b/core/src/test/java/google/registry/server/RegistryTestServer.java
@@ -83,7 +83,8 @@ public final class RegistryTestServer {
           route("/registrar-ote-setup", FrontendServlet.class),
           route("/registrar-ote-status", FrontendServlet.class),
           route("/registrar-settings", FrontendServlet.class),
-          route("/registry-lock-get", FrontendServlet.class));
+          route("/registry-lock-get", FrontendServlet.class),
+          route("/registry-lock-post", FrontendServlet.class));
 
   private static final ImmutableList<Class<? extends Filter>> FILTERS = ImmutableList.of(
       ObjectifyFilter.class,

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistryLockPostActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistryLockPostActionTest.java
@@ -194,7 +194,7 @@ public final class RegistryLockPostActionTest {
                 "clientId", "TheRegistrar",
                 "fullyQualifiedDomainName", "example.tld",
                 "password", "hi"));
-    assertFailureWithMessage(response, "Missing key for isLock: isLock");
+    assertFailureWithMessage(response, "Missing key for isLock");
   }
 
   @Test

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistryLockPostActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistryLockPostActionTest.java
@@ -1,0 +1,392 @@
+// Copyright 2019 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ui.server.registrar;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.model.EppResourceUtils.loadByForeignKey;
+import static google.registry.testing.DatastoreHelper.createTld;
+import static google.registry.testing.DatastoreHelper.newDomainBase;
+import static google.registry.testing.DatastoreHelper.persistResource;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.google.appengine.api.users.User;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSetMultimap;
+import google.registry.model.CreateAutoTimestamp;
+import google.registry.model.domain.DomainBase;
+import google.registry.model.registry.RegistryLockDao;
+import google.registry.model.transaction.JpaTransactionManagerRule;
+import google.registry.request.JsonActionRunner;
+import google.registry.request.JsonResponse;
+import google.registry.request.ResponseImpl;
+import google.registry.request.auth.AuthLevel;
+import google.registry.request.auth.AuthResult;
+import google.registry.request.auth.AuthenticatedRegistrarAccessor;
+import google.registry.request.auth.AuthenticatedRegistrarAccessor.Role;
+import google.registry.request.auth.UserAuthInfo;
+import google.registry.schema.domain.RegistryLock;
+import google.registry.schema.domain.RegistryLock.Action;
+import google.registry.testing.AppEngineRule;
+import google.registry.testing.FakeClock;
+import google.registry.util.Clock;
+import google.registry.util.EmailMessage;
+import google.registry.util.SendEmailService;
+import java.util.Map;
+import java.util.UUID;
+import javax.mail.internet.InternetAddress;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public final class RegistryLockPostActionTest {
+
+  @Rule public final AppEngineRule appEngineRule = AppEngineRule.builder().withDatastore().build();
+
+  @Rule
+  public final JpaTransactionManagerRule jpaTmRule =
+      new JpaTransactionManagerRule.Builder().build();
+
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
+  private final User userWithoutPermission =
+      new User("johndoe@theregistrar.com", "gmail.com", "31337");
+  // Marla Singer has registry lock auth permissions
+  private final User userWithLockPermission =
+      new User("Marla.Singer@crr.com", "gmail.com", "31337");
+  private final Clock clock = new FakeClock();
+
+  private AuthResult authResult;
+  private InternetAddress outgoingAddress;
+  private RegistryLockPostAction action;
+
+  @Mock SendEmailService emailService;
+  @Mock HttpServletResponse mockResponse;
+
+  @Before
+  public void setup() throws Exception {
+    createTld("tld");
+    persistResource(newDomainBase("example.tld"));
+
+    authResult =
+        AuthResult.create(AuthLevel.USER, UserAuthInfo.create(userWithLockPermission, false));
+    outgoingAddress = new InternetAddress("domain-registry@example.com");
+    JsonActionRunner jsonActionRunner =
+        new JsonActionRunner(ImmutableMap.of(), new JsonResponse(new ResponseImpl(mockResponse)));
+    AuthenticatedRegistrarAccessor registrarAccessor =
+        AuthenticatedRegistrarAccessor.createForTesting(
+            ImmutableSetMultimap.of("TheRegistrar", Role.OWNER, "NewRegistrar", Role.OWNER));
+    action =
+        new RegistryLockPostAction(
+            jsonActionRunner, authResult, registrarAccessor, emailService, clock, outgoingAddress);
+  }
+
+  @Test
+  public void testSuccess_lock() throws Exception {
+    Map<String, ?> response =
+        action.handleJsonRequest(
+            ImmutableMap.of(
+                "clientId", "TheRegistrar",
+                "fullyQualifiedDomainName", "example.tld",
+                "isLock", true,
+                "password", "hi"));
+    assertSuccess(response, "lock", "Marla.Singer@crr.com");
+  }
+
+  @Test
+  public void testSuccess_unlock() throws Exception {
+    RegistryLockDao.save(createLock().asBuilder().setCompletionTimestamp(clock.nowUtc()).build());
+    Map<String, ?> response =
+        action.handleJsonRequest(
+            ImmutableMap.of(
+                "clientId", "TheRegistrar",
+                "fullyQualifiedDomainName", "example.tld",
+                "isLock", false,
+                "password", "hi"));
+    assertSuccess(response, "unlock", "Marla.Singer@crr.com");
+  }
+
+  @Test
+  public void testSuccess_unlock_adminUnlockingAdmin() throws Exception {
+    RegistryLockDao.save(
+        createLock().asBuilder().isSuperuser(true).setCompletionTimestamp(clock.nowUtc()).build());
+    action.authResult =
+        AuthResult.create(AuthLevel.USER, UserAuthInfo.create(userWithoutPermission, true));
+    Map<String, ?> response =
+        action.handleJsonRequest(
+            ImmutableMap.of(
+                "clientId", "TheRegistrar",
+                "fullyQualifiedDomainName", "example.tld",
+                "isLock", false,
+                "password", "hi"));
+    assertSuccess(response, "unlock", "johndoe@theregistrar.com");
+  }
+
+  @Test
+  public void testFailure_unlock_noLock() {
+    Map<String, ?> response =
+        action.handleJsonRequest(
+            ImmutableMap.of(
+                "clientId", "TheRegistrar",
+                "fullyQualifiedDomainName", "example.tld",
+                "isLock", false,
+                "password", "hi"));
+    assertFailureWithMessage(response, "Cannot unlock a domain without a previously-verified lock");
+  }
+
+  @Test
+  public void testFailure_unlock_alreadyUnlocked() {
+    RegistryLockDao.save(
+        createLock()
+            .asBuilder()
+            .setAction(Action.UNLOCK)
+            .setCompletionTimestamp(clock.nowUtc())
+            .build());
+    Map<String, ?> response =
+        action.handleJsonRequest(
+            ImmutableMap.of(
+                "clientId", "TheRegistrar",
+                "fullyQualifiedDomainName", "example.tld",
+                "isLock", false,
+                "password", "hi"));
+    assertFailureWithMessage(response, "Cannot unlock a domain multiple times");
+  }
+
+  @Test
+  public void testFailure_unlock_nonAdminUnlockingAdmin() {
+    RegistryLockDao.save(
+        createLock().asBuilder().isSuperuser(true).setCompletionTimestamp(clock.nowUtc()).build());
+    Map<String, ?> response =
+        action.handleJsonRequest(
+            ImmutableMap.of(
+                "clientId", "TheRegistrar",
+                "fullyQualifiedDomainName", "example.tld",
+                "isLock", false,
+                "password", "hi"));
+    assertFailureWithMessage(response, "Non-admin user cannot unlock an admin-locked domain");
+  }
+
+  @Test
+  public void testSuccess_adminUser() throws Exception {
+    // Admin user should be able to lock/unlock regardless
+    action.authResult =
+        AuthResult.create(AuthLevel.USER, UserAuthInfo.create(userWithoutPermission, true));
+    Map<String, ?> response =
+        action.handleJsonRequest(
+            ImmutableMap.of(
+                "clientId", "TheRegistrar",
+                "fullyQualifiedDomainName", "example.tld",
+                "isLock", true,
+                "password", "hi"));
+    assertSuccess(response, "lock", "johndoe@theregistrar.com");
+  }
+
+  @Test
+  public void testFailure_noInput() {
+    Map<String, ?> response = action.handleJsonRequest(null);
+    assertFailureWithMessage(response, "Malformed JSON");
+  }
+
+  @Test
+  public void testFailure_noClientId() {
+    Map<String, ?> response = action.handleJsonRequest(ImmutableMap.of());
+    assertFailureWithMessage(response, "Missing key for client: clientId");
+  }
+
+  @Test
+  public void testFailure_emptyClientId() {
+    Map<String, ?> response = action.handleJsonRequest(ImmutableMap.of("clientId", ""));
+    assertFailureWithMessage(response, "Missing key for client: clientId");
+  }
+
+  @Test
+  public void testFailure_noDomainName() {
+    Map<String, ?> response =
+        action.handleJsonRequest(ImmutableMap.of("clientId", "TheRegistrar", "password", "hi"));
+    assertFailureWithMessage(response, "Missing key for fqdn: fullyQualifiedDomainName");
+  }
+
+  @Test
+  public void testFailure_noLockParam() {
+    Map<String, ?> response =
+        action.handleJsonRequest(
+            ImmutableMap.of(
+                "clientId",
+                "TheRegistrar",
+                "fullyQualifiedDomainName",
+                "example.tld",
+                "password",
+                "hi"));
+    assertFailureWithMessage(response, "Missing key for isLock: isLock");
+  }
+
+  @Test
+  public void testFailure_notAllowedOnRegistrar() {
+    Map<String, ?> response =
+        action.handleJsonRequest(
+            ImmutableMap.of(
+                "clientId", "NewRegistrar",
+                "fullyQualifiedDomainName", "example.tld",
+                "isLock", true,
+                "password", "password"));
+    assertFailureWithMessage(response, "Registry lock not allowed for this registrar");
+  }
+
+  @Test
+  public void testFailure_noPassword() {
+    Map<String, ?> response =
+        action.handleJsonRequest(
+            ImmutableMap.of(
+                "clientId", "TheRegistrar",
+                "fullyQualifiedDomainName", "example.tld",
+                "isLock", true));
+    assertFailureWithMessage(response, "Missing key for password: password");
+  }
+
+  @Test
+  public void testFailure_notEnabledForRegistrarContact() {
+    action.authResult =
+        AuthResult.create(AuthLevel.USER, UserAuthInfo.create(userWithoutPermission, false));
+    // A wrong password should give the same error as not-enabled-for-this-contact
+    Map<String, ?> response =
+        action.handleJsonRequest(
+            ImmutableMap.of(
+                "clientId", "TheRegistrar",
+                "fullyQualifiedDomainName", "example.tld",
+                "isLock", true,
+                "password", "hi"));
+    assertFailureWithMessage(response, "Incorrect registry lock password for contact");
+  }
+
+  @Test
+  public void testFailure_badPassword() {
+    Map<String, ?> response =
+        action.handleJsonRequest(
+            ImmutableMap.of(
+                "clientId", "TheRegistrar",
+                "fullyQualifiedDomainName", "example.tld",
+                "isLock", true,
+                "password", "badPassword"));
+    assertFailureWithMessage(response, "Incorrect registry lock password for contact");
+  }
+
+  @Test
+  public void testFailure_invalidDomain() {
+    Map<String, ?> response =
+        action.handleJsonRequest(
+            ImmutableMap.of(
+                "clientId", "TheRegistrar",
+                "fullyQualifiedDomainName", "bad.tld",
+                "isLock", true,
+                "password", "hi"));
+    assertFailureWithMessage(response, "Unknown domain bad.tld");
+  }
+
+  @Test
+  public void testSuccess_previousLockVerified() throws Exception {
+    RegistryLockDao.save(
+        createLock().asBuilder().setCompletionTimestamp(clock.nowUtc().minusMinutes(1)).build());
+
+    Map<String, ?> response =
+        action.handleJsonRequest(
+            ImmutableMap.of(
+                "clientId", "TheRegistrar",
+                "fullyQualifiedDomainName", "example.tld",
+                "isLock", true,
+                "password", "hi"));
+    assertSuccess(response, "lock", "Marla.Singer@crr.com");
+  }
+
+  @Test
+  public void testSuccess_previousLockExpired() throws Exception {
+    RegistryLockDao.save(
+        createLock()
+            .asBuilder()
+            .setCreationTimestamp(CreateAutoTimestamp.create(clock.nowUtc().minusHours(2)))
+            .build());
+
+    Map<String, ?> response =
+        action.handleJsonRequest(
+            ImmutableMap.of(
+                "clientId", "TheRegistrar",
+                "fullyQualifiedDomainName", "example.tld",
+                "isLock", true,
+                "password", "hi"));
+    assertSuccess(response, "lock", "Marla.Singer@crr.com");
+  }
+
+  @Test
+  public void testFailure_alreadyPendingLock() {
+    RegistryLockDao.save(createLock());
+
+    Map<String, ?> response =
+        action.handleJsonRequest(
+            ImmutableMap.of(
+                "clientId", "TheRegistrar",
+                "fullyQualifiedDomainName", "example.tld",
+                "isLock", true,
+                "password", "hi"));
+    assertFailureWithMessage(response, "A pending action already exists for example.tld");
+  }
+
+  private RegistryLock createLock() {
+    DomainBase domain = loadByForeignKey(DomainBase.class, "example.tld", clock.nowUtc()).get();
+    return new RegistryLock.Builder()
+        .setDomainName("example.tld")
+        .setAction(Action.LOCK)
+        .isSuperuser(false)
+        .setVerificationCode(UUID.randomUUID().toString())
+        .setRegistrarId("TheRegistrar")
+        .setRepoId(domain.getRepoId())
+        .setRegistrarPocId("Marla.Singer@crr.com")
+        .build();
+  }
+
+  private void assertSuccess(Map<String, ?> response, String lockAction, String recipient)
+      throws Exception {
+    assertThat(response)
+        .containsExactly(
+            "status", "SUCCESS",
+            "results", ImmutableList.of(),
+            "message", String.format("Successful %s", lockAction));
+    verifyEmail(recipient, lockAction);
+  }
+
+  private void assertFailureWithMessage(Map<String, ?> response, String message) {
+    assertThat(response)
+        .containsExactly("status", "ERROR", "results", ImmutableList.of(), "message", message);
+    verifyNoMoreInteractions(emailService);
+  }
+
+  private void verifyEmail(String recipient, String lockAction) throws Exception {
+    ArgumentCaptor<EmailMessage> emailCaptor = ArgumentCaptor.forClass(EmailMessage.class);
+    verify(emailService).sendEmail(emailCaptor.capture());
+    EmailMessage sentMessage = emailCaptor.getValue();
+    assertThat(sentMessage.subject())
+        .isEqualTo(String.format("Registry %s verification", lockAction));
+    assertThat(sentMessage.body()).startsWith("Please click the link below");
+    assertThat(sentMessage.from()).isEqualTo(new InternetAddress("domain-registry@example.com"));
+    assertThat(sentMessage.recipients()).containsExactly(new InternetAddress(recipient));
+  }
+}

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistryLockPostActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistryLockPostActionTest.java
@@ -183,7 +183,7 @@ public final class RegistryLockPostActionTest {
   public void testFailure_noDomainName() {
     Map<String, ?> response =
         action.handleJsonRequest(ImmutableMap.of("clientId", "TheRegistrar", "password", "hi"));
-    assertFailureWithMessage(response, "Missing key for fqdn: fullyQualifiedDomainName");
+    assertFailureWithMessage(response, "Missing key for fullyQualifiedDomainName");
   }
 
   @Test
@@ -213,7 +213,7 @@ public final class RegistryLockPostActionTest {
                 "clientId", "TheRegistrar",
                 "fullyQualifiedDomainName", "example.tld",
                 "isLock", true));
-    assertFailureWithMessage(response, "Missing key for password: password");
+    assertFailureWithMessage(response, "Missing key for password");
   }
 
   @Test


### PR DESCRIPTION
This is the second of the three asynchronously-pushed Registry Lock actions. This one creates the lock object, saves it as pending to the DB, and sends the email to the contact with the verification link. It does not actually change the domain at all -- that occurs in the verification action 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/362)
<!-- Reviewable:end -->
