### PR TITLE
Fix another bug in the proxy

### DIFF
--- a/networking/src/main/java/google/registry/networking/handler/SslServerInitializer.java
+++ b/networking/src/main/java/google/registry/networking/handler/SslServerInitializer.java
@@ -113,8 +113,6 @@ public class SslServerInitializer<C extends Channel> extends ChannelInitializer<
                               sslHandler.engine().getSession().getPeerCertificates()[0];
                       try {
                         clientCertificate.checkValidity();
-                        Promise<X509Certificate> unusedPromise =
-                            clientCertificatePromise.setSuccess(clientCertificate);
                       } catch (CertificateNotYetValidException | CertificateExpiredException e) {
                         logger.atWarning().withCause(e).log(
                             "Client certificate is not valid.\nHash: %s",
@@ -123,8 +121,11 @@ public class SslServerInitializer<C extends Channel> extends ChannelInitializer<
                           Promise<X509Certificate> unusedPromise =
                               clientCertificatePromise.setFailure(e);
                           ChannelFuture unusedFuture2 = channel.close();
+                          return;
                         }
                       }
+                      Promise<X509Certificate> unusedPromise =
+                          clientCertificatePromise.setSuccess(clientCertificate);
                     } else {
                       Promise<X509Certificate> unusedPromise =
                           clientCertificatePromise.setFailure(future.cause());


### PR DESCRIPTION
The promise should be set outside the try block because if we want
warning only, we still want the promise to be set even if the
clientCertificate.checkValidity() throws an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/419)
<!-- Reviewable:end -->
