### PR TITLE
Require explict tag when starting psql docker

### DIFF
--- a/config/presubmits.py
+++ b/config/presubmits.py
@@ -99,6 +99,12 @@ PRESUBMITS = {
         "System.(out|err).println is only allowed in tools/ packages. Please "
         "use a logger instead.",
 
+    # PostgreSQLContainer instantiation must specify docker tag
+    PresubmitCheck(
+        r"[\s\S]*new\s+PostgreSQLContainer(<[\s\S]*>)?\(\s*\)[\s\S]*",
+        "java", {}):
+      "PostgreSQLContainer instantiation must specify docker tag.",
+
     # Various Soy linting checks
     PresubmitCheck(
         r".* (/\*)?\* {?@param ",

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -243,6 +243,8 @@ dependencies {
   // Known issue: nebula-lint misses inherited dependency.
   compile project(':third_party')
   compile project(':util')
+  // Import NomulusPostreSql from ':db' for compile but exclude dependencies.
+  compile project(path: ':db', configuration: 'compileApi')
   testRuntime project(':db')
 
   // Include auto-value in compile until nebula-lint understands

--- a/core/src/main/java/google/registry/tools/GenerateSqlSchemaCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateSqlSchemaCommand.java
@@ -20,6 +20,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.common.annotations.VisibleForTesting;
 import google.registry.persistence.HibernateSchemaExporter;
+import google.registry.persistence.NomulusPostgreSql;
 import google.registry.persistence.PersistenceXmlUtility;
 import java.io.File;
 import java.io.IOException;
@@ -83,7 +84,7 @@ public class GenerateSqlSchemaCommand implements Command {
 
       // Start the container and store the address information.
       postgresContainer =
-          new PostgreSQLContainer()
+          new PostgreSQLContainer(NomulusPostgreSql.getDockerTag())
               .withDatabaseName(DB_NAME)
               .withUsername(DB_USERNAME)
               .withPassword(DB_PASSWORD);

--- a/core/src/test/java/google/registry/model/transaction/JpaTransactionManagerRule.java
+++ b/core/src/test/java/google/registry/model/transaction/JpaTransactionManagerRule.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.io.Resources;
 import google.registry.persistence.HibernateSchemaExporter;
+import google.registry.persistence.NomulusPostgreSql;
 import google.registry.persistence.PersistenceModule;
 import google.registry.persistence.PersistenceXmlUtility;
 import google.registry.testing.FakeClock;
@@ -90,7 +91,9 @@ public class JpaTransactionManagerRule extends ExternalResource {
   }
 
   private static JdbcDatabaseContainer create() {
-    PostgreSQLContainer container = new PostgreSQLContainer().withDatabaseName(MANAGEMENT_DB_NAME);
+    PostgreSQLContainer container =
+        new PostgreSQLContainer(NomulusPostgreSql.getDockerTag())
+            .withDatabaseName(MANAGEMENT_DB_NAME);
     container.start();
     Runtime.getRuntime().addShutdownHook(new Thread(() -> container.close()));
     return container;

--- a/core/src/test/java/google/registry/persistence/HibernateSchemaExporterTest.java
+++ b/core/src/test/java/google/registry/persistence/HibernateSchemaExporterTest.java
@@ -36,7 +36,10 @@ import org.testcontainers.containers.PostgreSQLContainer;
 /** Unit tests for {@link HibernateSchemaExporter}. */
 @RunWith(JUnit4.class)
 public class HibernateSchemaExporterTest {
-  @ClassRule public static final PostgreSQLContainer database = new PostgreSQLContainer();
+  @ClassRule
+  public static final PostgreSQLContainer database =
+      new PostgreSQLContainer(NomulusPostgreSql.getDockerTag());
+
   private static HibernateSchemaExporter exporter;
 
   @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();

--- a/core/src/test/java/google/registry/persistence/PersistenceModuleTest.java
+++ b/core/src/test/java/google/registry/persistence/PersistenceModuleTest.java
@@ -29,7 +29,8 @@ import org.testcontainers.containers.PostgreSQLContainer;
 /** Unit tests for {@link PersistenceModule}. */
 @RunWith(JUnit4.class)
 public class PersistenceModuleTest {
-  @Rule public PostgreSQLContainer database = new PostgreSQLContainer();
+  @Rule
+  public PostgreSQLContainer database = new PostgreSQLContainer(NomulusPostgreSql.getDockerTag());
 
   private EntityManagerFactory emf;
 

--- a/core/src/test/java/google/registry/tools/GenerateSqlSchemaCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateSqlSchemaCommandTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.io.Files;
+import google.registry.persistence.NomulusPostgreSql;
 import java.io.File;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -37,8 +38,9 @@ public class GenerateSqlSchemaCommandTest extends CommandTestCase<GenerateSqlSch
 
   @Rule public TemporaryFolder tmp = new TemporaryFolder();
 
-  @ClassRule public static PostgreSQLContainer postgres =
-      new PostgreSQLContainer()
+  @ClassRule
+  public static PostgreSQLContainer postgres =
+      new PostgreSQLContainer(NomulusPostgreSql.getDockerTag())
           .withDatabaseName("postgres")
           .withUsername("postgres")
           .withPassword("domain-registry");

--- a/db/build.gradle
+++ b/db/build.gradle
@@ -92,8 +92,23 @@ task schemaJar(type: Jar) {
   }
 }
 
+// Expose NomulusPostgreSql class to ':core' for compile, without leaking
+// unnecessary dependencies to the release artifacts through ':core'.
+// Jar is put in the 'compileApi' configuration.
+task compileApiJar(type: Jar) {
+  archiveBaseName = 'compile'
+  from(sourceSets.main.output) {
+    include 'google/registry/persistence/NomulusPostgreSql**'
+  }
+}
+
+configurations {
+  compileApi
+}
+
 artifacts {
   archives schemaJar
+  compileApi compileApiJar
 }
 
 publishing {

--- a/db/src/main/java/google/registry/persistence/NomulusPostgreSql.java
+++ b/db/src/main/java/google/registry/persistence/NomulusPostgreSql.java
@@ -1,0 +1,28 @@
+// Copyright 2019 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package google.registry.persistence;
+
+/** Information about Nomulus' Cloud SQL PostgreSql instance. */
+public class NomulusPostgreSql {
+
+  /** The current PostgreSql version in Cloud SQL. */
+  // TODO(weiminyu): setup periodic checks to detect version changes in Cloud SQL.
+  // TODO(weiminyu): Upgrade to 11.5, which apparently breaks JpaTransactionManagerRule.
+  private static final String TARGET_VERSION = "9.6.12";
+
+  /** Returns the docker image tag of the targeted Postgresql server version. */
+  public static String getDockerTag() {
+    return "postgres:" + TARGET_VERSION;
+  }
+}

--- a/db/src/test/java/google/registry/sql/flyway/SchemaTest.java
+++ b/db/src/test/java/google/registry/sql/flyway/SchemaTest.java
@@ -19,6 +19,7 @@ import static google.registry.testing.TextDiffSubject.assertThat;
 
 import com.google.common.base.Joiner;
 import com.google.common.io.Resources;
+import google.registry.persistence.NomulusPostgreSql;
 import java.io.File;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -54,7 +55,7 @@ public class SchemaTest {
    */
   @Rule
   public PostgreSQLContainer sqlContainer =
-      new PostgreSQLContainer<>("postgres:9.6.12")
+      new PostgreSQLContainer<>(NomulusPostgreSql.getDockerTag())
           .withClasspathResourceMapping(
               MOUNTED_RESOURCE_PATH, CONTAINER_MOUNT_POINT, BindMode.READ_WRITE);
 


### PR DESCRIPTION
Defined a util class to return docker tag of desired PSQL version.
Class is defined in ':db' and shared by ':db' and ':core'. Used
an artifact declaration to exclude unnecesary compile dependencies.

Added a presubmit check for instantiations without explicit tag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/368)
<!-- Reviewable:end -->
