### PR TITLE
Use JSON API for Maven Repo on GCS

### DIFF
--- a/release/build_nomulus_for_env.sh
+++ b/release/build_nomulus_for_env.sh
@@ -27,7 +27,7 @@ fi
 
 environment="$1"
 dest="$2"
-gcs_prefix="storage.googleapis.com/domain-registry-maven-repository"
+gcs_prefix="gcs://domain-registry-maven-repository"
 
 # Let Gradle put its caches (dependency cache and build cache) in the source
 # tree. This allows sharing of the caches between steps in a Cloud Build
@@ -42,8 +42,8 @@ then
   mkdir -p "${dest}"
 
   ./gradlew clean :core:buildToolImage \
-    -PmavenUrl=https://"${gcs_prefix}"/maven \
-    -PpluginsUrl=https://"${gcs_prefix}"/plugins
+    -PmavenUrl="${gcs_prefix}"/maven \
+    -PpluginsUrl="${gcs_prefix}"/plugins
 
   mv core/build/libs/nomulus.jar "${dest}"
 else
@@ -51,8 +51,8 @@ else
   mkdir -p "${dest}"
 
   ./gradlew clean stage -Penvironment="${environment}" \
-    -PmavenUrl=https://"${gcs_prefix}"/maven \
-    -PpluginsUrl=https://"${gcs_prefix}"/plugins
+    -PmavenUrl="${gcs_prefix}"/maven \
+    -PpluginsUrl="${gcs_prefix}"/plugins
 
   for service in default pubapi backend tools
   do

--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -27,8 +27,8 @@ steps:
   args: ['./gradlew',
          'test',
          '-PskipDockerIncompatibleTests=true',
-         '-PmavenUrl=https://storage.googleapis.com/domain-registry-maven-repository/maven',
-         '-PpluginsUrl=https://storage.googleapis.com/domain-registry-maven-repository/plugins'
+         '-PmavenUrl=gcs://domain-registry-maven-repository/maven',
+         '-PpluginsUrl=gcs://domain-registry-maven-repository/plugins'
         ]
 # Build the tool binary and image.
 - name: 'gcr.io/${PROJECT_ID}/builder:latest'
@@ -87,14 +87,14 @@ steps:
     set -e
     ./gradlew \
       :db:publish \
-      -PmavenUrl=https://storage.googleapis.com/domain-registry-maven-repository/maven \
-      -PpluginsUrl=https://storage.googleapis.com/domain-registry-maven-repository/plugins \
+      -PmavenUrl=gcs://domain-registry-maven-repository/maven \
+      -PpluginsUrl=gcs://domain-registry-maven-repository/plugins \
       -Ppublish_repo=gcs://${PROJECT_ID}-deployed-tags/maven \
       -Pschema_version=${TAG_NAME}
     ./gradlew \
       :core:publish \
-      -PmavenUrl=https://storage.googleapis.com/domain-registry-maven-repository/maven \
-      -PpluginsUrl=https://storage.googleapis.com/domain-registry-maven-repository/plugins \
+      -PmavenUrl=gcs://domain-registry-maven-repository/maven \
+      -PpluginsUrl=gcs://domain-registry-maven-repository/plugins \
       -Ppublish_repo=gcs://${PROJECT_ID}-deployed-tags/maven \
       -Pnomulus_version=${TAG_NAME}
     # Upload schema jar for use by schema deployment.

--- a/release/cloudbuild-proxy.yaml
+++ b/release/cloudbuild-proxy.yaml
@@ -19,8 +19,8 @@ steps:
   - ./gradlew
   - :proxy:test
   - :proxy:buildProxyImage
-  - -PmavenUrl=https://storage.googleapis.com/domain-registry-maven-repository/maven
-  - -PpluginsUrl=https://storage.googleapis.com/domain-registry-maven-repository/plugins
+  - -PmavenUrl=gcs://domain-registry-maven-repository/maven
+  - -PpluginsUrl=gcs://domain-registry-maven-repository/plugins
 # Tag and push the image. We can't let Cloud Build's default processing do that for us
 # because we need to push the image before we can sign it in the following step.
 - name: 'gcr.io/${PROJECT_ID}/builder:latest'


### PR DESCRIPTION
The url pattern https://storage.googleapis.com/{Bucket}/{Path}
uses the legacy XML API, which seems to be less robust than
the JSON API. We have observed connection resets after a few
thousand-file download bursts over 30 minutes.

This PR changes all urls to registry's Maven repo on GCS to
gcs://{Bucket}/{Path}. Gradle uses the JSON API for such urls.

TESTED=In Cloud Build with local change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/483)
<!-- Reviewable:end -->
