### PR TITLE
Fix the test server

### DIFF
--- a/core/src/test/java/google/registry/server/RegistryTestServerMain.java
+++ b/core/src/test/java/google/registry/server/RegistryTestServerMain.java
@@ -19,7 +19,6 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.common.collect.ImmutableList;
 import com.google.common.net.HostAndPort;
-import google.registry.persistence.transaction.JpaTestRules;
 import google.registry.testing.AppEngineRule;
 import google.registry.testing.UserInfo;
 import google.registry.tools.params.HostAndPortParameter;
@@ -156,23 +155,18 @@ public final class RegistryTestServerMain {
           }
         };
 
-    Statement withAppEngine =
-        AppEngineRule.builder()
-            .withDatastoreAndCloudSql()
-            .withUrlFetch()
-            .withTaskQueue()
-            .withLocalModules()
-            .withUserService(
-                loginIsAdmin
-                    ? UserInfo.createAdmin(loginEmail, loginUserId)
-                    : UserInfo.create(loginEmail, loginUserId))
-            .build()
-            .apply(runner, Description.EMPTY);
-
     System.out.printf("%sLoading SQL fixtures and AppEngineRule...%s\n", BLUE, RESET);
-    new JpaTestRules.Builder()
-        .buildIntegrationTestRule()
-        .apply(withAppEngine, Description.EMPTY)
+    AppEngineRule.builder()
+        .withDatastoreAndCloudSql()
+        .withUrlFetch()
+        .withTaskQueue()
+        .withLocalModules()
+        .withUserService(
+            loginIsAdmin
+                ? UserInfo.createAdmin(loginEmail, loginUserId)
+                : UserInfo.create(loginEmail, loginUserId))
+        .build()
+        .apply(runner, Description.EMPTY)
         .evaluate();
   }
 


### PR DESCRIPTION
This rule isn't necessary any more since we merged the SQL-starting rule
into the AppEngineRule logic. Furthermore, it actually causes the test
server to crash because we try to drop-and-create the DB twice, the
second time while the first instance is still connected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/521)
<!-- Reviewable:end -->
