### PR TITLE
Add generateSqlSchema as a build task

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -786,6 +786,17 @@ createToolTask(
     'google.registry.tools.DevTool',
     sourceSets.nonprod)
 
+project.tasks.create('generateSqlSchema', JavaExec) {
+  classpath = sourceSets.nonprod.runtimeClasspath
+  main = 'google.registry.tools.DevTool'
+  args = [
+      '-e', 'alpha',
+      'generate_sql_schema', '--start_postgresql', '-o',
+      "${rootProject.projectRootDir}/db/src/main/resources/sql/schema/" +
+      "db-schema.sql.generated"
+  ]
+}
+
 task generateGoldenImages(type: FilteringTest) {
   tests = ["**/webdriver/*"]
 


### PR DESCRIPTION
Add a build task for generateSqlSchema so we don't have to fill in all of the parameters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/454)
<!-- Reviewable:end -->
