### PR TITLE
Fix money conversion for JPY in PremiumListDao

### DIFF
--- a/core/src/main/java/google/registry/schema/tld/PremiumListDao.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumListDao.java
@@ -156,7 +156,11 @@ public class PremiumListDao {
         RevisionIdAndLabel.create(premiumList.getRevisionId(), label);
     try {
       Optional<BigDecimal> price = PremiumListCache.cachePremiumEntries.get(revisionIdAndLabel);
-      return price.map(p -> Money.of(premiumList.getCurrency(), p));
+      return price.map(
+          p ->
+              Money.of(
+                  premiumList.getCurrency(),
+                  p.setScale(premiumList.getCurrency().getDecimalPlaces())));
     } catch (InvalidCacheLoadException | ExecutionException e) {
       throw new RuntimeException(
           String.format(


### PR DESCRIPTION
The decimal places of JPY is 0 which caused failure when `Money.of(JPY, 1000.00)` is invoked. Set the scale of the amount to the decimal places of currency unit fixed the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/463)
<!-- Reviewable:end -->
