### PR TITLE
Drop postgresql schema instead of database in Sql tests

### DIFF
--- a/core/src/test/resources/google/registry/persistence/transaction/cleanup_database.sql
+++ b/core/src/test/resources/google/registry/persistence/transaction/cleanup_database.sql
@@ -12,5 +12,8 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-DROP DATABASE IF EXISTS postgres;
-CREATE DATABASE postgres;
+-- In Postgresql, recreating schema is faster than recreating the database.
+DROP SCHEMA public CASCADE;
+CREATE SCHEMA public;
+GRANT USAGE ON SCHEMA public to PUBLIC;
+GRANT CREATE ON SCHEMA public to PUBLIC;


### PR DESCRIPTION
Speed up the database cleanup between tests by dropping the 'schema'
(Postgresql term, not the DDL scripts) instead of the database. The new 
approach is much faster.

Ad hoc measurement on my desktop shows that :core:sqlIntegrationTest
improves from 73 seconds to 48 seconds, and :core:standardTest
improves from 12m40 to 7m40.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/530)
<!-- Reviewable:end -->
