### PR TITLE
Fix flakiness in JodaMoneyConverterTest

### DIFF
--- a/core/src/main/java/google/registry/persistence/HibernateSchemaExporter.java
+++ b/core/src/main/java/google/registry/persistence/HibernateSchemaExporter.java
@@ -32,6 +32,9 @@ import org.hibernate.tool.schema.TargetType;
 
 /** Utility class to export DDL script for given {@link javax.persistence.Entity} classes. */
 public class HibernateSchemaExporter {
+  // Hibernate proprietary mappings.
+  private static final String HIBERNATE_MAPPING_RESOURCES = "META-INF/orm.xml";
+
   private final String jdbcUrl;
   private final String username;
   private final String password;
@@ -63,6 +66,7 @@ public class HibernateSchemaExporter {
     try (StandardServiceRegistry registry =
         new StandardServiceRegistryBuilder().applySettings(settings).build()) {
       MetadataSources metadata = new MetadataSources(registry);
+      metadata.addResource(HIBERNATE_MAPPING_RESOURCES);
 
       // Note that we need to also add all converters to the Hibernate context because
       // the entity class may use the customized type.

--- a/core/src/test/java/google/registry/model/transaction/JpaTransactionManagerRule.java
+++ b/core/src/test/java/google/registry/model/transaction/JpaTransactionManagerRule.java
@@ -119,6 +119,9 @@ abstract class JpaTransactionManagerRule extends ExternalResource {
       // If there are user properties, create a new properties object with these added.
       ImmutableMap.Builder builder = properties.builder();
       builder.putAll(userProperties);
+      // Forbid Hibernate push to stay consistent with flyway-based schema management.
+      builder.put(Environment.HBM2DDL_AUTO, "none");
+      builder.put(Environment.SHOW_SQL, "true");
       properties = builder.build();
     }
     assertNormalActiveConnection();

--- a/core/src/test/java/google/registry/persistence/JodaMoneyConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/JodaMoneyConverterTest.java
@@ -35,7 +35,6 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.MapKeyColumn;
 import javax.persistence.PostLoad;
-import org.hibernate.cfg.Environment;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
 import org.junit.Rule;
@@ -67,7 +66,6 @@ public class JodaMoneyConverterTest {
   public final JpaUnitTestRule jpaRule =
       new JpaTestRules.Builder()
           .withEntityClass(TestEntity.class, ComplexTestEntity.class)
-          .withProperty(Environment.HBM2DDL_AUTO, "update")
           .buildUnitTestRule();
 
   @Test
@@ -82,7 +80,7 @@ public class JodaMoneyConverterTest {
                     jpaTm()
                         .getEntityManager()
                         .createNativeQuery(
-                            "SELECT amount, currency FROM TestEntity WHERE name = 'id'")
+                            "SELECT amount, currency FROM \"TestEntity\" WHERE name = 'id'")
                         .getResultList());
     assertThat(result.size()).isEqualTo(1);
     assertThat(Arrays.asList((Object[]) result.get(0)))
@@ -113,7 +111,7 @@ public class JodaMoneyConverterTest {
                         .getEntityManager()
                         .createNativeQuery(
                             "SELECT my_amount, my_currency, your_amount, your_currency FROM"
-                                + " ComplexTestEntity WHERE name = 'id'")
+                                + " \"ComplexTestEntity\" WHERE name = 'id'")
                         .getResultList());
     assertThat(result.size()).isEqualTo(1);
     assertThat(Arrays.asList((Object[]) result.get(0)))
@@ -127,7 +125,7 @@ public class JodaMoneyConverterTest {
                     jpaTm()
                         .getEntityManager()
                         .createNativeQuery(
-                            "SELECT map_amount, map_currency FROM MoneyMap"
+                            "SELECT map_amount, map_currency FROM \"MoneyMap\""
                                 + " WHERE entity_name = 'id' AND map_key = 'dos'")
                         .getResultList());
     ComplexTestEntity persisted =
@@ -148,7 +146,9 @@ public class JodaMoneyConverterTest {
     assertThat(persisted.moneyMap).containsExactlyEntriesIn(moneyMap);
   }
 
-  @Entity(name = "TestEntity") // Override entity name to avoid the nested class reference.
+  // Override entity name to exclude outer-class name in table name. Not necessary if class is not
+  // inner class. The double quotes are added to conform to our schema generation convention.
+  @Entity(name = "\"TestEntity\"")
   public static class TestEntity extends ImmutableObject {
 
     @Id String name = "id";
@@ -162,7 +162,8 @@ public class JodaMoneyConverterTest {
     }
   }
 
-  @Entity(name = "ComplexTestEntity") // Override entity name to avoid the nested class reference.
+  // See comments on the annotation for TestEntity above for reason.
+  @Entity(name = "\"ComplexTestEntity\"")
   // This entity is used to test column override for embedded fields and collections.
   public static class ComplexTestEntity extends ImmutableObject {
 


### PR DESCRIPTION
JpdaMoneyConverterTest relies on Hibernate to deploy its schema.
This introduces an extra jdbc connection in the middle of a test
suite, and may break the connection count checks between tests made
by JpaTransactionManagerRule.

This change updated HibernateSchemaExporter to include Hibernate
proprietary mappings in META-INF/orm.xml.

This change also disabled Hibernate schema push for all tests,
and enabled sql statement logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/421)
<!-- Reviewable:end -->
