### PR TITLE
Fix broken builds when Maven Central is used

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -169,10 +169,10 @@ allprojects {
   if (project.name == 'services') return
 
   repositories {
-    if (rootProject.mavenUrl) {
+    if (!mavenUrl.isEmpty()) {
       maven {
-        println "Java dependencies: Using repo $pluginsUrl..."
-        url rootProject.mavenUrl
+        println "Java dependencies: Using repo ${mavenUrl}..."
+        url mavenUrl
       }
     } else {
       println "Java dependencies: Using Maven Central..."

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 buildscript {
   if (project.enableDependencyLocking.toBoolean()) {
     // Lock buildscript dependencies.
@@ -40,13 +42,13 @@ if (rootProject.enableDependencyLocking.toBoolean()) {
 }
 
 repositories {
-  if (project.ext.properties.mavenUrl == null) {
-    println "Plugin dependencies: Using Maven central..."
+  if (isNullOrEmpty(project.ext.properties.mavenUrl)) {
+    println "Java dependencies: Using Maven central..."
     mavenCentral()
     google()
   } else {
     maven {
-      println "Plugin dependencies: Using repo ${mavenUrl}..."
+      println "Java dependencies: Using repo ${mavenUrl}..."
       url mavenUrl
     }
   }
@@ -82,6 +84,7 @@ dependencies {
   testCompile deps['com.google.truth:truth']
   testCompile deps['com.google.truth.extensions:truth-java8-extension']
   testCompile deps['junit:junit']
+  testCompile deps['org.junit.jupiter:junit-jupiter-api']
   testCompile deps['org.junit.jupiter:junit-jupiter-engine']
   testCompile deps['org.junit.vintage:junit-vintage-engine']
   testCompile deps['org.mockito:mockito-core']

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -62,6 +62,7 @@ dependencies {
   testingCompile deps['io.github.java-diff-utils:java-diff-utils']
 
   testCompile deps['junit:junit']
+  testCompile deps['org.junit.jupiter:junit-jupiter-api']
   testCompile deps['org.junit.jupiter:junit-jupiter-engine']
   testCompile deps['org.junit.vintage:junit-vintage-engine']
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -300,6 +300,7 @@ dependencies {
   testCompile deps['org.hamcrest:hamcrest-library']
   compile deps['org.hibernate:hibernate-hikaricp']
   testCompile deps['junit:junit']
+  testCompile deps['org.junit.jupiter:junit-jupiter-api']
   testCompile deps['org.junit.jupiter:junit-jupiter-engine']
   testCompile deps['org.junit.vintage:junit-vintage-engine']
   testCompile deps['org.mockito:mockito-core']

--- a/db/build.gradle
+++ b/db/build.gradle
@@ -155,6 +155,7 @@ dependencies {
   testCompile deps['com.google.truth:truth']
   testRuntime deps['io.github.java-diff-utils:java-diff-utils']
   testCompile deps['junit:junit']
+  testCompile deps['org.junit.jupiter:junit-jupiter-api']
   testCompile deps['org.junit.jupiter:junit-jupiter-engine']
   testCompile deps['org.junit.vintage:junit-vintage-engine']
   testCompile deps['org.testcontainers:postgresql']

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -98,6 +98,7 @@ ext {
       'jline:jline:1.0',
       'joda-time:joda-time:2.9.2',
       'junit:junit:4.13',
+      'org.junit.jupiter:junit-jupiter-api:5.6.0',
       'org.junit.jupiter:junit-jupiter-engine:5.6.0',
       'org.junit.vintage:junit-vintage-engine:5.6.0',
       'org.apache.avro:avro:1.8.2',

--- a/networking/build.gradle
+++ b/networking/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
   testCompile deps['com.google.truth:truth']
   testCompile deps['junit:junit']
+  testCompile deps['org.junit.jupiter:junit-jupiter-api']
   testCompile deps['org.junit.jupiter:junit-jupiter-engine']
   testCompile deps['org.junit.vintage:junit-vintage-engine']
   testCompile deps['org.bouncycastle:bcpkix-jdk15on']

--- a/prober/build.gradle
+++ b/prober/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     testCompile deps['com.google.monitoring-client:contrib']
     testCompile deps['com.google.truth:truth']
     testCompile deps['junit:junit']
+    testCompile deps['org.junit.jupiter:junit-jupiter-api']
     testCompile deps['org.junit.jupiter:junit-jupiter-engine']
     testCompile deps['org.junit.vintage:junit-vintage-engine']
     testCompile deps['org.mockito:mockito-core']

--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -76,6 +76,7 @@ dependencies {
   testCompile deps['com.google.truth:truth']
   testCompile deps['org.yaml:snakeyaml']
   testCompile deps['junit:junit']
+  testCompile deps['org.junit.jupiter:junit-jupiter-api']
   testCompile deps['org.junit.jupiter:junit-jupiter-engine']
   testCompile deps['org.junit.vintage:junit-vintage-engine']
   testCompile deps['org.mockito:mockito-core']

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-if (pluginsUrl) {
+if (!pluginsUrl.isEmpty()) {
   println "Plugins: Using repo $pluginsUrl..."
   pluginManagement {
     repositories {

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   testCompile deps['com.google.guava:guava-testlib']
   testCompile deps['com.google.truth:truth']
   testCompile deps['junit:junit']
+  testCompile deps['org.junit.jupiter:junit-jupiter-api']
   testCompile deps['org.junit.jupiter:junit-jupiter-engine']
   testCompile deps['org.junit.vintage:junit-vintage-engine']
   testCompile deps['org.hamcrest:hamcrest-all']


### PR DESCRIPTION
Gradle 6.2.1 apparently introduces a behavior change wrt boolean
expression: empty string used to eval to false, but now evals to
true.

Pre Gradle 6.2.1, root project's Gradle properties apparently were
not set to buildSrc. Now they are passed on to buildSrc -- mavenUrl
in buildSrc changes from null to "".

Both changes break the project when mavenUrl and/or pluginsUrl are
not set on command line.

Also added junit.jupiter-api as testCompile dependencies to projects.
This is a directly used dependency, whose absence causes a Lint
warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/509)
<!-- Reviewable:end -->
