### PR TITLE
Fix IcannReportingUploadAction to use correct year in January

### DIFF
--- a/core/src/main/java/google/registry/reporting/icann/IcannReportingStagingAction.java
+++ b/core/src/main/java/google/registry/reporting/icann/IcannReportingStagingAction.java
@@ -122,8 +122,7 @@ public final class IcannReportingStagingAction implements Runnable {
             TaskOptions uploadTask =
                 TaskOptions.Builder.withUrl(IcannReportingUploadAction.PATH)
                     .method(Method.POST)
-                    .countdownMillis(Duration.standardMinutes(2).getMillis())
-                    .param(PARAM_SUBDIR, subdir);
+                    .countdownMillis(Duration.standardMinutes(2).getMillis());
             QueueFactory.getQueue(CRON_QUEUE).add(uploadTask);
             return null;
           },

--- a/core/src/main/java/google/registry/reporting/icann/IcannReportingUploadAction.java
+++ b/core/src/main/java/google/registry/reporting/icann/IcannReportingUploadAction.java
@@ -20,7 +20,6 @@ import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static google.registry.model.common.Cursor.getCursorTimeOrStartOfTime;
 import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.reporting.icann.IcannReportingModule.PARAM_SUBDIR;
 import static google.registry.request.Action.Method.POST;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 
@@ -40,7 +39,6 @@ import google.registry.model.registry.Registry;
 import google.registry.model.registry.Registry.TldType;
 import google.registry.request.Action;
 import google.registry.request.HttpException.ServiceUnavailableException;
-import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
 import google.registry.request.lock.LockHandler;
@@ -90,8 +88,6 @@ public final class IcannReportingUploadAction implements Runnable {
   @Inject
   @Config("reportingBucket")
   String reportingBucket;
-
-  @Inject @Parameter(PARAM_SUBDIR) String subdir;
 
   @Inject GcsUtils gcsUtils;
   @Inject IcannHttpReporter icannReporter;
@@ -145,7 +141,12 @@ public final class IcannReportingUploadAction implements Runnable {
       CursorType cursorType,
       String tldStr,
       ImmutableMap.Builder<String, Boolean> reportSummaryBuilder) {
-    String reportBucketname = String.format("%s/%s", reportingBucket, subdir);
+    String reportSubdir =
+        String.format(
+            "icann/monthly/%d-%02d",
+            cursorTime.withDayOfMonth(1).minusMonths(1).getYear(),
+            cursorTime.withDayOfMonth(1).minusMonths(1).getMonthOfYear());
+    String reportBucketname = String.format("%s/%s", reportingBucket, reportSubdir);
     String filename = getFileName(cursorType, cursorTime, tldStr);
     final GcsFilename gcsFilename = new GcsFilename(reportBucketname, filename);
     logger.atInfo().log("Reading ICANN report %s from bucket %s", filename, reportBucketname);
@@ -199,7 +200,7 @@ public final class IcannReportingUploadAction implements Runnable {
         "%s%s%d%02d.csv",
         tld,
         (cursorType.equals(CursorType.ICANN_UPLOAD_ACTIVITY) ? "-activity-" : "-transactions-"),
-        cursorTime.year().get(),
+        cursorTime.withDayOfMonth(1).minusMonths(1).year().get(),
         cursorTime.withDayOfMonth(1).minusMonths(1).monthOfYear().get());
   }
 

--- a/core/src/main/java/google/registry/reporting/icann/IcannReportingUploadAction.java
+++ b/core/src/main/java/google/registry/reporting/icann/IcannReportingUploadAction.java
@@ -141,11 +141,11 @@ public final class IcannReportingUploadAction implements Runnable {
       CursorType cursorType,
       String tldStr,
       ImmutableMap.Builder<String, Boolean> reportSummaryBuilder) {
+    DateTime cursorTimeMinusMonth = cursorTime.withDayOfMonth(1).minusMonths(1);
     String reportSubdir =
         String.format(
             "icann/monthly/%d-%02d",
-            cursorTime.withDayOfMonth(1).minusMonths(1).getYear(),
-            cursorTime.withDayOfMonth(1).minusMonths(1).getMonthOfYear());
+            cursorTimeMinusMonth.getYear(), cursorTimeMinusMonth.getMonthOfYear());
     String reportBucketname = String.format("%s/%s", reportingBucket, reportSubdir);
     String filename = getFileName(cursorType, cursorTime, tldStr);
     final GcsFilename gcsFilename = new GcsFilename(reportBucketname, filename);
@@ -196,12 +196,13 @@ public final class IcannReportingUploadAction implements Runnable {
   }
 
   private String getFileName(CursorType cursorType, DateTime cursorTime, String tld) {
+    DateTime cursorTimeMinusMonth = cursorTime.withDayOfMonth(1).minusMonths(1);
     return String.format(
         "%s%s%d%02d.csv",
         tld,
         (cursorType.equals(CursorType.ICANN_UPLOAD_ACTIVITY) ? "-activity-" : "-transactions-"),
-        cursorTime.withDayOfMonth(1).minusMonths(1).year().get(),
-        cursorTime.withDayOfMonth(1).minusMonths(1).monthOfYear().get());
+        cursorTimeMinusMonth.year().get(),
+        cursorTimeMinusMonth.monthOfYear().get());
   }
 
   /** Returns a map of each cursor to the CursorType and tld. */

--- a/core/src/test/java/google/registry/reporting/icann/IcannReportingStagingActionTest.java
+++ b/core/src/test/java/google/registry/reporting/icann/IcannReportingStagingActionTest.java
@@ -81,12 +81,8 @@ public class IcannReportingStagingActionTest {
         .thenReturn(ImmutableList.of("c", "d"));
   }
 
-  private static void assertUploadTaskEnqueued(String subdir) {
-    TaskMatcher matcher =
-        new TaskMatcher()
-            .url("/_dr/task/icannReportingUpload")
-            .method("POST")
-            .param("subdir", subdir);
+  private static void assertUploadTaskEnqueued() {
+    TaskMatcher matcher = new TaskMatcher().url("/_dr/task/icannReportingUpload").method("POST");
     assertTasksEnqueued("retryable-cron-tasks", matcher);
   }
 
@@ -103,7 +99,7 @@ public class IcannReportingStagingActionTest {
                 "Completed staging the following 2 ICANN reports:\na\nb",
                 new InternetAddress("recipient@example.com"),
                 new InternetAddress("sender@example.com")));
-    assertUploadTaskEnqueued("default/dir");
+    assertUploadTaskEnqueued();
   }
 
   @Test
@@ -119,7 +115,7 @@ public class IcannReportingStagingActionTest {
                 "Completed staging the following 4 ICANN reports:\na\nb\nc\nd",
                 new InternetAddress("recipient@example.com"),
                 new InternetAddress("sender@example.com")));
-    assertUploadTaskEnqueued("default/dir");
+    assertUploadTaskEnqueued();
   }
 
   @Test
@@ -138,7 +134,7 @@ public class IcannReportingStagingActionTest {
                 "Completed staging the following 4 ICANN reports:\na\nb\nc\nd",
                 new InternetAddress("recipient@example.com"),
                 new InternetAddress("sender@example.com")));
-    assertUploadTaskEnqueued("default/dir");
+    assertUploadTaskEnqueued();
   }
 
   @Test

--- a/core/src/test/java/google/registry/reporting/icann/IcannReportingUploadActionTest.java
+++ b/core/src/test/java/google/registry/reporting/icann/IcannReportingUploadActionTest.java
@@ -151,7 +151,7 @@ public class IcannReportingUploadActionTest {
   }
 
   @Test
-  public void testSuccess_January() throws Exception {
+  public void testSuccess_january() throws Exception {
     clock.setTo(DateTime.parse("2006-01-22T00:30:00Z"));
     persistResource(
         Cursor.create(

--- a/core/src/test/java/google/registry/reporting/icann/IcannReportingUploadActionTest.java
+++ b/core/src/test/java/google/registry/reporting/icann/IcannReportingUploadActionTest.java
@@ -78,7 +78,6 @@ public class IcannReportingUploadActionTest {
     action.icannReporter = mockReporter;
     action.gcsUtils = new GcsUtils(gcsService, 1024);
     action.retrier = new Retrier(new FakeSleeper(new FakeClock()), 3);
-    action.subdir = "icann/monthly/2006-06";
     action.reportingBucket = "basin";
     action.emailService = emailService;
     action.sender = new InternetAddress("sender@example.com");
@@ -147,6 +146,43 @@ public class IcannReportingUploadActionTest {
                     + "tld-activity-200606.csv - FAILURE\n"
                     + "foo-transactions-200606.csv - SUCCESS\n"
                     + "tld-transactions-200606.csv - SUCCESS",
+                new InternetAddress("recipient@example.com"),
+                new InternetAddress("sender@example.com")));
+  }
+
+  @Test
+  public void testSuccess_January() throws Exception {
+    clock.setTo(DateTime.parse("2006-01-22T00:30:00Z"));
+    persistResource(
+        Cursor.create(
+            CursorType.ICANN_UPLOAD_ACTIVITY, DateTime.parse("2006-01-01TZ"), Registry.get("tld")));
+    persistResource(
+        Cursor.create(
+            CursorType.ICANN_UPLOAD_TX, DateTime.parse("2006-01-01TZ"), Registry.get("tld")));
+    writeGcsFile(
+        gcsService,
+        new GcsFilename("basin/icann/monthly/2005-12", "tld-transactions-200512.csv"),
+        PAYLOAD_SUCCESS);
+    writeGcsFile(
+        gcsService,
+        new GcsFilename("basin/icann/monthly/2005-12", "tld-activity-200512.csv"),
+        PAYLOAD_SUCCESS);
+    when(mockReporter.send(PAYLOAD_SUCCESS, "tld-activity-200512.csv")).thenReturn(true);
+    when(mockReporter.send(PAYLOAD_SUCCESS, "tld-transactions-200512.csv")).thenReturn(true);
+
+    IcannReportingUploadAction action = createAction();
+    action.run();
+    verify(mockReporter).send(PAYLOAD_SUCCESS, "tld-activity-200512.csv");
+    verify(mockReporter).send(PAYLOAD_SUCCESS, "tld-transactions-200512.csv");
+
+    verifyNoMoreInteractions(mockReporter);
+    verify(emailService)
+        .sendEmail(
+            EmailMessage.create(
+                "ICANN Monthly report upload summary: 2/2 succeeded",
+                "Report Filename - Upload status:\n"
+                    + "tld-activity-200512.csv - SUCCESS\n"
+                    + "tld-transactions-200512.csv - SUCCESS",
                 new InternetAddress("recipient@example.com"),
                 new InternetAddress("sender@example.com")));
   }
@@ -280,15 +316,18 @@ public class IcannReportingUploadActionTest {
 
   @Test
   public void testFail_fileNotFound() throws Exception {
+    clock.setTo(DateTime.parse("2006-01-22T00:30:00Z"));
+    persistResource(
+        Cursor.create(
+            CursorType.ICANN_UPLOAD_ACTIVITY, DateTime.parse("2006-01-01TZ"), Registry.get("tld")));
     IcannReportingUploadAction action = createAction();
-    action.subdir = "somewhere/else";
     action.run();
     assertAboutLogs()
         .that(logHandler)
         .hasLogAtLevelWithMessage(
             Level.SEVERE,
-            "Could not upload ICANN_UPLOAD_ACTIVITY report for foo because file"
-                + " foo-activity-200606.csv did not exist");
+            "Could not upload ICANN_UPLOAD_ACTIVITY report for tld because file"
+                + " tld-activity-200512.csv did not exist");
   }
 
   @Test
@@ -298,7 +337,6 @@ public class IcannReportingUploadActionTest {
             CursorType.ICANN_UPLOAD_ACTIVITY, DateTime.parse("2006-08-01TZ"), Registry.get("foo")));
     clock.setTo(DateTime.parse("2006-08-01T00:30:00Z"));
     IcannReportingUploadAction action = createAction();
-    action.subdir = "icann/monthly/2006-07";
     action.run();
     assertAboutLogs()
         .that(logHandler)


### PR DESCRIPTION
This fixes getFileName so that it uses the correct year when uploading the reports for December in January. The files to be updated are from the month before the cursor time. In the previous implementation the getFileName method was using the same year as the cursor time to construct the filename. This only caused an issue in the case where the cursor time is in January and the files to upload are from December of the previous year. 

This also changes IcannReportingUploadAction to no longer take in a sub directory as a parameter. Instead the sub directory is inferred based on the cursor time.  This allows for reports from different sub directories to be uploaded at the same time if the different cursors point to files located in different sub directories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/452)
<!-- Reviewable:end -->
