### PR TITLE
Use CA cert in tests

### DIFF
--- a/networking/build.gradle
+++ b/networking/build.gradle
@@ -41,12 +41,6 @@ dependencies {
   testAnnotationProcessor deps['com.google.dagger:dagger-compiler']
 }
 
-test {
-  // Temporarily allow non-CA cert as trust anchor (legacy behavior) in tests.
-  // TODO(weiminyu): generate test cert as a CA cert.
-  systemProperty 'jdk.security.allowNonCaAnchor', 'true'
-}
-
 // Make testing artifacts available to be depended up on by other projects.
 task testJar(type: Jar) {
   classifier = 'test'

--- a/networking/src/main/java/google/registry/networking/module/CertificateSupplierModule.java
+++ b/networking/src/main/java/google/registry/networking/module/CertificateSupplierModule.java
@@ -25,7 +25,7 @@ import com.google.common.collect.ImmutableList;
 import dagger.Lazy;
 import dagger.Module;
 import dagger.Provides;
-import io.netty.handler.ssl.util.SelfSignedCertificate;
+import google.registry.networking.util.SelfSignedCaCertificate;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -163,9 +163,9 @@ public final class CertificateSupplierModule {
 
   @Singleton
   @Provides
-  static SelfSignedCertificate provideSelfSignedCertificate() {
+  static SelfSignedCaCertificate provideSelfSignedCertificate() {
     try {
-      return new SelfSignedCertificate();
+      return SelfSignedCaCertificate.create();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -174,7 +174,7 @@ public final class CertificateSupplierModule {
   @Singleton
   @Provides
   @SelfSigned
-  static Supplier<PrivateKey> provideSelfSignedPrivateKeySupplier(SelfSignedCertificate ssc) {
+  static Supplier<PrivateKey> provideSelfSignedPrivateKeySupplier(SelfSignedCaCertificate ssc) {
     return Suppliers.ofInstance(ssc.key());
   }
 
@@ -182,7 +182,7 @@ public final class CertificateSupplierModule {
   @Provides
   @SelfSigned
   static Supplier<ImmutableList<X509Certificate>> provideSelfSignedCertificatesSupplier(
-      SelfSignedCertificate ssc) {
+      SelfSignedCaCertificate ssc) {
     return Suppliers.ofInstance(ImmutableList.of(ssc.cert()));
   }
 

--- a/networking/src/main/java/google/registry/networking/util/SelfSignedCaCertificate.java
+++ b/networking/src/main/java/google/registry/networking/util/SelfSignedCaCertificate.java
@@ -1,0 +1,112 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.networking.util;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Random;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+/** A self-signed certificate authority (CA) cert for use in tests. */
+// TODO(weiminyu): make this class test-only. Requires refactor in proxy and prober.
+public class SelfSignedCaCertificate {
+
+  private static final String DEFAULT_ISSUER_FQDN = "registry-test";
+  private static final Date DEFAULT_NOT_BEFORE =
+      Date.from(Instant.now().minus(Duration.ofHours(1)));
+  private static final Date DEFAULT_NOT_AFTER = Date.from(Instant.now().plus(Duration.ofDays(1)));
+
+  private static final Random RANDOM = new Random();
+  private static final BouncyCastleProvider PROVIDER = new BouncyCastleProvider();
+  private static final KeyPairGenerator keyGen = createKeyPairGenerator();
+
+  private final PrivateKey privateKey;
+  private final X509Certificate cert;
+
+  public SelfSignedCaCertificate(PrivateKey privateKey, X509Certificate cert) {
+    this.privateKey = privateKey;
+    this.cert = cert;
+  }
+
+  public PrivateKey key() {
+    return privateKey;
+  }
+
+  public X509Certificate cert() {
+    return cert;
+  }
+
+  public static SelfSignedCaCertificate create() throws Exception {
+    return create(
+        keyGen.generateKeyPair(), DEFAULT_ISSUER_FQDN, DEFAULT_NOT_BEFORE, DEFAULT_NOT_AFTER);
+  }
+
+  public static SelfSignedCaCertificate create(String fqdn) throws Exception {
+    return create(fqdn, DEFAULT_NOT_BEFORE, DEFAULT_NOT_AFTER);
+  }
+
+  public static SelfSignedCaCertificate create(String fqdn, Date from, Date to) throws Exception {
+    return create(keyGen.generateKeyPair(), fqdn, from, to);
+  }
+
+  public static SelfSignedCaCertificate create(KeyPair keyPair, String fqdn, Date from, Date to)
+      throws Exception {
+    return new SelfSignedCaCertificate(keyPair.getPrivate(), createCaCert(keyPair, fqdn, from, to));
+  }
+
+  static KeyPairGenerator createKeyPairGenerator() {
+    try {
+      KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA", PROVIDER);
+      keyGen.initialize(2048, new SecureRandom());
+      return keyGen;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /** Returns a self-signed Certificate Authority (CA) certificate. */
+  static X509Certificate createCaCert(KeyPair keyPair, String fqdn, Date from, Date to)
+      throws Exception {
+    X500Name owner = new X500Name("CN=" + fqdn);
+    ContentSigner signer =
+        new JcaContentSignerBuilder("SHA256WithRSAEncryption").build(keyPair.getPrivate());
+    X509v3CertificateBuilder builder =
+        new JcaX509v3CertificateBuilder(
+            owner, new BigInteger(64, RANDOM), from, to, owner, keyPair.getPublic());
+
+    // Mark cert as CA by adding basicConstraint with cA=true to the builder
+    BasicConstraints basicConstraints = new BasicConstraints(true);
+    builder.addExtension(new ASN1ObjectIdentifier("2.5.29.19"), true, basicConstraints);
+
+    X509CertificateHolder certHolder = builder.build(signer);
+    return new JcaX509CertificateConverter().setProvider(PROVIDER).getCertificate(certHolder);
+  }
+}

--- a/networking/src/test/java/google/registry/networking/handler/SslClientInitializerTest.java
+++ b/networking/src/test/java/google/registry/networking/handler/SslClientInitializerTest.java
@@ -21,6 +21,7 @@ import static google.registry.networking.handler.SslInitializerTestUtils.signKey
 import static google.registry.networking.handler.SslInitializerTestUtils.verifySslExcpetion;
 
 import com.google.common.collect.ImmutableList;
+import google.registry.networking.util.SelfSignedCaCertificate;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelPipeline;
@@ -35,7 +36,6 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
-import io.netty.handler.ssl.util.SelfSignedCertificate;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.cert.CertPathBuilderException;
@@ -153,7 +153,7 @@ public class SslClientInitializerTest {
 
   @Test
   public void testFailure_defaultTrustManager_rejectSelfSignedCert() throws Exception {
-    SelfSignedCertificate ssc = new SelfSignedCertificate(SSL_HOST);
+    SelfSignedCaCertificate ssc = SelfSignedCaCertificate.create(SSL_HOST);
     LocalAddress localAddress =
         new LocalAddress("DEFAULT_TRUST_MANAGER_REJECT_SELF_SIGNED_CERT_" + sslProvider);
     nettyRule.setUpServer(localAddress, getServerHandler(false, ssc.key(), ssc.cert()));
@@ -177,7 +177,7 @@ public class SslClientInitializerTest {
     KeyPair keyPair = getKeyPair();
 
     // Generate a self signed certificate, and use it to sign the key pair.
-    SelfSignedCertificate ssc = new SelfSignedCertificate();
+    SelfSignedCaCertificate ssc = SelfSignedCaCertificate.create();
     X509Certificate cert = signKeyPair(ssc, keyPair, SSL_HOST);
 
     // Set up the server to use the signed cert and private key to perform handshake;
@@ -206,7 +206,7 @@ public class SslClientInitializerTest {
     KeyPair keyPair = getKeyPair();
 
     // Generate a self signed certificate, and use it to sign the key pair.
-    SelfSignedCertificate ssc = new SelfSignedCertificate();
+    SelfSignedCaCertificate ssc = SelfSignedCaCertificate.create();
     X509Certificate cert =
         signKeyPair(
             ssc,
@@ -240,7 +240,7 @@ public class SslClientInitializerTest {
     KeyPair keyPair = getKeyPair();
 
     // Generate a self signed certificate, and use it to sign the key pair.
-    SelfSignedCertificate ssc = new SelfSignedCertificate();
+    SelfSignedCaCertificate ssc = SelfSignedCaCertificate.create();
     X509Certificate cert =
         signKeyPair(
             ssc,
@@ -272,8 +272,8 @@ public class SslClientInitializerTest {
         new LocalAddress(
             "CUSTOM_TRUST_MANAGER_ACCEPT_SELF_SIGNED_CERT_CLIENT_CERT_REQUIRED_" + sslProvider);
 
-    SelfSignedCertificate serverSsc = new SelfSignedCertificate(SSL_HOST);
-    SelfSignedCertificate clientSsc = new SelfSignedCertificate();
+    SelfSignedCaCertificate serverSsc = SelfSignedCaCertificate.create(SSL_HOST);
+    SelfSignedCaCertificate clientSsc = SelfSignedCaCertificate.create();
 
     // Set up the server to require client certificate.
     nettyRule.setUpServer(localAddress, getServerHandler(true, serverSsc.key(), serverSsc.cert()));
@@ -311,7 +311,7 @@ public class SslClientInitializerTest {
     KeyPair keyPair = getKeyPair();
 
     // Generate a self signed certificate, and use it to sign the key pair.
-    SelfSignedCertificate ssc = new SelfSignedCertificate();
+    SelfSignedCaCertificate ssc = SelfSignedCaCertificate.create();
     X509Certificate cert = signKeyPair(ssc, keyPair, "wrong.com");
 
     // Set up the server to use the signed cert and private key to perform handshake;

--- a/networking/src/test/java/google/registry/networking/module/CertificateSupplierModuleTest.java
+++ b/networking/src/test/java/google/registry/networking/module/CertificateSupplierModuleTest.java
@@ -26,7 +26,7 @@ import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
 import google.registry.networking.module.CertificateSupplierModule.Mode;
-import io.netty.handler.ssl.util.SelfSignedCertificate;
+import google.registry.networking.util.SelfSignedCaCertificate;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStreamWriter;
 import java.security.KeyPair;
@@ -47,7 +47,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class CertificateSupplierModuleTest {
 
-  private SelfSignedCertificate ssc;
+  private SelfSignedCaCertificate ssc;
   private PrivateKey key;
   private Certificate cert;
   private TestComponent component;
@@ -62,7 +62,7 @@ public class CertificateSupplierModuleTest {
 
   @Before
   public void setUp() throws Exception {
-    ssc = new SelfSignedCertificate();
+    ssc = SelfSignedCaCertificate.create();
     KeyPair keyPair = getKeyPair();
     key = keyPair.getPrivate();
     cert = signKeyPair(ssc, keyPair, "example.tld");

--- a/proxy/src/test/java/google/registry/proxy/EppProtocolModuleTest.java
+++ b/proxy/src/test/java/google/registry/proxy/EppProtocolModuleTest.java
@@ -23,6 +23,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.base.Throwables;
+import google.registry.networking.util.SelfSignedCaCertificate;
 import google.registry.proxy.handler.HttpsRelayServiceHandler.NonOkHttpResponseException;
 import google.registry.testing.FakeClock;
 import io.netty.buffer.ByteBuf;
@@ -34,7 +35,6 @@ import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
-import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.concurrent.Promise;
 import java.security.cert.X509Certificate;
 import org.junit.Before;
@@ -123,7 +123,7 @@ public class EppProtocolModuleTest extends ProtocolModuleTest {
   @Before
   public void setUp() throws Exception {
     testComponent = makeTestComponent(new FakeClock());
-    certificate = new SelfSignedCertificate().cert();
+    certificate = SelfSignedCaCertificate.create().cert();
     initializeChannel(
         ch -> {
           ch.attr(REMOTE_ADDRESS_KEY).set(CLIENT_ADDRESS);

--- a/proxy/src/test/java/google/registry/proxy/handler/EppServiceHandlerTest.java
+++ b/proxy/src/test/java/google/registry/proxy/handler/EppServiceHandlerTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.google.common.base.Throwables;
+import google.registry.networking.util.SelfSignedCaCertificate;
 import google.registry.proxy.TestUtils;
 import google.registry.proxy.handler.HttpsRelayServiceHandler.NonOkHttpResponseException;
 import google.registry.proxy.metric.FrontendMetrics;
@@ -41,7 +42,6 @@ import io.netty.handler.codec.http.HttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
-import io.netty.handler.ssl.util.SelfSignedCertificate;
 import io.netty.util.concurrent.Promise;
 import java.security.cert.X509Certificate;
 import org.junit.Before;
@@ -114,7 +114,7 @@ public class EppServiceHandlerTest {
 
   @Before
   public void setUp() throws Exception {
-    clientCertificate = new SelfSignedCertificate().cert();
+    clientCertificate = SelfSignedCaCertificate.create().cert();
     channel = setUpNewChannel(eppServiceHandler);
   }
 
@@ -179,7 +179,7 @@ public class EppServiceHandlerTest {
             HELLO.getBytes(UTF_8),
             metrics);
     EmbeddedChannel channel2 = setUpNewChannel(eppServiceHandler2);
-    X509Certificate clientCertificate2 = new SelfSignedCertificate().cert();
+    X509Certificate clientCertificate2 = SelfSignedCaCertificate.create().cert();
     setHandshakeSuccess(channel2, clientCertificate2);
     String certHash2 = getCertificateHash(clientCertificate2);
 


### PR DESCRIPTION
Our tests were using a self-signed cert created by a netty utility.
That cert is not CA, and cannot be used with newer JDK versions
(starting from u242 with Ubuntu openjdk).

Now we generate a unsafe cert for tests. The new cert,
SelfSignedCaCertificate, needs to be made test-only.
To do so we need to refactor both prober and proxy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/475)
<!-- Reviewable:end -->
