### PR TITLE
Use -t instead of main params for TLDs in nomulus count_domains command

### DIFF
--- a/core/src/main/java/google/registry/tools/CountDomainsCommand.java
+++ b/core/src/main/java/google/registry/tools/CountDomainsCommand.java
@@ -30,15 +30,18 @@ import org.joda.time.DateTime;
 @Parameters(separators = " =", commandDescription = "Show count of domains on TLD")
 final class CountDomainsCommand implements CommandWithRemoteApi {
 
-  @Parameter(description = "TLD(s) to count domains on", required = true)
-  private List<String> mainParameters;
+  @Parameter(
+      names = {"-t", "--tld", "--tlds"},
+      description = "Comma-delimited list of TLD(s) to count domains on",
+      required = true)
+  private List<String> tlds;
 
   @Inject Clock clock;
 
   @Override
   public void run() {
     DateTime now = clock.nowUtc();
-    assertTldsExist(mainParameters)
+    assertTldsExist(tlds)
         .forEach(tld -> System.out.printf("%s,%d\n", tld, getCountForTld(tld, now)));
   }
 

--- a/core/src/test/java/google/registry/tools/CountDomainsCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CountDomainsCommandTest.java
@@ -49,7 +49,7 @@ public class CountDomainsCommandTest extends CommandTestCase<CountDomainsCommand
         persistActiveDomain(String.format("test-%d.baz", i));
       }
     }
-    runCommand("foo");
+    runCommand("-t=foo");
     assertStdoutIs("foo,51\n");
   }
 
@@ -64,7 +64,7 @@ public class CountDomainsCommandTest extends CommandTestCase<CountDomainsCommand
       persistDeletedDomain(String.format("del-%d.foo", j), clock.nowUtc().minusYears(1));
     }
     persistActiveDomain("not-counted.qux");
-    runCommand("foo", "bar", "baz");
+    runCommand("--tlds=foo,bar,baz");
     assertStdoutIs("foo,29\nbar,0\nbaz,17\n");
   }
 }


### PR DESCRIPTION
This makes the command consistent with list_domains. I use both frequently and it
was annoying forgetting which one takes -t and which uses main parameters. Now
they both work the same way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/493)
<!-- Reviewable:end -->
