### PR TITLE
Always validate domain name on allocation token

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -120,6 +120,8 @@ import org.joda.time.Duration;
  * @error {@link
  *     google.registry.flows.domain.token.AllocationTokenFlowUtils.AllocationTokenNotInPromotionException}
  * @error {@link
+ *     google.registry.flows.domain.token.AllocationTokenFlowUtils.AllocationTokenNotValidForDomainException}
+ * @error {@link
  *     google.registry.flows.domain.token.AllocationTokenFlowUtils.AllocationTokenNotValidForRegistrarException}
  * @error {@link
  *     google.registry.flows.domain.token.AllocationTokenFlowUtils.AllocationTokenNotValidForTldException}

--- a/core/src/main/java/google/registry/tools/javascrap/BackfillRegistryLocksCommand.java
+++ b/core/src/main/java/google/registry/tools/javascrap/BackfillRegistryLocksCommand.java
@@ -144,12 +144,14 @@ public class BackfillRegistryLocksCommand extends ConfirmingCommand
 
   private ImmutableList<DomainBase> getLockedDomainsWithoutLocks(DateTime now) {
     return ImmutableList.copyOf(
-        ofy().load()
+        ofy()
+            .load()
             .keys(
                 roids.stream()
                     .map(roid -> Key.create(DomainBase.class, roid))
                     .collect(toImmutableList()))
-            .values().stream()
+            .values()
+            .stream()
             .filter(d -> d.getDeletionTime().isAfter(now))
             .filter(d -> d.getStatusValues().containsAll(REGISTRY_LOCK_STATUSES))
             .filter(d -> !RegistryLockDao.getMostRecentByRepoId(d.getRepoId()).isPresent())

--- a/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
@@ -186,7 +186,7 @@ public class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFl
             .build());
     doCheckTest(
         create(false, "example1.tld", "In use"),
-        create(true, "example2.tld", null),
+        create(false, "example2.tld", "Alloc token invalid for domain"),
         create(false, "reserved.tld", "Reserved"),
         create(true, "specificuse.tld", null));
   }
@@ -203,7 +203,7 @@ public class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFl
             .build());
     doCheckTest(
         create(false, "example1.tld", "In use"),
-        create(true, "example2.tld", null),
+        create(false, "example2.tld", "Alloc token invalid for domain"),
         create(false, "reserved.tld", "Reserved"),
         create(false, "specificuse.tld", "Allocation token required"));
   }
@@ -224,8 +224,8 @@ public class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFl
                     .build())
             .build());
     doCheckTest(
-        create(true, "example1.tld", null),
-        create(true, "example2.tld", null),
+        create(false, "example1.tld", "Alloc token invalid for domain"),
+        create(false, "example2.tld", "Alloc token invalid for domain"),
         create(false, "reserved.tld", "Reserved"),
         create(true, "specificuse.tld", null));
   }
@@ -246,8 +246,8 @@ public class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFl
                     .build())
             .build());
     doCheckTest(
-        create(false, "example1.tld", "Alloc token not in promo period"),
-        create(false, "example2.tld", "Alloc token not in promo period"),
+        create(false, "example1.tld", "Alloc token invalid for domain"),
+        create(false, "example2.tld", "Alloc token invalid for domain"),
         create(false, "reserved.tld", "Reserved"),
         create(false, "specificuse.tld", "Alloc token not in promo period"));
   }

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -357,6 +357,7 @@ An EPP flow that creates a new domain resource.
     *   Registrant is not whitelisted for this TLD.
     *   Requested domain does not require a claims notice.
 *   2305
+    *   The allocation token is not valid for this domain.
     *   The allocation token is not valid for this registrar.
     *   The allocation token is not valid for this TLD.
     *   The allocation token was already redeemed.


### PR DESCRIPTION
This is in response to a client-reported error, where they accidentally sent the
wrong domain name on a domain create that included an allocation token. What
should have happened (and that now happens as of this commit) is an error being
thrown that the allocation token does not match the domain name being created.
What happened instead was that, since the incorrectly submitted domain name was
not reserved, the create succeeded (as it would for all creates of unreserved
domains in GA) and the allocation token was redeemed, which is not what you'd
expect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/498)
<!-- Reviewable:end -->
