### PR TITLE
Get persistence of DomainBase actually working

### DIFF
--- a/core/src/main/java/google/registry/model/EppResource.java
+++ b/core/src/main/java/google/registry/model/EppResource.java
@@ -51,6 +51,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import javax.persistence.MappedSuperclass;
+import javax.persistence.Transient;
 import org.hibernate.annotations.Type;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
@@ -126,6 +127,7 @@ public abstract class EppResource extends BackupGroupRoot implements Buildable {
    *
    * @see google.registry.model.translators.CommitLogRevisionsTranslatorFactory
    */
+  @Transient
   ImmutableSortedMap<DateTime, Key<CommitLogManifest>> revisions = ImmutableSortedMap.of();
 
   public final String getRepoId() {

--- a/core/src/main/java/google/registry/model/EppResource.java
+++ b/core/src/main/java/google/registry/model/EppResource.java
@@ -87,7 +87,7 @@ public abstract class EppResource extends BackupGroupRoot implements Buildable {
   // Map the method to XML, not the field, because if we map the field (with an adaptor class) it
   // will never be omitted from the xml even if the timestamp inside creationTime is null and we
   // return null from the adaptor. (Instead it gets written as an empty tag.)
-  @Index @Transient CreateAutoTimestamp creationTime = CreateAutoTimestamp.create(null);
+  @Index CreateAutoTimestamp creationTime = CreateAutoTimestamp.create(null);
 
   /**
    * The time when this resource was or will be deleted.
@@ -104,7 +104,6 @@ public abstract class EppResource extends BackupGroupRoot implements Buildable {
    */
   @Index
   DateTime deletionTime;
-
 
   /**
    * The time that this resource was last updated.
@@ -136,15 +135,15 @@ public abstract class EppResource extends BackupGroupRoot implements Buildable {
     return creationTime.getTimestamp();
   }
 
-  public final String getCreationClientId() {
+  public String getCreationClientId() {
     return creationClientId;
   }
 
-  public final DateTime getLastEppUpdateTime() {
+  public DateTime getLastEppUpdateTime() {
     return lastEppUpdateTime;
   }
 
-  public final String getLastEppUpdateClientId() {
+  public String getLastEppUpdateClientId() {
     return lastEppUpdateClientId;
   }
 
@@ -162,7 +161,7 @@ public abstract class EppResource extends BackupGroupRoot implements Buildable {
     return nullToEmptyImmutableCopy(status);
   }
 
-  public final DateTime getDeletionTime() {
+  public DateTime getDeletionTime() {
     return deletionTime;
   }
 

--- a/core/src/main/java/google/registry/model/EppResource.java
+++ b/core/src/main/java/google/registry/model/EppResource.java
@@ -50,6 +50,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.Transient;
 import org.hibernate.annotations.Type;
@@ -117,6 +118,8 @@ public abstract class EppResource extends BackupGroupRoot implements Buildable {
 
   /** Status values associated with this resource. */
   @Type(type = "google.registry.model.eppcommon.StatusValue$StatusValueSetType")
+  @Column(name = "statuses")
+  // TODO(mmuller): rename to "statuses" once we're off datastore.
   Set<StatusValue> status;
 
   /**

--- a/core/src/main/java/google/registry/model/EppResource.java
+++ b/core/src/main/java/google/registry/model/EppResource.java
@@ -51,7 +51,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import javax.persistence.MappedSuperclass;
-import javax.persistence.Transient;
+import org.hibernate.annotations.Type;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
@@ -115,7 +115,8 @@ public abstract class EppResource extends BackupGroupRoot implements Buildable {
   DateTime lastEppUpdateTime;
 
   /** Status values associated with this resource. */
-  @Transient Set<StatusValue> status;
+  @Type(type = "google.registry.model.eppcommon.StatusValue$StatusValueSetType")
+  Set<StatusValue> status;
 
   /**
    * Sorted map of {@link DateTime} keys (modified time) to {@link CommitLogManifest} entries.

--- a/core/src/main/java/google/registry/model/domain/DesignatedContact.java
+++ b/core/src/main/java/google/registry/model/domain/DesignatedContact.java
@@ -21,7 +21,7 @@ import com.googlecode.objectify.annotation.Embed;
 import com.googlecode.objectify.annotation.Index;
 import google.registry.model.ImmutableObject;
 import google.registry.model.contact.ContactResource;
-import javax.persistence.Id;
+import javax.persistence.Embeddable;
 import javax.xml.bind.annotation.XmlEnumValue;
 
 /**
@@ -40,7 +40,7 @@ import javax.xml.bind.annotation.XmlEnumValue;
  *     - Contact and Client Identifiers</a>
  */
 @Embed
-@javax.persistence.Entity
+@Embeddable
 public class DesignatedContact extends ImmutableObject {
 
   /**
@@ -67,7 +67,7 @@ public class DesignatedContact extends ImmutableObject {
 
   Type type;
 
-  @Index @Id Key<ContactResource> contact;
+  @Index Key<ContactResource> contact;
 
   public Type getType() {
     return type;

--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -72,9 +72,11 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.persistence.AttributeOverride;
 import javax.persistence.AttributeOverrides;
+import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
+import javax.persistence.JoinColumn;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
@@ -130,7 +132,9 @@ public class DomainBase extends EppResource
    *
    * <p>These are stored in one field so that we can query across all contacts at once.
    */
-  @ElementCollection Set<DesignatedContact> allContacts;
+  @ElementCollection
+  @CollectionTable(name = "DomainBase_allContacts", joinColumns = @JoinColumn(name = "domain"))
+  Set<DesignatedContact> allContacts;
 
   /** Authorization info (aka transfer secret) of the domain. */
   @Embedded
@@ -285,7 +289,7 @@ public class DomainBase extends EppResource
   }
 
   @Override
-  public final TransferData getTransferData() {
+  public TransferData getTransferData() {
     return Optional.ofNullable(transferData).orElse(TransferData.EMPTY);
   }
 

--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -72,11 +72,10 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.persistence.AttributeOverride;
 import javax.persistence.AttributeOverrides;
-import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
-import javax.persistence.JoinColumn;
+import javax.persistence.Transient;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
 
@@ -132,9 +131,7 @@ public class DomainBase extends EppResource
    *
    * <p>These are stored in one field so that we can query across all contacts at once.
    */
-  @ElementCollection
-  @CollectionTable(name = "Domain_allContacts", joinColumns = @JoinColumn(name = "domain"))
-  Set<DesignatedContact> allContacts;
+  @Transient Set<DesignatedContact> allContacts;
 
   /** Authorization info (aka transfer secret) of the domain. */
   @Embedded
@@ -150,7 +147,7 @@ public class DomainBase extends EppResource
    * <p>This is {@literal @}XmlTransient because it needs to be returned under the "extension" tag
    * of an info response rather than inside the "infData" tag.
    */
-  @ElementCollection Set<DelegationSignerData> dsData;
+  @Transient Set<DelegationSignerData> dsData;
 
   /**
    * The claims notice supplied when this application or domain was created, if there was one. It's

--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -133,7 +133,7 @@ public class DomainBase extends EppResource
    * <p>These are stored in one field so that we can query across all contacts at once.
    */
   @ElementCollection
-  @CollectionTable(name = "DomainBase_allContacts", joinColumns = @JoinColumn(name = "domain"))
+  @CollectionTable(name = "Domain_allContacts", joinColumns = @JoinColumn(name = "domain"))
   Set<DesignatedContact> allContacts;
 
   /** Authorization info (aka transfer secret) of the domain. */

--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -213,7 +213,7 @@ public class DomainBase extends EppResource
   Key<PollMessage.Autorenew> autorenewPollMessage;
 
   /** The unexpired grace periods for this domain (some of which may not be active yet). */
-  @ElementCollection Set<GracePeriod> gracePeriods;
+  @Transient @ElementCollection Set<GracePeriod> gracePeriods;
 
   /**
    * The id of the signed mark that was used to create this domain in sunrise.

--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -90,8 +90,16 @@ import org.joda.time.Interval;
  */
 @ReportedOn
 @Entity
-@javax.persistence.Entity
-@javax.persistence.Table(name = "Domain")
+@javax.persistence.Entity(name = "Domain")
+@javax.persistence.Table(
+    name = "Domain",
+    indexes = {
+      @javax.persistence.Index(columnList = "creationTime"),
+      @javax.persistence.Index(columnList = "currentSponsorClientId"),
+      @javax.persistence.Index(columnList = "deletionTime"),
+      @javax.persistence.Index(columnList = "fullyQualifiedDomainName"),
+      @javax.persistence.Index(columnList = "tld")
+    })
 @ExternalMessagingName("domain")
 public class DomainBase extends EppResource
     implements ForeignKeyedEppResource, ResourceWithTransferData {
@@ -106,7 +114,7 @@ public class DomainBase extends EppResource
           StatusValue.INACTIVE,
           StatusValue.PENDING_DELETE,
           StatusValue.SERVER_HOLD);
-  
+
   /**
    * Fully qualified domain name (puny-coded), which serves as the foreign key for this domain.
    *
@@ -116,15 +124,14 @@ public class DomainBase extends EppResource
    *
    * @invariant fullyQualifiedDomainName == fullyQualifiedDomainName.toLowerCase(Locale.ENGLISH)
    */
-  @Index
-  String fullyQualifiedDomainName;
+  @Index String fullyQualifiedDomainName;
 
   /** The top level domain this is under, dernormalized from {@link #fullyQualifiedDomainName}. */
   @Index
   String tld;
 
   /** References to hosts that are the nameservers for the domain. */
-  @Index @ElementCollection Set<Key<HostResource>> nsHosts;
+  @Index @ElementCollection @Transient Set<Key<HostResource>> nsHosts;
 
   /**
    * The union of the contacts visible via {@link #getContacts} and {@link #getRegistrant}.
@@ -178,7 +185,8 @@ public class DomainBase extends EppResource
   String idnTableName;
 
   /** Fully qualified host names of this domain's active subordinate hosts. */
-  @ElementCollection Set<String> subordinateHosts;
+  @org.hibernate.annotations.Type(type = "google.registry.persistence.StringSetUserType")
+  Set<String> subordinateHosts;
 
   /** When this domain's registration will expire. */
   DateTime registrationExpirationTime;
@@ -190,7 +198,7 @@ public class DomainBase extends EppResource
    * refer to a {@link PollMessage} timed to when the domain is fully deleted. If the domain is
    * restored, the message should be deleted.
    */
-  Key<PollMessage.OneTime> deletePollMessage;
+  @Transient Key<PollMessage.OneTime> deletePollMessage;
 
   /**
    * The recurring billing event associated with this domain's autorenewals.
@@ -200,7 +208,7 @@ public class DomainBase extends EppResource
    * {@link #registrationExpirationTime} is changed the recurrence should be closed, a new one
    * should be created, and this field should be updated to point to the new one.
    */
-  Key<BillingEvent.Recurring> autorenewBillingEvent;
+  @Transient Key<BillingEvent.Recurring> autorenewBillingEvent;
 
   /**
    * The recurring poll message associated with this domain's autorenewals.
@@ -210,7 +218,7 @@ public class DomainBase extends EppResource
    * {@link #registrationExpirationTime} is changed the recurrence should be closed, a new one
    * should be created, and this field should be updated to point to the new one.
    */
-  Key<PollMessage.Autorenew> autorenewPollMessage;
+  @Transient Key<PollMessage.Autorenew> autorenewPollMessage;
 
   /** The unexpired grace periods for this domain (some of which may not be active yet). */
   @Transient @ElementCollection Set<GracePeriod> gracePeriods;
@@ -224,31 +232,7 @@ public class DomainBase extends EppResource
   String smdId;
 
   /** Data about any pending or past transfers on this domain. */
-  @Embedded
-  @AttributeOverrides({
-    @AttributeOverride(
-        name = "transferRequestTrid",
-        column = @Column(name = "transfer_data_request_trid")),
-    @AttributeOverride(
-        name = "transferPeriod",
-        column = @Column(name = "transfer_data_transfer_period")),
-    @AttributeOverride(
-        name = "transferredRegistrationExpirationTime",
-        column = @Column(name = "transfer_data_registration_expiration_time")),
-    @AttributeOverride(
-        name = "serverApproveEntities",
-        column = @Column(name = "transfer_data_server_approve_entities")),
-    @AttributeOverride(
-        name = "serverApproveBillingEvent",
-        column = @Column(name = "transfer_data_server_approve_billing_event")),
-    @AttributeOverride(
-        name = "serverApproveAutorenewEvent",
-        column = @Column(name = "transfer_data_server_approve_autorenrew_event")),
-    @AttributeOverride(
-        name = "serverApproveAutorenewPollMessage",
-        column = @Column(name = "transfer_data_server_approve_autorenrew_poll_message")),
-  })
-  TransferData transferData;
+  @Transient TransferData transferData;
 
   /**
    * The time that this resource was last transferred.

--- a/core/src/main/java/google/registry/model/eppcommon/StatusValue.java
+++ b/core/src/main/java/google/registry/model/eppcommon/StatusValue.java
@@ -25,6 +25,7 @@ import google.registry.model.domain.DomainBase;
 import google.registry.model.host.HostResource;
 import google.registry.model.translators.EnumToAttributeAdapter.EppEnum;
 import google.registry.model.translators.StatusValueAdapter;
+import google.registry.persistence.EnumSetUserType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
@@ -163,5 +164,13 @@ public enum StatusValue implements EppEnum {
 
   public static StatusValue fromXmlName(String xmlName) {
     return StatusValue.valueOf(LOWER_CAMEL.to(UPPER_UNDERSCORE, nullToEmpty(xmlName)));
+  }
+
+  /** Hibernate type for sets of {@link StatusValue}. */
+  public static class StatusValueSetType extends EnumSetUserType<StatusValue> {
+    @Override
+    protected Object convertToElem(Object value) {
+      return StatusValue.valueOf((String) value);
+    }
   }
 }

--- a/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
@@ -1,0 +1,182 @@
+// Copyright 2017 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.model.domain;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.model.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatastoreHelper.persistResource;
+import static google.registry.util.DateTimeUtils.START_OF_TIME;
+
+import com.google.common.collect.ImmutableSet;
+import com.googlecode.objectify.Key;
+import google.registry.model.EntityTestCase;
+import google.registry.model.billing.BillingEvent;
+import google.registry.model.contact.ContactResource;
+import google.registry.model.domain.DesignatedContact.Type;
+import google.registry.model.domain.launch.LaunchNotice;
+import google.registry.model.domain.rgp.GracePeriodStatus;
+import google.registry.model.domain.secdns.DelegationSignerData;
+import google.registry.model.eppcommon.AuthInfo.PasswordAuth;
+import google.registry.model.eppcommon.StatusValue;
+import google.registry.model.eppcommon.Trid;
+import google.registry.model.host.HostResource;
+import google.registry.model.poll.PollMessage;
+import google.registry.model.reporting.HistoryEntry;
+import google.registry.model.transaction.JpaTestRules;
+import google.registry.model.transaction.JpaTestRules.JpaIntegrationTestRule;
+import google.registry.model.transfer.TransferData;
+import google.registry.model.transfer.TransferStatus;
+import javax.persistence.EntityManager;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Verify that we can store/retrieve DomainBase objects from a SQL database. */
+@RunWith(JUnit4.class)
+public class DomainBaseSqlTest extends EntityTestCase {
+
+  @Rule
+  public final JpaIntegrationTestRule jpaRule =
+      new JpaTestRules.Builder().buildIntegrationTestRule();
+
+  DomainBase domain;
+
+  @Before
+  public void setUp() {
+    Key<DomainBase> domainKey = Key.create(null, DomainBase.class, "4-COM");
+    Key<HistoryEntry> historyEntryKey =
+        Key.create(persistResource(new HistoryEntry.Builder().setParent(domainKey).build()));
+    Key<ContactResource> contactKey =
+        Key.create(
+            persistResource(
+                new ContactResource.Builder()
+                    .setContactId("contact_id1")
+                    .setRepoId("2-COM")
+                    .build()));
+    Key<ContactResource> contact2Key =
+        Key.create(
+            persistResource(
+                new ContactResource.Builder()
+                    .setContactId("contact_id2")
+                    .setRepoId("2-COM")
+                    .build()));
+
+    Key<HostResource> hostKey =
+        Key.create(
+            persistResource(
+                new HostResource.Builder()
+                    .setFullyQualifiedHostName("ns1.example.com")
+                    .setSuperordinateDomain(domainKey)
+                    .setRepoId("1-COM")
+                    .build()));
+
+    Key<BillingEvent.OneTime> oneTimeBillKey =
+        Key.create(historyEntryKey, BillingEvent.OneTime.class, 1);
+    Key<BillingEvent.Recurring> recurringBillKey =
+        Key.create(historyEntryKey, BillingEvent.Recurring.class, 2);
+    Key<PollMessage.Autorenew> autorenewPollKey =
+        Key.create(historyEntryKey, PollMessage.Autorenew.class, 3);
+    Key<PollMessage.OneTime> onetimePollKey =
+        Key.create(historyEntryKey, PollMessage.OneTime.class, 1);
+
+    domain =
+        new DomainBase.Builder()
+            .setFullyQualifiedDomainName("example.com")
+            .setRepoId("4-COM")
+            .setCreationClientId("a registrar")
+            .setLastEppUpdateTime(clock.nowUtc())
+            .setLastEppUpdateClientId("AnotherRegistrar")
+            .setLastTransferTime(clock.nowUtc())
+            // TODO(mmuller): reinstate this as soon as we can persist Set<StatusValue>
+            // .setStatusValues(
+            //    ImmutableSet.of(
+            //        StatusValue.CLIENT_DELETE_PROHIBITED,
+            //        StatusValue.SERVER_DELETE_PROHIBITED,
+            //        StatusValue.SERVER_TRANSFER_PROHIBITED,
+            //        StatusValue.SERVER_UPDATE_PROHIBITED,
+            //        StatusValue.SERVER_RENEW_PROHIBITED,
+            //        StatusValue.SERVER_HOLD))
+            .setRegistrant(contactKey)
+            .setContacts(ImmutableSet.of(DesignatedContact.create(Type.ADMIN, contact2Key)))
+            .setNameservers(ImmutableSet.of(hostKey))
+            .setSubordinateHosts(ImmutableSet.of("ns1.example.com"))
+            .setPersistedCurrentSponsorClientId("losing")
+            .setRegistrationExpirationTime(clock.nowUtc().plusYears(1))
+            .setAuthInfo(DomainAuthInfo.create(PasswordAuth.create("password")))
+            .setDsData(ImmutableSet.of(DelegationSignerData.create(1, 2, 3, new byte[] {0, 1, 2})))
+            .setLaunchNotice(
+                LaunchNotice.create("tcnid", "validatorId", START_OF_TIME, START_OF_TIME))
+            .setTransferData(
+                new TransferData.Builder()
+                    .setGainingClientId("gaining")
+                    .setLosingClientId("losing")
+                    .setPendingTransferExpirationTime(clock.nowUtc())
+                    .setServerApproveEntities(
+                        ImmutableSet.of(oneTimeBillKey, recurringBillKey, autorenewPollKey))
+                    .setServerApproveBillingEvent(oneTimeBillKey)
+                    .setServerApproveAutorenewEvent(recurringBillKey)
+                    .setServerApproveAutorenewPollMessage(autorenewPollKey)
+                    .setTransferRequestTime(clock.nowUtc().plusDays(1))
+                    .setTransferStatus(TransferStatus.SERVER_APPROVED)
+                    .setTransferRequestTrid(Trid.create("client-trid", "server-trid"))
+                    .setTransferredRegistrationExpirationTime(clock.nowUtc().plusYears(2))
+                    .build())
+            .setDeletePollMessage(onetimePollKey)
+            .setAutorenewBillingEvent(recurringBillKey)
+            .setAutorenewPollMessage(autorenewPollKey)
+            .setSmdId("smdid")
+            .addGracePeriod(
+                GracePeriod.create(
+                    GracePeriodStatus.ADD, clock.nowUtc().plusDays(1), "registrar", null))
+            .build();
+  }
+
+  @Test
+  public void testDomainBasePersistence() {
+    jpaTm()
+        .transact(
+            () -> {
+
+              // Persist the domain and all of its contents.
+              EntityManager em = jpaTm().getEntityManager();
+              em.persist(domain);
+              for (DelegationSignerData ds : domain.getDsData()) {
+                em.persist(ds);
+              }
+              for (GracePeriod gp : domain.getGracePeriods()) {
+                em.persist(gp);
+              }
+            });
+
+    jpaTm()
+        .transact(
+            () -> {
+              // Load the domain in its entirety.
+              EntityManager em = jpaTm().getEntityManager();
+              DomainBase result = em.find(DomainBase.class, "4-COM");
+
+              // Fix status, since we can't persist it yet.
+              result = result.asBuilder().setStatusValues(ImmutableSet.of(StatusValue.OK)).build();
+
+              // Fix the original creation timestamp (this gets initialized on first write)
+              DomainBase org = domain.asBuilder().setCreationTime(result.getCreationTime()).build();
+
+              // Note that the equality comparison forces a lazy load of all fields.
+              assertThat(result).isEqualTo(org);
+            });
+  }
+}

--- a/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
@@ -15,7 +15,7 @@
 package google.registry.model.domain;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.model.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
 import com.google.common.collect.ImmutableSet;
@@ -27,8 +27,8 @@ import google.registry.model.domain.launch.LaunchNotice;
 import google.registry.model.domain.secdns.DelegationSignerData;
 import google.registry.model.eppcommon.AuthInfo.PasswordAuth;
 import google.registry.model.eppcommon.StatusValue;
-import google.registry.model.transaction.JpaTestRules;
-import google.registry.model.transaction.JpaTestRules.JpaIntegrationTestRule;
+import google.registry.persistence.transaction.JpaTestRules;
+import google.registry.persistence.transaction.JpaTestRules.JpaIntegrationWithCoverageRule;
 import javax.persistence.EntityManager;
 import org.junit.Before;
 import org.junit.Rule;
@@ -41,8 +41,8 @@ import org.junit.runners.JUnit4;
 public class DomainBaseSqlTest extends EntityTestCase {
 
   @Rule
-  public final JpaIntegrationTestRule jpaRule =
-      new JpaTestRules.Builder().buildIntegrationTestRule();
+  public final JpaIntegrationWithCoverageRule jpaRule =
+      new JpaTestRules.Builder().buildIntegrationWithCoverageRule();
 
   DomainBase domain;
   Key<ContactResource> contactKey;

--- a/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
@@ -127,16 +127,9 @@ public class DomainBaseSqlTest extends EntityTestCase {
     jpaTm()
         .transact(
             () -> {
-
-              // Persist the domain and all of its contents.
+              // Persist the domain.
               EntityManager em = jpaTm().getEntityManager();
               em.persist(domain);
-              for (DelegationSignerData ds : domain.getDsData()) {
-                em.persist(ds);
-              }
-              for (GracePeriod gp : domain.getGracePeriods()) {
-                em.persist(gp);
-              }
             });
 
     jpaTm()
@@ -146,7 +139,7 @@ public class DomainBaseSqlTest extends EntityTestCase {
               EntityManager em = jpaTm().getEntityManager();
               DomainBase result = em.find(DomainBase.class, "4-COM");
 
-              // Fix contacts and DS data, since we can't persist them yet.
+              // Fix contacts, grace period and DS data, since we can't persist them yet.
               result =
                   result
                       .asBuilder()
@@ -156,6 +149,9 @@ public class DomainBaseSqlTest extends EntityTestCase {
                       .setDsData(
                           ImmutableSet.of(
                               DelegationSignerData.create(1, 2, 3, new byte[] {0, 1, 2})))
+                      .addGracePeriod(
+                          GracePeriod.create(
+                              GracePeriodStatus.ADD, clock.nowUtc().plusDays(1), "registrar", null))
                       .build();
 
               // Fix the original creation timestamp (this gets initialized on first write)

--- a/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
@@ -53,12 +53,14 @@ public class DomainBaseSqlTest extends EntityTestCase {
       new JpaTestRules.Builder().buildIntegrationTestRule();
 
   DomainBase domain;
+  Key<ContactResource> contactKey;
+  Key<ContactResource> contact2Key;
 
   @Before
   public void setUp() {
     Key<HistoryEntry> historyEntryKey = Key.create(HistoryEntry.class, "history");
-    Key<ContactResource> contactKey = Key.create(ContactResource.class, "contact_id1");
-    Key<ContactResource> contact2Key = Key.create(ContactResource.class, "contact_id2");
+    contactKey = Key.create(ContactResource.class, "contact_id1");
+    contact2Key = Key.create(ContactResource.class, "contact_id2");
     Key<HostResource> hostKey = Key.create(HostResource.class, "host1");
     Key<BillingEvent.OneTime> oneTimeBillKey =
         Key.create(historyEntryKey, BillingEvent.OneTime.class, 1);
@@ -145,8 +147,18 @@ public class DomainBaseSqlTest extends EntityTestCase {
               EntityManager em = jpaTm().getEntityManager();
               DomainBase result = em.find(DomainBase.class, "4-COM");
 
-              // Fix status, since we can't persist it yet.
-              result = result.asBuilder().setStatusValues(ImmutableSet.of(StatusValue.OK)).build();
+              // Fix status, contacts and DS data, since we can't persist them yet.
+              result =
+                  result
+                      .asBuilder()
+                      .setStatusValues(ImmutableSet.of(StatusValue.OK))
+                      .setRegistrant(contactKey)
+                      .setContacts(
+                          ImmutableSet.of(DesignatedContact.create(Type.ADMIN, contact2Key)))
+                      .setDsData(
+                          ImmutableSet.of(
+                              DelegationSignerData.create(1, 2, 3, new byte[] {0, 1, 2})))
+                      .build();
 
               // Fix the original creation timestamp (this gets initialized on first write)
               DomainBase org = domain.asBuilder().setCreationTime(result.getCreationTime()).build();

--- a/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
@@ -79,15 +79,14 @@ public class DomainBaseSqlTest extends EntityTestCase {
             .setLastEppUpdateTime(clock.nowUtc())
             .setLastEppUpdateClientId("AnotherRegistrar")
             .setLastTransferTime(clock.nowUtc())
-            // TODO(mmuller): reinstate this as soon as we can persist Set<StatusValue>
-            // .setStatusValues(
-            //    ImmutableSet.of(
-            //        StatusValue.CLIENT_DELETE_PROHIBITED,
-            //        StatusValue.SERVER_DELETE_PROHIBITED,
-            //        StatusValue.SERVER_TRANSFER_PROHIBITED,
-            //        StatusValue.SERVER_UPDATE_PROHIBITED,
-            //        StatusValue.SERVER_RENEW_PROHIBITED,
-            //        StatusValue.SERVER_HOLD))
+            .setStatusValues(
+                ImmutableSet.of(
+                    StatusValue.CLIENT_DELETE_PROHIBITED,
+                    StatusValue.SERVER_DELETE_PROHIBITED,
+                    StatusValue.SERVER_TRANSFER_PROHIBITED,
+                    StatusValue.SERVER_UPDATE_PROHIBITED,
+                    StatusValue.SERVER_RENEW_PROHIBITED,
+                    StatusValue.SERVER_HOLD))
             .setRegistrant(contactKey)
             .setContacts(ImmutableSet.of(DesignatedContact.create(Type.ADMIN, contact2Key)))
             .setNameservers(ImmutableSet.of(hostKey))
@@ -147,11 +146,10 @@ public class DomainBaseSqlTest extends EntityTestCase {
               EntityManager em = jpaTm().getEntityManager();
               DomainBase result = em.find(DomainBase.class, "4-COM");
 
-              // Fix status, contacts and DS data, since we can't persist them yet.
+              // Fix contacts and DS data, since we can't persist them yet.
               result =
                   result
                       .asBuilder()
-                      .setStatusValues(ImmutableSet.of(StatusValue.OK))
                       .setRegistrant(contactKey)
                       .setContacts(
                           ImmutableSet.of(DesignatedContact.create(Type.ADMIN, contact2Key)))

--- a/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
@@ -16,7 +16,6 @@ package google.registry.model.domain;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.transaction.TransactionManagerFactory.jpaTm;
-import static google.registry.testing.DatastoreHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
 import com.google.common.collect.ImmutableSet;
@@ -57,33 +56,10 @@ public class DomainBaseSqlTest extends EntityTestCase {
 
   @Before
   public void setUp() {
-    Key<DomainBase> domainKey = Key.create(null, DomainBase.class, "4-COM");
-    Key<HistoryEntry> historyEntryKey =
-        Key.create(persistResource(new HistoryEntry.Builder().setParent(domainKey).build()));
-    Key<ContactResource> contactKey =
-        Key.create(
-            persistResource(
-                new ContactResource.Builder()
-                    .setContactId("contact_id1")
-                    .setRepoId("2-COM")
-                    .build()));
-    Key<ContactResource> contact2Key =
-        Key.create(
-            persistResource(
-                new ContactResource.Builder()
-                    .setContactId("contact_id2")
-                    .setRepoId("2-COM")
-                    .build()));
-
-    Key<HostResource> hostKey =
-        Key.create(
-            persistResource(
-                new HostResource.Builder()
-                    .setFullyQualifiedHostName("ns1.example.com")
-                    .setSuperordinateDomain(domainKey)
-                    .setRepoId("1-COM")
-                    .build()));
-
+    Key<HistoryEntry> historyEntryKey = Key.create(HistoryEntry.class, "history");
+    Key<ContactResource> contactKey = Key.create(ContactResource.class, "contact_id1");
+    Key<ContactResource> contact2Key = Key.create(ContactResource.class, "contact_id2");
+    Key<HostResource> hostKey = Key.create(HostResource.class, "host1");
     Key<BillingEvent.OneTime> oneTimeBillKey =
         Key.create(historyEntryKey, BillingEvent.OneTime.class, 1);
     Key<BillingEvent.Recurring> recurringBillKey =

--- a/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
+++ b/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
@@ -14,6 +14,7 @@
 
 package google.registry.schema.integration;
 
+import google.registry.model.domain.DomainBaseSqlTest;
 import com.google.common.truth.Expect;
 import google.registry.model.registry.RegistryLockDaoTest;
 import google.registry.persistence.transaction.JpaEntityCoverage;
@@ -55,6 +56,7 @@ import org.junit.runners.Suite.SuiteClasses;
   CursorDaoTest.class,
   DomainLockUtilsTest.class,
   LockDomainCommandTest.class,
+  DomainBaseSqlTest.class,
   PremiumListDaoTest.class,
   RegistryLockDaoTest.class,
   RegistryLockGetActionTest.class,

--- a/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
+++ b/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
@@ -14,8 +14,8 @@
 
 package google.registry.schema.integration;
 
-import google.registry.model.domain.DomainBaseSqlTest;
 import com.google.common.truth.Expect;
+import google.registry.model.domain.DomainBaseSqlTest;
 import google.registry.model.registry.RegistryLockDaoTest;
 import google.registry.persistence.transaction.JpaEntityCoverage;
 import google.registry.schema.cursor.CursorDaoTest;

--- a/db/src/main/resources/sql/flyway/V14__add_epp_resources.sql
+++ b/db/src/main/resources/sql/flyway/V14__add_epp_resources.sql
@@ -66,7 +66,7 @@
         primary key (domain_base_repo_id, ds_data_key_tag)
     );
 
-    create table "DomainBase_allContacts" (
+    create table "Domain_allContacts" (
        domain text not null,
         contact bytea not null,
         type int4
@@ -126,7 +126,7 @@
        foreign key (domain_base_repo_id)
        references "Domain";
 
-    alter table if exists "DomainBase_allContacts"
+    alter table if exists "Domain_allContacts"
        add constraint FKbh7x0hikqyo6jr50pj02tt6bu
        foreign key (domain)
        references "Domain";

--- a/db/src/main/resources/sql/flyway/V14__add_epp_resources.sql
+++ b/db/src/main/resources/sql/flyway/V14__add_epp_resources.sql
@@ -1,0 +1,148 @@
+-- Copyright 2019 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+    create table "DelegationSignerData" (
+       key_tag int4 not null,
+        algorithm int4 not null,
+        digest bytea,
+        digest_type int4 not null,
+        primary key (key_tag)
+    );
+
+    create table "Domain" (
+       repo_id text not null,
+        creation_client_id text,
+        creation_time timestamptz,
+        current_sponsor_client_id text,
+        deletion_time timestamptz,
+        last_epp_update_client_id text,
+        last_epp_update_time timestamptz,
+        revisions bytea,
+        auth_info_repo_id text,
+        auth_info_value text,
+        autorenew_billing_event bytea,
+        autorenew_poll_message bytea,
+        delete_poll_message bytea,
+        fully_qualified_domain_name text,
+        idn_table_name text,
+        last_transfer_time timestamptz,
+        launch_notice_accepted_time timestamptz,
+        launch_notice_expiration_time timestamptz,
+        launch_notice_tcn_id text,
+        launch_notice_validator_id text,
+        registration_expiration_time timestamptz,
+        smd_id text,
+        tld text,
+        transfer_data_server_approve_autorenrew_event bytea,
+        transfer_data_server_approve_autorenrew_poll_message bytea,
+        transfer_data_server_approve_billing_event bytea,
+        unit int4,
+        value int4,
+        client_transaction_id text,
+        server_transaction_id text,
+        transfer_data_registration_expiration_time timestamptz,
+        gaining_client_id text,
+        losing_client_id text,
+        pending_transfer_expiration_time timestamptz,
+        transfer_request_time timestamptz,
+        transfer_status int4,
+        primary key (repo_id)
+    );
+
+    create table "Domain_DelegationSignerData" (
+       domain_base_repo_id text not null,
+        ds_data_key_tag int4 not null,
+        primary key (domain_base_repo_id, ds_data_key_tag)
+    );
+
+    create table "DomainBase_allContacts" (
+       domain text not null,
+        contact bytea not null,
+        type int4
+    );
+
+    create table "Domain_GracePeriod" (
+       domain_base_repo_id text not null,
+        grace_periods_id int8 not null,
+        primary key (domain_base_repo_id, grace_periods_id)
+    );
+
+    create table "DomainBase_nsHosts" (
+       domain_base_repo_id text not null,
+        ns_hosts bytea
+    );
+
+    create table "DomainBase_serverApproveEntities" (
+       domain_base_repo_id text not null,
+        transfer_data_server_approve_entities bytea
+    );
+
+    create table "DomainBase_subordinateHosts" (
+       domain_base_repo_id text not null,
+        subordinate_hosts text
+    );
+
+    create table "GracePeriod" (
+       id  bigserial not null,
+        billing_event_one_time bytea,
+        billing_event_recurring bytea,
+        client_id text,
+        expiration_time timestamptz,
+        type int4,
+        primary key (id)
+    );
+
+    alter table if exists "Domain_GracePeriod"
+       add constraint UK_4ps2u4y8i5r91wu2n1x2xea28 unique (grace_periods_id);
+
+    alter table if exists "Domain_DelegationSignerData"
+       add constraint FKho8wxowo3f4e688ehdl4wpni5
+       foreign key (ds_data_key_tag)
+       references "DelegationSignerData";
+
+    alter table if exists "Domain_DelegationSignerData"
+       add constraint FK2nvqbovvy5wasa8arhyhy8mge
+       foreign key (domain_base_repo_id)
+       references "Domain";
+
+    alter table if exists "Domain_GracePeriod"
+       add constraint FKny62h7k1nd3910rp56gdo5pfi
+       foreign key (grace_periods_id)
+       references "GracePeriod";
+
+    alter table if exists "Domain_GracePeriod"
+       add constraint FKkpor7amcdp7gwe0hp3obng6do
+       foreign key (domain_base_repo_id)
+       references "Domain";
+
+    alter table if exists "DomainBase_allContacts"
+       add constraint FKbh7x0hikqyo6jr50pj02tt6bu
+       foreign key (domain)
+       references "Domain";
+
+    alter table if exists "DomainBase_nsHosts"
+       add constraint FKow28763fcl1ilx8unxrfjtbja
+       foreign key (domain_base_repo_id)
+       references "Domain";
+
+    alter table if exists "DomainBase_serverApproveEntities"
+       add constraint FK7vuyqcsmcfvpv5648femoxien
+       foreign key (domain_base_repo_id)
+       references "Domain";
+
+    alter table if exists "DomainBase_subordinateHosts"
+       add constraint FKkva2lb57ri8qf39hthcej538k
+       foreign key (domain_base_repo_id)
+       references "Domain";
+

--- a/db/src/main/resources/sql/flyway/V15__add_epp_resources.sql
+++ b/db/src/main/resources/sql/flyway/V15__add_epp_resources.sql
@@ -29,6 +29,7 @@
         last_epp_update_client_id text,
         last_epp_update_time timestamptz,
         revisions bytea,
+        status text[],
         auth_info_repo_id text,
         auth_info_value text,
         autorenew_billing_event bytea,

--- a/db/src/main/resources/sql/flyway/V15__add_epp_resources.sql
+++ b/db/src/main/resources/sql/flyway/V15__add_epp_resources.sql
@@ -60,18 +60,6 @@
         primary key (repo_id)
     );
 
-    create table "Domain_DelegationSignerData" (
-       domain_base_repo_id text not null,
-        ds_data_key_tag int4 not null,
-        primary key (domain_base_repo_id, ds_data_key_tag)
-    );
-
-    create table "Domain_allContacts" (
-       domain text not null,
-        contact bytea not null,
-        type int4
-    );
-
     create table "Domain_GracePeriod" (
        domain_base_repo_id text not null,
         grace_periods_id int8 not null,
@@ -106,16 +94,6 @@
     alter table if exists "Domain_GracePeriod"
        add constraint UK_4ps2u4y8i5r91wu2n1x2xea28 unique (grace_periods_id);
 
-    alter table if exists "Domain_DelegationSignerData"
-       add constraint FKho8wxowo3f4e688ehdl4wpni5
-       foreign key (ds_data_key_tag)
-       references "DelegationSignerData";
-
-    alter table if exists "Domain_DelegationSignerData"
-       add constraint FK2nvqbovvy5wasa8arhyhy8mge
-       foreign key (domain_base_repo_id)
-       references "Domain";
-
     alter table if exists "Domain_GracePeriod"
        add constraint FKny62h7k1nd3910rp56gdo5pfi
        foreign key (grace_periods_id)
@@ -124,11 +102,6 @@
     alter table if exists "Domain_GracePeriod"
        add constraint FKkpor7amcdp7gwe0hp3obng6do
        foreign key (domain_base_repo_id)
-       references "Domain";
-
-    alter table if exists "Domain_allContacts"
-       add constraint FKbh7x0hikqyo6jr50pj02tt6bu
-       foreign key (domain)
        references "Domain";
 
     alter table if exists "DomainBase_nsHosts"

--- a/db/src/main/resources/sql/flyway/V15__add_epp_resources.sql
+++ b/db/src/main/resources/sql/flyway/V15__add_epp_resources.sql
@@ -1,4 +1,4 @@
--- Copyright 2019 The Nomulus Authors. All Rights Reserved.
+-- Copyright 2020 The Nomulus Authors. All Rights Reserved.
 --
 -- Licensed under the Apache License, Version 2.0 (the "License");
 -- you may not use this file except in compliance with the License.
@@ -11,14 +11,6 @@
 -- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
-
-    create table "DelegationSignerData" (
-       key_tag int4 not null,
-        algorithm int4 not null,
-        digest bytea,
-        digest_type int4 not null,
-        primary key (key_tag)
-    );
 
     create table "Domain" (
        repo_id text not null,
@@ -61,12 +53,6 @@
         primary key (repo_id)
     );
 
-    create table "Domain_GracePeriod" (
-       domain_base_repo_id text not null,
-        grace_periods_id int8 not null,
-        primary key (domain_base_repo_id, grace_periods_id)
-    );
-
     create table "DomainBase_nsHosts" (
        domain_base_repo_id text not null,
         ns_hosts bytea
@@ -81,29 +67,6 @@
        domain_base_repo_id text not null,
         subordinate_hosts text
     );
-
-    create table "GracePeriod" (
-       id  bigserial not null,
-        billing_event_one_time bytea,
-        billing_event_recurring bytea,
-        client_id text,
-        expiration_time timestamptz,
-        type int4,
-        primary key (id)
-    );
-
-    alter table if exists "Domain_GracePeriod"
-       add constraint UK_4ps2u4y8i5r91wu2n1x2xea28 unique (grace_periods_id);
-
-    alter table if exists "Domain_GracePeriod"
-       add constraint FKny62h7k1nd3910rp56gdo5pfi
-       foreign key (grace_periods_id)
-       references "GracePeriod";
-
-    alter table if exists "Domain_GracePeriod"
-       add constraint FKkpor7amcdp7gwe0hp3obng6do
-       foreign key (domain_base_repo_id)
-       references "Domain";
 
     alter table if exists "DomainBase_nsHosts"
        add constraint FKow28763fcl1ilx8unxrfjtbja

--- a/db/src/main/resources/sql/flyway/V15__add_epp_resources.sql
+++ b/db/src/main/resources/sql/flyway/V15__add_epp_resources.sql
@@ -20,7 +20,7 @@
         deletion_time timestamptz,
         last_epp_update_client_id text,
         last_epp_update_time timestamptz,
-        status text[],
+        statuses text[],
         auth_info_repo_id text,
         auth_info_value text,
         fully_qualified_domain_name text,

--- a/db/src/main/resources/sql/flyway/V15__add_epp_resources.sql
+++ b/db/src/main/resources/sql/flyway/V15__add_epp_resources.sql
@@ -20,13 +20,9 @@
         deletion_time timestamptz,
         last_epp_update_client_id text,
         last_epp_update_time timestamptz,
-        revisions bytea,
         status text[],
         auth_info_repo_id text,
         auth_info_value text,
-        autorenew_billing_event bytea,
-        autorenew_poll_message bytea,
-        delete_poll_message bytea,
         fully_qualified_domain_name text,
         idn_table_name text,
         last_transfer_time timestamptz,
@@ -36,50 +32,13 @@
         launch_notice_validator_id text,
         registration_expiration_time timestamptz,
         smd_id text,
+        subordinate_hosts text[],
         tld text,
-        transfer_data_server_approve_autorenrew_event bytea,
-        transfer_data_server_approve_autorenrew_poll_message bytea,
-        transfer_data_server_approve_billing_event bytea,
-        unit int4,
-        value int4,
-        client_transaction_id text,
-        server_transaction_id text,
-        transfer_data_registration_expiration_time timestamptz,
-        gaining_client_id text,
-        losing_client_id text,
-        pending_transfer_expiration_time timestamptz,
-        transfer_request_time timestamptz,
-        transfer_status int4,
         primary key (repo_id)
     );
 
-    create table "DomainBase_nsHosts" (
-       domain_base_repo_id text not null,
-        ns_hosts bytea
-    );
-
-    create table "DomainBase_serverApproveEntities" (
-       domain_base_repo_id text not null,
-        transfer_data_server_approve_entities bytea
-    );
-
-    create table "DomainBase_subordinateHosts" (
-       domain_base_repo_id text not null,
-        subordinate_hosts text
-    );
-
-    alter table if exists "DomainBase_nsHosts"
-       add constraint FKow28763fcl1ilx8unxrfjtbja
-       foreign key (domain_base_repo_id)
-       references "Domain";
-
-    alter table if exists "DomainBase_serverApproveEntities"
-       add constraint FK7vuyqcsmcfvpv5648femoxien
-       foreign key (domain_base_repo_id)
-       references "Domain";
-
-    alter table if exists "DomainBase_subordinateHosts"
-       add constraint FKkva2lb57ri8qf39hthcej538k
-       foreign key (domain_base_repo_id)
-       references "Domain";
-
+create index IDX8nr0ke9mrrx4ewj6pd2ag4rmr on "Domain" (creation_time);
+create index IDX8ffrqm27qtj20jac056j7yq07 on "Domain" (current_sponsor_client_id);
+create index IDX5mnf0wn20tno4b9do88j61klr on "Domain" (deletion_time);
+create index IDX1rcgkdd777bpvj0r94sltwd5y on "Domain" (fully_qualified_domain_name);
+create index IDXrwl38wwkli1j7gkvtywi9jokq on "Domain" (tld);

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -94,7 +94,7 @@
         primary key (domain_base_repo_id, grace_periods_id)
     );
 
-    create table "DomainBase_allContacts" (
+    create table "Domain_allContacts" (
        domain text not null,
         contact bytea,
         type int4
@@ -211,7 +211,7 @@ create index reservedlist_name_idx on "ReservedList" (name);
        foreign key (domain_base_repo_id) 
        references "Domain";
 
-    alter table if exists "DomainBase_allContacts" 
+    alter table if exists "Domain_allContacts" 
        add constraint FKbh7x0hikqyo6jr50pj02tt6bu 
        foreign key (domain) 
        references "Domain";

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -82,6 +82,12 @@
         primary key (repo_id)
     );
 
+    create table "Domain_allContacts" (
+       domain text not null,
+        contact bytea,
+        type int4
+    );
+
     create table "Domain_DelegationSignerData" (
        domain_base_repo_id text not null,
         ds_data_key_tag int4 not null,
@@ -92,12 +98,6 @@
        domain_base_repo_id text not null,
         grace_periods_id int8 not null,
         primary key (domain_base_repo_id, grace_periods_id)
-    );
-
-    create table "Domain_allContacts" (
-       domain text not null,
-        contact bytea,
-        type int4
     );
 
     create table "DomainBase_nsHosts" (
@@ -191,6 +191,11 @@ create index reservedlist_name_idx on "ReservedList" (name);
        foreign key (revision_id) 
        references "ClaimsList";
 
+    alter table if exists "Domain_allContacts" 
+       add constraint FK18qrnc2nrjlcb124qna6pwfh9 
+       foreign key (domain) 
+       references "Domain";
+
     alter table if exists "Domain_DelegationSignerData" 
        add constraint FKho8wxowo3f4e688ehdl4wpni5 
        foreign key (ds_data_key_tag) 
@@ -209,11 +214,6 @@ create index reservedlist_name_idx on "ReservedList" (name);
     alter table if exists "Domain_GracePeriod" 
        add constraint FKkpor7amcdp7gwe0hp3obng6do 
        foreign key (domain_base_repo_id) 
-       references "Domain";
-
-    alter table if exists "Domain_allContacts" 
-       add constraint FKbh7x0hikqyo6jr50pj02tt6bu 
-       foreign key (domain) 
        references "Domain";
 
     alter table if exists "DomainBase_nsHosts" 

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -42,15 +42,10 @@
         primary key (key_tag)
     );
 
-    create table "DesignatedContact" (
-       contact bytea not null,
-        type int4,
-        primary key (contact)
-    );
-
     create table "Domain" (
        repo_id text not null,
         creation_client_id text,
+        creation_time timestamptz,
         current_sponsor_client_id text,
         deletion_time timestamptz,
         last_epp_update_client_id text,
@@ -93,16 +88,16 @@
         primary key (domain_base_repo_id, ds_data_key_tag)
     );
 
-    create table "Domain_DesignatedContact" (
-       domain_base_repo_id text not null,
-        all_contacts_contact bytea not null,
-        primary key (domain_base_repo_id, all_contacts_contact)
-    );
-
     create table "Domain_GracePeriod" (
        domain_base_repo_id text not null,
         grace_periods_id int8 not null,
         primary key (domain_base_repo_id, grace_periods_id)
+    );
+
+    create table "DomainBase_allContacts" (
+       domain text not null,
+        contact bytea,
+        type int4
     );
 
     create table "DomainBase_nsHosts" (
@@ -181,9 +176,6 @@
     alter table if exists "Domain_DelegationSignerData" 
        add constraint UK_2yp55erx1i51pa7gnb8bu7tjn unique (ds_data_key_tag);
 
-    alter table if exists "Domain_DesignatedContact" 
-       add constraint UK_4ys6wdxcmndimlr6af3tsl0ow unique (all_contacts_contact);
-
     alter table if exists "Domain_GracePeriod" 
        add constraint UK_4ps2u4y8i5r91wu2n1x2xea28 unique (grace_periods_id);
 create index premiumlist_name_idx on "PremiumList" (name);
@@ -209,16 +201,6 @@ create index reservedlist_name_idx on "ReservedList" (name);
        foreign key (domain_base_repo_id) 
        references "Domain";
 
-    alter table if exists "Domain_DesignatedContact" 
-       add constraint FKqnnsrj0vi9eqhoth305cd4bi7 
-       foreign key (all_contacts_contact) 
-       references "DesignatedContact";
-
-    alter table if exists "Domain_DesignatedContact" 
-       add constraint FK169lte99hlt3otom9di13ubfn 
-       foreign key (domain_base_repo_id) 
-       references "Domain";
-
     alter table if exists "Domain_GracePeriod" 
        add constraint FKny62h7k1nd3910rp56gdo5pfi 
        foreign key (grace_periods_id) 
@@ -227,6 +209,11 @@ create index reservedlist_name_idx on "ReservedList" (name);
     alter table if exists "Domain_GracePeriod" 
        add constraint FKkpor7amcdp7gwe0hp3obng6do 
        foreign key (domain_base_repo_id) 
+       references "Domain";
+
+    alter table if exists "DomainBase_allContacts" 
+       add constraint FKbh7x0hikqyo6jr50pj02tt6bu 
+       foreign key (domain) 
        references "Domain";
 
     alter table if exists "DomainBase_nsHosts" 

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -50,13 +50,9 @@
         deletion_time timestamptz,
         last_epp_update_client_id text,
         last_epp_update_time timestamptz,
-        revisions bytea,
         status text[],
         auth_info_repo_id text,
         auth_info_value text,
-        autorenew_billing_event bytea,
-        autorenew_poll_message bytea,
-        delete_poll_message bytea,
         fully_qualified_domain_name text,
         idn_table_name text,
         last_transfer_time timestamptz,
@@ -66,36 +62,9 @@
         launch_notice_validator_id text,
         registration_expiration_time timestamptz,
         smd_id text,
+        subordinate_hosts text[],
         tld text,
-        transfer_data_server_approve_autorenrew_event bytea,
-        transfer_data_server_approve_autorenrew_poll_message bytea,
-        transfer_data_server_approve_billing_event bytea,
-        unit int4,
-        value int4,
-        client_transaction_id text,
-        server_transaction_id text,
-        transfer_data_registration_expiration_time timestamptz,
-        gaining_client_id text,
-        losing_client_id text,
-        pending_transfer_expiration_time timestamptz,
-        transfer_request_time timestamptz,
-        transfer_status int4,
         primary key (repo_id)
-    );
-
-    create table "DomainBase_nsHosts" (
-       domain_base_repo_id text not null,
-        ns_hosts bytea
-    );
-
-    create table "DomainBase_serverApproveEntities" (
-       domain_base_repo_id text not null,
-        transfer_data_server_approve_entities bytea
-    );
-
-    create table "DomainBase_subordinateHosts" (
-       domain_base_repo_id text not null,
-        subordinate_hosts text
     );
 
     create table "GracePeriod" (
@@ -155,6 +124,11 @@
         should_publish boolean not null,
         primary key (revision_id)
     );
+create index IDX8nr0ke9mrrx4ewj6pd2ag4rmr on "Domain" (creation_time);
+create index IDX8ffrqm27qtj20jac056j7yq07 on "Domain" (current_sponsor_client_id);
+create index IDX5mnf0wn20tno4b9do88j61klr on "Domain" (deletion_time);
+create index IDX1rcgkdd777bpvj0r94sltwd5y on "Domain" (fully_qualified_domain_name);
+create index IDXrwl38wwkli1j7gkvtywi9jokq on "Domain" (tld);
 create index premiumlist_name_idx on "PremiumList" (name);
 create index idx_registry_lock_verification_code on "RegistryLock" (verification_code);
 create index idx_registry_lock_registrar_id on "RegistryLock" (registrar_id);
@@ -167,21 +141,6 @@ create index reservedlist_name_idx on "ReservedList" (name);
        add constraint FK6sc6at5hedffc0nhdcab6ivuq 
        foreign key (revision_id) 
        references "ClaimsList";
-
-    alter table if exists "DomainBase_nsHosts" 
-       add constraint FKow28763fcl1ilx8unxrfjtbja 
-       foreign key (domain_base_repo_id) 
-       references "Domain";
-
-    alter table if exists "DomainBase_serverApproveEntities" 
-       add constraint FK7vuyqcsmcfvpv5648femoxien 
-       foreign key (domain_base_repo_id) 
-       references "Domain";
-
-    alter table if exists "DomainBase_subordinateHosts" 
-       add constraint FKkva2lb57ri8qf39hthcej538k 
-       foreign key (domain_base_repo_id) 
-       references "Domain";
 
     alter table if exists "PremiumEntry" 
        add constraint FKo0gw90lpo1tuee56l0nb6y6g5 

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -82,18 +82,6 @@
         primary key (repo_id)
     );
 
-    create table "Domain_allContacts" (
-       domain text not null,
-        contact bytea,
-        type int4
-    );
-
-    create table "Domain_DelegationSignerData" (
-       domain_base_repo_id text not null,
-        ds_data_key_tag int4 not null,
-        primary key (domain_base_repo_id, ds_data_key_tag)
-    );
-
     create table "Domain_GracePeriod" (
        domain_base_repo_id text not null,
         grace_periods_id int8 not null,
@@ -173,9 +161,6 @@
         primary key (revision_id)
     );
 
-    alter table if exists "Domain_DelegationSignerData" 
-       add constraint UK_2yp55erx1i51pa7gnb8bu7tjn unique (ds_data_key_tag);
-
     alter table if exists "Domain_GracePeriod" 
        add constraint UK_4ps2u4y8i5r91wu2n1x2xea28 unique (grace_periods_id);
 create index premiumlist_name_idx on "PremiumList" (name);
@@ -190,21 +175,6 @@ create index reservedlist_name_idx on "ReservedList" (name);
        add constraint FK6sc6at5hedffc0nhdcab6ivuq 
        foreign key (revision_id) 
        references "ClaimsList";
-
-    alter table if exists "Domain_allContacts" 
-       add constraint FK18qrnc2nrjlcb124qna6pwfh9 
-       foreign key (domain) 
-       references "Domain";
-
-    alter table if exists "Domain_DelegationSignerData" 
-       add constraint FKho8wxowo3f4e688ehdl4wpni5 
-       foreign key (ds_data_key_tag) 
-       references "DelegationSignerData";
-
-    alter table if exists "Domain_DelegationSignerData" 
-       add constraint FK2nvqbovvy5wasa8arhyhy8mge 
-       foreign key (domain_base_repo_id) 
-       references "Domain";
 
     alter table if exists "Domain_GracePeriod" 
        add constraint FKny62h7k1nd3910rp56gdo5pfi 

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -51,6 +51,7 @@
         last_epp_update_client_id text,
         last_epp_update_time timestamptz,
         revisions bytea,
+        status text[],
         auth_info_repo_id text,
         auth_info_value text,
         autorenew_billing_event bytea,

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -50,7 +50,7 @@
         deletion_time timestamptz,
         last_epp_update_client_id text,
         last_epp_update_time timestamptz,
-        status text[],
+        statuses text[],
         auth_info_repo_id text,
         auth_info_value text,
         fully_qualified_domain_name text,

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -83,12 +83,6 @@
         primary key (repo_id)
     );
 
-    create table "Domain_GracePeriod" (
-       domain_base_repo_id text not null,
-        grace_periods_id int8 not null,
-        primary key (domain_base_repo_id, grace_periods_id)
-    );
-
     create table "DomainBase_nsHosts" (
        domain_base_repo_id text not null,
         ns_hosts bytea
@@ -161,9 +155,6 @@
         should_publish boolean not null,
         primary key (revision_id)
     );
-
-    alter table if exists "Domain_GracePeriod" 
-       add constraint UK_4ps2u4y8i5r91wu2n1x2xea28 unique (grace_periods_id);
 create index premiumlist_name_idx on "PremiumList" (name);
 create index idx_registry_lock_verification_code on "RegistryLock" (verification_code);
 create index idx_registry_lock_registrar_id on "RegistryLock" (registrar_id);
@@ -176,16 +167,6 @@ create index reservedlist_name_idx on "ReservedList" (name);
        add constraint FK6sc6at5hedffc0nhdcab6ivuq 
        foreign key (revision_id) 
        references "ClaimsList";
-
-    alter table if exists "Domain_GracePeriod" 
-       add constraint FKny62h7k1nd3910rp56gdo5pfi 
-       foreign key (grace_periods_id) 
-       references "GracePeriod";
-
-    alter table if exists "Domain_GracePeriod" 
-       add constraint FKkpor7amcdp7gwe0hp3obng6do 
-       foreign key (domain_base_repo_id) 
-       references "Domain";
 
     alter table if exists "DomainBase_nsHosts" 
        add constraint FKow28763fcl1ilx8unxrfjtbja 

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -144,17 +144,6 @@ CREATE TABLE public."Domain" (
 
 
 --
--- Name: DomainBase_allContacts; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."DomainBase_allContacts" (
-    domain text NOT NULL,
-    contact bytea NOT NULL,
-    type integer
-);
-
-
---
 -- Name: DomainBase_nsHosts; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -201,6 +190,17 @@ CREATE TABLE public."Domain_DelegationSignerData" (
 CREATE TABLE public."Domain_GracePeriod" (
     domain_base_repo_id text NOT NULL,
     grace_periods_id bigint NOT NULL
+);
+
+
+--
+-- Name: Domain_allContacts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."Domain_allContacts" (
+    domain text NOT NULL,
+    contact bytea NOT NULL,
+    type integer
 );
 
 
@@ -570,10 +570,10 @@ ALTER TABLE ONLY public."DomainBase_serverApproveEntities"
 
 
 --
--- Name: DomainBase_allContacts fkbh7x0hikqyo6jr50pj02tt6bu; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: Domain_allContacts fkbh7x0hikqyo6jr50pj02tt6bu; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public."DomainBase_allContacts"
+ALTER TABLE ONLY public."Domain_allContacts"
     ADD CONSTRAINT fkbh7x0hikqyo6jr50pj02tt6bu FOREIGN KEY (domain) REFERENCES public."Domain"(repo_id);
 
 

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -99,13 +99,9 @@ CREATE TABLE public."Domain" (
     deletion_time timestamp with time zone,
     last_epp_update_client_id text,
     last_epp_update_time timestamp with time zone,
-    revisions bytea,
     status text[],
     auth_info_repo_id text,
     auth_info_value text,
-    autorenew_billing_event bytea,
-    autorenew_poll_message bytea,
-    delete_poll_message bytea,
     fully_qualified_domain_name text,
     idn_table_name text,
     last_transfer_time timestamp with time zone,
@@ -115,50 +111,8 @@ CREATE TABLE public."Domain" (
     launch_notice_validator_id text,
     registration_expiration_time timestamp with time zone,
     smd_id text,
-    tld text,
-    transfer_data_server_approve_autorenrew_event bytea,
-    transfer_data_server_approve_autorenrew_poll_message bytea,
-    transfer_data_server_approve_billing_event bytea,
-    unit integer,
-    value integer,
-    client_transaction_id text,
-    server_transaction_id text,
-    transfer_data_registration_expiration_time timestamp with time zone,
-    gaining_client_id text,
-    losing_client_id text,
-    pending_transfer_expiration_time timestamp with time zone,
-    transfer_request_time timestamp with time zone,
-    transfer_status integer
-);
-
-
---
--- Name: DomainBase_nsHosts; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."DomainBase_nsHosts" (
-    domain_base_repo_id text NOT NULL,
-    ns_hosts bytea
-);
-
-
---
--- Name: DomainBase_serverApproveEntities; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."DomainBase_serverApproveEntities" (
-    domain_base_repo_id text NOT NULL,
-    transfer_data_server_approve_entities bytea
-);
-
-
---
--- Name: DomainBase_subordinateHosts; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."DomainBase_subordinateHosts" (
-    domain_base_repo_id text NOT NULL,
-    subordinate_hosts text
+    subordinate_hosts text[],
+    tld text
 );
 
 
@@ -396,6 +350,34 @@ ALTER TABLE ONLY public."RegistryLock"
 
 
 --
+-- Name: idx1rcgkdd777bpvj0r94sltwd5y; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx1rcgkdd777bpvj0r94sltwd5y ON public."Domain" USING btree (fully_qualified_domain_name);
+
+
+--
+-- Name: idx5mnf0wn20tno4b9do88j61klr; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx5mnf0wn20tno4b9do88j61klr ON public."Domain" USING btree (deletion_time);
+
+
+--
+-- Name: idx8ffrqm27qtj20jac056j7yq07; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx8ffrqm27qtj20jac056j7yq07 ON public."Domain" USING btree (current_sponsor_client_id);
+
+
+--
+-- Name: idx8nr0ke9mrrx4ewj6pd2ag4rmr; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx8nr0ke9mrrx4ewj6pd2ag4rmr ON public."Domain" USING btree (creation_time);
+
+
+--
 -- Name: idx_registry_lock_registrar_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -407,6 +389,13 @@ CREATE INDEX idx_registry_lock_registrar_id ON public."RegistryLock" USING btree
 --
 
 CREATE INDEX idx_registry_lock_verification_code ON public."RegistryLock" USING btree (verification_code);
+
+
+--
+-- Name: idxrwl38wwkli1j7gkvtywi9jokq; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idxrwl38wwkli1j7gkvtywi9jokq ON public."Domain" USING btree (tld);
 
 
 --
@@ -432,14 +421,6 @@ ALTER TABLE ONLY public."ClaimsEntry"
 
 
 --
--- Name: DomainBase_serverApproveEntities fk7vuyqcsmcfvpv5648femoxien; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."DomainBase_serverApproveEntities"
-    ADD CONSTRAINT fk7vuyqcsmcfvpv5648femoxien FOREIGN KEY (domain_base_repo_id) REFERENCES public."Domain"(repo_id);
-
-
---
 -- Name: ReservedEntry fkgq03rk0bt1hb915dnyvd3vnfc; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -448,27 +429,11 @@ ALTER TABLE ONLY public."ReservedEntry"
 
 
 --
--- Name: DomainBase_subordinateHosts fkkva2lb57ri8qf39hthcej538k; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."DomainBase_subordinateHosts"
-    ADD CONSTRAINT fkkva2lb57ri8qf39hthcej538k FOREIGN KEY (domain_base_repo_id) REFERENCES public."Domain"(repo_id);
-
-
---
 -- Name: PremiumEntry fko0gw90lpo1tuee56l0nb6y6g5; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public."PremiumEntry"
     ADD CONSTRAINT fko0gw90lpo1tuee56l0nb6y6g5 FOREIGN KEY (revision_id) REFERENCES public."PremiumList"(revision_id);
-
-
---
--- Name: DomainBase_nsHosts fkow28763fcl1ilx8unxrfjtbja; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."DomainBase_nsHosts"
-    ADD CONSTRAINT fkow28763fcl1ilx8unxrfjtbja FOREIGN KEY (domain_base_repo_id) REFERENCES public."Domain"(repo_id);
 
 
 --

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -88,18 +88,6 @@ CREATE TABLE public."Cursor" (
 
 
 --
--- Name: DelegationSignerData; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."DelegationSignerData" (
-    key_tag integer NOT NULL,
-    algorithm integer NOT NULL,
-    digest bytea,
-    digest_type integer NOT NULL
-);
-
-
---
 -- Name: Domain; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -172,49 +160,6 @@ CREATE TABLE public."DomainBase_subordinateHosts" (
     domain_base_repo_id text NOT NULL,
     subordinate_hosts text
 );
-
-
---
--- Name: Domain_GracePeriod; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."Domain_GracePeriod" (
-    domain_base_repo_id text NOT NULL,
-    grace_periods_id bigint NOT NULL
-);
-
-
---
--- Name: GracePeriod; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."GracePeriod" (
-    id bigint NOT NULL,
-    billing_event_one_time bytea,
-    billing_event_recurring bytea,
-    client_id text,
-    expiration_time timestamp with time zone,
-    type integer
-);
-
-
---
--- Name: GracePeriod_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public."GracePeriod_id_seq"
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: GracePeriod_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public."GracePeriod_id_seq" OWNED BY public."GracePeriod".id;
 
 
 --
@@ -350,13 +295,6 @@ ALTER TABLE ONLY public."ClaimsList" ALTER COLUMN revision_id SET DEFAULT nextva
 
 
 --
--- Name: GracePeriod id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."GracePeriod" ALTER COLUMN id SET DEFAULT nextval('public."GracePeriod_id_seq"'::regclass);
-
-
---
 -- Name: PremiumList revision_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -402,35 +340,11 @@ ALTER TABLE ONLY public."Cursor"
 
 
 --
--- Name: DelegationSignerData DelegationSignerData_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."DelegationSignerData"
-    ADD CONSTRAINT "DelegationSignerData_pkey" PRIMARY KEY (key_tag);
-
-
---
--- Name: Domain_GracePeriod Domain_GracePeriod_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Domain_GracePeriod"
-    ADD CONSTRAINT "Domain_GracePeriod_pkey" PRIMARY KEY (domain_base_repo_id, grace_periods_id);
-
-
---
 -- Name: Domain Domain_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public."Domain"
     ADD CONSTRAINT "Domain_pkey" PRIMARY KEY (repo_id);
-
-
---
--- Name: GracePeriod GracePeriod_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."GracePeriod"
-    ADD CONSTRAINT "GracePeriod_pkey" PRIMARY KEY (id);
 
 
 --
@@ -479,14 +393,6 @@ ALTER TABLE ONLY public."ReservedList"
 
 ALTER TABLE ONLY public."RegistryLock"
     ADD CONSTRAINT idx_registry_lock_repo_id_revision_id UNIQUE (repo_id, revision_id);
-
-
---
--- Name: Domain_GracePeriod uk_4ps2u4y8i5r91wu2n1x2xea28; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Domain_GracePeriod"
-    ADD CONSTRAINT uk_4ps2u4y8i5r91wu2n1x2xea28 UNIQUE (grace_periods_id);
 
 
 --
@@ -542,27 +448,11 @@ ALTER TABLE ONLY public."ReservedEntry"
 
 
 --
--- Name: Domain_GracePeriod fkkpor7amcdp7gwe0hp3obng6do; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Domain_GracePeriod"
-    ADD CONSTRAINT fkkpor7amcdp7gwe0hp3obng6do FOREIGN KEY (domain_base_repo_id) REFERENCES public."Domain"(repo_id);
-
-
---
 -- Name: DomainBase_subordinateHosts fkkva2lb57ri8qf39hthcej538k; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public."DomainBase_subordinateHosts"
     ADD CONSTRAINT fkkva2lb57ri8qf39hthcej538k FOREIGN KEY (domain_base_repo_id) REFERENCES public."Domain"(repo_id);
-
-
---
--- Name: Domain_GracePeriod fkny62h7k1nd3910rp56gdo5pfi; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Domain_GracePeriod"
-    ADD CONSTRAINT fkny62h7k1nd3910rp56gdo5pfi FOREIGN KEY (grace_periods_id) REFERENCES public."GracePeriod"(id);
 
 
 --

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -88,6 +88,156 @@ CREATE TABLE public."Cursor" (
 
 
 --
+-- Name: DelegationSignerData; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."DelegationSignerData" (
+    key_tag integer NOT NULL,
+    algorithm integer NOT NULL,
+    digest bytea,
+    digest_type integer NOT NULL
+);
+
+
+--
+-- Name: Domain; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."Domain" (
+    repo_id text NOT NULL,
+    creation_client_id text,
+    creation_time timestamp with time zone,
+    current_sponsor_client_id text,
+    deletion_time timestamp with time zone,
+    last_epp_update_client_id text,
+    last_epp_update_time timestamp with time zone,
+    revisions bytea,
+    auth_info_repo_id text,
+    auth_info_value text,
+    autorenew_billing_event bytea,
+    autorenew_poll_message bytea,
+    delete_poll_message bytea,
+    fully_qualified_domain_name text,
+    idn_table_name text,
+    last_transfer_time timestamp with time zone,
+    launch_notice_accepted_time timestamp with time zone,
+    launch_notice_expiration_time timestamp with time zone,
+    launch_notice_tcn_id text,
+    launch_notice_validator_id text,
+    registration_expiration_time timestamp with time zone,
+    smd_id text,
+    tld text,
+    transfer_data_server_approve_autorenrew_event bytea,
+    transfer_data_server_approve_autorenrew_poll_message bytea,
+    transfer_data_server_approve_billing_event bytea,
+    unit integer,
+    value integer,
+    client_transaction_id text,
+    server_transaction_id text,
+    transfer_data_registration_expiration_time timestamp with time zone,
+    gaining_client_id text,
+    losing_client_id text,
+    pending_transfer_expiration_time timestamp with time zone,
+    transfer_request_time timestamp with time zone,
+    transfer_status integer
+);
+
+
+--
+-- Name: DomainBase_allContacts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."DomainBase_allContacts" (
+    domain text NOT NULL,
+    contact bytea NOT NULL,
+    type integer
+);
+
+
+--
+-- Name: DomainBase_nsHosts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."DomainBase_nsHosts" (
+    domain_base_repo_id text NOT NULL,
+    ns_hosts bytea
+);
+
+
+--
+-- Name: DomainBase_serverApproveEntities; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."DomainBase_serverApproveEntities" (
+    domain_base_repo_id text NOT NULL,
+    transfer_data_server_approve_entities bytea
+);
+
+
+--
+-- Name: DomainBase_subordinateHosts; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."DomainBase_subordinateHosts" (
+    domain_base_repo_id text NOT NULL,
+    subordinate_hosts text
+);
+
+
+--
+-- Name: Domain_DelegationSignerData; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."Domain_DelegationSignerData" (
+    domain_base_repo_id text NOT NULL,
+    ds_data_key_tag integer NOT NULL
+);
+
+
+--
+-- Name: Domain_GracePeriod; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."Domain_GracePeriod" (
+    domain_base_repo_id text NOT NULL,
+    grace_periods_id bigint NOT NULL
+);
+
+
+--
+-- Name: GracePeriod; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."GracePeriod" (
+    id bigint NOT NULL,
+    billing_event_one_time bytea,
+    billing_event_recurring bytea,
+    client_id text,
+    expiration_time timestamp with time zone,
+    type integer
+);
+
+
+--
+-- Name: GracePeriod_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public."GracePeriod_id_seq"
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: GracePeriod_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public."GracePeriod_id_seq" OWNED BY public."GracePeriod".id;
+
+
+--
 -- Name: PremiumEntry; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -220,6 +370,13 @@ ALTER TABLE ONLY public."ClaimsList" ALTER COLUMN revision_id SET DEFAULT nextva
 
 
 --
+-- Name: GracePeriod id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."GracePeriod" ALTER COLUMN id SET DEFAULT nextval('public."GracePeriod_id_seq"'::regclass);
+
+
+--
 -- Name: PremiumList revision_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -262,6 +419,46 @@ ALTER TABLE ONLY public."ClaimsList"
 
 ALTER TABLE ONLY public."Cursor"
     ADD CONSTRAINT "Cursor_pkey" PRIMARY KEY (scope, type);
+
+
+--
+-- Name: DelegationSignerData DelegationSignerData_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."DelegationSignerData"
+    ADD CONSTRAINT "DelegationSignerData_pkey" PRIMARY KEY (key_tag);
+
+
+--
+-- Name: Domain_DelegationSignerData Domain_DelegationSignerData_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Domain_DelegationSignerData"
+    ADD CONSTRAINT "Domain_DelegationSignerData_pkey" PRIMARY KEY (domain_base_repo_id, ds_data_key_tag);
+
+
+--
+-- Name: Domain_GracePeriod Domain_GracePeriod_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Domain_GracePeriod"
+    ADD CONSTRAINT "Domain_GracePeriod_pkey" PRIMARY KEY (domain_base_repo_id, grace_periods_id);
+
+
+--
+-- Name: Domain Domain_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Domain"
+    ADD CONSTRAINT "Domain_pkey" PRIMARY KEY (repo_id);
+
+
+--
+-- Name: GracePeriod GracePeriod_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."GracePeriod"
+    ADD CONSTRAINT "GracePeriod_pkey" PRIMARY KEY (id);
 
 
 --
@@ -313,6 +510,14 @@ ALTER TABLE ONLY public."RegistryLock"
 
 
 --
+-- Name: Domain_GracePeriod uk_4ps2u4y8i5r91wu2n1x2xea28; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Domain_GracePeriod"
+    ADD CONSTRAINT uk_4ps2u4y8i5r91wu2n1x2xea28 UNIQUE (grace_periods_id);
+
+
+--
 -- Name: idx_registry_lock_registrar_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -341,11 +546,35 @@ CREATE INDEX reservedlist_name_idx ON public."ReservedList" USING btree (name);
 
 
 --
+-- Name: Domain_DelegationSignerData fk2nvqbovvy5wasa8arhyhy8mge; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Domain_DelegationSignerData"
+    ADD CONSTRAINT fk2nvqbovvy5wasa8arhyhy8mge FOREIGN KEY (domain_base_repo_id) REFERENCES public."Domain"(repo_id);
+
+
+--
 -- Name: ClaimsEntry fk6sc6at5hedffc0nhdcab6ivuq; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public."ClaimsEntry"
     ADD CONSTRAINT fk6sc6at5hedffc0nhdcab6ivuq FOREIGN KEY (revision_id) REFERENCES public."ClaimsList"(revision_id);
+
+
+--
+-- Name: DomainBase_serverApproveEntities fk7vuyqcsmcfvpv5648femoxien; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."DomainBase_serverApproveEntities"
+    ADD CONSTRAINT fk7vuyqcsmcfvpv5648femoxien FOREIGN KEY (domain_base_repo_id) REFERENCES public."Domain"(repo_id);
+
+
+--
+-- Name: DomainBase_allContacts fkbh7x0hikqyo6jr50pj02tt6bu; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."DomainBase_allContacts"
+    ADD CONSTRAINT fkbh7x0hikqyo6jr50pj02tt6bu FOREIGN KEY (domain) REFERENCES public."Domain"(repo_id);
 
 
 --
@@ -357,11 +586,51 @@ ALTER TABLE ONLY public."ReservedEntry"
 
 
 --
+-- Name: Domain_DelegationSignerData fkho8wxowo3f4e688ehdl4wpni5; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Domain_DelegationSignerData"
+    ADD CONSTRAINT fkho8wxowo3f4e688ehdl4wpni5 FOREIGN KEY (ds_data_key_tag) REFERENCES public."DelegationSignerData"(key_tag);
+
+
+--
+-- Name: Domain_GracePeriod fkkpor7amcdp7gwe0hp3obng6do; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Domain_GracePeriod"
+    ADD CONSTRAINT fkkpor7amcdp7gwe0hp3obng6do FOREIGN KEY (domain_base_repo_id) REFERENCES public."Domain"(repo_id);
+
+
+--
+-- Name: DomainBase_subordinateHosts fkkva2lb57ri8qf39hthcej538k; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."DomainBase_subordinateHosts"
+    ADD CONSTRAINT fkkva2lb57ri8qf39hthcej538k FOREIGN KEY (domain_base_repo_id) REFERENCES public."Domain"(repo_id);
+
+
+--
+-- Name: Domain_GracePeriod fkny62h7k1nd3910rp56gdo5pfi; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Domain_GracePeriod"
+    ADD CONSTRAINT fkny62h7k1nd3910rp56gdo5pfi FOREIGN KEY (grace_periods_id) REFERENCES public."GracePeriod"(id);
+
+
+--
 -- Name: PremiumEntry fko0gw90lpo1tuee56l0nb6y6g5; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public."PremiumEntry"
     ADD CONSTRAINT fko0gw90lpo1tuee56l0nb6y6g5 FOREIGN KEY (revision_id) REFERENCES public."PremiumList"(revision_id);
+
+
+--
+-- Name: DomainBase_nsHosts fkow28763fcl1ilx8unxrfjtbja; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."DomainBase_nsHosts"
+    ADD CONSTRAINT fkow28763fcl1ilx8unxrfjtbja FOREIGN KEY (domain_base_repo_id) REFERENCES public."Domain"(repo_id);
 
 
 --

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -112,6 +112,7 @@ CREATE TABLE public."Domain" (
     last_epp_update_client_id text,
     last_epp_update_time timestamp with time zone,
     revisions bytea,
+    status text[],
     auth_info_repo_id text,
     auth_info_value text,
     autorenew_billing_event bytea,

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -174,33 +174,12 @@ CREATE TABLE public."DomainBase_subordinateHosts" (
 
 
 --
--- Name: Domain_DelegationSignerData; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."Domain_DelegationSignerData" (
-    domain_base_repo_id text NOT NULL,
-    ds_data_key_tag integer NOT NULL
-);
-
-
---
 -- Name: Domain_GracePeriod; Type: TABLE; Schema: public; Owner: -
 --
 
 CREATE TABLE public."Domain_GracePeriod" (
     domain_base_repo_id text NOT NULL,
     grace_periods_id bigint NOT NULL
-);
-
-
---
--- Name: Domain_allContacts; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public."Domain_allContacts" (
-    domain text NOT NULL,
-    contact bytea NOT NULL,
-    type integer
 );
 
 
@@ -430,14 +409,6 @@ ALTER TABLE ONLY public."DelegationSignerData"
 
 
 --
--- Name: Domain_DelegationSignerData Domain_DelegationSignerData_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Domain_DelegationSignerData"
-    ADD CONSTRAINT "Domain_DelegationSignerData_pkey" PRIMARY KEY (domain_base_repo_id, ds_data_key_tag);
-
-
---
 -- Name: Domain_GracePeriod Domain_GracePeriod_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -546,14 +517,6 @@ CREATE INDEX reservedlist_name_idx ON public."ReservedList" USING btree (name);
 
 
 --
--- Name: Domain_DelegationSignerData fk2nvqbovvy5wasa8arhyhy8mge; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Domain_DelegationSignerData"
-    ADD CONSTRAINT fk2nvqbovvy5wasa8arhyhy8mge FOREIGN KEY (domain_base_repo_id) REFERENCES public."Domain"(repo_id);
-
-
---
 -- Name: ClaimsEntry fk6sc6at5hedffc0nhdcab6ivuq; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -570,27 +533,11 @@ ALTER TABLE ONLY public."DomainBase_serverApproveEntities"
 
 
 --
--- Name: Domain_allContacts fkbh7x0hikqyo6jr50pj02tt6bu; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Domain_allContacts"
-    ADD CONSTRAINT fkbh7x0hikqyo6jr50pj02tt6bu FOREIGN KEY (domain) REFERENCES public."Domain"(repo_id);
-
-
---
 -- Name: ReservedEntry fkgq03rk0bt1hb915dnyvd3vnfc; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public."ReservedEntry"
     ADD CONSTRAINT fkgq03rk0bt1hb915dnyvd3vnfc FOREIGN KEY (revision_id) REFERENCES public."ReservedList"(revision_id);
-
-
---
--- Name: Domain_DelegationSignerData fkho8wxowo3f4e688ehdl4wpni5; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Domain_DelegationSignerData"
-    ADD CONSTRAINT fkho8wxowo3f4e688ehdl4wpni5 FOREIGN KEY (ds_data_key_tag) REFERENCES public."DelegationSignerData"(key_tag);
 
 
 --

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -99,7 +99,7 @@ CREATE TABLE public."Domain" (
     deletion_time timestamp with time zone,
     last_epp_update_client_id text,
     last_epp_update_time timestamp with time zone,
-    status text[],
+    statuses text[],
     auth_info_repo_id text,
     auth_info_value text,
     fully_qualified_domain_name text,


### PR DESCRIPTION
Fix all of the existing problems with DomainBase persistence:
- Remove "final" keywords on getters that cause errors during startup.
- Remove Transient from creationTime (since there's a converter for
  CreateAutoTimestamp)
- Fix DesignatedContext persistence so that it only creates a single table.
  This is a lot more efficient given that these are many-to-one with their
  domains.
- Add a flyway script, update the golden schema.
- Create a unit test, add it to the integration test suite.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/438)
<!-- Reviewable:end -->
