### PR TITLE
Fix test on use of external schema jar

### DIFF
--- a/core/src/test/java/google/registry/model/transaction/JpaTransactionManagerRuleTest.java
+++ b/core/src/test/java/google/registry/model/transaction/JpaTransactionManagerRuleTest.java
@@ -80,6 +80,7 @@ public class JpaTransactionManagerRuleTest {
 
   @Test
   public void testInitScriptUrl_noOverride() {
+    systemPropertyRule.setProperty(GOLDEN_SCHEMA_RESOURCE_ROOT_PROP, null);
     assertThat(jpaTmRule.getInitScriptUrlOverride()).isEmpty();
   }
 


### PR DESCRIPTION
One test breaks if path to external schema is set and
test is run from the sqlIntegrationTest task.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/412)
<!-- Reviewable:end -->
