### PR TITLE
Use dependency cache in all Gradle tasks in GCB

### DIFF
--- a/release/build_nomulus_for_env.sh
+++ b/release/build_nomulus_for_env.sh
@@ -34,6 +34,7 @@ gcs_prefix="storage.googleapis.com/domain-registry-maven-repository"
 # task. (See ./cloudbuild-nomulus.yaml, which calls this script in several
 # steps). If left at their default location, the caches will be lost after
 # each step.
+# Note: must be consistent with value in ./cloudbuild-nomulus.yaml
 export GRADLE_USER_HOME="./cloudbuild-caches"
 
 if [ "${environment}" == tool ]

--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -21,7 +21,20 @@ steps:
   args: ['mkdir', 'nomulus']
 # Run tests
 - name: 'gcr.io/${PROJECT_ID}/builder:latest'
-  args: ['./gradlew', 'test', '-PskipDockerIncompatibleTests=true']
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    # Set home for Gradle caches. Must be consistent with last step below
+    # and ./build_nomulus_for_env.sh
+    export GRADLE_USER_HOME="./cloudbuild-caches"
+    ./gradlew \
+      test \
+      -PskipDockerIncompatibleTests=true \
+      -PmavenUrl=https://storage.googleapis.com/domain-registry-maven-repository/maven \
+      -PpluginsUrl=https://storage.googleapis.com/domain-registry-maven-repository/plugins \
+
 # Build the tool binary and image.
 - name: 'gcr.io/${PROJECT_ID}/builder:latest'
   args: ['release/build_nomulus_for_env.sh', 'tool', 'output']
@@ -74,6 +87,9 @@ steps:
   - -c
   - |
     set -e
+    # Set home for Gradle caches. Must be consistent with second step above
+    # and ./build_nomulus_for_env.sh
+    export GRADLE_USER_HOME="./cloudbuild-caches"
     ./gradlew \
       :db:publish \
       -PmavenUrl=https://storage.googleapis.com/domain-registry-maven-repository/maven \

--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -21,20 +21,15 @@ steps:
   args: ['mkdir', 'nomulus']
 # Run tests
 - name: 'gcr.io/${PROJECT_ID}/builder:latest'
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    set -e
-    # Set home for Gradle caches. Must be consistent with last step below
-    # and ./build_nomulus_for_env.sh
-    export GRADLE_USER_HOME="./cloudbuild-caches"
-    ./gradlew \
-      test \
-      -PskipDockerIncompatibleTests=true \
-      -PmavenUrl=https://storage.googleapis.com/domain-registry-maven-repository/maven \
-      -PpluginsUrl=https://storage.googleapis.com/domain-registry-maven-repository/plugins \
-
+  # Set home for Gradle caches. Must be consistent with last step below
+  # and ./build_nomulus_for_env.sh
+  env: [ 'GRADLE_USER_HOME=./cloudbuild-caches' ]
+  args: ['./gradlew',
+         'test',
+         '-PskipDockerIncompatibleTests=true',
+         '-PmavenUrl=https://storage.googleapis.com/domain-registry-maven-repository/maven',
+         '-PpluginsUrl=https://storage.googleapis.com/domain-registry-maven-repository/plugins'
+        ]
 # Build the tool binary and image.
 - name: 'gcr.io/${PROJECT_ID}/builder:latest'
   args: ['release/build_nomulus_for_env.sh', 'tool', 'output']
@@ -83,13 +78,13 @@ steps:
 # server/schema compatibility tests.
 - name: 'gcr.io/${PROJECT_ID}/builder:latest'
   entrypoint: /bin/bash
+  # Set home for Gradle caches. Must be consistent with second step above
+  # and ./build_nomulus_for_env.sh
+  env: [ 'GRADLE_USER_HOME=./cloudbuild-caches' ]
   args:
   - -c
   - |
     set -e
-    # Set home for Gradle caches. Must be consistent with second step above
-    # and ./build_nomulus_for_env.sh
-    export GRADLE_USER_HOME="./cloudbuild-caches"
     ./gradlew \
       :db:publish \
       -PmavenUrl=https://storage.googleapis.com/domain-registry-maven-repository/maven \


### PR DESCRIPTION
Make the initial test and the final publishing steps use the shared
dependency cache.

Also make the initial test use the registry's own maven repo instead
of Maven Central.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/481)
<!-- Reviewable:end -->
