### PR TITLE
Respect certificate validity period

### DIFF
--- a/networking/build.gradle
+++ b/networking/build.gradle
@@ -24,6 +24,7 @@ dependencies {
   compile deps['io.netty:netty-handler']
   compile deps['io.netty:netty-transport']
   compile deps['javax.inject:javax.inject']
+  compile project(':util')
 
   runtime deps['com.google.flogger:flogger-system-backend']
   runtime deps['io.netty:netty-tcnative-boringssl-static']

--- a/networking/gradle/dependency-locks/compile.lockfile
+++ b/networking/gradle/dependency-locks/compile.lockfile
@@ -1,13 +1,30 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-core:2.9.9
+com.google.api-client:google-api-client:1.29.2
+com.google.appengine:appengine-api-1.0-sdk:1.9.48
+com.google.appengine:appengine-testing:1.9.58
+com.google.auth:google-auth-library-credentials:0.16.1
+com.google.auth:google-auth-library-oauth2-http:0.16.1
+com.google.auto.value:auto-value-annotations:1.6.3
+com.google.auto.value:auto-value:1.6.3
 com.google.code.findbugs:jsr305:3.0.2
+com.google.dagger:dagger:2.21
 com.google.errorprone:error_prone_annotations:2.3.2
 com.google.flogger:flogger:0.1
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:28.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+com.google.http-client:google-http-client-jackson2:1.30.1
+com.google.http-client:google-http-client:1.30.1
 com.google.j2objc:j2objc-annotations:1.3
+com.google.oauth-client:google-oauth-client:1.29.2
+com.google.re2j:re2j:1.1
+com.ibm.icu:icu4j:57.1
+commons-codec:commons-codec:1.11
+commons-logging:commons-logging:1.2
+io.grpc:grpc-context:1.19.0
 io.netty:netty-buffer:4.1.31.Final
 io.netty:netty-codec-http:4.1.31.Final
 io.netty:netty-codec:4.1.31.Final
@@ -15,6 +32,15 @@ io.netty:netty-common:4.1.31.Final
 io.netty:netty-handler:4.1.31.Final
 io.netty:netty-resolver:4.1.31.Final
 io.netty:netty-transport:4.1.31.Final
+io.opencensus:opencensus-api:0.21.0
+io.opencensus:opencensus-contrib-http-util:0.21.0
+javax.activation:activation:1.1
 javax.inject:javax.inject:1
+javax.mail:mail:1.4
+javax.xml.bind:jaxb-api:2.3.0
+joda-time:joda-time:2.9.2
+org.apache.httpcomponents:httpclient:4.5.8
+org.apache.httpcomponents:httpcore:4.4.11
 org.checkerframework:checker-qual:2.8.1
 org.codehaus.mojo:animal-sniffer-annotations:1.18
+org.yaml:snakeyaml:1.17

--- a/networking/gradle/dependency-locks/compileClasspath.lockfile
+++ b/networking/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,13 +1,30 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-core:2.9.9
+com.google.api-client:google-api-client:1.29.2
+com.google.appengine:appengine-api-1.0-sdk:1.9.48
+com.google.appengine:appengine-testing:1.9.58
+com.google.auth:google-auth-library-credentials:0.16.1
+com.google.auth:google-auth-library-oauth2-http:0.16.1
+com.google.auto.value:auto-value-annotations:1.6.3
+com.google.auto.value:auto-value:1.6.3
 com.google.code.findbugs:jsr305:3.0.2
+com.google.dagger:dagger:2.21
 com.google.errorprone:error_prone_annotations:2.3.2
 com.google.flogger:flogger:0.1
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:28.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+com.google.http-client:google-http-client-jackson2:1.30.1
+com.google.http-client:google-http-client:1.30.1
 com.google.j2objc:j2objc-annotations:1.3
+com.google.oauth-client:google-oauth-client:1.29.2
+com.google.re2j:re2j:1.1
+com.ibm.icu:icu4j:57.1
+commons-codec:commons-codec:1.11
+commons-logging:commons-logging:1.2
+io.grpc:grpc-context:1.19.0
 io.netty:netty-buffer:4.1.31.Final
 io.netty:netty-codec-http:4.1.31.Final
 io.netty:netty-codec:4.1.31.Final
@@ -15,6 +32,15 @@ io.netty:netty-common:4.1.31.Final
 io.netty:netty-handler:4.1.31.Final
 io.netty:netty-resolver:4.1.31.Final
 io.netty:netty-transport:4.1.31.Final
+io.opencensus:opencensus-api:0.21.0
+io.opencensus:opencensus-contrib-http-util:0.21.0
+javax.activation:activation:1.1
 javax.inject:javax.inject:1
+javax.mail:mail:1.4
+javax.xml.bind:jaxb-api:2.3.0
+joda-time:joda-time:2.9.2
+org.apache.httpcomponents:httpclient:4.5.8
+org.apache.httpcomponents:httpcore:4.4.11
 org.checkerframework:checker-qual:2.8.1
 org.codehaus.mojo:animal-sniffer-annotations:1.18
+org.yaml:snakeyaml:1.17

--- a/networking/gradle/dependency-locks/default.lockfile
+++ b/networking/gradle/dependency-locks/default.lockfile
@@ -1,14 +1,31 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-core:2.9.9
+com.google.api-client:google-api-client:1.29.2
+com.google.appengine:appengine-api-1.0-sdk:1.9.48
+com.google.appengine:appengine-testing:1.9.58
+com.google.auth:google-auth-library-credentials:0.16.1
+com.google.auth:google-auth-library-oauth2-http:0.16.1
+com.google.auto.value:auto-value-annotations:1.6.3
+com.google.auto.value:auto-value:1.6.3
 com.google.code.findbugs:jsr305:3.0.2
+com.google.dagger:dagger:2.21
 com.google.errorprone:error_prone_annotations:2.3.2
 com.google.flogger:flogger-system-backend:0.1
 com.google.flogger:flogger:0.1
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:28.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+com.google.http-client:google-http-client-jackson2:1.30.1
+com.google.http-client:google-http-client:1.30.1
 com.google.j2objc:j2objc-annotations:1.3
+com.google.oauth-client:google-oauth-client:1.29.2
+com.google.re2j:re2j:1.1
+com.ibm.icu:icu4j:57.1
+commons-codec:commons-codec:1.11
+commons-logging:commons-logging:1.2
+io.grpc:grpc-context:1.19.0
 io.netty:netty-buffer:4.1.31.Final
 io.netty:netty-codec-http:4.1.31.Final
 io.netty:netty-codec:4.1.31.Final
@@ -17,6 +34,15 @@ io.netty:netty-handler:4.1.31.Final
 io.netty:netty-resolver:4.1.31.Final
 io.netty:netty-tcnative-boringssl-static:2.0.22.Final
 io.netty:netty-transport:4.1.31.Final
+io.opencensus:opencensus-api:0.21.0
+io.opencensus:opencensus-contrib-http-util:0.21.0
+javax.activation:activation:1.1
 javax.inject:javax.inject:1
+javax.mail:mail:1.4
+javax.xml.bind:jaxb-api:2.3.0
+joda-time:joda-time:2.9.2
+org.apache.httpcomponents:httpclient:4.5.8
+org.apache.httpcomponents:httpcore:4.4.11
 org.checkerframework:checker-qual:2.8.1
 org.codehaus.mojo:animal-sniffer-annotations:1.18
+org.yaml:snakeyaml:1.17

--- a/networking/gradle/dependency-locks/runtime.lockfile
+++ b/networking/gradle/dependency-locks/runtime.lockfile
@@ -1,14 +1,31 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-core:2.9.9
+com.google.api-client:google-api-client:1.29.2
+com.google.appengine:appengine-api-1.0-sdk:1.9.48
+com.google.appengine:appengine-testing:1.9.58
+com.google.auth:google-auth-library-credentials:0.16.1
+com.google.auth:google-auth-library-oauth2-http:0.16.1
+com.google.auto.value:auto-value-annotations:1.6.3
+com.google.auto.value:auto-value:1.6.3
 com.google.code.findbugs:jsr305:3.0.2
+com.google.dagger:dagger:2.21
 com.google.errorprone:error_prone_annotations:2.3.2
 com.google.flogger:flogger-system-backend:0.1
 com.google.flogger:flogger:0.1
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:28.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+com.google.http-client:google-http-client-jackson2:1.30.1
+com.google.http-client:google-http-client:1.30.1
 com.google.j2objc:j2objc-annotations:1.3
+com.google.oauth-client:google-oauth-client:1.29.2
+com.google.re2j:re2j:1.1
+com.ibm.icu:icu4j:57.1
+commons-codec:commons-codec:1.11
+commons-logging:commons-logging:1.2
+io.grpc:grpc-context:1.19.0
 io.netty:netty-buffer:4.1.31.Final
 io.netty:netty-codec-http:4.1.31.Final
 io.netty:netty-codec:4.1.31.Final
@@ -17,6 +34,15 @@ io.netty:netty-handler:4.1.31.Final
 io.netty:netty-resolver:4.1.31.Final
 io.netty:netty-tcnative-boringssl-static:2.0.22.Final
 io.netty:netty-transport:4.1.31.Final
+io.opencensus:opencensus-api:0.21.0
+io.opencensus:opencensus-contrib-http-util:0.21.0
+javax.activation:activation:1.1
 javax.inject:javax.inject:1
+javax.mail:mail:1.4
+javax.xml.bind:jaxb-api:2.3.0
+joda-time:joda-time:2.9.2
+org.apache.httpcomponents:httpclient:4.5.8
+org.apache.httpcomponents:httpcore:4.4.11
 org.checkerframework:checker-qual:2.8.1
 org.codehaus.mojo:animal-sniffer-annotations:1.18
+org.yaml:snakeyaml:1.17

--- a/networking/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/networking/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,14 +1,31 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-core:2.9.9
+com.google.api-client:google-api-client:1.29.2
+com.google.appengine:appengine-api-1.0-sdk:1.9.48
+com.google.appengine:appengine-testing:1.9.58
+com.google.auth:google-auth-library-credentials:0.16.1
+com.google.auth:google-auth-library-oauth2-http:0.16.1
+com.google.auto.value:auto-value-annotations:1.6.3
+com.google.auto.value:auto-value:1.6.3
 com.google.code.findbugs:jsr305:3.0.2
+com.google.dagger:dagger:2.21
 com.google.errorprone:error_prone_annotations:2.3.2
 com.google.flogger:flogger-system-backend:0.1
 com.google.flogger:flogger:0.1
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:28.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+com.google.http-client:google-http-client-jackson2:1.30.1
+com.google.http-client:google-http-client:1.30.1
 com.google.j2objc:j2objc-annotations:1.3
+com.google.oauth-client:google-oauth-client:1.29.2
+com.google.re2j:re2j:1.1
+com.ibm.icu:icu4j:57.1
+commons-codec:commons-codec:1.11
+commons-logging:commons-logging:1.2
+io.grpc:grpc-context:1.19.0
 io.netty:netty-buffer:4.1.31.Final
 io.netty:netty-codec-http:4.1.31.Final
 io.netty:netty-codec:4.1.31.Final
@@ -17,6 +34,15 @@ io.netty:netty-handler:4.1.31.Final
 io.netty:netty-resolver:4.1.31.Final
 io.netty:netty-tcnative-boringssl-static:2.0.22.Final
 io.netty:netty-transport:4.1.31.Final
+io.opencensus:opencensus-api:0.21.0
+io.opencensus:opencensus-contrib-http-util:0.21.0
+javax.activation:activation:1.1
 javax.inject:javax.inject:1
+javax.mail:mail:1.4
+javax.xml.bind:jaxb-api:2.3.0
+joda-time:joda-time:2.9.2
+org.apache.httpcomponents:httpclient:4.5.8
+org.apache.httpcomponents:httpcore:4.4.11
 org.checkerframework:checker-qual:2.8.1
 org.codehaus.mojo:animal-sniffer-annotations:1.18
+org.yaml:snakeyaml:1.17

--- a/networking/gradle/dependency-locks/testCompile.lockfile
+++ b/networking/gradle/dependency-locks/testCompile.lockfile
@@ -1,16 +1,32 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-core:2.9.9
+com.google.api-client:google-api-client:1.29.2
+com.google.appengine:appengine-api-1.0-sdk:1.9.48
+com.google.appengine:appengine-testing:1.9.58
+com.google.auth:google-auth-library-credentials:0.16.1
+com.google.auth:google-auth-library-oauth2-http:0.16.1
 com.google.auto.value:auto-value-annotations:1.6.3
+com.google.auto.value:auto-value:1.6.3
 com.google.code.findbugs:jsr305:3.0.2
+com.google.dagger:dagger:2.21
 com.google.errorprone:error_prone_annotations:2.3.2
 com.google.flogger:flogger:0.1
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:28.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+com.google.http-client:google-http-client-jackson2:1.30.1
+com.google.http-client:google-http-client:1.30.1
 com.google.j2objc:j2objc-annotations:1.3
+com.google.oauth-client:google-oauth-client:1.29.2
+com.google.re2j:re2j:1.1
 com.google.truth:truth:1.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
+com.ibm.icu:icu4j:57.1
+commons-codec:commons-codec:1.11
+commons-logging:commons-logging:1.2
+io.grpc:grpc-context:1.19.0
 io.netty:netty-buffer:4.1.31.Final
 io.netty:netty-codec-http:4.1.31.Final
 io.netty:netty-codec:4.1.31.Final
@@ -18,11 +34,20 @@ io.netty:netty-common:4.1.31.Final
 io.netty:netty-handler:4.1.31.Final
 io.netty:netty-resolver:4.1.31.Final
 io.netty:netty-transport:4.1.31.Final
+io.opencensus:opencensus-api:0.21.0
+io.opencensus:opencensus-contrib-http-util:0.21.0
+javax.activation:activation:1.1
 javax.inject:javax.inject:1
+javax.mail:mail:1.4
+javax.xml.bind:jaxb-api:2.3.0
+joda-time:joda-time:2.9.2
 junit:junit:4.12
+org.apache.httpcomponents:httpclient:4.5.8
+org.apache.httpcomponents:httpcore:4.4.11
 org.bouncycastle:bcpkix-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5
 org.checkerframework:checker-qual:2.8.1
 org.codehaus.mojo:animal-sniffer-annotations:1.18
 org.hamcrest:hamcrest-core:1.3
+org.yaml:snakeyaml:1.17

--- a/networking/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/networking/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -1,16 +1,32 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-core:2.9.9
+com.google.api-client:google-api-client:1.29.2
+com.google.appengine:appengine-api-1.0-sdk:1.9.48
+com.google.appengine:appengine-testing:1.9.58
+com.google.auth:google-auth-library-credentials:0.16.1
+com.google.auth:google-auth-library-oauth2-http:0.16.1
 com.google.auto.value:auto-value-annotations:1.6.3
+com.google.auto.value:auto-value:1.6.3
 com.google.code.findbugs:jsr305:3.0.2
+com.google.dagger:dagger:2.21
 com.google.errorprone:error_prone_annotations:2.3.2
 com.google.flogger:flogger:0.1
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:28.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+com.google.http-client:google-http-client-jackson2:1.30.1
+com.google.http-client:google-http-client:1.30.1
 com.google.j2objc:j2objc-annotations:1.3
+com.google.oauth-client:google-oauth-client:1.29.2
+com.google.re2j:re2j:1.1
 com.google.truth:truth:1.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
+com.ibm.icu:icu4j:57.1
+commons-codec:commons-codec:1.11
+commons-logging:commons-logging:1.2
+io.grpc:grpc-context:1.19.0
 io.netty:netty-buffer:4.1.31.Final
 io.netty:netty-codec-http:4.1.31.Final
 io.netty:netty-codec:4.1.31.Final
@@ -18,11 +34,20 @@ io.netty:netty-common:4.1.31.Final
 io.netty:netty-handler:4.1.31.Final
 io.netty:netty-resolver:4.1.31.Final
 io.netty:netty-transport:4.1.31.Final
+io.opencensus:opencensus-api:0.21.0
+io.opencensus:opencensus-contrib-http-util:0.21.0
+javax.activation:activation:1.1
 javax.inject:javax.inject:1
+javax.mail:mail:1.4
+javax.xml.bind:jaxb-api:2.3.0
+joda-time:joda-time:2.9.2
 junit:junit:4.12
+org.apache.httpcomponents:httpclient:4.5.8
+org.apache.httpcomponents:httpcore:4.4.11
 org.bouncycastle:bcpkix-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5
 org.checkerframework:checker-qual:2.8.1
 org.codehaus.mojo:animal-sniffer-annotations:1.18
 org.hamcrest:hamcrest-core:1.3
+org.yaml:snakeyaml:1.17

--- a/networking/gradle/dependency-locks/testRuntime.lockfile
+++ b/networking/gradle/dependency-locks/testRuntime.lockfile
@@ -1,17 +1,33 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-core:2.9.9
+com.google.api-client:google-api-client:1.29.2
+com.google.appengine:appengine-api-1.0-sdk:1.9.48
+com.google.appengine:appengine-testing:1.9.58
+com.google.auth:google-auth-library-credentials:0.16.1
+com.google.auth:google-auth-library-oauth2-http:0.16.1
 com.google.auto.value:auto-value-annotations:1.6.3
+com.google.auto.value:auto-value:1.6.3
 com.google.code.findbugs:jsr305:3.0.2
+com.google.dagger:dagger:2.21
 com.google.errorprone:error_prone_annotations:2.3.2
 com.google.flogger:flogger-system-backend:0.1
 com.google.flogger:flogger:0.1
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:28.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+com.google.http-client:google-http-client-jackson2:1.30.1
+com.google.http-client:google-http-client:1.30.1
 com.google.j2objc:j2objc-annotations:1.3
+com.google.oauth-client:google-oauth-client:1.29.2
+com.google.re2j:re2j:1.1
 com.google.truth:truth:1.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
+com.ibm.icu:icu4j:57.1
+commons-codec:commons-codec:1.11
+commons-logging:commons-logging:1.2
+io.grpc:grpc-context:1.19.0
 io.netty:netty-buffer:4.1.31.Final
 io.netty:netty-codec-http:4.1.31.Final
 io.netty:netty-codec:4.1.31.Final
@@ -20,11 +36,20 @@ io.netty:netty-handler:4.1.31.Final
 io.netty:netty-resolver:4.1.31.Final
 io.netty:netty-tcnative-boringssl-static:2.0.22.Final
 io.netty:netty-transport:4.1.31.Final
+io.opencensus:opencensus-api:0.21.0
+io.opencensus:opencensus-contrib-http-util:0.21.0
+javax.activation:activation:1.1
 javax.inject:javax.inject:1
+javax.mail:mail:1.4
+javax.xml.bind:jaxb-api:2.3.0
+joda-time:joda-time:2.9.2
 junit:junit:4.12
+org.apache.httpcomponents:httpclient:4.5.8
+org.apache.httpcomponents:httpcore:4.4.11
 org.bouncycastle:bcpkix-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5
 org.checkerframework:checker-qual:2.8.1
 org.codehaus.mojo:animal-sniffer-annotations:1.18
 org.hamcrest:hamcrest-core:1.3
+org.yaml:snakeyaml:1.17

--- a/networking/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/networking/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -1,17 +1,33 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-core:2.9.9
+com.google.api-client:google-api-client:1.29.2
+com.google.appengine:appengine-api-1.0-sdk:1.9.48
+com.google.appengine:appengine-testing:1.9.58
+com.google.auth:google-auth-library-credentials:0.16.1
+com.google.auth:google-auth-library-oauth2-http:0.16.1
 com.google.auto.value:auto-value-annotations:1.6.3
+com.google.auto.value:auto-value:1.6.3
 com.google.code.findbugs:jsr305:3.0.2
+com.google.dagger:dagger:2.21
 com.google.errorprone:error_prone_annotations:2.3.2
 com.google.flogger:flogger-system-backend:0.1
 com.google.flogger:flogger:0.1
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:28.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+com.google.http-client:google-http-client-jackson2:1.30.1
+com.google.http-client:google-http-client:1.30.1
 com.google.j2objc:j2objc-annotations:1.3
+com.google.oauth-client:google-oauth-client:1.29.2
+com.google.re2j:re2j:1.1
 com.google.truth:truth:1.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
+com.ibm.icu:icu4j:57.1
+commons-codec:commons-codec:1.11
+commons-logging:commons-logging:1.2
+io.grpc:grpc-context:1.19.0
 io.netty:netty-buffer:4.1.31.Final
 io.netty:netty-codec-http:4.1.31.Final
 io.netty:netty-codec:4.1.31.Final
@@ -20,11 +36,20 @@ io.netty:netty-handler:4.1.31.Final
 io.netty:netty-resolver:4.1.31.Final
 io.netty:netty-tcnative-boringssl-static:2.0.22.Final
 io.netty:netty-transport:4.1.31.Final
+io.opencensus:opencensus-api:0.21.0
+io.opencensus:opencensus-contrib-http-util:0.21.0
+javax.activation:activation:1.1
 javax.inject:javax.inject:1
+javax.mail:mail:1.4
+javax.xml.bind:jaxb-api:2.3.0
+joda-time:joda-time:2.9.2
 junit:junit:4.12
+org.apache.httpcomponents:httpclient:4.5.8
+org.apache.httpcomponents:httpcore:4.4.11
 org.bouncycastle:bcpkix-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5
 org.checkerframework:checker-qual:2.8.1
 org.codehaus.mojo:animal-sniffer-annotations:1.18
 org.hamcrest:hamcrest-core:1.3
+org.yaml:snakeyaml:1.17

--- a/proxy/src/main/java/google/registry/proxy/EppProtocolModule.java
+++ b/proxy/src/main/java/google/registry/proxy/EppProtocolModule.java
@@ -162,7 +162,8 @@ public final class EppProtocolModule {
       SslProvider sslProvider,
       Supplier<PrivateKey> privateKeySupplier,
       Supplier<ImmutableList<X509Certificate>> certificatesSupplier) {
-    return new SslServerInitializer<>(true, sslProvider, privateKeySupplier, certificatesSupplier);
+    return new SslServerInitializer<>(
+        true, false, sslProvider, privateKeySupplier, certificatesSupplier);
   }
 
   @Provides

--- a/proxy/src/main/java/google/registry/proxy/WebWhoisProtocolsModule.java
+++ b/proxy/src/main/java/google/registry/proxy/WebWhoisProtocolsModule.java
@@ -134,6 +134,7 @@ public final class WebWhoisProtocolsModule {
       SslProvider sslProvider,
       Supplier<PrivateKey> privateKeySupplier,
       Supplier<ImmutableList<X509Certificate>> certificatesSupplier) {
-    return new SslServerInitializer<>(false, sslProvider, privateKeySupplier, certificatesSupplier);
+    return new SslServerInitializer<>(
+        false, false, sslProvider, privateKeySupplier, certificatesSupplier);
   }
 }


### PR DESCRIPTION
Client SSL handler already performs the necessary validation. Only tests are
added.

Server SSL handler does not currently check for the validity period of
the client certificate as the insecure trust manager is used. This PR
added the check but does not actually terminate the connection yet. It
will log the expired certificates so that we can contact the registrars
to update them.

Once we are certain that all certificates are updated, we can turn off
dryrun mode.

We should also consider checking if the certificate has too long a
validity period as it defeats the purpose of using regularly updated
certificates to deprecate insecure cipher suites.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/391)
<!-- Reviewable:end -->
