### PR TITLE
Allow non-CA cert as trust anchor in tests

### DIFF
--- a/networking/build.gradle
+++ b/networking/build.gradle
@@ -41,6 +41,12 @@ dependencies {
   testAnnotationProcessor deps['com.google.dagger:dagger-compiler']
 }
 
+test {
+  // Temporarily allow non-CA cert as trust anchor (legacy behavior) in tests.
+  // TODO(weiminyu): generate test cert as a CA cert.
+  systemProperty 'jdk.security.allowNonCaAnchor', 'true'
+}
+
 // Make testing artifacts available to be depended up on by other projects.
 task testJar(type: Jar) {
   classifier = 'test'


### PR DESCRIPTION
Stay with the legacy behavior to unblock release build.
We will update the test cert generation code later.

TESTED=reproduced and fixed test failures in builder container

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/468)
<!-- Reviewable:end -->
