### PR TITLE
Add a new method to load all Registry entities of a given type

### DIFF
--- a/core/src/test/java/google/registry/model/registry/RegistriesTest.java
+++ b/core/src/test/java/google/registry/model/registry/RegistriesTest.java
@@ -17,9 +17,12 @@ package google.registry.model.registry;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static google.registry.testing.DatastoreHelper.createTlds;
+import static google.registry.testing.DatastoreHelper.newRegistry;
+import static google.registry.testing.DatastoreHelper.persistResource;
 import static google.registry.testing.JUnitBackports.assertThrows;
 
 import com.google.common.net.InternetDomainName;
+import google.registry.model.registry.Registry.TldType;
 import google.registry.testing.AppEngineRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,6 +35,7 @@ public class RegistriesTest {
 
   @Rule
   public final AppEngineRule appEngine = AppEngineRule.builder().withDatastore().build();
+
   private void initTestTlds() {
     createTlds("foo", "a.b.c"); // Test a multipart tld.
   }
@@ -40,6 +44,16 @@ public class RegistriesTest {
   public void testGetTlds() {
     initTestTlds();
     assertThat(Registries.getTlds()).containsExactly("foo", "a.b.c");
+  }
+
+  @Test
+  public void test_getTldEntities() {
+    initTestTlds();
+    persistResource(newRegistry("testtld", "TESTTLD").asBuilder().setTldType(TldType.TEST).build());
+    assertThat(Registries.getTldEntitiesOfType(TldType.REAL))
+        .containsExactly(Registry.get("foo"), Registry.get("a.b.c"));
+    assertThat(Registries.getTldEntitiesOfType(TldType.TEST))
+        .containsExactly(Registry.get("testtld"));
   }
 
   @Test


### PR DESCRIPTION
This is useful for things that need to know more than just the TLD strings
themselves, which is all Registries currently provides.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/373)
<!-- Reviewable:end -->
