### PR TITLE
Disambiguate naming of VKey.create() overloads

### DIFF
--- a/core/src/main/java/google/registry/persistence/VKey.java
+++ b/core/src/main/java/google/registry/persistence/VKey.java
@@ -43,11 +43,11 @@ public class VKey<T> extends ImmutableObject {
     return new VKey(kind, ofyKey, primaryKey);
   }
 
-  public static <T> VKey<T> create(Class<? extends T> kind, Object primaryKey) {
+  public static <T> VKey<T> createSql(Class<? extends T> kind, Object primaryKey) {
     return new VKey(kind, null, primaryKey);
   }
 
-  public static <T> VKey<T> create(
+  public static <T> VKey<T> createOfy(
       Class<? extends T> kind, com.googlecode.objectify.Key<T> ofyKey) {
     return new VKey(kind, ofyKey, null);
   }

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerImplTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerImplTest.java
@@ -43,11 +43,11 @@ public class JpaTransactionManagerImplTest {
 
   private final FakeClock fakeClock = new FakeClock();
   private final TestEntity theEntity = new TestEntity("theEntity", "foo");
-  private final VKey<TestEntity> theEntityKey = VKey.create(TestEntity.class, "theEntity");
+  private final VKey<TestEntity> theEntityKey = VKey.createSql(TestEntity.class, "theEntity");
   private final TestCompoundIdEntity compoundIdEntity =
       new TestCompoundIdEntity("compoundIdEntity", 10, "foo");
   private final VKey<TestCompoundIdEntity> compoundIdEntityKey =
-      VKey.create(TestCompoundIdEntity.class, new CompoundId("compoundIdEntity", 10));
+      VKey.createSql(TestCompoundIdEntity.class, new CompoundId("compoundIdEntity", 10));
   private final ImmutableList<TestEntity> moreEntities =
       ImmutableList.of(
           new TestEntity("entity1", "foo"),
@@ -225,7 +225,7 @@ public class JpaTransactionManagerImplTest {
   public void update_succeeds() {
     jpaTm().transact(() -> jpaTm().saveNew(theEntity));
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().load(VKey.create(TestEntity.class, "theEntity"))).get();
+        jpaTm().transact(() -> jpaTm().load(VKey.createSql(TestEntity.class, "theEntity"))).get();
     assertThat(persisted.data).isEqualTo("foo");
     theEntity.data = "bar";
     jpaTm().transact(() -> jpaTm().update(theEntity));

--- a/core/src/test/java/google/registry/schema/registrar/RegistrarDaoTest.java
+++ b/core/src/test/java/google/registry/schema/registrar/RegistrarDaoTest.java
@@ -32,7 +32,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class RegistrarDaoTest extends EntityTestCase {
 
-  private final VKey<Registrar> registrarKey = VKey.create(Registrar.class, "registrarId");
+  private final VKey<Registrar> registrarKey = VKey.createSql(Registrar.class, "registrarId");
 
   private Registrar testRegistrar;
 

--- a/core/src/test/java/google/registry/tools/UpdateRegistrarCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateRegistrarCommandTest.java
@@ -52,7 +52,7 @@ public class UpdateRegistrarCommandTest extends CommandTestCase<UpdateRegistrarC
     assertThat(loadRegistrar("NewRegistrar").verifyPassword("some_password")).isTrue();
     assertThat(
             jpaTm()
-                .transact(() -> jpaTm().load(VKey.create(Registrar.class, "NewRegistrar")))
+                .transact(() -> jpaTm().load(VKey.createSql(Registrar.class, "NewRegistrar")))
                 .get()
                 .verifyPassword("some_password"))
         .isTrue();


### PR DESCRIPTION
It was discovered in the course of trying to convert the larger codebase
to VKey.create() calls that method overloading isn't a very effective
discriminator in cases where "Object" is one of the distinguishing
argument types:-)

Convert the two specialized create() methods to createOfy() and
createSql() so that (at least in the former case) we'll get a
compile-time error if we aim to create a VKey for an Ofy key from an
object of the incorrect type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/513)
<!-- Reviewable:end -->
