### PR TITLE
Remove MapUserTypeTest from Integration TestSuite

### DIFF
--- a/core/src/test/java/google/registry/persistence/MapUserTypeTest.java
+++ b/core/src/test/java/google/registry/persistence/MapUserTypeTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.ImmutableObject;
 import google.registry.model.transaction.JpaTestRules;
-import google.registry.model.transaction.JpaTestRules.JpaIntegrationTestRule;
+import google.registry.model.transaction.JpaTestRules.JpaUnitTestRule;
 import java.util.Map;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -36,11 +36,14 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class MapUserTypeTest {
 
-  // Note that JpaIntegrationTestRule is used here as the hstore extension is installed
-  // when nomulus.golden.sql is executed as the init script.
+  // Reusing production script sql/flyway/V14__load_extension_for_hstore.sql, which loads the
+  // hstore extension but nothing else.
   @Rule
-  public final JpaIntegrationTestRule jpaRule =
-      new JpaTestRules.Builder().withEntityClass(TestEntity.class).buildIntegrationTestRule();
+  public final JpaUnitTestRule jpaRule =
+      new JpaTestRules.Builder()
+          .withInitScript("sql/flyway/V14__load_extension_for_hstore.sql")
+          .withEntityClass(TestEntity.class)
+          .buildUnitTestRule();
 
   @Test
   public void roundTripConversion_returnsSameMap() {

--- a/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
+++ b/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
@@ -16,7 +16,6 @@ package google.registry.schema.integration;
 
 import google.registry.model.registry.RegistryLockDaoTest;
 import google.registry.model.transaction.JpaTestRules.JpaIntegrationTestRule;
-import google.registry.persistence.MapUserTypeTest;
 import google.registry.schema.cursor.CursorDaoTest;
 import google.registry.schema.tld.PremiumListDaoTest;
 import google.registry.schema.tld.PremiumListUtilsTest;
@@ -46,7 +45,6 @@ import org.junit.runners.Suite.SuiteClasses;
   CreateReservedListCommandTest.class,
   CursorDaoTest.class,
   CreatePremiumListActionTest.class,
-  MapUserTypeTest.class,
   PremiumListDaoTest.class,
   PremiumListUtilsTest.class,
   RegistryLockDaoTest.class,


### PR DESCRIPTION
Integration tests should only test features that would break the server binary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/449)
<!-- Reviewable:end -->
