### PR TITLE
Relax premium list existence check to allow Cloud SQL migration

### DIFF
--- a/core/src/main/java/google/registry/schema/tld/PremiumListDao.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumListDao.java
@@ -66,10 +66,15 @@ public class PremiumListDao {
     jpaTm()
         .transact(
             () -> {
-              checkArgument(
-                  checkExists(premiumList.getName()),
-                  "Can't update non-existent premium list '%s'",
-                  premiumList.getName());
+              // This check is currently disabled because, during the Cloud SQL migration, we need
+              // to be able to update premium lists in Datastore while simultaneously creating their
+              // first revision in Cloud SQL (i.e. if they haven't been migrated over yet).
+              // TODO(b/147246613): Reinstate this once all premium lists are migrated to Cloud SQL,
+              //                 and re-enable the test update_throwsWhenListDoesntExist().
+              // checkArgument(
+              //     checkExists(premiumList.getName()),
+              //     "Can't update non-existent premium list '%s'",
+              //     premiumList.getName());
               jpaTm().getEntityManager().persist(premiumList);
             });
   }

--- a/core/src/test/java/google/registry/schema/tld/PremiumListDaoTest.java
+++ b/core/src/test/java/google/registry/schema/tld/PremiumListDaoTest.java
@@ -35,6 +35,7 @@ import java.math.BigDecimal;
 import java.util.Optional;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -125,7 +126,9 @@ public class PremiumListDaoTest {
     assertThat(thrown).hasMessageThat().isEqualTo("Premium list 'testlist' already exists");
   }
 
+  // TODO(b/147246613): Un-ignore this.
   @Test
+  @Ignore
   public void update_throwsWhenListDoesntExist() {
     IllegalArgumentException thrown =
         assertThrows(


### PR DESCRIPTION
We need to be able to simultaneously update premium lists that already exist in
Datastore and create them in Cloud SQL (because they haven't been migrated over
yet). This temporarily relaxes the existence check for Cloud SQL so that
"updates" will work even when the list doesn't yet exist there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/428)
<!-- Reviewable:end -->
