### PR TITLE
Implement changes suggested by testcontainer dev

### DIFF
--- a/core/src/test/java/google/registry/model/transaction/JpaTransactionManagerRule.java
+++ b/core/src/test/java/google/registry/model/transaction/JpaTransactionManagerRule.java
@@ -97,7 +97,6 @@ abstract class JpaTransactionManagerRule extends ExternalResource {
         new PostgreSQLContainer(NomulusPostgreSql.getDockerTag())
             .withDatabaseName(MANAGEMENT_DB_NAME);
     container.start();
-    Runtime.getRuntime().addShutdownHook(new Thread(() -> container.close()));
     return container;
   }
 

--- a/core/src/test/java/google/registry/webdriver/DockerWebDriverRule.java
+++ b/core/src/test/java/google/registry/webdriver/DockerWebDriverRule.java
@@ -52,7 +52,8 @@ class DockerWebDriverRule extends ExternalResource {
       url =
           new URL(
               String.format(
-                  "http://localhost:%d/wd/hub",
+                  "http://%s:%d/wd/hub",
+                  container.getContainerIpAddress(),
                   container.getMappedPort(CHROME_DRIVER_SERVICE_PORT)));
     } catch (MalformedURLException e) {
       throw new IllegalArgumentException(e);


### PR DESCRIPTION
See https://github.com/google/nomulus/issues/401
Specifically:
- Use getContainerIpAddress() instead of localhost to insulate us from
  off-machine docker usage.
- Remove shutdown hook to close the container, as testcontainers does this for
  us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/426)
<!-- Reviewable:end -->
