### PR TITLE
Add Lock dual write

### DIFF
--- a/core/src/main/java/google/registry/model/server/Lock.java
+++ b/core/src/main/java/google/registry/model/server/Lock.java
@@ -28,6 +28,7 @@ import com.googlecode.objectify.annotation.Id;
 import google.registry.model.ImmutableObject;
 import google.registry.model.annotations.NotBackedUp;
 import google.registry.model.annotations.NotBackedUp.Reason;
+import google.registry.schema.server.LockDao;
 import google.registry.util.RequestStatusChecker;
 import google.registry.util.RequestStatusCheckerImpl;
 import java.io.Serializable;
@@ -177,8 +178,7 @@ public class Lock extends ImmutableObject implements Serializable {
     // access to resources like GCS that can't be transactionally rolled back. Therefore, the lock
     // must be definitively acquired before it is used, even when called inside another transaction.
     AcquireResult acquireResult =
-        tm()
-            .transactNew(
+        tm().transactNew(
                 () -> {
                   DateTime now = tm().getTransactionTime();
 
@@ -207,6 +207,25 @@ public class Lock extends ImmutableObject implements Serializable {
                   // contention) and
                   // don't need to be backed up.
                   ofy().saveWithoutBackup().entity(newLock);
+
+                  // create and save the lock to Cloud SQL
+                  try {
+                    google.registry.schema.server.Lock cloudSqlLock =
+                        google.registry.schema.server.Lock.create(
+                            resourceName,
+                            Optional.ofNullable(tld).orElse("GLOBAL"),
+                            requestStatusChecker.getLogId(),
+                            now,
+                            leaseLength);
+                    // cloudSqlLock should not already exist in Cloud SQL, but call delete just in
+                    // case
+                    LockDao.delete(cloudSqlLock);
+                    LockDao.saveNew(cloudSqlLock);
+                  } catch (Exception e) {
+                    logger.atSevere().withCause(e).log(
+                        "Error saving lock to Cloud SQL: %s", newLock);
+                  }
+
                   return AcquireResult.create(now, lock, newLock, lockState);
                 });
 
@@ -218,8 +237,7 @@ public class Lock extends ImmutableObject implements Serializable {
   /** Release the lock. */
   public void release() {
     // Just use the default clock because we aren't actually doing anything that will use the clock.
-    tm()
-        .transact(
+    tm().transact(
             () -> {
               // To release a lock, check that no one else has already obtained it and if not
               // delete it. If the lock in Datastore was different then this lock is gone already;
@@ -231,6 +249,22 @@ public class Lock extends ImmutableObject implements Serializable {
                 // lock.
                 logger.atInfo().log("Deleting lock: %s", lockId);
                 ofy().deleteWithoutBackup().entity(Lock.this);
+
+                // Remove the lock from Cloud SQL
+                try {
+                  google.registry.schema.server.Lock cloudSqlLock =
+                      google.registry.schema.server.Lock.create(
+                          resourceName,
+                          Optional.ofNullable(tld).orElse("GLOBAL"),
+                          requestLogId,
+                          acquiredTime,
+                          new Duration(acquiredTime, expirationTime));
+                  LockDao.delete(cloudSqlLock);
+                } catch (Exception e) {
+                  logger.atSevere().withCause(e).log(
+                      "Error deleting lock from Cloud SQL: %s", loadedLock);
+                }
+
                 lockMetrics.recordRelease(
                     resourceName, tld, new Duration(acquiredTime, tm().getTransactionTime()));
               } else {

--- a/core/src/main/java/google/registry/schema/server/LockDao.java
+++ b/core/src/main/java/google/registry/schema/server/LockDao.java
@@ -51,26 +51,29 @@ public class LockDao {
    * else empty.
    */
   public static Optional<Lock> load(String resourceName) {
-    checkArgumentNotNull(resourceName, "The resource name of the lock to load cannot be null");
-    return Optional.ofNullable(
-        jpaTm()
-            .transact(
-                () ->
-                    jpaTm().getEntityManager().find(Lock.class, new LockId(resourceName, GLOBAL))));
+    return load(resourceName, GLOBAL);
   }
 
   /**
-   * Deletes the given {@link Lock} object from Cloud SQL. This method is idempotent and will simply
-   * return if the lock has already been deleted.
+   * Deletes the {@link Lock} object with the given resourceName and tld from Cloud SQL. This method
+   * is idempotent and will simply return if the lock has already been deleted.
    */
-  public static void delete(Lock lock) {
+  public static void delete(String resourceName, String tld) {
     jpaTm()
         .transact(
             () -> {
-              Optional<Lock> loadedLock = load(lock.resourceName, lock.tld);
+              Optional<Lock> loadedLock = load(resourceName, tld);
               if (loadedLock.isPresent()) {
                 jpaTm().getEntityManager().remove(loadedLock.get());
               }
             });
+  }
+
+  /**
+   * Deletes the global {@link Lock} object with the given resourceName from Cloud SQL. This method
+   * is idempotent and will simply return if the lock has already been deleted.
+   */
+  public static void delete(String resourceName) {
+    delete(resourceName, GLOBAL);
   }
 }

--- a/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
+++ b/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
@@ -18,6 +18,7 @@ import com.google.common.truth.Expect;
 import google.registry.model.common.CursorTest;
 import google.registry.model.domain.DomainBaseSqlTest;
 import google.registry.model.registry.RegistryLockDaoTest;
+import google.registry.model.server.LockTest;
 import google.registry.persistence.transaction.JpaEntityCoverage;
 import google.registry.schema.cursor.CursorDaoTest;
 import google.registry.schema.registrar.RegistrarDaoTest;
@@ -64,10 +65,11 @@ import org.junit.runners.Suite.SuiteClasses;
   CreateReservedListCommandTest.class,
   CursorDaoTest.class,
   CursorTest.class,
+  DomainBaseSqlTest.class,
   DomainLockUtilsTest.class,
   LockDaoTest.class,
   LockDomainCommandTest.class,
-  DomainBaseSqlTest.class,
+  LockTest.class,
   PremiumListDaoTest.class,
   RegistrarDaoTest.class,
   RegistryLockDaoTest.class,

--- a/core/src/test/java/google/registry/schema/server/LockDaoTest.java
+++ b/core/src/test/java/google/registry/schema/server/LockDaoTest.java
@@ -103,7 +103,7 @@ public class LockDaoTest {
     LockDao.saveNew(lock);
     Optional<Lock> returnedLock = LockDao.load("testResource", "tld");
     assertThat(returnedLock.get().expirationTime).isEqualTo(lock.expirationTime);
-    LockDao.delete(lock);
+    LockDao.delete("testResource", "tld");
     returnedLock = LockDao.load("testResource", "tld");
     assertThat(returnedLock.isPresent()).isFalse();
   }
@@ -115,15 +115,13 @@ public class LockDaoTest {
     LockDao.saveNew(lock);
     Optional<Lock> returnedLock = LockDao.load("testResource");
     assertThat(returnedLock.get().expirationTime).isEqualTo(lock.expirationTime);
-    LockDao.delete(lock);
+    LockDao.delete("testResource");
     returnedLock = LockDao.load("testResource");
     assertThat(returnedLock.isPresent()).isFalse();
   }
 
   @Test
   public void delete_succeedsLockDoesntExist() {
-    Lock lock =
-        Lock.createGlobal("testResource", "testLogId", fakeClock.nowUtc(), Duration.millis(2));
-    LockDao.delete(lock);
+    LockDao.delete("testResource");
   }
 }


### PR DESCRIPTION
Modifies acquire() and release() to write lock to Cloud SQL and delete lock from Cloud SQL whenever a create or delete is done for a lock in Datastore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/496)
<!-- Reviewable:end -->
