### PR TITLE
Make Gradle dependency cache shareable in GCB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ nomulus.iws
 !/gradle/wrapper/**/*.jar
 .gradle/
 **/build
+cloudbuild-caches/
 node_modules/**
 /repos/
 

--- a/config/presubmits.py
+++ b/config/presubmits.py
@@ -22,7 +22,7 @@ import sys
 import re
 
 # We should never analyze any generated files
-UNIVERSALLY_SKIPPED_PATTERNS = {"/build/", "/out/"}
+UNIVERSALLY_SKIPPED_PATTERNS = {"/build/", "cloudbuild-caches", "/out/"}
 # We can't rely on CI to have the Enum package installed so we do this instead.
 FORBIDDEN = 1
 REQUIRED = 2

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -115,6 +115,7 @@ spotless {
   format 'misc', {
     clearSteps()
     target '**/*.gradle'
+    targetExclude '**/cloudbuild-caches/**'
     trimTrailingWhitespace()
     indentWithSpaces(2)
     endWithNewline()

--- a/release/build_nomulus_for_env.sh
+++ b/release/build_nomulus_for_env.sh
@@ -29,6 +29,13 @@ environment="$1"
 dest="$2"
 gcs_prefix="storage.googleapis.com/domain-registry-maven-repository"
 
+# Let Gradle put its caches (dependency cache and build cache) in the source
+# tree. This allows sharing of the caches between steps in a Cloud Build
+# task. (See ./cloudbuild-nomulus.yaml, which calls this script in several
+# steps). If left at their default location, the caches will be lost after
+# each step.
+export GRADLE_USER_HOME="./cloudbuild-caches"
+
 if [ "${environment}" == tool ]
 then
   mkdir -p "${dest}"


### PR DESCRIPTION
Make Gradle put its caches in the source tree so that
they can be preserved across steps. When left at their
default location, caches are lost after each step. This
results in repeated downloads of the same dependencies,
which might be the cause of the recent build errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/479)
<!-- Reviewable:end -->
