### PR TITLE
Don't rely on the password field's existence for admins

### DIFF
--- a/core/src/main/javascript/google/registry/ui/js/registrar/registry_lock.js
+++ b/core/src/main/javascript/google/registry/ui/js/registrar/registry_lock.js
@@ -121,7 +121,10 @@ registry.registrar.RegistryLock.prototype.showModal_ = function(targetElement, d
   if (domain == null) {
     goog.dom.getRequiredElement('domain-lock-input-value').focus();
   } else {
-    goog.dom.getRequiredElement('domain-lock-password').focus();
+    var passwordElem = goog.dom.getElement('domain-lock-password');
+    if (passwordElem != null) {
+      passwordElem.focus();
+    }
   }
   // delete the modal when the user clicks the cancel button
   goog.events.listen(
@@ -162,7 +165,8 @@ registry.registrar.RegistryLock.prototype.showModal_ = function(targetElement, d
  */
 registry.registrar.RegistryLock.prototype.lockOrUnlockDomain_ = function(isLock, e) {
   var domain = goog.dom.getRequiredElement('domain-lock-input-value').value;
-  var password = goog.dom.getRequiredElement('domain-lock-password').value;
+  var passwordElem = goog.dom.getElement('domain-lock-password');
+  var password = passwordElem == null ? null : passwordElem.value;
   goog.net.XhrIo.send('/registry-lock-post',
       e => this.fillLocksPage_(e),
       'POST',


### PR DESCRIPTION
We don't have the field when it's an admin user that's logged in. A
nicer language would have caught this unfortunately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/534)
<!-- Reviewable:end -->
