### PR TITLE
Handle both ways the UI passes in booleans

### DIFF
--- a/core/src/main/java/google/registry/ui/server/RegistrarFormFields.java
+++ b/core/src/main/java/google/registry/ui/server/RegistrarFormFields.java
@@ -37,6 +37,7 @@ import google.registry.util.X509Utils;
 import java.security.cert.CertificateParsingException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -204,8 +205,10 @@ public final class RegistrarFormFields {
   public static final FormField<String, String> CONTACT_GAE_USER_ID_FIELD =
       FormFields.NAME.asBuilderNamed("gaeUserId").build();
 
-  public static final FormField<Boolean, Boolean> CONTACT_ALLOWED_TO_SET_REGISTRY_LOCK_PASSWORD =
-      FormField.named("allowedToSetRegistryLockPassword", Boolean.class).build();
+  public static final FormField<Object, Boolean> CONTACT_ALLOWED_TO_SET_REGISTRY_LOCK_PASSWORD =
+      FormField.named("allowedToSetRegistryLockPassword", Object.class)
+          .transform(Boolean.class, b -> Boolean.valueOf(Objects.toString(b)))
+          .build();
 
   public static final FormField<String, String> CONTACT_REGISTRY_LOCK_PASSWORD_FIELD =
       FormFields.NAME.asBuilderNamed("registryLockPassword").build();
@@ -384,6 +387,8 @@ public final class RegistrarFormFields {
     builder.setFaxNumber(CONTACT_FAX_NUMBER_FIELD.extractUntyped(args).orElse(null));
     builder.setTypes(CONTACT_TYPES.extractUntyped(args).orElse(ImmutableSet.of()));
     builder.setGaeUserId(CONTACT_GAE_USER_ID_FIELD.extractUntyped(args).orElse(null));
+    // The parser is inconsistent with whether it retrieves boolean values as strings or booleans.
+    // As a result, use a potentially-redundant converter that can deal with both.
     builder.setAllowedToSetRegistryLockPassword(
         CONTACT_ALLOWED_TO_SET_REGISTRY_LOCK_PASSWORD.extractUntyped(args).orElse(false));
 

--- a/core/src/main/resources/google/registry/ui/soy/registrar/ContactSettings.soy
+++ b/core/src/main/resources/google/registry/ui/soy/registrar/ContactSettings.soy
@@ -258,9 +258,9 @@
   {/if}
   <input type="hidden" name="{$namePrefix}allowedToSetRegistryLockPassword"
       {if isNonnull($item['allowedToSetRegistryLockPassword'])}
-      value={$item['allowedToSetRegistryLockPassword']}
+         value="{$item['allowedToSetRegistryLockPassword']}"
       {else}
-      value=false
+         value="false"
       {/if}
   >
   <tr>

--- a/core/src/main/resources/google/registry/ui/soy/registrar/ContactSettings.soy
+++ b/core/src/main/resources/google/registry/ui/soy/registrar/ContactSettings.soy
@@ -256,10 +256,13 @@
       {param placeholder: $placeholder /}
     {/call}
   {/if}
-  {if isNonnull($item['allowedToSetRegistryLockPassword'])}
-    <input type="hidden" name="allowedToSetRegistryLockPassword"
-           value="{$item['allowedToSetRegistryLockPassword']}">
-  {/if}
+  <input type="hidden" name="{$namePrefix}allowedToSetRegistryLockPassword"
+      {if isNonnull($item['allowedToSetRegistryLockPassword'])}
+      value={$item['allowedToSetRegistryLockPassword']}
+      {else}
+      value=false
+      {/if}
+  >
   <tr>
     <td colspan="2">
       <hr>

--- a/core/src/test/javascript/google/registry/ui/js/registrar/contact_settings_test.js
+++ b/core/src/test/javascript/google/registry/ui/js/registrar/contact_settings_test.js
@@ -335,7 +335,8 @@ describe("contact settings test", function() {
       visibleInWhoisAsAdmin: false,
       visibleInWhoisAsTech: false,
       visibleInDomainWhoisAsAbuse: false,
-      types: 'ADMIN'
+      types: 'ADMIN',
+      allowedToSetRegistryLockPassword: 'false'
     };
   }
 


### PR DESCRIPTION
Basically, no matter how we quote it in the Soy file, sometimes it's true/false, and sometimes it's "true"/"false with hidden input fields. This is annoying.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/500)
<!-- Reviewable:end -->
