### PR TITLE
Work around Spinnaker issue wrt variables

### DIFF
--- a/release/cloudbuild-deploy.yaml
+++ b/release/cloudbuild-deploy.yaml
@@ -12,16 +12,23 @@
 #
 # To trigger a build automatically, follow the instructions below and add a trigger:
 # https://cloud.google.com/cloud-build/docs/running-builds/automate-builds
+#
+# Note: to work around issue in Spinnaker's 'Deployment Manifest' stage,
+# variable references must avoid the ${var} format. Valid formats include
+# $var or ${"${var}"}. This file use the former. Since TAG_NAME and _ENV are
+# hardened in the copies sent to Spinnaker, we preserve the brackets around
+# them for safe pattern matching during release.
+# See https://github.com/spinnaker/spinnaker/issues/3028 for more information.
 steps:
 # Pull the credential for nomulus tool.
-- name: 'gcr.io/${PROJECT_ID}/builder:latest'
+- name: 'gcr.io/$PROJECT_ID/builder:latest'
   args:
   - gsutil
   - cp
-  - gs://${PROJECT_ID}-deploy/secrets/tool-credential.json.enc
+  - gs://$PROJECT_ID-deploy/secrets/tool-credential.json.enc
   - .
 # Decrypt the credential.
-- name: 'gcr.io/${PROJECT_ID}/builder:latest'
+- name: 'gcr.io/$PROJECT_ID/builder:latest'
   entrypoint: /bin/bash
   args:
   - -c
@@ -31,7 +38,7 @@ steps:
       --ciphertext-file=- --plaintext-file=tool-credential.json \
       --location=global --keyring=nomulus-tool-keyring --key=nomulus-tool-key
 # Deploy the Spec11 pipeline to GCS.
-- name: 'gcr.io/${PROJECT_ID}/nomulus-tool:latest'
+- name: 'gcr.io/$PROJECT_ID/nomulus-tool:latest'
   args:
   - -e
   - ${_ENV}
@@ -39,7 +46,7 @@ steps:
   - tool-credential.json
   - deploy_spec11_pipeline
 # Deploy the invoicing pipeline to GCS.
-- name: 'gcr.io/${PROJECT_ID}/nomulus-tool:latest'
+- name: 'gcr.io/$PROJECT_ID/nomulus-tool:latest'
   args:
   - -e
   - ${_ENV}
@@ -49,18 +56,18 @@ steps:
 # Save the deployed tag for the current environment on GCS. Because of b/137891685
 # which causes the for-loop in the next step to fail, this may not be the last step.
 # TODO(weiminyu): do this in last step.
-- name: 'gcr.io/${PROJECT_ID}/builder:latest'
+- name: 'gcr.io/$PROJECT_ID/builder:latest'
   entrypoint: /bin/bash
   args:
   - -c
   - |
     set -e
     echo ${TAG_NAME} | \
-      gsutil cp - gs://${PROJECT_ID}-deployed-tags/nomulus.${_ENV}.tag
+      gsutil cp - gs://$PROJECT_ID-deployed-tags/nomulus.${_ENV}.tag
 # Deploy the GAE config files.
 # First authorize the gcloud tool to use the credential json file, then
 # download and unzip the tarball that contains the relevant config files
-- name: 'gcr.io/${PROJECT_ID}/builder:latest'
+- name: 'gcr.io/$PROJECT_ID/builder:latest'
   entrypoint: /bin/bash
   args:
   - -c
@@ -72,13 +79,13 @@ steps:
     else
       project_id="domain-registry-${_ENV}"
     fi
-    gsutil cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/${_ENV}.tar .
+    gsutil cp gs://$PROJECT_ID-deploy/${TAG_NAME}/${_ENV}.tar .
     tar -xvf ${_ENV}.tar
     # Note that this currently does not work for google.com projects that
     # we use due to b/137891685. External projects are likely to work.
     for filename in cron dispatch dos index queue; do
-      gcloud -q --project ${project_id} app deploy \
-        default/WEB-INF/appengine-generated/${filename}.yaml
+      gcloud -q --project $project_id app deploy \
+        default/WEB-INF/appengine-generated/$filename.yaml
     done
 
 timeout: 3600s

--- a/release/cloudbuild-deploy.yaml
+++ b/release/cloudbuild-deploy.yaml
@@ -16,7 +16,7 @@
 # Note: to work around issue in Spinnaker's 'Deployment Manifest' stage,
 # variable references must avoid the ${var} format. Valid formats include
 # $var or ${"${var}"}. This file use the former. Since TAG_NAME and _ENV are
-# hardened in the copies sent to Spinnaker, we preserve the brackets around
+# expanded in the copies sent to Spinnaker, we preserve the brackets around
 # them for safe pattern matching during release.
 # See https://github.com/spinnaker/spinnaker/issues/3028 for more information.
 steps:

--- a/release/cloudbuild-schema-deploy.yaml
+++ b/release/cloudbuild-schema-deploy.yaml
@@ -15,14 +15,22 @@
 #
 # Note that the release process hardens the tags and variables in this file:
 # - The 'latest' tag on docker images will be replaced by their image digests.
-# - The ${TAG_NAME} pattern will be replaced by the acutal release tag.
+# - The ${TAG_NAME} pattern will be replaced by the actual release tag.
+# - The ${_ENV} pattern will be replaced by the actual environment name.
 # Please refer to ./cloudbuild-release.yaml for more details.
+
+# Note 2: to work around issue in Spinnaker's 'Deployment Manifest' stage,
+# variable references must avoid the ${var} format. Valid formats include
+# $var or ${"${var}"}. This file use the former. Since TAG_NAME and _ENV are
+# hardened in the copies sent to Spinnaker, we preserve the brackets around
+# them for safe pattern matching during release.
+# See https://github.com/spinnaker/spinnaker/issues/3028 for more information.
 steps:
 # Download and decrypt the nomulus tool credential, which has the privilege to
 # start Cloud SQL proxy to all environments.
 # Also download and decrypt the admin_credential file, which has the cloud
 # instance name and database login name and password.
-- name: 'gcr.io/${PROJECT_ID}/builder:latest'
+- name: 'gcr.io/$PROJECT_ID/builder:latest'
   volumes:
   - name: 'secrets'
     path: '/secrets'
@@ -31,13 +39,13 @@ steps:
   - -c
   - |
     set -e
-    gsutil cp gs://${PROJECT_ID}-deploy/secrets/tool-credential.json.enc - \
+    gsutil cp gs://$PROJECT_ID-deploy/secrets/tool-credential.json.enc - \
       | base64 -d \
       | gcloud kms decrypt \
         --ciphertext-file=- \
         --plaintext-file=/secrets/cloud_sql_credential.json \
         --location=global --keyring=nomulus-tool-keyring --key=nomulus-tool-key
-    gsutil cp gs://${PROJECT_ID}-deploy/cloudsql-credentials/${_ENV}/admin_credential.enc - \
+    gsutil cp gs://$PROJECT_ID-deploy/cloudsql-credentials/${_ENV}/admin_credential.enc - \
       | base64 -d \
       | gcloud kms decrypt \
         --ciphertext-file=- \
@@ -45,7 +53,7 @@ steps:
         --location global --keyring=nomulus-tool-keyring \
         --key=nomulus-tool-key
 # Download the schema jar to be deployed.
-- name: 'gcr.io/${PROJECT_ID}/builder:latest'
+- name: 'gcr.io/$PROJECT_ID/builder:latest'
   volumes:
   - name: 'flyway'
     path: '/flyway/jars'
@@ -54,10 +62,10 @@ steps:
   - -c
   - |
     set -e
-    gsutil cp gs://domain-registry-dev-deploy/${TAG_NAME}/schema.jar \
+    gsutil cp gs://$PROJECT_ID-deploy/${TAG_NAME}/schema.jar \
       /flyway/jars
 # Deploy SQL schema
-- name: 'gcr.io/${PROJECT_ID}/schema_deployer:latest'
+- name: 'gcr.io/$PROJECT_ID/schema_deployer:latest'
   volumes:
   - name: 'secrets'
     path: '/secrets'
@@ -68,14 +76,14 @@ steps:
 # location. Do not use the 'artifacts' section for this since it will
 # upload an extra metadata file every time and pollute the folder.
 # TODO(weiminyu): modify this step so that TAG_NAME may be 'live'.
-- name: 'gcr.io/${PROJECT_ID}/builder:latest'
+- name: 'gcr.io/$PROJECT_ID/builder:latest'
   entrypoint: /bin/bash
   args:
   - -c
   - |
     set -e
     echo ${TAG_NAME} | \
-      gsutil cp - gs://${PROJECT_ID}-deployed-tags/sql.${_ENV}.tag\
+      gsutil cp - gs://$PROJECT_ID-deployed-tags/sql.${_ENV}.tag\
 timeout: 3600s
 options:
   machineType: 'N1_HIGHCPU_8'

--- a/release/cloudbuild-schema-deploy.yaml
+++ b/release/cloudbuild-schema-deploy.yaml
@@ -22,7 +22,7 @@
 # Note 2: to work around issue in Spinnaker's 'Deployment Manifest' stage,
 # variable references must avoid the ${var} format. Valid formats include
 # $var or ${"${var}"}. This file use the former. Since TAG_NAME and _ENV are
-# hardened in the copies sent to Spinnaker, we preserve the brackets around
+# expanded in the copies sent to Spinnaker, we preserve the brackets around
 # them for safe pattern matching during release.
 # See https://github.com/spinnaker/spinnaker/issues/3028 for more information.
 steps:

--- a/release/cloudbuild-sync.yaml
+++ b/release/cloudbuild-sync.yaml
@@ -9,16 +9,23 @@
 #
 # To trigger a build automatically, follow the instructions below and add a trigger:
 # https://cloud.google.com/cloud-build/docs/running-builds/automate-builds
+#
+# Note: to work around issue in Spinnaker's 'Deployment Manifest' stage,
+# variable references must avoid the ${var} format. Valid formats include
+# $var or ${"${var}"}. This file use the former. Since TAG_NAME is
+# hardened in the copies sent to Spinnaker, we preserve the brackets around
+# them for safe pattern matching during release.
+# See https://github.com/spinnaker/spinnaker/issues/3028 for more information.
 steps:
 # Rsync the folder.
-- name: 'gcr.io/${PROJECT_ID}/builder:latest'
+- name: 'gcr.io/$PROJECT_ID/builder:latest'
   args:
   - gsutil
   - -m
   - rsync
   - -d
-  - gs://${PROJECT_ID}-deploy/${TAG_NAME}
-  - gs://${PROJECT_ID}-deploy/live
+  - gs://$PROJECT_ID-deploy/${TAG_NAME}
+  - gs://$PROJECT_ID-deploy/live
 timeout: 3600s
 options:
   machineType: 'N1_HIGHCPU_8'

--- a/release/cloudbuild-sync.yaml
+++ b/release/cloudbuild-sync.yaml
@@ -13,7 +13,7 @@
 # Note: to work around issue in Spinnaker's 'Deployment Manifest' stage,
 # variable references must avoid the ${var} format. Valid formats include
 # $var or ${"${var}"}. This file use the former. Since TAG_NAME is
-# hardened in the copies sent to Spinnaker, we preserve the brackets around
+# expanded in the copies sent to Spinnaker, we preserve the brackets around
 # them for safe pattern matching during release.
 # See https://github.com/spinnaker/spinnaker/issues/3028 for more information.
 steps:

--- a/release/cloudbuild-tag.yaml
+++ b/release/cloudbuild-tag.yaml
@@ -11,15 +11,22 @@
 #
 # To trigger a build automatically, follow the instructions below and add a trigger:
 # https://cloud.google.com/cloud-build/docs/running-builds/automate-builds
+#
+# Note: to work around issue in Spinnaker's 'Deployment Manifest' stage,
+# variable references must avoid the ${var} format. Valid formats include
+# $var or ${"${var}"}. This file use the former. Since TAG_NAME is
+# hardened in the copies sent to Spinnaker, we preserve the brackets around
+# them for safe pattern matching during release.
+# See https://github.com/spinnaker/spinnaker/issues/3028 for more information.
 steps:
-- name: 'gcr.io/${PROJECT_ID}/builder:latest'
+- name: 'gcr.io/$PROJECT_ID/builder:latest'
   args:
   - gcloud
   - container
   - images
   - add-tag
-  - gcr.io/${PROJECT_ID}/${_IMAGE}:${TAG_NAME}
-  - gcr.io/${PROJECT_ID}/${_IMAGE}:live
+  - gcr.io/$PROJECT_ID/${_IMAGE}:${TAG_NAME}
+  - gcr.io/$PROJECT_ID/${_IMAGE}:live
 timeout: 3600s
 options:
   machineType: 'N1_HIGHCPU_8'

--- a/release/cloudbuild-tag.yaml
+++ b/release/cloudbuild-tag.yaml
@@ -15,7 +15,7 @@
 # Note: to work around issue in Spinnaker's 'Deployment Manifest' stage,
 # variable references must avoid the ${var} format. Valid formats include
 # $var or ${"${var}"}. This file use the former. Since TAG_NAME is
-# hardened in the copies sent to Spinnaker, we preserve the brackets around
+# expanded in the copies sent to Spinnaker, we preserve the brackets around
 # them for safe pattern matching during release.
 # See https://github.com/spinnaker/spinnaker/issues/3028 for more information.
 steps:


### PR DESCRIPTION
Cloud Build variable reference need to stay from the  ${var} pattern
to prevent Spinnaker from trying to resolve it. In all files that
are used by Spinnaker, we change variable reference to the $var form.

We made the minimum amount of change possible, and will review this
issue after the permanent solution is available.

TESTED=In the deploy schema to sandbox pipeline

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/465)
<!-- Reviewable:end -->
