### PR TITLE
Set focus correctly in lock modal

### DIFF
--- a/core/src/main/javascript/google/registry/ui/js/registrar/registry_lock.js
+++ b/core/src/main/javascript/google/registry/ui/js/registrar/registry_lock.js
@@ -117,7 +117,11 @@ registry.registrar.RegistryLock.prototype.showModal_ = function(targetElement, d
   var modalElement = goog.soy.renderAsElement(
       registry.soy.registrar.registrylock.confirmModal, {domain: domain, isLock: isLock});
   parentElement.prepend(modalElement);
-  goog.dom.getRequiredElement('domain-lock-password').focus();
+  if (domain == null) {
+    goog.dom.getRequiredElement('domain-lock-input-value').focus();
+  } else {
+    goog.dom.getRequiredElement('domain-lock-password').focus();
+  }
   // delete the modal when the user clicks the cancel button
   goog.events.listen(
       goog.dom.getRequiredElement('domain-lock-cancel'),


### PR DESCRIPTION
If there's a domain (this is an unlock) then it means the domain field is disabled so we should focus on the password field. If there isn't a domain (this is a lock) then we should focus on the domain field since it's first. 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/499)
<!-- Reviewable:end -->
