### PR TITLE
Make Jacoco work with multiple test tasks

### DIFF
--- a/java_common.gradle
+++ b/java_common.gradle
@@ -121,6 +121,11 @@ spotless {
   }
 }
 
+jacocoTestReport {
+    // Use coverage data from all tests tasks, not just the one named 'test'.
+    getExecutionData().setFrom(fileTree(buildDir).include("/jacoco/*.exec"))
+}
+
 // Initialize for coverage minimum determination for each sub project.
 task initCoverageMinimums {
   // Use current coverage ratio of each subproject as placeholder value.


### PR DESCRIPTION
By default Jacoco only looks at execution data from
the 'test' task. This is a problem to 'core' which
has multiple test sets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/437)
<!-- Reviewable:end -->
