### PR TITLE
Fix exDate calculation in domain transfer flows

### DIFF
--- a/core/src/main/java/google/registry/flows/ResourceFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/ResourceFlowUtils.java
@@ -253,6 +253,8 @@ public final class ResourceFlowUtils {
    * Computes the exDate for the domain at the given transfer approval time with an adjusted amount
    * of transfer period years if the domain is in the auto renew grace period at the time of
    * approval.
+   *
+   * @param domain is the domain already projected at approvalTime
    */
   public static DateTime computeExDateForApprovalTime(
       DomainBase domain, DateTime approvalTime, Period period) {

--- a/core/src/main/java/google/registry/flows/ResourceFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/ResourceFlowUtils.java
@@ -259,6 +259,9 @@ public final class ResourceFlowUtils {
     boolean inAutoRenew = domain.getGracePeriodStatuses().contains(GracePeriodStatus.AUTO_RENEW);
     // inAutoRenew is set to false if the period is zero because a zero-period transfer should not
     // subsume an autorenew.
+    // https://www.icann.org/resources/unthemed-pages/appendix-07-2010-01-06-en section 3.1.2
+    // specifies that when a transfer occurs without a change to the expiration date, the losing
+    // registrar's account should still be charged for the autorenew.
     if (period.getValue() == 0) {
       inAutoRenew = false;
     }

--- a/core/src/main/java/google/registry/flows/ResourceFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/ResourceFlowUtils.java
@@ -42,6 +42,8 @@ import google.registry.model.EppResource.ForeignKeyedEppResource;
 import google.registry.model.EppResource.ResourceWithTransferData;
 import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.DomainBase;
+import google.registry.model.domain.Period;
+import google.registry.model.domain.rgp.GracePeriodStatus;
 import google.registry.model.eppcommon.AuthInfo;
 import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.index.ForeignKeyIndex;
@@ -245,6 +247,25 @@ public final class ResourceFlowUtils {
         throw new StatusNotClientSettableException(statusValue.getXmlName());
       }
     }
+  }
+
+  /**
+   * Computes the exDate for the domain at the given transfer approval time with an adjusted amount
+   * of transfer period years if the domain is in the auto renew grace period at the time of
+   * approval.
+   */
+  public static DateTime computeExDateForApprovalTime(
+      DomainBase domain, DateTime approvalTime, Period period) {
+    boolean inAutoRenew = domain.getGracePeriodStatuses().contains(GracePeriodStatus.AUTO_RENEW);
+    // inAutoRenew is set to false if the period is zero because a zero-period transfer should not
+    // subsume an autorenew.
+    if (period.getValue() == 0) {
+      inAutoRenew = false;
+    }
+    return DomainBase.extendRegistrationWithCap(
+        approvalTime,
+        domain.getRegistrationExpirationTime(),
+        period.getValue() - (inAutoRenew ? 1 : 0));
   }
 
   /** Resource with this id does not exist. */

--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -389,9 +389,8 @@ public class DomainBase extends EppResource
           domainAtTransferTime
               .asBuilder()
               // Extend the registration by the correct number of years from the expiration time
-              // that
-              // was current on the domain right before the transfer, capped at 10 years from the
-              // moment of the transfer.
+              // that was current on the domain right before the transfer, capped at 10 years from
+              // the moment of the transfer.
               .setRegistrationExpirationTime(
                   ResourceFlowUtils.computeExDateForApprovalTime(
                       domainAtTransferTime,

--- a/core/src/main/java/google/registry/rde/DomainBaseToXjcConverter.java
+++ b/core/src/main/java/google/registry/rde/DomainBaseToXjcConverter.java
@@ -30,7 +30,6 @@ import google.registry.model.domain.secdns.DelegationSignerData;
 import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.rde.RdeMode;
 import google.registry.model.transfer.TransferData;
-import google.registry.model.transfer.TransferStatus;
 import google.registry.util.Idn;
 import google.registry.xjc.domain.XjcDomainContactAttrType;
 import google.registry.xjc.domain.XjcDomainContactType;
@@ -45,7 +44,6 @@ import google.registry.xjc.rgp.XjcRgpStatusType;
 import google.registry.xjc.rgp.XjcRgpStatusValueType;
 import google.registry.xjc.secdns.XjcSecdnsDsDataType;
 import google.registry.xjc.secdns.XjcSecdnsDsOrKeyType;
-import org.joda.time.DateTime;
 
 /** Utility class that turns {@link DomainBase} as {@link XjcRdeDomainElement}. */
 final class DomainBaseToXjcConverter {
@@ -241,8 +239,7 @@ final class DomainBaseToXjcConverter {
           // empty transfer records to get generated for deleted domains.
           // TODO(b/33289763): remove the hasGainingAndLosingRegistrars check in February 2017
           if (hasGainingAndLosingRegistrars(model)) {
-            bean.setTrnData(convertTransferData(model.getTransferData(),
-                model.getRegistrationExpirationTime()));
+            bean.setTrnData(convertTransferData(model.getTransferData()));
           }
         }
 
@@ -261,8 +258,7 @@ final class DomainBaseToXjcConverter {
   }
 
   /** Converts {@link TransferData} to {@link XjcRdeDomainTransferDataType}. */
-  private static XjcRdeDomainTransferDataType convertTransferData(
-      TransferData model, DateTime domainExpires) {
+  private static XjcRdeDomainTransferDataType convertTransferData(TransferData model) {
     XjcRdeDomainTransferDataType bean = new XjcRdeDomainTransferDataType();
     bean.setTrStatus(
         XjcEppcomTrStatusType.fromValue(model.getTransferStatus().getXmlName()));
@@ -270,12 +266,7 @@ final class DomainBaseToXjcConverter {
     bean.setAcRr(RdeUtil.makeXjcRdeRrType(model.getLosingClientId()));
     bean.setReDate(model.getTransferRequestTime());
     bean.setAcDate(model.getPendingTransferExpirationTime());
-    // TODO(b/25084229): fix exDate computation logic.
-    if (model.getTransferStatus() == TransferStatus.PENDING) {
-      bean.setExDate(domainExpires.plusYears(1));
-    } else {
-      bean.setExDate(domainExpires);
-    }
+    bean.setExDate(model.getTransferredRegistrationExpirationTime());
     return bean;
   }
 

--- a/core/src/test/java/google/registry/batch/ResaveEntityActionTest.java
+++ b/core/src/test/java/google/registry/batch/ResaveEntityActionTest.java
@@ -118,8 +118,7 @@ public class ResaveEntityActionTest extends ShardableTestCase {
                 DateTime.parse("2017-01-02T10:11:00Z")),
             DateTime.parse("2016-02-06T10:00:00Z"),
             DateTime.parse("2016-02-11T10:00:00Z"),
-            DateTime.parse("2017-01-02T10:11:00Z"),
-            DateTime.parse("2016-02-06T10:00:00Z"));
+            DateTime.parse("2017-01-02T10:11:00Z"));
     clock.advanceOneMilli();
     assertThat(domain.getCurrentSponsorClientId()).isEqualTo("TheRegistrar");
     runAction(Key.create(domain), DateTime.parse("2016-02-06T10:00:01Z"), ImmutableSortedSet.of());

--- a/core/src/test/java/google/registry/flows/EppLifecycleDomainTest.java
+++ b/core/src/test/java/google/registry/flows/EppLifecycleDomainTest.java
@@ -56,6 +56,12 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class EppLifecycleDomainTest extends EppTestCase {
 
+  private static final ImmutableMap<String, String> DEFAULT_TRANSFER_RESPONSE_PARMS =
+      ImmutableMap.of(
+          "REDATE", "2002-05-30T00:00:00Z",
+          "ACDATE", "2002-06-04T00:00:00Z",
+          "EXDATE", "2003-06-01T00:04:00Z");
+
   @Rule
   public final AppEngineRule appEngine =
       AppEngineRule.builder().withDatastore().withTaskQueue().build();
@@ -552,7 +558,7 @@ public class EppLifecycleDomainTest extends EppTestCase {
     assertThatLoginSucceeds("TheRegistrar", "password2");
     assertThatCommand("domain_transfer_request.xml")
         .atTime("2002-05-30T00:00:00Z")
-        .hasResponse("domain_transfer_response.xml");
+        .hasResponse("domain_transfer_response.xml", DEFAULT_TRANSFER_RESPONSE_PARMS);
     assertThatLogoutSucceeds();
 
     // Log back in as the first registrar and verify things.
@@ -590,7 +596,7 @@ public class EppLifecycleDomainTest extends EppTestCase {
     assertThatLoginSucceeds("TheRegistrar", "password2");
     assertThatCommand("domain_transfer_request.xml")
         .atTime("2002-05-30T00:00:00Z")
-        .hasResponse("domain_transfer_response.xml");
+        .hasResponse("domain_transfer_response.xml", DEFAULT_TRANSFER_RESPONSE_PARMS);
     assertThatLogoutSucceeds();
 
     // Log back in as the first registrar and verify domain is pending transfer.
@@ -640,7 +646,7 @@ public class EppLifecycleDomainTest extends EppTestCase {
     assertThatLoginSucceeds("TheRegistrar", "password2");
     assertThatCommand("domain_transfer_request.xml")
         .atTime("2002-05-30T00:00:00Z")
-        .hasResponse("domain_transfer_response.xml");
+        .hasResponse("domain_transfer_response.xml", DEFAULT_TRANSFER_RESPONSE_PARMS);
     assertThatLogoutSucceeds();
 
     // Log back in as the first registrar and delete then restore the domain while the transfer
@@ -1026,5 +1032,54 @@ public class EppLifecycleDomainTest extends EppTestCase {
                 "EXDATE", "2015-09-09T09:10:09Z"));
 
     assertThatLogoutSucceeds();
+  }
+
+  @Test
+  public void testDomainTransfer_duringAutorenewGrace() throws Exception {
+    // Creation date of fakesite: 2000-06-01T00:04:00.0Z
+    // Expiration date: 2002-06-01T00:04:00.0Z
+    assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
+    createFakesite();
+    assertThatLogoutSucceeds();
+
+    assertThatLoginSucceeds("TheRegistrar", "password2");
+    assertThatCommand("domain_transfer_request.xml")
+        .atTime("2002-06-05T00:02:00.0Z")
+        .hasResponse(
+            "domain_transfer_response.xml",
+            ImmutableMap.of(
+                "REDATE", "2002-06-05T00:02:00Z",
+                "ACDATE", "2002-06-10T00:02:00Z",
+                "EXDATE", "2003-06-01T00:04:00Z"));
+  }
+
+  @Test
+  public void testDomainTransfer_queryForServerApproved() throws Exception {
+    // Creation date of fakesite: 2000-06-01T00:04:00.0Z
+    // Expiration date: 2002-06-01T00:04:00.0Z
+    assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
+    createFakesite();
+    assertThatLogoutSucceeds();
+
+    assertThatLoginSucceeds("TheRegistrar", "password2");
+    assertThatCommand("domain_transfer_request.xml")
+        .atTime("2001-01-01T00:00:00.0Z")
+        .hasResponse(
+            "domain_transfer_response.xml",
+            ImmutableMap.of(
+                "REDATE", "2001-01-01T00:00:00Z",
+                "ACDATE", "2001-01-06T00:00:00Z",
+                "EXDATE", "2003-06-01T00:04:00Z"));
+    assertThatLogoutSucceeds();
+
+    assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
+    // Verify that reID is set correctly.
+    assertThatCommand("domain_transfer_query_fakesite.xml")
+        .atTime("2001-01-03T00:00:00Z")
+        .hasResponse("domain_transfer_query_response_fakesite.xml");
+
+    assertThatCommand("domain_transfer_query_fakesite.xml")
+        .atTime("2001-01-08T00:00:00Z")
+        .hasResponse("domain_transfer_query_response_completed_fakesite.xml");
   }
 }

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferCancelFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferCancelFlowTest.java
@@ -101,7 +101,6 @@ public class DomainTransferCancelFlowTest
             "NewRegistrar",
             TRANSFER_REQUEST_TIME,
             TRANSFER_EXPIRATION_TIME,
-            TRANSFER_REQUEST_TIME,
             EXTENDED_REGISTRATION_EXPIRATION_TIME));
     assertPollMessages(
         "TheRegistrar",
@@ -111,7 +110,6 @@ public class DomainTransferCancelFlowTest
             "TheRegistrar",
             TRANSFER_REQUEST_TIME,
             TRANSFER_EXPIRATION_TIME,
-            TRANSFER_REQUEST_TIME,
             EXTENDED_REGISTRATION_EXPIRATION_TIME));
     clock.advanceOneMilli();
 

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferFlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferFlowTestCase.java
@@ -94,8 +94,7 @@ public class DomainTransferFlowTestCase<F extends Flow, R extends EppResource>
         domain,
         TRANSFER_REQUEST_TIME,
         TRANSFER_EXPIRATION_TIME,
-        EXTENDED_REGISTRATION_EXPIRATION_TIME,
-        TRANSFER_REQUEST_TIME);
+        EXTENDED_REGISTRATION_EXPIRATION_TIME);
   }
 
   /** Adds a domain with no pending transfer on it. */

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
@@ -1093,11 +1093,8 @@ public class DomainTransferRequestFlowTest
                         domain.getAutorenewBillingEvent()))
                 .build());
     clock.advanceOneMilli();
-    // Since the autorenew grace period will have ended by the automatic transfer time, subsuming
-    // will not occur in the server-approve case, so the transfer will add 1 year to the current
-    // expiration time as usual, and no Cancellation will be issued.  Note however that if the
-    // transfer were to be manually approved before the autorenew grace period ends, then the
-    // DomainTransferApproveFlow will still issue a Cancellation.
+    // The response from DomainTransferRequestFlow returns exDate based on if the transfer were to
+    // occur now.
     doSuccessfulTest(
         "domain_transfer_request.xml",
         "domain_transfer_request_response_autorenew_grace_at_request_only.xml",

--- a/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
@@ -143,7 +143,6 @@ public class DomainBaseTest extends EntityTestCase {
                             .setTransferRequestTime(clock.nowUtc().plusDays(1))
                             .setTransferStatus(TransferStatus.SERVER_APPROVED)
                             .setTransferRequestTrid(Trid.create("client-trid", "server-trid"))
-                            .setTransferredRegistrationExpirationTime(clock.nowUtc().plusYears(2))
                             .build())
                     .setDeletePollMessage(onetimePollKey)
                     .setAutorenewBillingEvent(recurringBillKey)

--- a/core/src/test/java/google/registry/rde/DomainBaseToXjcConverterTest.java
+++ b/core/src/test/java/google/registry/rde/DomainBaseToXjcConverterTest.java
@@ -238,106 +238,139 @@ public class DomainBaseToXjcConverterTest {
             .setBillingTime(DateTime.parse("1910-01-01T00:00:00Z"))
             .setParent(historyEntry)
             .build());
-    domain = domain.asBuilder()
-        .setAuthInfo(DomainAuthInfo.create(PasswordAuth.create("secret")))
-        .setContacts(ImmutableSet.of(
-            DesignatedContact.create(DesignatedContact.Type.ADMIN, Key.create(
-                makeContactResource(clock, "10-Q9JYB4C", "5372808-IRL",
-                    "be that word our sign in parting", "BOFH@cat.みんな"))),
-            DesignatedContact.create(DesignatedContact.Type.TECH, Key.create(
-                makeContactResource(clock, "11-Q9JYB4C", "5372808-TRL",
-                    "bird or fiend!? i shrieked upstarting", "bog@cat.みんな")))))
-        .setCreationClientId("LawyerCat")
-        .setCreationTimeForTest(DateTime.parse("1900-01-01T00:00:00Z"))
-        .setPersistedCurrentSponsorClientId("GetTheeBack")
-        .setDsData(ImmutableSet.of(DelegationSignerData.create(
-              123, 200, 230, base16().decode("1234567890"))))
-        .setFullyQualifiedDomainName(Idn.toASCII("love.みんな"))
-        .setLastTransferTime(DateTime.parse("1910-01-01T00:00:00Z"))
-        .setLastEppUpdateClientId("IntoTheTempest")
-        .setLastEppUpdateTime(DateTime.parse("1920-01-01T00:00:00Z"))
-        .setNameservers(ImmutableSet.of(
-            Key.create(
-                makeHostResource(clock, "3-Q9JYB4C", "bird.or.devil.みんな", "1.2.3.4")),
-            Key.create(
-                    makeHostResource(clock, "4-Q9JYB4C", "ns2.cat.みんな", "bad:f00d:cafe::15:beef"))))
-        .setRegistrant(Key.create(makeContactResource(
-            clock, "12-Q9JYB4C", "5372808-ERL", "(◕‿◕) nevermore", "prophet@evil.みんな")))
-        .setRegistrationExpirationTime(DateTime.parse("1930-01-01T00:00:00Z"))
-        .setGracePeriods(ImmutableSet.of(
-            GracePeriod.forBillingEvent(GracePeriodStatus.RENEW,
-                persistResource(
-                    new BillingEvent.OneTime.Builder()
-                        .setReason(Reason.RENEW)
-                        .setTargetId("love.xn--q9jyb4c")
-                        .setClientId("TheRegistrar")
-                        .setCost(Money.of(USD, 456))
-                        .setPeriodYears(2)
-                        .setEventTime(DateTime.parse("1920-01-01T00:00:00Z"))
-                        .setBillingTime(DateTime.parse("1920-01-01T00:00:00Z"))
-                        .setParent(historyEntry)
-                        .build())),
-            GracePeriod.create(
-                GracePeriodStatus.TRANSFER, DateTime.parse("1920-01-01T00:00:00Z"), "foo", null)))
-        .setSubordinateHosts(ImmutableSet.of("home.by.horror.haunted"))
-        .setStatusValues(ImmutableSet.of(
-            StatusValue.CLIENT_DELETE_PROHIBITED,
-            StatusValue.CLIENT_RENEW_PROHIBITED,
-            StatusValue.CLIENT_TRANSFER_PROHIBITED,
-            StatusValue.SERVER_UPDATE_PROHIBITED))
-        .setAutorenewBillingEvent(
-            Key.create(persistResource(
-                new BillingEvent.Recurring.Builder()
-                    .setReason(Reason.RENEW)
-                    .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
-                    .setTargetId("lol")
-                    .setClientId("TheRegistrar")
-                    .setEventTime(END_OF_TIME)
-                    .setRecurrenceEndTime(END_OF_TIME)
-                    .setParent(historyEntry)
-                    .build())))
-        .setAutorenewPollMessage(
-            Key.create(persistResource(
-                new PollMessage.Autorenew.Builder()
-                    .setTargetId("lol")
-                    .setClientId("TheRegistrar")
-                    .setEventTime(END_OF_TIME)
-                    .setAutorenewEndTime(END_OF_TIME)
-                    .setMsg("Domain was auto-renewed.")
-                    .setParent(historyEntry)
-                    .build())))
-        .setTransferData(new TransferData.Builder()
-            .setGainingClientId("gaining")
-            .setLosingClientId("losing")
-            .setPendingTransferExpirationTime(DateTime.parse("1925-04-20T00:00:00Z"))
-            .setServerApproveBillingEvent(Key.create(billingEvent))
-            .setServerApproveAutorenewEvent(
-                Key.create(persistResource(
-                    new BillingEvent.Recurring.Builder()
-                        .setReason(Reason.RENEW)
-                        .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
-                        .setTargetId("example.xn--q9jyb4c")
-                        .setClientId("TheRegistrar")
-                        .setEventTime(END_OF_TIME)
-                        .setRecurrenceEndTime(END_OF_TIME)
-                        .setParent(historyEntry)
-                        .build())))
-            .setServerApproveAutorenewPollMessage(Key.create(persistResource(
-                new Autorenew.Builder()
-                    .setTargetId("example.xn--q9jyb4c")
-                    .setClientId("TheRegistrar")
-                    .setEventTime(END_OF_TIME)
-                    .setAutorenewEndTime(END_OF_TIME)
-                    .setMsg("Domain was auto-renewed.")
-                    .setParent(historyEntry)
-                    .build())))
-            .setServerApproveEntities(ImmutableSet.of(
-                Key.create(billingEvent)))
-            .setTransferRequestTime(DateTime.parse("1919-01-01T00:00:00Z"))
-            .setTransferStatus(TransferStatus.PENDING)
-            .setTransferRequestTrid(Trid.create("client-trid", "server-trid"))
-            .build())
-        .build();
+    domain =
+        domain
+            .asBuilder()
+            .setAuthInfo(DomainAuthInfo.create(PasswordAuth.create("secret")))
+            .setContacts(
+                ImmutableSet.of(
+                    DesignatedContact.create(
+                        DesignatedContact.Type.ADMIN,
+                        Key.create(
+                            makeContactResource(
+                                clock,
+                                "10-Q9JYB4C",
+                                "5372808-IRL",
+                                "be that word our sign in parting",
+                                "BOFH@cat.みんな"))),
+                    DesignatedContact.create(
+                        DesignatedContact.Type.TECH,
+                        Key.create(
+                            makeContactResource(
+                                clock,
+                                "11-Q9JYB4C",
+                                "5372808-TRL",
+                                "bird or fiend!? i shrieked upstarting",
+                                "bog@cat.みんな")))))
+            .setCreationClientId("LawyerCat")
+            .setCreationTimeForTest(DateTime.parse("1900-01-01T00:00:00Z"))
+            .setPersistedCurrentSponsorClientId("GetTheeBack")
+            .setDsData(
+                ImmutableSet.of(
+                    DelegationSignerData.create(123, 200, 230, base16().decode("1234567890"))))
+            .setFullyQualifiedDomainName(Idn.toASCII("love.みんな"))
+            .setLastTransferTime(DateTime.parse("1910-01-01T00:00:00Z"))
+            .setLastEppUpdateClientId("IntoTheTempest")
+            .setLastEppUpdateTime(DateTime.parse("1920-01-01T00:00:00Z"))
+            .setNameservers(
+                ImmutableSet.of(
+                    Key.create(
+                        makeHostResource(clock, "3-Q9JYB4C", "bird.or.devil.みんな", "1.2.3.4")),
+                    Key.create(
+                        makeHostResource(
+                            clock, "4-Q9JYB4C", "ns2.cat.みんな", "bad:f00d:cafe::15:beef"))))
+            .setRegistrant(
+                Key.create(
+                    makeContactResource(
+                        clock, "12-Q9JYB4C", "5372808-ERL", "(◕‿◕) nevermore", "prophet@evil.みんな")))
+            .setRegistrationExpirationTime(DateTime.parse("1930-01-01T00:00:00Z"))
+            .setGracePeriods(
+                ImmutableSet.of(
+                    GracePeriod.forBillingEvent(
+                        GracePeriodStatus.RENEW,
+                        persistResource(
+                            new BillingEvent.OneTime.Builder()
+                                .setReason(Reason.RENEW)
+                                .setTargetId("love.xn--q9jyb4c")
+                                .setClientId("TheRegistrar")
+                                .setCost(Money.of(USD, 456))
+                                .setPeriodYears(2)
+                                .setEventTime(DateTime.parse("1920-01-01T00:00:00Z"))
+                                .setBillingTime(DateTime.parse("1920-01-01T00:00:00Z"))
+                                .setParent(historyEntry)
+                                .build())),
+                    GracePeriod.create(
+                        GracePeriodStatus.TRANSFER,
+                        DateTime.parse("1920-01-01T00:00:00Z"),
+                        "foo",
+                        null)))
+            .setSubordinateHosts(ImmutableSet.of("home.by.horror.haunted"))
+            .setStatusValues(
+                ImmutableSet.of(
+                    StatusValue.CLIENT_DELETE_PROHIBITED,
+                    StatusValue.CLIENT_RENEW_PROHIBITED,
+                    StatusValue.CLIENT_TRANSFER_PROHIBITED,
+                    StatusValue.SERVER_UPDATE_PROHIBITED))
+            .setAutorenewBillingEvent(
+                Key.create(
+                    persistResource(
+                        new BillingEvent.Recurring.Builder()
+                            .setReason(Reason.RENEW)
+                            .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
+                            .setTargetId("lol")
+                            .setClientId("TheRegistrar")
+                            .setEventTime(END_OF_TIME)
+                            .setRecurrenceEndTime(END_OF_TIME)
+                            .setParent(historyEntry)
+                            .build())))
+            .setAutorenewPollMessage(
+                Key.create(
+                    persistResource(
+                        new PollMessage.Autorenew.Builder()
+                            .setTargetId("lol")
+                            .setClientId("TheRegistrar")
+                            .setEventTime(END_OF_TIME)
+                            .setAutorenewEndTime(END_OF_TIME)
+                            .setMsg("Domain was auto-renewed.")
+                            .setParent(historyEntry)
+                            .build())))
+            .setTransferData(
+                new TransferData.Builder()
+                    .setGainingClientId("gaining")
+                    .setLosingClientId("losing")
+                    .setPendingTransferExpirationTime(DateTime.parse("1925-04-20T00:00:00Z"))
+                    .setServerApproveBillingEvent(Key.create(billingEvent))
+                    .setServerApproveAutorenewEvent(
+                        Key.create(
+                            persistResource(
+                                new BillingEvent.Recurring.Builder()
+                                    .setReason(Reason.RENEW)
+                                    .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
+                                    .setTargetId("example.xn--q9jyb4c")
+                                    .setClientId("TheRegistrar")
+                                    .setEventTime(END_OF_TIME)
+                                    .setRecurrenceEndTime(END_OF_TIME)
+                                    .setParent(historyEntry)
+                                    .build())))
+                    .setServerApproveAutorenewPollMessage(
+                        Key.create(
+                            persistResource(
+                                new Autorenew.Builder()
+                                    .setTargetId("example.xn--q9jyb4c")
+                                    .setClientId("TheRegistrar")
+                                    .setEventTime(END_OF_TIME)
+                                    .setAutorenewEndTime(END_OF_TIME)
+                                    .setMsg("Domain was auto-renewed.")
+                                    .setParent(historyEntry)
+                                    .build())))
+                    .setServerApproveEntities(ImmutableSet.of(Key.create(billingEvent)))
+                    .setTransferRequestTime(DateTime.parse("1919-01-01T00:00:00Z"))
+                    .setTransferStatus(TransferStatus.PENDING)
+                    .setTransferredRegistrationExpirationTime(
+                        DateTime.parse("1931-01-01T00:00:00Z"))
+                    .setTransferRequestTrid(Trid.create("client-trid", "server-trid"))
+                    .build())
+            .build();
     clock.advanceOneMilli();
     return persistResource(domain);
   }

--- a/core/src/test/java/google/registry/rde/RdeFixtures.java
+++ b/core/src/test/java/google/registry/rde/RdeFixtures.java
@@ -79,106 +79,131 @@ final class RdeFixtures {
             .setBillingTime(DateTime.parse("1990-01-01T00:00:00Z"))
             .setParent(historyEntry)
             .build());
-    domain = domain.asBuilder()
-        .setAuthInfo(DomainAuthInfo.create(PasswordAuth.create("secret")))
-        .setContacts(ImmutableSet.of(
-            DesignatedContact.create(DesignatedContact.Type.ADMIN, Key.create(
-                makeContactResource(clock, "5372808-IRL",
-                    "be that word our sign in parting", "BOFH@cat.みんな"))),
-            DesignatedContact.create(DesignatedContact.Type.TECH, Key.create(
-                makeContactResource(clock, "5372808-TRL",
-                    "bird or fiend!? i shrieked upstarting", "bog@cat.みんな")))))
-        .setCreationClientId("TheRegistrar")
-        .setPersistedCurrentSponsorClientId("TheRegistrar")
-        .setCreationTimeForTest(clock.nowUtc())
-        .setDsData(ImmutableSet.of(DelegationSignerData.create(
-              123, 200, 230, base16().decode("1234567890"))))
-        .setFullyQualifiedDomainName(Idn.toASCII("love." + tld))
-        .setLastTransferTime(DateTime.parse("1990-01-01T00:00:00Z"))
-        .setLastEppUpdateClientId("IntoTheTempest")
-        .setLastEppUpdateTime(clock.nowUtc())
-        .setIdnTableName("extended_latin")
-        .setNameservers(ImmutableSet.of(
-            Key.create(
-                makeHostResource(clock, "bird.or.devil.みんな", "1.2.3.4")),
-            Key.create(
-                makeHostResource(
-                    clock, "ns2.cat.みんな", "bad:f00d:cafe::15:beef"))))
-        .setRegistrationExpirationTime(DateTime.parse("1994-01-01T00:00:00Z"))
-        .setGracePeriods(ImmutableSet.of(
-            GracePeriod.forBillingEvent(GracePeriodStatus.RENEW,
-                persistResource(
-                    new BillingEvent.OneTime.Builder()
-                        .setReason(Reason.RENEW)
-                        .setTargetId("love." + tld)
-                        .setClientId("TheRegistrar")
-                        .setCost(Money.of(USD, 456))
-                        .setPeriodYears(2)
-                        .setEventTime(DateTime.parse("1992-01-01T00:00:00Z"))
-                        .setBillingTime(DateTime.parse("1992-01-01T00:00:00Z"))
-                        .setParent(historyEntry)
-                        .build())),
-            GracePeriod.create(
-                GracePeriodStatus.TRANSFER, DateTime.parse("1992-01-01T00:00:00Z"), "foo", null)))
-        .setSubordinateHosts(ImmutableSet.of("home.by.horror.haunted"))
-        .setStatusValues(ImmutableSet.of(
-            StatusValue.CLIENT_DELETE_PROHIBITED,
-            StatusValue.CLIENT_RENEW_PROHIBITED,
-            StatusValue.CLIENT_TRANSFER_PROHIBITED,
-            StatusValue.SERVER_UPDATE_PROHIBITED))
-        .setAutorenewBillingEvent(
-            Key.create(persistResource(
-                new BillingEvent.Recurring.Builder()
-                    .setReason(Reason.RENEW)
-                    .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
-                    .setTargetId(tld)
-                    .setClientId("TheRegistrar")
-                    .setEventTime(END_OF_TIME)
-                    .setRecurrenceEndTime(END_OF_TIME)
-                    .setParent(historyEntry)
-                    .build())))
-        .setAutorenewPollMessage(
-            Key.create(persistSimpleResource(
-                new PollMessage.Autorenew.Builder()
-                    .setTargetId(tld)
-                    .setClientId("TheRegistrar")
-                    .setEventTime(END_OF_TIME)
-                    .setAutorenewEndTime(END_OF_TIME)
-                    .setMsg("Domain was auto-renewed.")
-                    .setParent(historyEntry)
-                    .build())))
-        .setTransferData(new TransferData.Builder()
-            .setGainingClientId("gaining")
-            .setLosingClientId("losing")
-            .setPendingTransferExpirationTime(DateTime.parse("1993-04-20T00:00:00Z"))
-            .setServerApproveBillingEvent(Key.create(billingEvent))
-            .setServerApproveAutorenewEvent(
-                Key.create(persistResource(
-                    new BillingEvent.Recurring.Builder()
-                        .setReason(Reason.RENEW)
-                        .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
-                        .setTargetId("example." + tld)
-                        .setClientId("TheRegistrar")
-                        .setEventTime(END_OF_TIME)
-                        .setRecurrenceEndTime(END_OF_TIME)
-                        .setParent(historyEntry)
-                        .build())))
-            .setServerApproveAutorenewPollMessage(Key.create(persistResource(
-                new Autorenew.Builder()
-                    .setTargetId("example." + tld)
-                    .setClientId("TheRegistrar")
-                    .setEventTime(END_OF_TIME)
-                    .setAutorenewEndTime(END_OF_TIME)
-                    .setMsg("Domain was auto-renewed.")
-                    .setParent(historyEntry)
-                    .build())))
-            .setServerApproveEntities(ImmutableSet.of(
-                Key.create(billingEvent)))
-            .setTransferRequestTime(DateTime.parse("1991-01-01T00:00:00Z"))
-            .setTransferStatus(TransferStatus.PENDING)
-            .setTransferRequestTrid(Trid.create("client-trid", "server-trid"))
-            .build())
-        .build();
+    domain =
+        domain
+            .asBuilder()
+            .setAuthInfo(DomainAuthInfo.create(PasswordAuth.create("secret")))
+            .setContacts(
+                ImmutableSet.of(
+                    DesignatedContact.create(
+                        DesignatedContact.Type.ADMIN,
+                        Key.create(
+                            makeContactResource(
+                                clock,
+                                "5372808-IRL",
+                                "be that word our sign in parting",
+                                "BOFH@cat.みんな"))),
+                    DesignatedContact.create(
+                        DesignatedContact.Type.TECH,
+                        Key.create(
+                            makeContactResource(
+                                clock,
+                                "5372808-TRL",
+                                "bird or fiend!? i shrieked upstarting",
+                                "bog@cat.みんな")))))
+            .setCreationClientId("TheRegistrar")
+            .setPersistedCurrentSponsorClientId("TheRegistrar")
+            .setCreationTimeForTest(clock.nowUtc())
+            .setDsData(
+                ImmutableSet.of(
+                    DelegationSignerData.create(123, 200, 230, base16().decode("1234567890"))))
+            .setFullyQualifiedDomainName(Idn.toASCII("love." + tld))
+            .setLastTransferTime(DateTime.parse("1990-01-01T00:00:00Z"))
+            .setLastEppUpdateClientId("IntoTheTempest")
+            .setLastEppUpdateTime(clock.nowUtc())
+            .setIdnTableName("extended_latin")
+            .setNameservers(
+                ImmutableSet.of(
+                    Key.create(makeHostResource(clock, "bird.or.devil.みんな", "1.2.3.4")),
+                    Key.create(makeHostResource(clock, "ns2.cat.みんな", "bad:f00d:cafe::15:beef"))))
+            .setRegistrationExpirationTime(DateTime.parse("1994-01-01T00:00:00Z"))
+            .setGracePeriods(
+                ImmutableSet.of(
+                    GracePeriod.forBillingEvent(
+                        GracePeriodStatus.RENEW,
+                        persistResource(
+                            new BillingEvent.OneTime.Builder()
+                                .setReason(Reason.RENEW)
+                                .setTargetId("love." + tld)
+                                .setClientId("TheRegistrar")
+                                .setCost(Money.of(USD, 456))
+                                .setPeriodYears(2)
+                                .setEventTime(DateTime.parse("1992-01-01T00:00:00Z"))
+                                .setBillingTime(DateTime.parse("1992-01-01T00:00:00Z"))
+                                .setParent(historyEntry)
+                                .build())),
+                    GracePeriod.create(
+                        GracePeriodStatus.TRANSFER,
+                        DateTime.parse("1992-01-01T00:00:00Z"),
+                        "foo",
+                        null)))
+            .setSubordinateHosts(ImmutableSet.of("home.by.horror.haunted"))
+            .setStatusValues(
+                ImmutableSet.of(
+                    StatusValue.CLIENT_DELETE_PROHIBITED,
+                    StatusValue.CLIENT_RENEW_PROHIBITED,
+                    StatusValue.CLIENT_TRANSFER_PROHIBITED,
+                    StatusValue.SERVER_UPDATE_PROHIBITED))
+            .setAutorenewBillingEvent(
+                Key.create(
+                    persistResource(
+                        new BillingEvent.Recurring.Builder()
+                            .setReason(Reason.RENEW)
+                            .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
+                            .setTargetId(tld)
+                            .setClientId("TheRegistrar")
+                            .setEventTime(END_OF_TIME)
+                            .setRecurrenceEndTime(END_OF_TIME)
+                            .setParent(historyEntry)
+                            .build())))
+            .setAutorenewPollMessage(
+                Key.create(
+                    persistSimpleResource(
+                        new PollMessage.Autorenew.Builder()
+                            .setTargetId(tld)
+                            .setClientId("TheRegistrar")
+                            .setEventTime(END_OF_TIME)
+                            .setAutorenewEndTime(END_OF_TIME)
+                            .setMsg("Domain was auto-renewed.")
+                            .setParent(historyEntry)
+                            .build())))
+            .setTransferData(
+                new TransferData.Builder()
+                    .setGainingClientId("gaining")
+                    .setLosingClientId("losing")
+                    .setPendingTransferExpirationTime(DateTime.parse("1993-04-20T00:00:00Z"))
+                    .setServerApproveBillingEvent(Key.create(billingEvent))
+                    .setServerApproveAutorenewEvent(
+                        Key.create(
+                            persistResource(
+                                new BillingEvent.Recurring.Builder()
+                                    .setReason(Reason.RENEW)
+                                    .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
+                                    .setTargetId("example." + tld)
+                                    .setClientId("TheRegistrar")
+                                    .setEventTime(END_OF_TIME)
+                                    .setRecurrenceEndTime(END_OF_TIME)
+                                    .setParent(historyEntry)
+                                    .build())))
+                    .setServerApproveAutorenewPollMessage(
+                        Key.create(
+                            persistResource(
+                                new Autorenew.Builder()
+                                    .setTargetId("example." + tld)
+                                    .setClientId("TheRegistrar")
+                                    .setEventTime(END_OF_TIME)
+                                    .setAutorenewEndTime(END_OF_TIME)
+                                    .setMsg("Domain was auto-renewed.")
+                                    .setParent(historyEntry)
+                                    .build())))
+                    .setServerApproveEntities(ImmutableSet.of(Key.create(billingEvent)))
+                    .setTransferRequestTime(DateTime.parse("1991-01-01T00:00:00Z"))
+                    .setTransferStatus(TransferStatus.PENDING)
+                    .setTransferredRegistrationExpirationTime(
+                        DateTime.parse("2001-01-01T00:00:00.000Z"))
+                    .setTransferRequestTrid(Trid.create("client-trid", "server-trid"))
+                    .build())
+            .build();
     clock.advanceOneMilli();
     return persistResourceWithCommitLog(domain);
   }

--- a/core/src/test/java/google/registry/rde/RdeFixtures.java
+++ b/core/src/test/java/google/registry/rde/RdeFixtures.java
@@ -200,7 +200,7 @@ final class RdeFixtures {
                     .setTransferRequestTime(DateTime.parse("1991-01-01T00:00:00Z"))
                     .setTransferStatus(TransferStatus.PENDING)
                     .setTransferredRegistrationExpirationTime(
-                        DateTime.parse("2001-01-01T00:00:00.000Z"))
+                        DateTime.parse("1995-01-01T00:00:00.000Z"))
                     .setTransferRequestTrid(Trid.create("client-trid", "server-trid"))
                     .build())
             .build();

--- a/core/src/test/java/google/registry/testing/DatastoreHelper.java
+++ b/core/src/test/java/google/registry/testing/DatastoreHelper.java
@@ -409,7 +409,7 @@ public class DatastoreHelper {
         .setClientId(clientId)
         .setEventTime(expirationTime)
         .setMsg("Transfer server approved.")
-        .setResponseData(ImmutableList.of(createTransferResponse(resource, transferData, now)))
+        .setResponseData(ImmutableList.of(createTransferResponse(resource, transferData)))
         .setParent(historyEntry)
         .build();
   }

--- a/core/src/test/java/google/registry/testing/DatastoreHelper.java
+++ b/core/src/test/java/google/registry/testing/DatastoreHelper.java
@@ -399,7 +399,6 @@ public class DatastoreHelper {
       String clientId,
       DateTime requestTime,
       DateTime expirationTime,
-      DateTime now,
       @Nullable DateTime extendedRegistrationExpirationTime) {
     TransferData transferData =
         createTransferDataBuilder(requestTime, expirationTime)
@@ -458,7 +457,6 @@ public class DatastoreHelper {
                             "NewRegistrar",
                             requestTime,
                             expirationTime,
-                            now,
                             null))),
                     Key.create(persistResource(
                         createPollMessageForImplicitTransfer(
@@ -467,7 +465,6 @@ public class DatastoreHelper {
                             "TheRegistrar",
                             requestTime,
                             expirationTime,
-                            now,
                             null)))))
                 .setTransferRequestTrid(Trid.create("transferClient-trid", "transferServer-trid"))
                 .build())
@@ -538,8 +535,7 @@ public class DatastoreHelper {
       DomainBase domain,
       DateTime requestTime,
       DateTime expirationTime,
-      DateTime extendedRegistrationExpirationTime,
-      DateTime now) {
+      DateTime extendedRegistrationExpirationTime) {
     HistoryEntry historyEntryDomainTransfer = persistResource(
         new HistoryEntry.Builder()
             .setType(HistoryEntry.Type.DOMAIN_TRANSFER_REQUEST)
@@ -608,7 +604,6 @@ public class DatastoreHelper {
                         "NewRegistrar",
                         requestTime,
                         expirationTime,
-                        now,
                         extendedRegistrationExpirationTime))),
                 Key.create(persistResource(
                     createPollMessageForImplicitTransfer(
@@ -617,7 +612,6 @@ public class DatastoreHelper {
                         "TheRegistrar",
                         requestTime,
                         expirationTime,
-                        now,
                         extendedRegistrationExpirationTime)))))
             .setTransferRequestTrid(Trid.create("transferClient-trid", "transferServer-trid"))
             .build())

--- a/core/src/test/resources/google/registry/flows/domain/domain_transfer_request_response_autorenew_grace_at_request_only.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_transfer_request_response_autorenew_grace_at_request_only.xml
@@ -12,7 +12,7 @@
         <domain:reDate>2000-06-09T22:00:00.0Z</domain:reDate>
         <domain:acID>TheRegistrar</domain:acID>
         <domain:acDate>2000-06-14T22:00:00.0Z</domain:acDate>
-        <domain:exDate>2002-04-26T22:00:00.0Z</domain:exDate>
+        <domain:exDate>2001-04-26T22:00:00.0Z</domain:exDate>
       </domain:trnData>
     </resData>
     <trID>

--- a/core/src/test/resources/google/registry/flows/domain/domain_transfer_request_response_autorenew_grace_throughout_transfer_window.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_transfer_request_response_autorenew_grace_throughout_transfer_window.xml
@@ -12,8 +12,7 @@
         <domain:reDate>2000-06-09T22:00:00.0Z</domain:reDate>
         <domain:acID>TheRegistrar</domain:acID>
         <domain:acDate>2000-06-14T22:00:00.0Z</domain:acDate>
-        <!-- TODO(b/25084229): Exdate should be 2001; needs fixing. -->
-        <domain:exDate>2002-06-08T22:00:00.0Z</domain:exDate>
+        <domain:exDate>2001-06-08T22:00:00.0Z</domain:exDate>
       </domain:trnData>
     </resData>
     <trID>

--- a/core/src/test/resources/google/registry/flows/domain_info_response_after_transfer_after_argp.xml
+++ b/core/src/test/resources/google/registry/flows/domain_info_response_after_transfer_after_argp.xml
@@ -1,0 +1,36 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <response>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
+    </result>
+    <resData>
+      <domain:infData
+          xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>fakesite.example</domain:name>
+        <domain:roid>IGNORED</domain:roid>
+        <domain:status s="ok"/>
+        <domain:registrant>jd1234</domain:registrant>
+        <domain:contact type="admin">sh8013</domain:contact>
+        <domain:contact type="tech">sh8013</domain:contact>
+        <domain:ns>
+          <domain:hostObj>ns1.example.external</domain:hostObj>
+          <domain:hostObj>ns2.example.external</domain:hostObj>
+        </domain:ns>
+        <domain:clID>TheRegistrar</domain:clID>
+        <domain:crID>NewRegistrar</domain:crID>
+        <domain:crDate>2000-06-01T00:04:00.0Z</domain:crDate>
+        <domain:upID>TheRegistrar</domain:upID>
+        <domain:upDate>2002-06-15T00:02:00.000Z</domain:upDate>
+        <domain:exDate>2003-06-01T00:04:00.0Z</domain:exDate>
+        <domain:trDate>2002-06-10T00:02:00.000Z</domain:trDate>
+        <domain:authInfo>
+          <domain:pw>2fooBAR</domain:pw>
+        </domain:authInfo>
+      </domain:infData>
+    </resData>
+         <trID>
+    <clTRID>ABC-12345</clTRID>
+    <svTRID>server-trid</svTRID>
+  </trID>
+  </response>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain_info_response_after_transfer_during_argp.xml
+++ b/core/src/test/resources/google/registry/flows/domain_info_response_after_transfer_during_argp.xml
@@ -1,0 +1,40 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <response>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
+    </result>
+    <resData>
+      <domain:infData
+          xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>fakesite.example</domain:name>
+        <domain:roid>IGNORED</domain:roid>
+        <domain:status s="ok"/>
+        <domain:registrant>jd1234</domain:registrant>
+        <domain:contact type="admin">sh8013</domain:contact>
+        <domain:contact type="tech">sh8013</domain:contact>
+        <domain:ns>
+          <domain:hostObj>ns1.example.external</domain:hostObj>
+          <domain:hostObj>ns2.example.external</domain:hostObj>
+        </domain:ns>
+        <domain:clID>TheRegistrar</domain:clID>
+        <domain:crID>NewRegistrar</domain:crID>
+        <domain:crDate>2000-06-01T00:04:00.0Z</domain:crDate>
+        <domain:upID>TheRegistrar</domain:upID>
+        <domain:upDate>2002-06-10T00:02:00.000Z</domain:upDate>
+        <domain:exDate>2003-06-01T00:04:00.0Z</domain:exDate>
+        <domain:trDate>2002-06-10T00:02:00.000Z</domain:trDate>
+        <domain:authInfo>
+          <domain:pw>2fooBAR</domain:pw>
+        </domain:authInfo>
+      </domain:infData>
+    </resData>
+    <extension>
+      <rgp:infData xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0">
+        <rgp:rgpStatus s="transferPeriod"/>
+      </rgp:infData>
+    </extension>      <trID>
+      <clTRID>ABC-12345</clTRID>
+      <svTRID>server-trid</svTRID>
+    </trID>
+  </response>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain_info_response_before_transfer_and_argp.xml
+++ b/core/src/test/resources/google/registry/flows/domain_info_response_before_transfer_and_argp.xml
@@ -1,0 +1,35 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <response>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
+    </result>
+    <resData>
+      <domain:infData
+          xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>fakesite.example</domain:name>
+        <domain:roid>IGNORED</domain:roid>
+        <domain:status s="ok"/>
+        <domain:registrant>jd1234</domain:registrant>
+        <domain:contact type="admin">sh8013</domain:contact>
+        <domain:contact type="tech">sh8013</domain:contact>
+        <domain:ns>
+          <domain:hostObj>ns1.example.external</domain:hostObj>
+          <domain:hostObj>ns2.example.external</domain:hostObj>
+        </domain:ns>
+        <domain:clID>NewRegistrar</domain:clID>
+        <domain:crID>NewRegistrar</domain:crID>
+        <domain:crDate>2000-06-01T00:04:00.0Z</domain:crDate>
+        <domain:upID>NewRegistrar</domain:upID>
+        <domain:upDate>2000-06-06T00:04:00.000Z</domain:upDate>
+        <domain:exDate>2002-06-01T00:04:00.0Z</domain:exDate>
+        <domain:authInfo>
+          <domain:pw>2fooBAR</domain:pw>
+        </domain:authInfo>
+      </domain:infData>
+    </resData>
+    <trID>
+      <clTRID>ABC-12345</clTRID>
+      <svTRID>server-trid</svTRID>
+    </trID>
+  </response>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain_info_response_before_transfer_during_argp.xml
+++ b/core/src/test/resources/google/registry/flows/domain_info_response_before_transfer_during_argp.xml
@@ -1,0 +1,39 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <response>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
+    </result>
+    <resData>
+      <domain:infData
+          xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>fakesite.example</domain:name>
+        <domain:roid>IGNORED</domain:roid>
+        <domain:status s="ok"/>
+        <domain:registrant>jd1234</domain:registrant>
+        <domain:contact type="admin">sh8013</domain:contact>
+        <domain:contact type="tech">sh8013</domain:contact>
+        <domain:ns>
+          <domain:hostObj>ns1.example.external</domain:hostObj>
+          <domain:hostObj>ns2.example.external</domain:hostObj>
+        </domain:ns>
+        <domain:clID>NewRegistrar</domain:clID>
+        <domain:crID>NewRegistrar</domain:crID>
+        <domain:crDate>2000-06-01T00:04:00.0Z</domain:crDate>
+        <domain:upID>NewRegistrar</domain:upID>
+        <domain:upDate>2002-06-01T00:04:00.000Z</domain:upDate>
+        <domain:exDate>2003-06-01T00:04:00.0Z</domain:exDate>
+        <domain:authInfo>
+          <domain:pw>2fooBAR</domain:pw>
+        </domain:authInfo>
+      </domain:infData>
+    </resData>
+    <extension>
+      <rgp:infData xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0">
+        <rgp:rgpStatus s="autoRenewPeriod"/>
+      </rgp:infData>
+    </extension>    <trID>
+      <clTRID>ABC-12345</clTRID>
+      <svTRID>server-trid</svTRID>
+    </trID>
+  </response>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain_info_response_during_transfer_during_argp.xml
+++ b/core/src/test/resources/google/registry/flows/domain_info_response_during_transfer_during_argp.xml
@@ -1,0 +1,39 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <response>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
+    </result>
+    <resData>
+      <domain:infData
+          xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>fakesite.example</domain:name>
+        <domain:roid>IGNORED</domain:roid>
+        <domain:status s="pendingTransfer"/>
+        <domain:registrant>jd1234</domain:registrant>
+        <domain:contact type="admin">sh8013</domain:contact>
+        <domain:contact type="tech">sh8013</domain:contact>
+        <domain:ns>
+          <domain:hostObj>ns1.example.external</domain:hostObj>
+          <domain:hostObj>ns2.example.external</domain:hostObj>
+        </domain:ns>
+        <domain:clID>NewRegistrar</domain:clID>
+        <domain:crID>NewRegistrar</domain:crID>
+        <domain:crDate>2000-06-01T00:04:00.0Z</domain:crDate>
+        <domain:upID>TheRegistrar</domain:upID>
+        <domain:upDate>2002-06-05T00:02:00.000Z</domain:upDate>
+        <domain:exDate>2003-06-01T00:04:00.0Z</domain:exDate>
+        <domain:authInfo>
+          <domain:pw>2fooBAR</domain:pw>
+        </domain:authInfo>
+      </domain:infData>
+    </resData>
+    <extension>
+      <rgp:infData xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0">
+        <rgp:rgpStatus s="autoRenewPeriod"/>
+      </rgp:infData>
+    </extension>      <trID>
+    <clTRID>ABC-12345</clTRID>
+    <svTRID>server-trid</svTRID>
+  </trID>
+  </response>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain_transfer_query_response_completed_fakesite.xml
+++ b/core/src/test/resources/google/registry/flows/domain_transfer_query_response_completed_fakesite.xml
@@ -11,7 +11,7 @@
         <domain:reDate>2001-01-01T00:00:00.000Z</domain:reDate>
         <domain:acID>NewRegistrar</domain:acID>
         <domain:acDate>2001-01-06T00:00:00.000Z</domain:acDate>
-        <domain:exDate>2004-06-01T00:04:00.000Z</domain:exDate>
+        <domain:exDate>2003-06-01T00:04:00.000Z</domain:exDate>
       </domain:trnData>
     </resData>
     <trID>

--- a/core/src/test/resources/google/registry/flows/domain_transfer_query_response_wildcard.xml
+++ b/core/src/test/resources/google/registry/flows/domain_transfer_query_response_wildcard.xml
@@ -1,0 +1,22 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <response>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
+    </result>
+    <resData>
+      <domain:trnData xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>fakesite.example</domain:name>
+        <domain:trStatus>%STATUS%</domain:trStatus>
+        <domain:reID>TheRegistrar</domain:reID>
+        <domain:reDate>%REDATE%</domain:reDate>
+        <domain:acID>NewRegistrar</domain:acID>
+        <domain:acDate>%ACDATE%</domain:acDate>
+        <domain:exDate>%EXDATE%</domain:exDate>
+      </domain:trnData>
+    </resData>
+    <trID>
+      <clTRID>ABC-12345</clTRID>
+      <svTRID>server-trid</svTRID>
+    </trID>
+  </response>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain_transfer_query_response_wildcard_not_requested.xml
+++ b/core/src/test/resources/google/registry/flows/domain_transfer_query_response_wildcard_not_requested.xml
@@ -1,0 +1,11 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <response>
+    <result code="2002">
+      <msg>Object has no transfer history</msg>
+    </result>
+    <trID>
+      <clTRID>ABC-12345</clTRID>
+      <svTRID>server-trid</svTRID>
+    </trID>
+  </response>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain_transfer_response.xml
+++ b/core/src/test/resources/google/registry/flows/domain_transfer_response.xml
@@ -8,10 +8,10 @@
         <domain:name>fakesite.example</domain:name>
         <domain:trStatus>pending</domain:trStatus>
         <domain:reID>TheRegistrar</domain:reID>
-        <domain:reDate>2002-05-30T00:00:00Z</domain:reDate>
+        <domain:reDate>%REDATE%</domain:reDate>
         <domain:acID>NewRegistrar</domain:acID>
-        <domain:acDate>2002-06-04T00:00:00Z</domain:acDate>
-        <domain:exDate>2003-06-01T00:04:00Z</domain:exDate>
+        <domain:acDate>%ACDATE%</domain:acDate>
+        <domain:exDate>%EXDATE%</domain:exDate>
       </domain:trnData>
     </resData>
     <trID>

--- a/core/src/test/resources/google/registry/rde/testMapReduce_withDomain_producesExpectedXml.xml
+++ b/core/src/test/resources/google/registry/rde/testMapReduce_withDomain_producesExpectedXml.xml
@@ -167,7 +167,7 @@
         <rdeDomain:reDate>1991-01-01T00:00:00Z</rdeDomain:reDate>
         <rdeDomain:acRr>losing</rdeDomain:acRr>
         <rdeDomain:acDate>1993-04-20T00:00:00Z</rdeDomain:acDate>
-        <rdeDomain:exDate>2001-01-01T00:00:00Z</rdeDomain:exDate>
+        <rdeDomain:exDate>1995-01-01T00:00:00Z</rdeDomain:exDate>
     </rdeDomain:trnData>
 </rdeDomain:domain>
 


### PR DESCRIPTION
This fixes both b/25084229 and b/145229815 where the TransferResponses from the domain transfer flows are incorrectly calculating exDate.

ExDate is currently always calculated based on the current domain expiration time which causes issues when a domain is autorenewed before or during transfer. 

Steps taken to fix this issue:

1. Add a computeExDateForApprovalTime function to ResourceFlowUtils to call ExtendRegistrationWithCap with the correct number of years based on whether the domain is in Auto Renew Grace Period at given transferTime.

2. When the transfer is requested, computeExDateForApprovalTime is called with approvalTime = automatedTransferTime and stored in TransferData. DomainTransferRequestFlow, however, returns exDate based on if the approval time were now.

3. When the transfer is queried, the stored expiration date in TransferData is ignored, and DomainTransferQueryFlow returns exDate based on approvalTime=now. (If DomainTransferQueryFlow is run on a transfer that has already been approved, then the persisted exDate from TransferData is returned)

4. When a transfer is client-approved the exDate is computed for approvalTime=now and persisted in TransferData.

5. When a transfer is server-approved the persisted exDate in TransferData is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/389)
<!-- Reviewable:end -->
