### PR TITLE
Restore a deployed schema scrip to original form

### DIFF
--- a/db/src/main/resources/sql/flyway/V9__premium_list_currency_type.sql
+++ b/db/src/main/resources/sql/flyway/V9__premium_list_currency_type.sql
@@ -15,5 +15,5 @@
 -- Note: We're OK with dropping this data since it's not live in production yet.
 alter table "PremiumList" drop column if exists currency;
 
--- Note: This default was removed in V11.
+-- TODO(mcilwain): Add a subsequent schema change to remove this default.
 alter table "PremiumList" add column currency text not null default 'USD';


### PR DESCRIPTION
V9__premium_list_currency_type.sql has already been deployed
to sandbox when its todo line is removed. Flyway refuses to
push it because file checksum does not match.

Lessons learned:
- Do not put TODO in flyway scripts
- Need presubmit check for change to deployed scripts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/417)
<!-- Reviewable:end -->
