### PR TITLE
Check SQL dependency in super class for SqlIntegrationMembershipTest

### DIFF
--- a/core/src/test/java/google/registry/schema/integration/SqlIntegrationMembershipTest.java
+++ b/core/src/test/java/google/registry/schema/integration/SqlIntegrationMembershipTest.java
@@ -71,8 +71,13 @@ public class SqlIntegrationMembershipTest {
   }
 
   private static boolean isSqlDependent(Class<?> testClass) {
-    return Stream.of(testClass.getDeclaredFields())
-        .map(Field::getType)
-        .anyMatch(JpaTransactionManagerRule.class::equals);
+    for (Class<?> clazz = testClass; clazz != null; clazz = clazz.getSuperclass()) {
+      if (Stream.of(clazz.getDeclaredFields())
+          .map(Field::getType)
+          .anyMatch(JpaTransactionManagerRule.class::equals)) {
+        return true;
+      }
+    }
+    return false;
   }
 }


### PR DESCRIPTION
In some cases, we define JpaTransactionManagerRule in a TestCase
class which is extended by the concrete test class. So, we need
to check if JpaTransactionManagerRule is also defined in the super
class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/398)
<!-- Reviewable:end -->
