### PR TITLE
Save an admin lock object during (un)lock domain commands

### DIFF
--- a/core/src/main/java/google/registry/tools/LockDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/LockDomainCommand.java
@@ -27,6 +27,7 @@ import com.google.common.flogger.FluentLogger;
 import com.google.template.soy.data.SoyMapData;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.eppcommon.StatusValue;
+import google.registry.schema.domain.RegistryLock.Action;
 import google.registry.tools.soy.DomainUpdateSoyInfo;
 import java.util.Optional;
 import org.joda.time.DateTime;
@@ -77,6 +78,7 @@ public class LockDomainCommand extends LockOrUnlockDomainCommand {
               "addDsRecords", ImmutableList.of(),
               "removeDsRecords", ImmutableList.of(),
               "removeAllDsRecords", false));
+      saveLockObject(domainBase.get(), now, Action.LOCK);
     }
   }
 }

--- a/core/src/main/java/google/registry/tools/LockDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/LockDomainCommand.java
@@ -78,7 +78,7 @@ public class LockDomainCommand extends LockOrUnlockDomainCommand {
               "addDsRecords", ImmutableList.of(),
               "removeDsRecords", ImmutableList.of(),
               "removeAllDsRecords", false));
-      saveLockObject(domainBase.get(), now, Action.LOCK);
+      stageRegistryLockObject(domainBase.get(), now, Action.LOCK);
     }
   }
 }

--- a/core/src/main/java/google/registry/tools/UnlockDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/UnlockDomainCommand.java
@@ -27,6 +27,7 @@ import com.google.common.flogger.FluentLogger;
 import com.google.template.soy.data.SoyMapData;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.eppcommon.StatusValue;
+import google.registry.schema.domain.RegistryLock.Action;
 import google.registry.tools.soy.DomainUpdateSoyInfo;
 import java.util.Optional;
 import org.joda.time.DateTime;
@@ -77,6 +78,7 @@ public class UnlockDomainCommand extends LockOrUnlockDomainCommand {
               "addDsRecords", ImmutableList.of(),
               "removeDsRecords", ImmutableList.of(),
               "removeAllDsRecords", false));
+      saveLockObject(domainBase.get(), now, Action.UNLOCK);
     }
   }
 }

--- a/core/src/main/java/google/registry/tools/UnlockDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/UnlockDomainCommand.java
@@ -78,7 +78,7 @@ public class UnlockDomainCommand extends LockOrUnlockDomainCommand {
               "addDsRecords", ImmutableList.of(),
               "removeDsRecords", ImmutableList.of(),
               "removeAllDsRecords", false));
-      saveLockObject(domainBase.get(), now, Action.UNLOCK);
+      stageRegistryLockObject(domainBase.get(), now, Action.UNLOCK);
     }
   }
 }

--- a/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
+++ b/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
@@ -26,6 +26,8 @@ import google.registry.persistence.JodaMoneyConverterTest;
 import google.registry.persistence.UpdateAutoTimestampConverterTest;
 import google.registry.persistence.ZonedDateTimeConverterTest;
 import google.registry.schema.tld.PremiumListDaoTest;
+import google.registry.tools.LockDomainCommandTest;
+import google.registry.tools.UnlockDomainCommandTest;
 import google.registry.ui.server.registrar.RegistryLockGetActionTest;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
@@ -51,9 +53,11 @@ import org.junit.runners.Suite.SuiteClasses;
   JodaMoneyConverterTest.class,
   JpaTransactionManagerImplTest.class,
   JpaTransactionManagerRuleTest.class,
+  LockDomainCommandTest.class,
   PremiumListDaoTest.class,
   RegistryLockDaoTest.class,
   RegistryLockGetActionTest.class,
+  UnlockDomainCommandTest.class,
   UpdateAutoTimestampConverterTest.class,
   ZonedDateTimeConverterTest.class
 })

--- a/core/src/test/java/google/registry/tools/EppToolVerifier.java
+++ b/core/src/test/java/google/registry/tools/EppToolVerifier.java
@@ -162,6 +162,11 @@ public class EppToolVerifier {
         .isEmpty();
   }
 
+  /** Returns the (mock) Connection that is being monitored by this verifier. */
+  AppEngineConnection getConnection() {
+    return connection;
+  }
+
   private void setArgumentsIfNeeded() throws Exception {
     if (capturedParams != null) {
       return;
@@ -193,10 +198,5 @@ public class EppToolVerifier {
     assertXmlEquals(expectedXmlContent, prettyPrint(bytesToXml(capturedParams.get(paramIndex))));
     paramIndex++;
     return this;
-  }
-
-  /** Returns the (mock) Connection that is being monitored by this verifier. */
-  private AppEngineConnection getConnection() {
-    return connection;
   }
 }

--- a/core/src/test/resources/google/registry/tools/server/epp_failure_example.xml
+++ b/core/src/test/resources/google/registry/tools/server/epp_failure_example.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <response>
+    <result code="2400">
+      <msg>Command failed</msg>
+    </result>
+    <trID>
+      <clTRID>RegistryTool</clTRID>
+      <svTRID>jxdx2JCZRNiGmBfwuJJ9sQ==-2</svTRID>
+    </trID>
+  </response>
+</epp>

--- a/core/src/test/resources/google/registry/tools/server/epp_success_example.xml
+++ b/core/src/test/resources/google/registry/tools/server/epp_success_example.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <response>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
+    </result>
+    <trID>
+      <clTRID>RegistryTool</clTRID>
+      <svTRID>5f+7o56FTb+HYSQXNCPQ2w==-2</svTRID>
+    </trID>
+  </response>
+</epp>


### PR DESCRIPTION
We would like for both the command-line and the web console lock actions to create the lock object so that we have a single source of truth as to what lock/unlock actions have been performed on a domain. This also gets us the necessary benefit of non-admins not being allowed, through the web console, to unlock domains that were locked with the command-line tool

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/366)
<!-- Reviewable:end -->
