### PR TITLE
Set postgres package back to runtime dependency

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -198,7 +198,7 @@ dependencies {
   compile deps['com.google.auth:google-auth-library-credentials']
   compile deps['com.google.auth:google-auth-library-oauth2-http']
   compile deps['com.google.cloud.sql:jdbc-socket-factory-core']
-  compile deps['com.google.cloud.sql:postgres-socket-factory']
+  runtimeOnly deps['com.google.cloud.sql:postgres-socket-factory']
   compile deps['com.google.code.gson:gson']
   compile deps['com.google.auto.value:auto-value-annotations']
   compile deps['com.google.code.findbugs:jsr305']

--- a/core/gradle/dependency-locks/compile.lockfile
+++ b/core/gradle/dependency-locks/compile.lockfile
@@ -75,7 +75,6 @@ com.google.cloud.bigdataoss:util:1.9.16
 com.google.cloud.bigtable:bigtable-client-core:1.8.0
 com.google.cloud.datastore:datastore-v1-proto-client:1.6.0
 com.google.cloud.sql:jdbc-socket-factory-core:1.0.12
-com.google.cloud.sql:postgres-socket-factory:1.0.12
 com.google.cloud:google-cloud-bigquerystorage:0.79.0-alpha
 com.google.cloud:google-cloud-bigtable-admin:0.73.0-alpha
 com.google.cloud:google-cloud-bigtable:0.73.0-alpha

--- a/core/gradle/dependency-locks/compileClasspath.lockfile
+++ b/core/gradle/dependency-locks/compileClasspath.lockfile
@@ -75,7 +75,6 @@ com.google.cloud.bigdataoss:util:1.9.16
 com.google.cloud.bigtable:bigtable-client-core:1.8.0
 com.google.cloud.datastore:datastore-v1-proto-client:1.6.0
 com.google.cloud.sql:jdbc-socket-factory-core:1.0.12
-com.google.cloud.sql:postgres-socket-factory:1.0.12
 com.google.cloud:google-cloud-bigquerystorage:0.79.0-alpha
 com.google.cloud:google-cloud-bigtable-admin:0.73.0-alpha
 com.google.cloud:google-cloud-bigtable:0.73.0-alpha

--- a/core/gradle/dependency-locks/nonprodCompile.lockfile
+++ b/core/gradle/dependency-locks/nonprodCompile.lockfile
@@ -75,7 +75,6 @@ com.google.cloud.bigdataoss:util:1.9.16
 com.google.cloud.bigtable:bigtable-client-core:1.8.0
 com.google.cloud.datastore:datastore-v1-proto-client:1.6.0
 com.google.cloud.sql:jdbc-socket-factory-core:1.0.12
-com.google.cloud.sql:postgres-socket-factory:1.0.12
 com.google.cloud:google-cloud-bigquerystorage:0.79.0-alpha
 com.google.cloud:google-cloud-bigtable-admin:0.73.0-alpha
 com.google.cloud:google-cloud-bigtable:0.73.0-alpha

--- a/core/gradle/dependency-locks/nonprodCompileClasspath.lockfile
+++ b/core/gradle/dependency-locks/nonprodCompileClasspath.lockfile
@@ -75,7 +75,6 @@ com.google.cloud.bigdataoss:util:1.9.16
 com.google.cloud.bigtable:bigtable-client-core:1.8.0
 com.google.cloud.datastore:datastore-v1-proto-client:1.6.0
 com.google.cloud.sql:jdbc-socket-factory-core:1.0.12
-com.google.cloud.sql:postgres-socket-factory:1.0.12
 com.google.cloud:google-cloud-bigquerystorage:0.79.0-alpha
 com.google.cloud:google-cloud-bigtable-admin:0.73.0-alpha
 com.google.cloud:google-cloud-bigtable:0.73.0-alpha

--- a/core/gradle/dependency-locks/nonprodRuntime.lockfile
+++ b/core/gradle/dependency-locks/nonprodRuntime.lockfile
@@ -75,7 +75,6 @@ com.google.cloud.bigdataoss:util:1.9.16
 com.google.cloud.bigtable:bigtable-client-core:1.8.0
 com.google.cloud.datastore:datastore-v1-proto-client:1.6.0
 com.google.cloud.sql:jdbc-socket-factory-core:1.0.12
-com.google.cloud.sql:postgres-socket-factory:1.0.12
 com.google.cloud:google-cloud-bigquerystorage:0.79.0-alpha
 com.google.cloud:google-cloud-bigtable-admin:0.73.0-alpha
 com.google.cloud:google-cloud-bigtable:0.73.0-alpha

--- a/core/gradle/dependency-locks/nonprodRuntimeClasspath.lockfile
+++ b/core/gradle/dependency-locks/nonprodRuntimeClasspath.lockfile
@@ -75,7 +75,6 @@ com.google.cloud.bigdataoss:util:1.9.16
 com.google.cloud.bigtable:bigtable-client-core:1.8.0
 com.google.cloud.datastore:datastore-v1-proto-client:1.6.0
 com.google.cloud.sql:jdbc-socket-factory-core:1.0.12
-com.google.cloud.sql:postgres-socket-factory:1.0.12
 com.google.cloud:google-cloud-bigquerystorage:0.79.0-alpha
 com.google.cloud:google-cloud-bigtable-admin:0.73.0-alpha
 com.google.cloud:google-cloud-bigtable:0.73.0-alpha

--- a/core/gradle/dependency-locks/runtime.lockfile
+++ b/core/gradle/dependency-locks/runtime.lockfile
@@ -75,7 +75,6 @@ com.google.cloud.bigdataoss:util:1.9.16
 com.google.cloud.bigtable:bigtable-client-core:1.8.0
 com.google.cloud.datastore:datastore-v1-proto-client:1.6.0
 com.google.cloud.sql:jdbc-socket-factory-core:1.0.12
-com.google.cloud.sql:postgres-socket-factory:1.0.12
 com.google.cloud:google-cloud-bigquerystorage:0.79.0-alpha
 com.google.cloud:google-cloud-bigtable-admin:0.73.0-alpha
 com.google.cloud:google-cloud-bigtable:0.73.0-alpha

--- a/core/gradle/dependency-locks/testCompile.lockfile
+++ b/core/gradle/dependency-locks/testCompile.lockfile
@@ -76,7 +76,6 @@ com.google.cloud.bigdataoss:util:1.9.16
 com.google.cloud.bigtable:bigtable-client-core:1.8.0
 com.google.cloud.datastore:datastore-v1-proto-client:1.6.0
 com.google.cloud.sql:jdbc-socket-factory-core:1.0.12
-com.google.cloud.sql:postgres-socket-factory:1.0.12
 com.google.cloud:google-cloud-bigquerystorage:0.79.0-alpha
 com.google.cloud:google-cloud-bigtable-admin:0.73.0-alpha
 com.google.cloud:google-cloud-bigtable:0.73.0-alpha

--- a/core/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/core/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -76,7 +76,6 @@ com.google.cloud.bigdataoss:util:1.9.16
 com.google.cloud.bigtable:bigtable-client-core:1.8.0
 com.google.cloud.datastore:datastore-v1-proto-client:1.6.0
 com.google.cloud.sql:jdbc-socket-factory-core:1.0.12
-com.google.cloud.sql:postgres-socket-factory:1.0.12
 com.google.cloud:google-cloud-bigquerystorage:0.79.0-alpha
 com.google.cloud:google-cloud-bigtable-admin:0.73.0-alpha
 com.google.cloud:google-cloud-bigtable:0.73.0-alpha


### PR DESCRIPTION
It turns out that we need `com.google.cloud.sql:jdbc-socket-factory-core` as a compile dependency instead of `com.google.cloud.sql:postgres-socket-factory`. Though, `com.google.cloud.sql:postgres-socket-factory` depends on `com.google.cloud.sql:jdbc-socket-factory-core`.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/522)
<!-- Reviewable:end -->
