### PR TITLE
Use randomly-generated base-58 strings for RegistryLock verification codes

### DIFF
--- a/core/src/main/java/google/registry/tools/LockDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/LockDomainCommand.java
@@ -60,11 +60,11 @@ public class LockDomainCommand extends LockOrUnlockDomainCommand {
 
   @Override
   protected RegistryLock createLock(String domain) {
-    return DomainLockUtils.createRegistryLockRequest(domain, clientId, null, true, clock);
+    return domainLockUtils.createRegistryLockRequest(domain, clientId, null, true, clock);
   }
 
   @Override
   protected void finalizeLockOrUnlockRequest(RegistryLock lock) {
-    DomainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), true, clock);
+    domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), true, clock);
   }
 }

--- a/core/src/main/java/google/registry/tools/LockOrUnlockDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/LockOrUnlockDomainCommand.java
@@ -57,6 +57,8 @@ public abstract class LockOrUnlockDomainCommand extends ConfirmingCommand
 
   @Inject Clock clock;
 
+  @Inject DomainLockUtils domainLockUtils;
+
   protected ImmutableSet<String> relevantDomains = ImmutableSet.of();
 
   protected ImmutableSet<String> getDomains() {

--- a/core/src/main/java/google/registry/tools/UnlockDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/UnlockDomainCommand.java
@@ -60,11 +60,11 @@ public class UnlockDomainCommand extends LockOrUnlockDomainCommand {
 
   @Override
   protected RegistryLock createLock(String domain) {
-    return DomainLockUtils.createRegistryUnlockRequest(domain, clientId, true, clock);
+    return domainLockUtils.createRegistryUnlockRequest(domain, clientId, true, clock);
   }
 
   @Override
   protected void finalizeLockOrUnlockRequest(RegistryLock lock) {
-    DomainLockUtils.verifyAndApplyUnlock(lock.getVerificationCode(), true, clock);
+    domainLockUtils.verifyAndApplyUnlock(lock.getVerificationCode(), true, clock);
   }
 }

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistryLockPostAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistryLockPostAction.java
@@ -83,6 +83,7 @@ public class RegistryLockPostAction implements Runnable, JsonActionRunner.JsonAc
   private final AuthenticatedRegistrarAccessor registrarAccessor;
   private final SendEmailService sendEmailService;
   private final Clock clock;
+  private final DomainLockUtils domainLockUtils;
   private final InternetAddress gSuiteOutgoingEmailAddress;
 
   @Inject
@@ -92,12 +93,14 @@ public class RegistryLockPostAction implements Runnable, JsonActionRunner.JsonAc
       AuthenticatedRegistrarAccessor registrarAccessor,
       SendEmailService sendEmailService,
       Clock clock,
+      DomainLockUtils domainLockUtils,
       @Config("gSuiteOutgoingEmailAddress") InternetAddress gSuiteOutgoingEmailAddress) {
     this.jsonActionRunner = jsonActionRunner;
     this.authResult = authResult;
     this.registrarAccessor = registrarAccessor;
     this.sendEmailService = sendEmailService;
     this.clock = clock;
+    this.domainLockUtils = domainLockUtils;
     this.gSuiteOutgoingEmailAddress = gSuiteOutgoingEmailAddress;
   }
 
@@ -129,13 +132,13 @@ public class RegistryLockPostAction implements Runnable, JsonActionRunner.JsonAc
               () -> {
                 RegistryLock registryLock =
                     postInput.isLock
-                        ? DomainLockUtils.createRegistryLockRequest(
+                        ? domainLockUtils.createRegistryLockRequest(
                             postInput.fullyQualifiedDomainName,
                             postInput.clientId,
                             postInput.pocId,
                             isAdmin,
                             clock)
-                        : DomainLockUtils.createRegistryUnlockRequest(
+                        : domainLockUtils.createRegistryUnlockRequest(
                             postInput.fullyQualifiedDomainName, postInput.clientId, isAdmin, clock);
                 sendVerificationEmail(registryLock, postInput.isLock);
               });

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistryLockVerifyAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistryLockVerifyAction.java
@@ -49,15 +49,18 @@ public final class RegistryLockVerifyAction extends HtmlAction {
           google.registry.ui.soy.registrar.RegistryLockVerificationSoyInfo.getInstance());
 
   private final Clock clock;
+  private final DomainLockUtils domainLockUtils;
   private final String lockVerificationCode;
   private final Boolean isLock;
 
   @Inject
   public RegistryLockVerifyAction(
       Clock clock,
+      DomainLockUtils domainLockUtils,
       @Parameter("lockVerificationCode") String lockVerificationCode,
       @Parameter("isLock") Boolean isLock) {
     this.clock = clock;
+    this.domainLockUtils = domainLockUtils;
     this.lockVerificationCode = lockVerificationCode;
     this.isLock = isLock;
   }
@@ -68,9 +71,9 @@ public final class RegistryLockVerifyAction extends HtmlAction {
       boolean isAdmin = authResult.userAuthInfo().get().isUserAdmin();
       final RegistryLock resultLock;
       if (isLock) {
-        resultLock = DomainLockUtils.verifyAndApplyLock(lockVerificationCode, isAdmin, clock);
+        resultLock = domainLockUtils.verifyAndApplyLock(lockVerificationCode, isAdmin, clock);
       } else {
-        resultLock = DomainLockUtils.verifyAndApplyUnlock(lockVerificationCode, isAdmin, clock);
+        resultLock = domainLockUtils.verifyAndApplyUnlock(lockVerificationCode, isAdmin, clock);
       }
       data.put("isLock", isLock);
       data.put("success", true);

--- a/core/src/test/java/google/registry/model/registry/RegistryLockDaoTest.java
+++ b/core/src/test/java/google/registry/model/registry/RegistryLockDaoTest.java
@@ -25,7 +25,6 @@ import google.registry.schema.domain.RegistryLock;
 import google.registry.testing.AppEngineRule;
 import google.registry.testing.FakeClock;
 import java.util.Optional;
-import java.util.UUID;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -201,7 +200,7 @@ public final class RegistryLockDaoTest {
         .setRepoId("repoId")
         .setDomainName("example.test")
         .setRegistrarId("TheRegistrar")
-        .setVerificationCode(UUID.randomUUID().toString())
+        .setVerificationCode("123456789ABCDEFGHJKLMNPQRSTUVWXY")
         .isSuperuser(true)
         .build();
   }

--- a/core/src/test/java/google/registry/tools/LockDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/LockDomainCommandTest.java
@@ -30,7 +30,9 @@ import google.registry.model.registrar.Registrar.Type;
 import google.registry.model.registry.RegistryLockDao;
 import google.registry.persistence.transaction.JpaTestRules;
 import google.registry.persistence.transaction.JpaTestRules.JpaIntegrationWithCoverageRule;
+import google.registry.testing.DeterministicStringGenerator;
 import google.registry.testing.FakeClock;
+import google.registry.util.StringGenerator.Alphabets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -51,6 +53,8 @@ public class LockDomainCommandTest extends CommandTestCase<LockDomainCommand> {
     createTld("tld");
     command.registryAdminClientId = "adminreg";
     command.clock = new FakeClock();
+    command.domainLockUtils =
+        new DomainLockUtils(new DeterministicStringGenerator(Alphabets.BASE_58));
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/UnlockDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UnlockDomainCommandTest.java
@@ -33,7 +33,9 @@ import google.registry.model.registry.RegistryLockDao;
 import google.registry.persistence.transaction.JpaTestRules;
 import google.registry.persistence.transaction.JpaTestRules.JpaIntegrationWithCoverageRule;
 import google.registry.schema.domain.RegistryLock;
+import google.registry.testing.DeterministicStringGenerator;
 import google.registry.testing.FakeClock;
+import google.registry.util.StringGenerator.Alphabets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -54,14 +56,16 @@ public class UnlockDomainCommandTest extends CommandTestCase<UnlockDomainCommand
     createTld("tld");
     command.registryAdminClientId = "adminreg";
     command.clock = new FakeClock();
+    command.domainLockUtils =
+        new DomainLockUtils(new DeterministicStringGenerator(Alphabets.BASE_58));
   }
 
   private DomainBase persistLockedDomain(String domainName, String registrarId) {
     DomainBase domain = persistResource(newDomainBase(domainName));
     RegistryLock lock =
-        DomainLockUtils.createRegistryLockRequest(
+        command.domainLockUtils.createRegistryLockRequest(
             domainName, registrarId, null, true, command.clock);
-    DomainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), true, command.clock);
+    command.domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), true, command.clock);
     return reloadResource(domain);
   }
 

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistryLockGetActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistryLockGetActionTest.java
@@ -43,7 +43,6 @@ import google.registry.testing.FakeClock;
 import google.registry.testing.FakeResponse;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Rule;
@@ -97,7 +96,7 @@ public final class RegistryLockGetActionTest {
             .setRepoId("repoId")
             .setDomainName("example.test")
             .setRegistrarId("TheRegistrar")
-            .setVerificationCode(UUID.randomUUID().toString())
+            .setVerificationCode("123456789ABCDEFGHJKLMNPQRSTUVWXY")
             .setRegistrarPocId("johndoe@theregistrar.com")
             .setLockCompletionTimestamp(fakeClock.nowUtc())
             .build();
@@ -107,7 +106,7 @@ public final class RegistryLockGetActionTest {
             .setRepoId("repoId")
             .setDomainName("adminexample.test")
             .setRegistrarId("TheRegistrar")
-            .setVerificationCode(UUID.randomUUID().toString())
+            .setVerificationCode("122222222ABCDEFGHJKLMNPQRSTUVWXY")
             .isSuperuser(true)
             .setLockCompletionTimestamp(fakeClock.nowUtc())
             .build();
@@ -116,7 +115,7 @@ public final class RegistryLockGetActionTest {
             .setRepoId("repoId")
             .setDomainName("incomplete.test")
             .setRegistrarId("TheRegistrar")
-            .setVerificationCode(UUID.randomUUID().toString())
+            .setVerificationCode("111111111ABCDEFGHJKLMNPQRSTUVWXY")
             .setRegistrarPocId("johndoe@theregistrar.com")
             .build();
 
@@ -126,7 +125,7 @@ public final class RegistryLockGetActionTest {
             .setDomainName("unlocked.test")
             .setRegistrarId("TheRegistrar")
             .setRegistrarPocId("johndoe@theregistrar.com")
-            .setVerificationCode(UUID.randomUUID().toString())
+            .setVerificationCode("123456789ABCDEFGHJKLMNPQRSTUUUUU")
             .setLockCompletionTimestamp(fakeClock.nowUtc())
             .setUnlockRequestTimestamp(fakeClock.nowUtc())
             .setUnlockCompletionTimestamp(fakeClock.nowUtc())

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistryLockPostActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistryLockPostActionTest.java
@@ -42,9 +42,12 @@ import google.registry.request.auth.AuthenticatedRegistrarAccessor.Role;
 import google.registry.request.auth.UserAuthInfo;
 import google.registry.schema.domain.RegistryLock;
 import google.registry.testing.AppEngineRule;
+import google.registry.testing.DeterministicStringGenerator;
 import google.registry.testing.FakeClock;
+import google.registry.tools.DomainLockUtils;
 import google.registry.util.EmailMessage;
 import google.registry.util.SendEmailService;
+import google.registry.util.StringGenerator.Alphabets;
 import java.util.Map;
 import java.util.UUID;
 import javax.mail.internet.InternetAddress;
@@ -402,7 +405,15 @@ public final class RegistryLockPostActionTest {
             ImmutableSetMultimap.of("TheRegistrar", Role.OWNER, "NewRegistrar", Role.OWNER));
     JsonActionRunner jsonActionRunner =
         new JsonActionRunner(ImmutableMap.of(), new JsonResponse(new ResponseImpl(mockResponse)));
+    DomainLockUtils domainLockUtils =
+        new DomainLockUtils(new DeterministicStringGenerator(Alphabets.BASE_58));
     return new RegistryLockPostAction(
-        jsonActionRunner, authResult, registrarAccessor, emailService, clock, outgoingAddress);
+        jsonActionRunner,
+        authResult,
+        registrarAccessor,
+        emailService,
+        clock,
+        domainLockUtils,
+        outgoingAddress);
   }
 }


### PR DESCRIPTION
We were using UUIDs before which are also fine, but unnecessarily long.
The RegistryLock class itself does not enforce any particular format for
the lock verification codes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/464)
<!-- Reviewable:end -->
