### PR TITLE
Add daily cron job for IcannReportingUploadAction

### DIFF
--- a/core/src/main/java/google/registry/env/production/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/production/default/WEB-INF/cron.xml
@@ -280,6 +280,15 @@
   </cron>
 
   <cron>
+    <url><![CDATA[/_dr/task/icannReportingUpload]]></url>
+    <description>
+      Checks each ICANN cursor and uploads the corresponding ICANN report if the cursorTime is before now.
+    </description>
+    <schedule>every day 15:00</schedule>
+    <target>backend</target>
+  </cron>
+
+  <cron>
     <url><![CDATA[/_dr/cron/fanout?queue=retryable-cron-tasks&endpoint=/_dr/task/generateInvoices&runInEmpty]]></url>
     <description>
       Starts the beam/invoicing/InvoicingPipeline Dataflow template, which creates the overall invoice and

--- a/core/src/main/java/google/registry/env/production/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/production/default/WEB-INF/cron.xml
@@ -282,7 +282,10 @@
   <cron>
     <url><![CDATA[/_dr/task/icannReportingUpload]]></url>
     <description>
-      Checks each ICANN cursor and uploads the corresponding ICANN report if the cursorTime is before now.
+      Checks if the monthly ICANN reports have been successfully uploaded. If they have not, attempts to upload them again.
+      Most of the time, this job should not do anything since the uploads are triggered when the reports are staged.
+      However, in the event that an upload failed for any reason (e.g. ICANN server is down, IP whitelist issues),
+      this cron job will continue to retry uploads daily until they succeed.
     </description>
     <schedule>every day 15:00</schedule>
     <target>backend</target>


### PR DESCRIPTION
This job checks each ICANN cursor's cursorTime. If all cursorTime values are in the future, the action exits and does nothing. For each cursor that has a cursorTime in the past, the corresponding report is uploaded if it is staged, or logs an error message if the report has not been staged yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/385)
<!-- Reviewable:end -->
