### PR TITLE
Stop publish Cloud SQL schema jar to maven repo

### DIFF
--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -65,8 +65,8 @@ steps:
 # Build and package the deployment files for production.
 - name: 'gcr.io/${PROJECT_ID}/builder:latest'
   args: ['release/build_nomulus_for_env.sh', 'production', 'output']
-# Tentatively build and publish Cloud SQL schema jar here, before schema release
-# process is finalized.
+# Tentatively build Cloud SQL schema jar here, before schema release process
+# is finalized.
 - name: 'gcr.io/${PROJECT_ID}/builder:latest'
   entrypoint: /bin/bash
   args:
@@ -74,11 +74,9 @@ steps:
   - |
     set -e
     ./gradlew \
-      :db:publish \
+      :db:schemaJar \
       -PmavenUrl=https://storage.googleapis.com/domain-registry-maven-repository/maven \
-      -PpluginsUrl=https://storage.googleapis.com/domain-registry-maven-repository/plugins \
-      -Pschema_publish_repo=gcs://domain-registry-maven-repository/nomulus \
-      -Pschema_version=${TAG_NAME}
+      -PpluginsUrl=https://storage.googleapis.com/domain-registry-maven-repository/plugins
     cp db/build/libs/schema.jar output/
 # The tarballs and jars to upload to GCS.
 artifacts:


### PR DESCRIPTION
The original purpose of the maven publication is for
use by the server/schema compatibility tests. A command line
flag can direct a test run to use difference versions of
the schema jar. However, this won't work due to dependency
locking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/383)
<!-- Reviewable:end -->
