### PR TITLE
Update the Registries cache to leverage/populate the Registry cache

### DIFF
--- a/core/src/test/java/google/registry/export/ExportReservedTermsActionTest.java
+++ b/core/src/test/java/google/registry/export/ExportReservedTermsActionTest.java
@@ -48,10 +48,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ExportReservedTermsActionTest {
 
-  @Rule
-  public final AppEngineRule appEngine = AppEngineRule.builder()
-      .withDatastore()
-      .build();
+  @Rule public final AppEngineRule appEngine = AppEngineRule.builder().withDatastore().build();
 
   private final DriveConnection driveConnection = mock(DriveConnection.class);
   private final Response response = mock(Response.class);
@@ -133,6 +130,6 @@ public class ExportReservedTermsActionTest {
     assertThat(thrown)
         .hasCauseThat()
         .hasMessageThat()
-        .isEqualTo("No registry object found for fakeTld");
+        .isEqualTo("No registry object(s) found for fakeTld");
   }
 }

--- a/core/src/test/java/google/registry/model/registry/RegistryTest.java
+++ b/core/src/test/java/google/registry/model/registry/RegistryTest.java
@@ -51,6 +51,7 @@ import org.junit.Test;
 
 /** Unit tests for {@link Registry}. */
 public class RegistryTest extends EntityTestCase {
+
   Registry registry;
 
   @Before
@@ -144,6 +145,19 @@ public class RegistryTest extends EntityTestCase {
     Registry registry = newRegistry("foo", "FOO");
     assertThat(registry.getReservedLists()).isNotNull();
     assertThat(registry.getReservedLists()).isEmpty();
+  }
+
+  @Test
+  public void testGetAll() {
+    createTld("foo");
+    assertThat(Registry.getAll(ImmutableSet.of("foo", "tld")))
+        .containsExactlyElementsIn(
+            ofy()
+                .load()
+                .keys(
+                    Key.create(getCrossTldKey(), Registry.class, "foo"),
+                    Key.create(getCrossTldKey(), Registry.class, "tld"))
+                .values());
   }
 
   @Test


### PR DESCRIPTION
This is accomplished by also providing a loadAll() method on the Registry cache
that can be used to load an entire batch of Registry objects at once.

This improves efficiency, because now, any operation on Registries that loads
all the Registry entities (getTlds(), getTldsOfType(), and getTldEntities()), is
plumbed through the Registry cache, therefore loading it from that cache if it
exists and only hitting the DB if not. If not, this populates the Registry cache
upon loading, so that subsequent calls to Registry.get() will now hit the cache
instead of the DB.

To give a concrete example, the following code:

```
    for (String tld : Registries.getTlds()) {
      // ...
      doSomethingWith(Registry.get(tld));
      // ...
    }
```

is now much more efficient, because the initial call to Registries.getTlds()
populates all the entities in cache, and the subsequent individual calls to
Registry.get(tld) now retrieve them from the cache. Prior to this change,
Registries.getTlds() did not populate the Registry cache, and each subsequent
Registry.get(tld) had the potential to trigger an individual round-trip to the
DB, which is obviously bad for performance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/382)
<!-- Reviewable:end -->
