### PR TITLE
Change reserved messages for domains w/ required allocation token

### DIFF
--- a/core/src/main/java/google/registry/model/registry/label/ReservationType.java
+++ b/core/src/main/java/google/registry/model/registry/label/ReservationType.java
@@ -38,10 +38,10 @@ public enum ReservationType {
   ALLOWED_IN_SUNRISE("Reserved", 0),
 
   /** The domain can only be registered by providing a specific token. */
-  RESERVED_FOR_SPECIFIC_USE("Reserved", 1),
+  RESERVED_FOR_SPECIFIC_USE("Allocation token required", 1),
 
   /** The domain is for an anchor tenant and can only be registered using a specific token. */
-  RESERVED_FOR_ANCHOR_TENANT("Reserved", 2),
+  RESERVED_FOR_ANCHOR_TENANT("Allocation token required", 2),
 
   /**
    * The domain can only be registered during sunrise for defensive purposes, and will never

--- a/core/src/test/java/google/registry/flows/CheckApiActionTest.java
+++ b/core/src/test/java/google/registry/flows/CheckApiActionTest.java
@@ -72,7 +72,10 @@ public class CheckApiActionTest {
             .asBuilder()
             .setReservedLists(
                 persistReservedList(
-                    "example-reserved", "foo,FULLY_BLOCKED", "gold,RESERVED_FOR_SPECIFIC_USE"))
+                    "example-reserved",
+                    "foo,FULLY_BLOCKED",
+                    "gold,RESERVED_FOR_SPECIFIC_USE",
+                    "platinum,FULLY_BLOCKED"))
             .build());
   }
 
@@ -258,12 +261,24 @@ public class CheckApiActionTest {
 
   @Test
   public void testSuccess_reserved_premium() {
-    assertThat(getCheckResponse("gold.example"))
+    assertThat(getCheckResponse("platinum.example"))
         .containsExactly(
             "tier", "premium",
             "status", "success",
             "available", false,
             "reason", "Reserved");
+
+    verifySuccessMetric(PREMIUM, RESERVED);
+  }
+
+  @Test
+  public void testSuccess_reservedForSpecificUse_premium() {
+    assertThat(getCheckResponse("gold.example"))
+        .containsExactly(
+            "tier", "premium",
+            "status", "success",
+            "available", false,
+            "reason", "Allocation token required");
 
     verifySuccessMetric(PREMIUM, RESERVED);
   }

--- a/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
@@ -141,7 +141,7 @@ public class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFl
         create(false, "example1.tld", "In use"),
         create(false, "example2.tld", "The allocation token is invalid"),
         create(false, "reserved.tld", "Reserved"),
-        create(false, "specificuse.tld", "Reserved"));
+        create(false, "specificuse.tld", "Allocation token required"));
   }
 
   @Test
@@ -154,7 +154,7 @@ public class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFl
         create(false, "example1.tld", "In use"),
         create(true, "example2.tld", null),
         create(false, "reserved.tld", "Reserved"),
-        create(false, "specificuse.tld", "Reserved"));
+        create(false, "specificuse.tld", "Allocation token required"));
   }
 
   @Test
@@ -171,7 +171,7 @@ public class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFl
         create(false, "example1.tld", "In use"),
         create(false, "example2.tld", "Alloc token was already redeemed"),
         create(false, "reserved.tld", "Reserved"),
-        create(false, "specificuse.tld", "Reserved"));
+        create(false, "specificuse.tld", "Allocation token required"));
   }
 
   @Test
@@ -205,7 +205,7 @@ public class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFl
         create(false, "example1.tld", "In use"),
         create(true, "example2.tld", null),
         create(false, "reserved.tld", "Reserved"),
-        create(false, "specificuse.tld", "Reserved"));
+        create(false, "specificuse.tld", "Allocation token required"));
   }
 
   @Test
@@ -260,7 +260,7 @@ public class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFl
     doCheckTest(
         create(false, "collision.tld", "Cannot be delegated"),
         create(false, "reserved.tld", "Reserved"),
-        create(false, "anchor.tld", "Reserved"),
+        create(false, "anchor.tld", "Allocation token required"),
         create(false, "allowedinsunrise.tld", "Reserved"),
         create(false, "premiumcollision.tld", "Cannot be delegated"));
   }
@@ -395,7 +395,7 @@ public class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFl
   @Test
   public void testSuccess_anchorTenantReserved() throws Exception {
     setEppInput("domain_check_anchor.xml");
-    doCheckTest(create(false, "anchor.tld", "Reserved"));
+    doCheckTest(create(false, "anchor.tld", "Allocation token required"));
   }
 
   @Test


### PR DESCRIPTION
In domain check reasons for unavailable domains, we were previously saying that
domains were "Reserved" regardless of whether the domain was fully blocked or
reserved for an anchor tenant or other specific use (e.g. the .new Limited
Release Program). This commit changes the message for the latter situations to
be "Allocation token required", so that registrars have a hint that domain will
show as available if the correct allocation token is supplied to the domain
check command using the allocation token extension.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/455)
<!-- Reviewable:end -->
