### PR TITLE
Add dual write for Cursors

### DIFF
--- a/core/src/main/java/google/registry/batch/ExpandRecurringBillingEventsAction.java
+++ b/core/src/main/java/google/registry/batch/ExpandRecurringBillingEventsAction.java
@@ -58,6 +58,7 @@ import google.registry.request.Action;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
+import google.registry.schema.cursor.CursorDao;
 import google.registry.util.Clock;
 import java.util.Optional;
 import java.util.Set;
@@ -313,8 +314,7 @@ public class ExpandRecurringBillingEventsAction implements Runnable {
       logger.atInfo().log(
           "Recurring event expansion %s complete for billing event range [%s, %s).",
           isDryRun ? "(dry run) " : "", cursorTime, executionTime);
-      tm()
-          .transact(
+      tm().transact(
               () -> {
                 Cursor cursor = ofy().load().key(Cursor.createGlobalKey(RECURRING_BILLING)).now();
                 DateTime currentCursorTime =
@@ -326,7 +326,9 @@ public class ExpandRecurringBillingEventsAction implements Runnable {
                   return;
                 }
                 if (!isDryRun) {
-                  ofy().save().entity(Cursor.createGlobal(RECURRING_BILLING, executionTime));
+                  CursorDao.saveCursor(
+                      Cursor.createGlobal(RECURRING_BILLING, executionTime),
+                      google.registry.schema.cursor.Cursor.GLOBAL);
                 }
               });
     }

--- a/core/src/main/java/google/registry/export/sheet/SyncRegistrarsSheet.java
+++ b/core/src/main/java/google/registry/export/sheet/SyncRegistrarsSheet.java
@@ -25,7 +25,6 @@ import static google.registry.model.registrar.RegistrarContact.Type.LEGAL;
 import static google.registry.model.registrar.RegistrarContact.Type.MARKETING;
 import static google.registry.model.registrar.RegistrarContact.Type.TECH;
 import static google.registry.model.registrar.RegistrarContact.Type.WHOIS;
-import static google.registry.model.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
 import com.google.common.base.Joiner;
@@ -37,6 +36,7 @@ import google.registry.model.common.Cursor;
 import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.RegistrarAddress;
 import google.registry.model.registrar.RegistrarContact;
+import google.registry.schema.cursor.CursorDao;
 import google.registry.util.Clock;
 import google.registry.util.DateTimeUtils;
 import java.io.IOException;
@@ -153,9 +153,9 @@ class SyncRegistrarsSheet {
                   return builder.build();
                 })
             .collect(toImmutableList()));
-    tm()
-        .transact(
-            () -> ofy().save().entity(Cursor.createGlobal(SYNC_REGISTRAR_SHEET, executionTime)));
+    CursorDao.saveCursor(
+        Cursor.createGlobal(SYNC_REGISTRAR_SHEET, executionTime),
+        google.registry.schema.cursor.Cursor.GLOBAL);
   }
 
   private static String convertContacts(

--- a/core/src/main/java/google/registry/model/common/Cursor.java
+++ b/core/src/main/java/google/registry/model/common/Cursor.java
@@ -129,6 +129,11 @@ public class Cursor extends ImmutableObject {
     return lastUpdateTime.getTimestamp();
   }
 
+  public CursorType getType() {
+    List<String> id = Splitter.on('_').splitToList(this.id);
+    return CursorType.valueOf(String.join("_", id.subList(1, id.size())));
+  }
+
   /**
    * Checks that the type of the scoped object (or null) matches the required type for the specified
    * cursor (or null, if the cursor is a global cursor).
@@ -192,11 +197,6 @@ public class Cursor extends ImmutableObject {
    */
   public static DateTime getCursorTimeOrStartOfTime(Cursor cursor) {
     return cursor != null ? cursor.getCursorTime() : START_OF_TIME;
-  }
-
-  public static CursorType getType(Cursor cursor) {
-    List<String> id = Splitter.on('_').splitToList(cursor.id);
-    return CursorType.valueOf(String.join("_", id.subList(1, id.size())));
   }
 
   public DateTime getCursorTime() {

--- a/core/src/main/java/google/registry/model/common/Cursor.java
+++ b/core/src/main/java/google/registry/model/common/Cursor.java
@@ -20,6 +20,7 @@ import static google.registry.model.common.EntityGroupRoot.getCrossTldKey;
 import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
+import com.google.common.base.Splitter;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
@@ -27,6 +28,7 @@ import com.googlecode.objectify.annotation.Parent;
 import google.registry.model.ImmutableObject;
 import google.registry.model.UpdateAutoTimestamp;
 import google.registry.model.registry.Registry;
+import java.util.List;
 import org.joda.time.DateTime;
 
 /**
@@ -193,8 +195,8 @@ public class Cursor extends ImmutableObject {
   }
 
   public static CursorType getType(Cursor cursor) {
-    String[] id = cursor.id.split("_", 2);
-    return CursorType.valueOf(id[1]);
+    List<String> id = Splitter.on('_').splitToList(cursor.id);
+    return CursorType.valueOf(String.join("_", id.subList(1, id.size())));
   }
 
   public DateTime getCursorTime() {

--- a/core/src/main/java/google/registry/model/common/Cursor.java
+++ b/core/src/main/java/google/registry/model/common/Cursor.java
@@ -192,6 +192,11 @@ public class Cursor extends ImmutableObject {
     return cursor != null ? cursor.getCursorTime() : START_OF_TIME;
   }
 
+  public static CursorType getType(Cursor cursor) {
+    String[] id = cursor.id.split("_", 2);
+    return CursorType.valueOf(id[1]);
+  }
+
   public DateTime getCursorTime() {
     return cursorTime;
   }

--- a/core/src/main/java/google/registry/rde/EscrowTaskRunner.java
+++ b/core/src/main/java/google/registry/rde/EscrowTaskRunner.java
@@ -15,7 +15,6 @@
 package google.registry.rde;
 
 import static google.registry.model.ofy.ObjectifyService.ofy;
-import static google.registry.model.transaction.TransactionManagerFactory.tm;
 
 import com.google.common.flogger.FluentLogger;
 import google.registry.model.common.Cursor;
@@ -24,6 +23,7 @@ import google.registry.model.registry.Registry;
 import google.registry.request.HttpException.NoContentException;
 import google.registry.request.HttpException.ServiceUnavailableException;
 import google.registry.request.lock.LockHandler;
+import google.registry.schema.cursor.CursorDao;
 import google.registry.util.Clock;
 import java.util.concurrent.Callable;
 import javax.inject.Inject;
@@ -99,7 +99,7 @@ class EscrowTaskRunner {
           task.runWithLock(nextRequiredRun);
           DateTime nextRun = nextRequiredRun.plus(interval);
           logger.atInfo().log("Rolling cursor forward to %s.", nextRun);
-          tm().transact(() -> ofy().save().entity(Cursor.create(cursorType, nextRun, registry)));
+          CursorDao.saveCursor(Cursor.create(cursorType, nextRun, registry), registry.getTldStr());
           return null;
         };
     String lockName = String.format("EscrowTaskRunner %s", task.getClass().getSimpleName());

--- a/core/src/main/java/google/registry/rde/PendingDepositChecker.java
+++ b/core/src/main/java/google/registry/rde/PendingDepositChecker.java
@@ -27,6 +27,7 @@ import google.registry.model.rde.RdeMode;
 import google.registry.model.registry.Registries;
 import google.registry.model.registry.Registry;
 import google.registry.model.registry.Registry.TldType;
+import google.registry.schema.cursor.CursorDao;
 import google.registry.util.Clock;
 import javax.inject.Inject;
 import org.joda.time.DateTime;
@@ -107,14 +108,14 @@ public final class PendingDepositChecker {
       final Registry registry,
       final CursorType cursorType,
       final DateTime initialValue) {
-    return tm()
-        .transact(
+    return tm().transact(
             () -> {
               Cursor cursor = ofy().load().key(Cursor.createKey(cursorType, registry)).now();
               if (cursor != null) {
                 return cursor.getCursorTime();
               }
-              ofy().save().entity(Cursor.create(cursorType, initialValue, registry));
+              CursorDao.saveCursor(
+                  Cursor.create(cursorType, initialValue, registry), registry.getTldStr());
               return initialValue;
             });
   }

--- a/core/src/main/java/google/registry/rde/RdeUploadAction.java
+++ b/core/src/main/java/google/registry/rde/RdeUploadAction.java
@@ -52,6 +52,7 @@ import google.registry.request.Parameter;
 import google.registry.request.RequestParameters;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
+import google.registry.schema.cursor.CursorDao;
 import google.registry.util.Clock;
 import google.registry.util.Retrier;
 import google.registry.util.TaskQueueUtils;
@@ -170,12 +171,11 @@ public final class RdeUploadAction implements Runnable, EscrowTask {
         () -> upload(xmlFilename, xmlLength, watermark, name), JSchException.class);
     logger.atInfo().log(
         "Updating RDE cursor '%s' for TLD '%s' following successful upload.", RDE_UPLOAD_SFTP, tld);
-    tm()
-        .transact(
+    tm().transact(
             () -> {
-              Cursor updatedSftpCursor =
-                  Cursor.create(RDE_UPLOAD_SFTP, tm().getTransactionTime(), Registry.get(tld));
-              ofy().save().entity(updatedSftpCursor);
+              DateTime transactionTime = tm().getTransactionTime();
+              CursorDao.saveCursor(
+                  Cursor.create(RDE_UPLOAD_SFTP, transactionTime, Registry.get(tld)), tld);
             });
     response.setContentType(PLAIN_TEXT_UTF_8);
     response.setPayload(String.format("OK %s %s\n", tld, watermark));

--- a/core/src/main/java/google/registry/rde/RdeUploadAction.java
+++ b/core/src/main/java/google/registry/rde/RdeUploadAction.java
@@ -173,9 +173,9 @@ public final class RdeUploadAction implements Runnable, EscrowTask {
         "Updating RDE cursor '%s' for TLD '%s' following successful upload.", RDE_UPLOAD_SFTP, tld);
     tm().transact(
             () -> {
-              DateTime transactionTime = tm().getTransactionTime();
               CursorDao.saveCursor(
-                  Cursor.create(RDE_UPLOAD_SFTP, transactionTime, Registry.get(tld)), tld);
+                  Cursor.create(RDE_UPLOAD_SFTP, tm().getTransactionTime(), Registry.get(tld)),
+                  tld);
             });
     response.setContentType(PLAIN_TEXT_UTF_8);
     response.setPayload(String.format("OK %s %s\n", tld, watermark));

--- a/core/src/main/java/google/registry/reporting/icann/IcannReportingUploadAction.java
+++ b/core/src/main/java/google/registry/reporting/icann/IcannReportingUploadAction.java
@@ -44,6 +44,7 @@ import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
 import google.registry.request.lock.LockHandler;
+import google.registry.schema.cursor.CursorDao;
 import google.registry.util.Clock;
 import google.registry.util.EmailMessage;
 import google.registry.util.Retrier;
@@ -186,7 +187,8 @@ public final class IcannReportingUploadAction implements Runnable {
               cursorType,
               cursorTime.withTimeAtStartOfDay().withDayOfMonth(1).plusMonths(1),
               Registry.get(tldStr));
-      tm().transact(() -> ofy().save().entity(newCursor));
+      CursorDao.saveCursor(
+          newCursor, (tldStr == null ? google.registry.schema.cursor.Cursor.GLOBAL : tldStr));
     }
   }
 

--- a/core/src/main/java/google/registry/reporting/icann/IcannReportingUploadAction.java
+++ b/core/src/main/java/google/registry/reporting/icann/IcannReportingUploadAction.java
@@ -52,6 +52,7 @@ import google.registry.util.SendEmailService;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -188,7 +189,8 @@ public final class IcannReportingUploadAction implements Runnable {
               cursorTime.withTimeAtStartOfDay().withDayOfMonth(1).plusMonths(1),
               Registry.get(tldStr));
       CursorDao.saveCursor(
-          newCursor, (tldStr == null ? google.registry.schema.cursor.Cursor.GLOBAL : tldStr));
+          newCursor,
+          Optional.ofNullable(tldStr).orElse(google.registry.schema.cursor.Cursor.GLOBAL));
     }
   }
 

--- a/core/src/main/java/google/registry/schema/cursor/CursorDao.java
+++ b/core/src/main/java/google/registry/schema/cursor/CursorDao.java
@@ -92,12 +92,12 @@ public class CursorDao {
    */
   public static void saveCursor(google.registry.model.common.Cursor cursor, String scope) {
     tm().transact(() -> ofy().save().entity(cursor));
-    CursorType type = google.registry.model.common.Cursor.getType(cursor);
+    CursorType type = cursor.getType();
     try {
       Cursor cloudSqlCursor = Cursor.create(type, scope, cursor.getCursorTime());
       save(cloudSqlCursor);
     } catch (Exception e) {
-      logger.atSevere().withCause(e).log("Error saving cursor to Cloud SQL");
+      logger.atSevere().withCause(e).log("Error saving cursor to Cloud SQL.");
     }
   }
 
@@ -124,12 +124,10 @@ public class CursorDao {
               cursor ->
                   cloudSqlCursors.add(
                       Cursor.create(
-                          google.registry.model.common.Cursor.getType(cursor),
-                          cursors.get(cursor),
-                          cursor.getCursorTime())));
+                          cursor.getType(), cursors.get(cursor), cursor.getCursorTime())));
       saveAll(cloudSqlCursors.build());
     } catch (Exception e) {
-      logger.atSevere().withCause(e).log("Error saving cursor to Cloud SQL");
+      logger.atSevere().withCause(e).log("Error saving cursor to Cloud SQL.");
     }
   }
 }

--- a/core/src/main/java/google/registry/schema/cursor/CursorDao.java
+++ b/core/src/main/java/google/registry/schema/cursor/CursorDao.java
@@ -15,14 +15,19 @@
 package google.registry.schema.cursor;
 
 import static com.google.appengine.api.search.checkers.Preconditions.checkNotNull;
+import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.model.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.model.transaction.TransactionManagerFactory.tm;
 
+import com.google.common.flogger.FluentLogger;
 import google.registry.model.common.Cursor.CursorType;
 import google.registry.schema.cursor.Cursor.CursorId;
 import java.util.List;
 
 /** Data access object class for {@link Cursor}. */
 public class CursorDao {
+
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   public static void save(Cursor cursor) {
     jpaTm()
@@ -34,7 +39,7 @@ public class CursorDao {
 
   public static Cursor load(CursorType type, String scope) {
     checkNotNull(scope, "The scope of the cursor to load cannot be null");
-    checkNotNull(type, "The type of the cursor to load must be specified");
+    checkNotNull(type, "The type of the cursor to load cannot be null");
     return jpaTm()
         .transact(() -> jpaTm().getEntityManager().find(Cursor.class, new CursorId(type, scope)));
   }
@@ -66,5 +71,22 @@ public class CursorDao {
                         "SELECT cursor FROM Cursor cursor WHERE cursor.type = :type", Cursor.class)
                     .setParameter("type", type)
                     .getResultList());
+  }
+
+  /**
+   * This writes the given cursor to datastore. If the save to datastore succeeds, then a new
+   * Schema/Cursor object is created and attempted to save to Cloud SQL. If the save to Cloud SQL
+   * fails, the exception is logged, but does not cause the method to fail.
+   */
+  public static void saveCursor(google.registry.model.common.Cursor cursor, String scope) {
+    tm().transact(() -> ofy().save().entity(cursor));
+    CursorType type = google.registry.model.common.Cursor.getType(cursor);
+    try {
+      Cursor cloudSqlCursor = Cursor.create(type, scope, cursor.getCursorTime());
+      save(cloudSqlCursor);
+    } catch (Exception e) {
+      logger.atInfo().log("Issue saving cursor to CloudSql: " + e.getMessage());
+      e.printStackTrace();
+    }
   }
 }

--- a/core/src/main/java/google/registry/tools/UpdateCursorsCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdateCursorsCommand.java
@@ -29,7 +29,7 @@ import org.joda.time.DateTime;
 
 /** Modifies {@link Cursor} timestamps used by locking rolling cursor tasks, like in RDE. */
 @Parameters(separators = " =", commandDescription = "Modifies cursor timestamps used by LRC tasks")
-final class UpdateCursorsCommand extends ConfirmingCommand {
+final class UpdateCursorsCommand extends ConfirmingCommand implements CommandWithCloudSql {
 
   @Parameter(description = "TLDs on which to operate. Omit for global cursors.")
   private List<String> tlds;

--- a/core/src/main/java/google/registry/tools/UpdateCursorsCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdateCursorsCommand.java
@@ -14,7 +14,6 @@
 
 package google.registry.tools;
 
-import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.util.CollectionUtils.isNullOrEmpty;
 
 import com.beust.jcommander.Parameter;
@@ -22,6 +21,7 @@ import com.beust.jcommander.Parameters;
 import google.registry.model.common.Cursor;
 import google.registry.model.common.Cursor.CursorType;
 import google.registry.model.registry.Registry;
+import google.registry.schema.cursor.CursorDao;
 import google.registry.tools.params.DateTimeParameter;
 import java.util.List;
 import org.joda.time.DateTime;
@@ -49,15 +49,14 @@ final class UpdateCursorsCommand extends MutatingCommand {
   @Override
   protected void init() {
     if (isNullOrEmpty(tlds)) {
-      Cursor cursor = ofy().load().key(Cursor.createGlobalKey(cursorType)).now();
-      stageEntityChange(cursor, Cursor.createGlobal(cursorType, newTimestamp));
+      CursorDao.saveCursor(
+          Cursor.createGlobal(cursorType, newTimestamp),
+          google.registry.schema.cursor.Cursor.GLOBAL);
     } else {
       for (String tld : tlds) {
         Registry registry = Registry.get(tld);
-        Cursor cursor = ofy().load().key(Cursor.createKey(cursorType, registry)).now();
-        stageEntityChange(
-            cursor,
-            Cursor.create(cursorType, newTimestamp, registry));
+        CursorDao.saveCursor(
+            Cursor.create(cursorType, newTimestamp, registry), registry.getTldStr());
       }
     }
   }

--- a/core/src/main/java/google/registry/tools/UpdateCursorsCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdateCursorsCommand.java
@@ -51,7 +51,7 @@ final class UpdateCursorsCommand extends ConfirmingCommand {
 
   @Override
   protected void init() {
-    ImmutableMap.Builder<Cursor, String> cursorsToUpdateBuilder = ImmutableMap.builder();
+    ImmutableMap.Builder<Cursor, String> cursorsToUpdateBuilder = new ImmutableMap.Builder<>();
     if (isNullOrEmpty(tlds)) {
       cursorsToUpdateBuilder.put(
           Cursor.createGlobal(cursorType, newTimestamp),
@@ -69,7 +69,7 @@ final class UpdateCursorsCommand extends ConfirmingCommand {
   @Override
   protected String execute() throws Exception {
     CursorDao.saveCursors(cursorsToUpdate);
-    return String.format("Updated %d entities.\n", cursorsToUpdate.size());
+    return String.format("Updated %d cursors.\n", cursorsToUpdate.size());
   }
 
   /** Returns the changes that have been staged thus far. */
@@ -87,6 +87,6 @@ final class UpdateCursorsCommand extends ConfirmingCommand {
   private String getChangeString(Cursor cursor, String scope) {
     return String.format(
         "Change cursorTime of %s for Scope:%s to %s\n",
-        Cursor.getType(cursor), scope, cursor.getCursorTime());
+        cursor.getType(), scope, cursor.getCursorTime());
   }
 }

--- a/core/src/test/java/google/registry/backup/CommitLogCheckpointStrategyTest.java
+++ b/core/src/test/java/google/registry/backup/CommitLogCheckpointStrategyTest.java
@@ -17,7 +17,6 @@ package google.registry.backup;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.common.Cursor.CursorType.RDE_REPORT;
 import static google.registry.model.ofy.CommitLogBucket.getBucketKey;
-import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.testing.DatastoreHelper.createTld;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
@@ -30,7 +29,6 @@ import google.registry.model.ofy.CommitLogCheckpoint;
 import google.registry.model.ofy.DatastoreTransactionManager;
 import google.registry.model.ofy.Ofy;
 import google.registry.model.registry.Registry;
-import google.registry.model.transaction.JpaTransactionManagerRule;
 import google.registry.model.transaction.TransactionManager;
 import google.registry.schema.cursor.CursorDao;
 import google.registry.testing.AppEngineRule;
@@ -56,9 +54,6 @@ public class CommitLogCheckpointStrategyTest {
   @Rule
   public final InjectRule inject = new InjectRule();
 
-  @Rule
-  public final JpaTransactionManagerRule jpaTmRule =
-      new JpaTransactionManagerRule.Builder().build();
 
   final FakeClock clock = new FakeClock(DateTime.parse("2000-01-01TZ"));
   final Ofy ofy = new Ofy(clock);

--- a/core/src/test/java/google/registry/batch/ExpandRecurringBillingEventsActionTest.java
+++ b/core/src/test/java/google/registry/batch/ExpandRecurringBillingEventsActionTest.java
@@ -49,7 +49,6 @@ import google.registry.model.registry.Registry;
 import google.registry.model.reporting.DomainTransactionRecord;
 import google.registry.model.reporting.DomainTransactionRecord.TransactionReportField;
 import google.registry.model.reporting.HistoryEntry;
-import google.registry.model.transaction.JpaTransactionManagerRule;
 import google.registry.schema.cursor.CursorDao;
 import google.registry.testing.FakeClock;
 import google.registry.testing.FakeResponse;
@@ -72,10 +71,6 @@ public class ExpandRecurringBillingEventsActionTest
     extends MapreduceTestCase<ExpandRecurringBillingEventsAction> {
   @Rule
   public final InjectRule inject = new InjectRule();
-
-  @Rule
-  public final JpaTransactionManagerRule jpaTmRule =
-      new JpaTransactionManagerRule.Builder().build();
 
   private final DateTime beginningOfTest = DateTime.parse("2000-10-02T00:00:00Z");
   private final FakeClock clock = new FakeClock(beginningOfTest);

--- a/core/src/test/java/google/registry/batch/ExpandRecurringBillingEventsActionTest.java
+++ b/core/src/test/java/google/registry/batch/ExpandRecurringBillingEventsActionTest.java
@@ -19,7 +19,6 @@ import static google.registry.model.common.Cursor.CursorType.RECURRING_BILLING;
 import static google.registry.model.domain.Period.Unit.YEARS;
 import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.model.reporting.HistoryEntry.Type.DOMAIN_AUTORENEW;
-import static google.registry.model.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatastoreHelper.assertBillingEvents;
 import static google.registry.testing.DatastoreHelper.assertBillingEventsForResource;
 import static google.registry.testing.DatastoreHelper.createTld;
@@ -50,6 +49,8 @@ import google.registry.model.registry.Registry;
 import google.registry.model.reporting.DomainTransactionRecord;
 import google.registry.model.reporting.DomainTransactionRecord.TransactionReportField;
 import google.registry.model.reporting.HistoryEntry;
+import google.registry.model.transaction.JpaTransactionManagerRule;
+import google.registry.schema.cursor.CursorDao;
 import google.registry.testing.FakeClock;
 import google.registry.testing.FakeResponse;
 import google.registry.testing.InjectRule;
@@ -71,6 +72,10 @@ public class ExpandRecurringBillingEventsActionTest
     extends MapreduceTestCase<ExpandRecurringBillingEventsAction> {
   @Rule
   public final InjectRule inject = new InjectRule();
+
+  @Rule
+  public final JpaTransactionManagerRule jpaTmRule =
+      new JpaTransactionManagerRule.Builder().build();
 
   private final DateTime beginningOfTest = DateTime.parse("2000-10-02T00:00:00Z");
   private final FakeClock clock = new FakeClock(beginningOfTest);
@@ -103,7 +108,9 @@ public class ExpandRecurringBillingEventsActionTest
   }
 
   private void saveCursor(final DateTime cursorTime) {
-    tm().transact(() -> ofy().save().entity(Cursor.createGlobal(RECURRING_BILLING, cursorTime)));
+    CursorDao.saveCursor(
+        Cursor.createGlobal(RECURRING_BILLING, cursorTime),
+        google.registry.schema.cursor.Cursor.GLOBAL);
   }
 
   private void runMapreduce() throws Exception {

--- a/core/src/test/java/google/registry/export/sheet/SyncRegistrarsSheetTest.java
+++ b/core/src/test/java/google/registry/export/sheet/SyncRegistrarsSheetTest.java
@@ -38,7 +38,6 @@ import google.registry.model.ofy.Ofy;
 import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.RegistrarAddress;
 import google.registry.model.registrar.RegistrarContact;
-import google.registry.model.transaction.JpaTransactionManagerRule;
 import google.registry.testing.AppEngineRule;
 import google.registry.testing.DatastoreHelper;
 import google.registry.testing.FakeClock;
@@ -63,9 +62,6 @@ public class SyncRegistrarsSheetTest {
   @Rule public final MockitoRule mocks = MockitoJUnit.rule();
   @Rule public final InjectRule inject = new InjectRule();
 
-  @Rule
-  public final JpaTransactionManagerRule jpaTmRule =
-      new JpaTransactionManagerRule.Builder().build();
 
   @Captor private ArgumentCaptor<ImmutableList<ImmutableMap<String, String>>> rowsCaptor;
   @Mock private SheetSynchronizer sheetSynchronizer;

--- a/core/src/test/java/google/registry/export/sheet/SyncRegistrarsSheetTest.java
+++ b/core/src/test/java/google/registry/export/sheet/SyncRegistrarsSheetTest.java
@@ -38,6 +38,7 @@ import google.registry.model.ofy.Ofy;
 import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.RegistrarAddress;
 import google.registry.model.registrar.RegistrarContact;
+import google.registry.model.transaction.JpaTransactionManagerRule;
 import google.registry.testing.AppEngineRule;
 import google.registry.testing.DatastoreHelper;
 import google.registry.testing.FakeClock;
@@ -61,6 +62,10 @@ public class SyncRegistrarsSheetTest {
   @Rule public final AppEngineRule appEngine = AppEngineRule.builder().withDatastore().build();
   @Rule public final MockitoRule mocks = MockitoJUnit.rule();
   @Rule public final InjectRule inject = new InjectRule();
+
+  @Rule
+  public final JpaTransactionManagerRule jpaTmRule =
+      new JpaTransactionManagerRule.Builder().build();
 
   @Captor private ArgumentCaptor<ImmutableList<ImmutableMap<String, String>>> rowsCaptor;
   @Mock private SheetSynchronizer sheetSynchronizer;

--- a/core/src/test/java/google/registry/model/common/CursorTest.java
+++ b/core/src/test/java/google/registry/model/common/CursorTest.java
@@ -27,18 +27,12 @@ import static org.junit.Assert.assertThrows;
 import google.registry.model.EntityTestCase;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.registry.Registry;
-import google.registry.model.transaction.JpaTransactionManagerRule;
 import google.registry.schema.cursor.CursorDao;
 import org.joda.time.DateTime;
-import org.junit.Rule;
 import org.junit.Test;
 
 /** Unit tests for {@link Cursor}. */
 public class CursorTest extends EntityTestCase {
-
-  @Rule
-  public final JpaTransactionManagerRule jpaTmRule =
-      new JpaTransactionManagerRule.Builder().build();
 
   @Test
   public void testSuccess_persistScopedCursor() {

--- a/core/src/test/java/google/registry/model/common/CursorTest.java
+++ b/core/src/test/java/google/registry/model/common/CursorTest.java
@@ -19,7 +19,6 @@ import static google.registry.model.common.Cursor.CursorType.BRDA;
 import static google.registry.model.common.Cursor.CursorType.RDE_UPLOAD;
 import static google.registry.model.common.Cursor.CursorType.RECURRING_BILLING;
 import static google.registry.model.ofy.ObjectifyService.ofy;
-import static google.registry.model.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatastoreHelper.createTld;
 import static google.registry.testing.DatastoreHelper.persistActiveDomain;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
@@ -28,18 +27,25 @@ import static org.junit.Assert.assertThrows;
 import google.registry.model.EntityTestCase;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.registry.Registry;
+import google.registry.model.transaction.JpaTransactionManagerRule;
+import google.registry.schema.cursor.CursorDao;
 import org.joda.time.DateTime;
+import org.junit.Rule;
 import org.junit.Test;
 
 /** Unit tests for {@link Cursor}. */
 public class CursorTest extends EntityTestCase {
+
+  @Rule
+  public final JpaTransactionManagerRule jpaTmRule =
+      new JpaTransactionManagerRule.Builder().build();
 
   @Test
   public void testSuccess_persistScopedCursor() {
     createTld("tld");
     clock.advanceOneMilli();
     final DateTime time = DateTime.parse("2012-07-12T03:30:00.000Z");
-    tm().transact(() -> ofy().save().entity(Cursor.create(RDE_UPLOAD, time, Registry.get("tld"))));
+    CursorDao.saveCursor(Cursor.create(RDE_UPLOAD, time, Registry.get("tld")), "tld");
     assertThat(ofy().load().key(Cursor.createKey(BRDA, Registry.get("tld"))).now()).isNull();
     assertThat(
             ofy()
@@ -53,7 +59,8 @@ public class CursorTest extends EntityTestCase {
   @Test
   public void testSuccess_persistGlobalCursor() {
     final DateTime time = DateTime.parse("2012-07-12T03:30:00.000Z");
-    tm().transact(() -> ofy().save().entity(Cursor.createGlobal(RECURRING_BILLING, time)));
+    CursorDao.saveCursor(
+        Cursor.createGlobal(RECURRING_BILLING, time), google.registry.schema.cursor.Cursor.GLOBAL);
     assertThat(ofy().load().key(Cursor.createGlobalKey(RECURRING_BILLING)).now().getCursorTime())
         .isEqualTo(time);
   }
@@ -61,7 +68,8 @@ public class CursorTest extends EntityTestCase {
   @Test
   public void testIndexing() throws Exception {
     final DateTime time = DateTime.parse("2012-07-12T03:30:00.000Z");
-    tm().transact(() -> ofy().save().entity(Cursor.createGlobal(RECURRING_BILLING, time)));
+    CursorDao.saveCursor(
+        Cursor.createGlobal(RECURRING_BILLING, time), google.registry.schema.cursor.Cursor.GLOBAL);
     Cursor cursor = ofy().load().key(Cursor.createGlobalKey(RECURRING_BILLING)).now();
     verifyIndexing(cursor);
   }
@@ -75,8 +83,7 @@ public class CursorTest extends EntityTestCase {
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () ->
-                tm().transact(() -> ofy().save().entity(Cursor.create(RDE_UPLOAD, time, domain))));
+            () -> CursorDao.saveCursor(Cursor.create(RDE_UPLOAD, time, domain), domain.getTld()));
     assertThat(thrown)
         .hasMessageThat()
         .contains("Class required for cursor does not match scope class");

--- a/core/src/test/java/google/registry/rde/EscrowTaskRunnerTest.java
+++ b/core/src/test/java/google/registry/rde/EscrowTaskRunnerTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.verify;
 import google.registry.model.common.Cursor;
 import google.registry.model.common.Cursor.CursorType;
 import google.registry.model.registry.Registry;
-import google.registry.model.transaction.JpaTransactionManagerRule;
 import google.registry.rde.EscrowTaskRunner.EscrowTask;
 import google.registry.request.HttpException.NoContentException;
 import google.registry.request.HttpException.ServiceUnavailableException;
@@ -59,10 +58,6 @@ public class EscrowTaskRunnerTest {
   private DateTimeZone previousDateTimeZone;
   private EscrowTaskRunner runner;
   private Registry registry;
-
-  @Rule
-  public final JpaTransactionManagerRule jpaTmRule =
-      new JpaTransactionManagerRule.Builder().build();
 
   @Before
   public void before() {

--- a/core/src/test/java/google/registry/rde/EscrowTaskRunnerTest.java
+++ b/core/src/test/java/google/registry/rde/EscrowTaskRunnerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.verify;
 import google.registry.model.common.Cursor;
 import google.registry.model.common.Cursor.CursorType;
 import google.registry.model.registry.Registry;
+import google.registry.model.transaction.JpaTransactionManagerRule;
 import google.registry.rde.EscrowTaskRunner.EscrowTask;
 import google.registry.request.HttpException.NoContentException;
 import google.registry.request.HttpException.ServiceUnavailableException;
@@ -59,6 +60,9 @@ public class EscrowTaskRunnerTest {
   private EscrowTaskRunner runner;
   private Registry registry;
 
+  @Rule
+  public final JpaTransactionManagerRule jpaTmRule =
+      new JpaTransactionManagerRule.Builder().build();
 
   @Before
   public void before() {

--- a/core/src/test/java/google/registry/rde/PendingDepositCheckerTest.java
+++ b/core/src/test/java/google/registry/rde/PendingDepositCheckerTest.java
@@ -30,7 +30,6 @@ import google.registry.model.common.Cursor;
 import google.registry.model.common.Cursor.CursorType;
 import google.registry.model.ofy.Ofy;
 import google.registry.model.registry.Registry;
-import google.registry.model.transaction.JpaTransactionManagerRule;
 import google.registry.schema.cursor.CursorDao;
 import google.registry.testing.AppEngineRule;
 import google.registry.testing.FakeClock;
@@ -53,10 +52,6 @@ public class PendingDepositCheckerTest {
   public final AppEngineRule appEngine = AppEngineRule.builder()
       .withDatastore()
       .build();
-
-  @Rule
-  public final JpaTransactionManagerRule jpaTmRule =
-      new JpaTransactionManagerRule.Builder().build();
 
   private final FakeClock clock = new FakeClock();
   private final PendingDepositChecker checker = new PendingDepositChecker();

--- a/core/src/test/java/google/registry/rde/RdeStagingActionTest.java
+++ b/core/src/test/java/google/registry/rde/RdeStagingActionTest.java
@@ -52,7 +52,6 @@ import google.registry.model.common.Cursor.CursorType;
 import google.registry.model.host.HostResource;
 import google.registry.model.ofy.Ofy;
 import google.registry.model.registry.Registry;
-import google.registry.model.transaction.JpaTransactionManagerRule;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.RequestParameters;
 import google.registry.schema.cursor.CursorDao;
@@ -109,10 +108,6 @@ public class RdeStagingActionTest extends MapreduceTestCase<RdeStagingAction> {
 
   @Rule
   public final InjectRule inject = new InjectRule();
-
-  @Rule
-  public final JpaTransactionManagerRule jpaTmRule =
-      new JpaTransactionManagerRule.Builder().build();
 
   private final FakeClock clock = new FakeClock();
   private final FakeResponse response = new FakeResponse();

--- a/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
+++ b/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
@@ -60,7 +60,6 @@ import google.registry.model.common.Cursor;
 import google.registry.model.common.Cursor.CursorType;
 import google.registry.model.rde.RdeRevision;
 import google.registry.model.registry.Registry;
-import google.registry.model.transaction.JpaTransactionManagerRule;
 import google.registry.rde.JSchSshSession.JSchSshSessionFactory;
 import google.registry.request.HttpException.NoContentException;
 import google.registry.request.RequestParameters;
@@ -134,9 +133,6 @@ public class RdeUploadActionTest {
       .withTaskQueue()
       .build();
 
-  @Rule
-  public final JpaTransactionManagerRule jpaTmRule =
-      new JpaTransactionManagerRule.Builder().build();
 
   private final FakeResponse response = new FakeResponse();
   private final EscrowTaskRunner runner = mock(EscrowTaskRunner.class);

--- a/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
+++ b/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
@@ -60,6 +60,7 @@ import google.registry.model.common.Cursor;
 import google.registry.model.common.Cursor.CursorType;
 import google.registry.model.rde.RdeRevision;
 import google.registry.model.registry.Registry;
+import google.registry.model.transaction.JpaTransactionManagerRule;
 import google.registry.rde.JSchSshSession.JSchSshSessionFactory;
 import google.registry.request.HttpException.NoContentException;
 import google.registry.request.RequestParameters;
@@ -132,6 +133,10 @@ public class RdeUploadActionTest {
       .withDatastore()
       .withTaskQueue()
       .build();
+
+  @Rule
+  public final JpaTransactionManagerRule jpaTmRule =
+      new JpaTransactionManagerRule.Builder().build();
 
   private final FakeResponse response = new FakeResponse();
   private final EscrowTaskRunner runner = mock(EscrowTaskRunner.class);

--- a/core/src/test/java/google/registry/reporting/icann/IcannReportingUploadActionTest.java
+++ b/core/src/test/java/google/registry/reporting/icann/IcannReportingUploadActionTest.java
@@ -36,6 +36,7 @@ import google.registry.gcs.GcsUtils;
 import google.registry.model.common.Cursor;
 import google.registry.model.common.Cursor.CursorType;
 import google.registry.model.registry.Registry;
+import google.registry.model.transaction.JpaTransactionManagerRule;
 import google.registry.request.HttpException.ServiceUnavailableException;
 import google.registry.testing.AppEngineRule;
 import google.registry.testing.FakeClock;
@@ -61,6 +62,10 @@ import org.junit.runners.JUnit4;
 public class IcannReportingUploadActionTest {
 
   @Rule public final AppEngineRule appEngine = AppEngineRule.builder().withDatastore().build();
+
+  @Rule
+  public final JpaTransactionManagerRule jpaTmRule =
+      new JpaTransactionManagerRule.Builder().build();
 
   private static final byte[] PAYLOAD_SUCCESS = "test,csv\n13,37".getBytes(UTF_8);
   private static final byte[] PAYLOAD_FAIL = "ahah,csv\n12,34".getBytes(UTF_8);

--- a/core/src/test/java/google/registry/reporting/icann/IcannReportingUploadActionTest.java
+++ b/core/src/test/java/google/registry/reporting/icann/IcannReportingUploadActionTest.java
@@ -36,7 +36,6 @@ import google.registry.gcs.GcsUtils;
 import google.registry.model.common.Cursor;
 import google.registry.model.common.Cursor.CursorType;
 import google.registry.model.registry.Registry;
-import google.registry.model.transaction.JpaTransactionManagerRule;
 import google.registry.request.HttpException.ServiceUnavailableException;
 import google.registry.testing.AppEngineRule;
 import google.registry.testing.FakeClock;
@@ -62,10 +61,6 @@ import org.junit.runners.JUnit4;
 public class IcannReportingUploadActionTest {
 
   @Rule public final AppEngineRule appEngine = AppEngineRule.builder().withDatastore().build();
-
-  @Rule
-  public final JpaTransactionManagerRule jpaTmRule =
-      new JpaTransactionManagerRule.Builder().build();
 
   private static final byte[] PAYLOAD_SUCCESS = "test,csv\n13,37".getBytes(UTF_8);
   private static final byte[] PAYLOAD_FAIL = "ahah,csv\n12,34".getBytes(UTF_8);

--- a/core/src/test/java/google/registry/schema/cursor/CursorDaoTest.java
+++ b/core/src/test/java/google/registry/schema/cursor/CursorDaoTest.java
@@ -200,7 +200,7 @@ public class CursorDaoTest {
     CursorDao.saveCursor(cursor, null);
     assertAboutLogs()
         .that(logHandler)
-        .hasLogAtLevelWithMessage(Level.SEVERE, "Error saving cursor to Cloud SQL");
+        .hasLogAtLevelWithMessage(Level.SEVERE, "Error saving cursor to Cloud SQL.");
     google.registry.model.common.Cursor dataStoreCursor =
         ofy()
             .load()

--- a/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
+++ b/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
@@ -52,7 +52,7 @@ import org.junit.runners.Suite.SuiteClasses;
   RegistryLockDaoTest.class,
   RegistryLockGetActionTest.class,
   ReservedListDaoTest.class,
-  UpdatePremiumListActionTest.class,
+    UpdatePremiumListActionTest.class,
   UpdateReservedListCommandTest.class
 })
 public class SqlIntegrationTestSuite {}

--- a/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
+++ b/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
@@ -52,7 +52,7 @@ import org.junit.runners.Suite.SuiteClasses;
   RegistryLockDaoTest.class,
   RegistryLockGetActionTest.class,
   ReservedListDaoTest.class,
-    UpdatePremiumListActionTest.class,
+  UpdatePremiumListActionTest.class,
   UpdateReservedListCommandTest.class
 })
 public class SqlIntegrationTestSuite {}

--- a/core/src/test/java/google/registry/tools/UpdateCursorsCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateCursorsCommandTest.java
@@ -44,6 +44,9 @@ public class UpdateCursorsCommandTest extends CommandTestCase<UpdateCursorsComma
     runCommandForced("--type=brda", "--timestamp=1984-12-18T00:00:00Z", "foo");
     assertThat(ofy().load().key(Cursor.createKey(CursorType.BRDA, registry)).now().getCursorTime())
         .isEqualTo(DateTime.parse("1984-12-18TZ"));
+    String changes = command.prompt();
+    assertThat(changes)
+        .isEqualTo("Change cursorTime of BRDA for Scope:foo to 1984-12-18T00:00:00.000Z\n");
   }
 
   void doGlobalUpdateTest() throws Exception {
@@ -55,6 +58,11 @@ public class UpdateCursorsCommandTest extends CommandTestCase<UpdateCursorsComma
                 .now()
                 .getCursorTime())
         .isEqualTo(DateTime.parse("1984-12-18TZ"));
+    String changes = command.prompt();
+    assertThat(changes)
+        .isEqualTo(
+            "Change cursorTime of RECURRING_BILLING for Scope:GLOBAL to"
+                + " 1984-12-18T00:00:00.000Z\n");
   }
 
   @Test
@@ -94,6 +102,11 @@ public class UpdateCursorsCommandTest extends CommandTestCase<UpdateCursorsComma
         .isEqualTo(DateTime.parse("1984-12-18TZ"));
     assertThat(ofy().load().key(Cursor.createKey(CursorType.BRDA, registry2)).now().getCursorTime())
         .isEqualTo(DateTime.parse("1984-12-18TZ"));
+    String changes = command.prompt();
+    assertThat(changes)
+        .isEqualTo(
+            "Change cursorTime of BRDA for Scope:foo to 1984-12-18T00:00:00.000Z\n"
+                + "Change cursorTime of BRDA for Scope:bar to 1984-12-18T00:00:00.000Z\n");
   }
 
   @Test
@@ -107,6 +120,11 @@ public class UpdateCursorsCommandTest extends CommandTestCase<UpdateCursorsComma
         .isEqualTo(DateTime.parse("1984-12-18TZ"));
     assertThat(ofy().load().key(Cursor.createKey(CursorType.BRDA, registry2)).now().getCursorTime())
         .isEqualTo(DateTime.parse("1984-12-18TZ"));
+    String changes = command.prompt();
+    assertThat(changes)
+        .isEqualTo(
+            "Change cursorTime of BRDA for Scope:foo to 1984-12-18T00:00:00.000Z\n"
+                + "Change cursorTime of BRDA for Scope:bar to 1984-12-18T00:00:00.000Z\n");
   }
 
   @Test


### PR DESCRIPTION
This adds a helper method that is used in all places where the code saves a cursor. The helper function saves the cursor to Datastore. If that succeeds, it constructs a new Cursor object and attempts to save it to Cloud SQL. All Cloud SQL exceptions are caught and logged, but don't cause the helper method to fail. 

Note: There were a few places in the code that saved the cursor to Datastore transactionally. With this helper method, no cursors will be saved transactionally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/414)
<!-- Reviewable:end -->
