### PR TITLE
Persist DomainBase.nsHosts VKeys to SQL 

### DIFF
--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -79,6 +79,7 @@ import javax.persistence.Column;
 import javax.persistence.Convert;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
+import javax.persistence.JoinTable;
 import javax.persistence.Transient;
 import org.joda.time.DateTime;
 import org.joda.time.Interval;
@@ -144,6 +145,7 @@ public class DomainBase extends EppResource
 
   @Ignore
   @ElementCollection
+  @JoinTable(name = "DomainHost")
   @Convert(converter = HostResource.VKeyHostResourceConverter.class)
   Set<VKey<HostResource>> nsHostVKeys;
 

--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -76,6 +76,7 @@ import javax.annotation.Nullable;
 import javax.persistence.AttributeOverride;
 import javax.persistence.AttributeOverrides;
 import javax.persistence.Column;
+import javax.persistence.Convert;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embedded;
 import javax.persistence.Transient;
@@ -141,7 +142,10 @@ public class DomainBase extends EppResource
    */
   @Index @ElementCollection @Transient Set<Key<HostResource>> nsHosts;
 
-  @Ignore @Transient Set<VKey<HostResource>> nsHostVKeys;
+  @Ignore
+  @ElementCollection
+  @Convert(converter = HostResource.VKeyHostResourceConverter.class)
+  Set<VKey<HostResource>> nsHostVKeys;
 
   /**
    * The union of the contacts visible via {@link #getContacts} and {@link #getRegistrant}.

--- a/core/src/main/java/google/registry/model/host/HostResource.java
+++ b/core/src/main/java/google/registry/model/host/HostResource.java
@@ -34,22 +34,25 @@ import google.registry.model.annotations.ReportedOn;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.transfer.TransferData;
 import google.registry.persistence.VKey;
+import google.registry.persistence.converter.VKeyConverter;
 import java.net.InetAddress;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
+import javax.persistence.ElementCollection;
 import org.joda.time.DateTime;
 
 /**
  * A persistable Host resource including mutable and non-mutable fields.
  *
- * <p>A host's {@link TransferData} is stored on the superordinate domain.  Non-subordinate hosts
+ * <p>A host's {@link TransferData} is stored on the superordinate domain. Non-subordinate hosts
  * don't carry a full set of TransferData; all they have is lastTransferTime.
  *
  * @see <a href="https://tools.ietf.org/html/rfc5732">RFC 5732</a>
  */
 @ReportedOn
 @Entity
+@javax.persistence.Entity
 @ExternalMessagingName("host")
 public class HostResource extends EppResource implements ForeignKeyedEppResource {
 
@@ -64,8 +67,7 @@ public class HostResource extends EppResource implements ForeignKeyedEppResource
   String fullyQualifiedHostName;
 
   /** IP Addresses for this host. Can be null if this is an external host. */
-  @Index
-  Set<InetAddress> inetAddresses;
+  @Index @ElementCollection Set<InetAddress> inetAddresses;
 
   /** The superordinate domain of this host, or null if this is an external host. */
   @Index
@@ -208,6 +210,13 @@ public class HostResource extends EppResource implements ForeignKeyedEppResource
     public Builder setLastTransferTime(DateTime lastTransferTime) {
       getInstance().lastTransferTime = lastTransferTime;
       return this;
+    }
+  }
+
+  public static class VKeyHostResourceConverter extends VKeyConverter<HostResource> {
+    @Override
+    protected Class<HostResource> getAttributeClass() {
+      return HostResource.class;
     }
   }
 }

--- a/core/src/main/resources/META-INF/persistence.xml
+++ b/core/src/main/resources/META-INF/persistence.xml
@@ -20,6 +20,7 @@
       *  Use Hibernate's ServiceRegistry for bootstrapping (not JPA-compliant)
     -->
     <class>google.registry.model.domain.DomainBase</class>
+    <class>google.registry.model.host.HostResource</class>
     <class>google.registry.model.registrar.Registrar</class>
     <class>google.registry.model.registrar.RegistrarContact</class>
     <class>google.registry.schema.domain.RegistryLock</class>
@@ -45,6 +46,7 @@
     <class>google.registry.persistence.converter.StringListConverter</class>
     <class>google.registry.persistence.converter.StringSetConverter</class>
     <class>google.registry.persistence.converter.UpdateAutoTimestampConverter</class>
+    <class>google.registry.persistence.converter.VKeyConverter</class>
     <class>google.registry.persistence.converter.ZonedDateTimeConverter</class>
 
     <!-- TODO(weiminyu): check out application-layer validation. -->

--- a/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.joda.time.DateTimeZone.UTC;
+import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableSet;
 import com.googlecode.objectify.Key;
@@ -27,11 +28,15 @@ import google.registry.model.domain.launch.LaunchNotice;
 import google.registry.model.domain.secdns.DelegationSignerData;
 import google.registry.model.eppcommon.AuthInfo.PasswordAuth;
 import google.registry.model.eppcommon.StatusValue;
+import google.registry.model.host.HostResource;
+import google.registry.persistence.VKey;
 import google.registry.persistence.transaction.JpaTestRules;
 import google.registry.persistence.transaction.JpaTestRules.JpaIntegrationWithCoverageExtension;
 import google.registry.testing.DatastoreEntityExtension;
 import google.registry.testing.FakeClock;
+import java.sql.SQLException;
 import javax.persistence.EntityManager;
+import javax.persistence.RollbackException;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
@@ -54,11 +59,15 @@ public class DomainBaseSqlTest {
   DomainBase domain;
   Key<ContactResource> contactKey;
   Key<ContactResource> contact2Key;
+  VKey<HostResource> host1VKey;
+  HostResource host;
 
   @BeforeEach
   public void setUp() {
     contactKey = Key.create(ContactResource.class, "contact_id1");
     contact2Key = Key.create(ContactResource.class, "contact_id2");
+
+    host1VKey = VKey.createSql(HostResource.class, "host1");
 
     domain =
         new DomainBase.Builder()
@@ -68,6 +77,7 @@ public class DomainBaseSqlTest {
             .setLastEppUpdateTime(fakeClock.nowUtc())
             .setLastEppUpdateClientId("AnotherRegistrar")
             .setLastTransferTime(fakeClock.nowUtc())
+            .setNameservers(host1VKey)
             .setStatusValues(
                 ImmutableSet.of(
                     StatusValue.CLIENT_DELETE_PROHIBITED,
@@ -87,6 +97,12 @@ public class DomainBaseSqlTest {
                 LaunchNotice.create("tcnid", "validatorId", START_OF_TIME, START_OF_TIME))
             .setSmdId("smdid")
             .build();
+
+    host =
+        new HostResource.Builder()
+            .setRepoId("host1")
+            .setFullyQualifiedHostName("ns1.example.com")
+            .build();
   }
 
   @Test
@@ -97,6 +113,9 @@ public class DomainBaseSqlTest {
               // Persist the domain.
               EntityManager em = jpaTm().getEntityManager();
               em.persist(domain);
+
+              // Persist the host.
+              em.persist(host);
             });
 
     jpaTm()
@@ -124,5 +143,33 @@ public class DomainBaseSqlTest {
               // Note that the equality comparison forces a lazy load of all fields.
               assertThat(result).isEqualTo(org);
             });
+  }
+
+  @Test
+  public void testForeignKeyConstraints() {
+    Exception e =
+        assertThrows(
+            RollbackException.class,
+            () -> {
+              jpaTm()
+                  .transact(
+                      () -> {
+                        // Persist the domain without the associated host object.
+                        EntityManager em = jpaTm().getEntityManager();
+                        em.persist(domain);
+                      });
+            });
+    assertThat(e)
+        .hasCauseThat() // ConstraintViolationException
+        .hasCauseThat() // ConstraintViolationException
+        .hasCauseThat()
+        .isInstanceOf(SQLException.class);
+    assertThat(e)
+        .hasCauseThat() // ConstraintViolationException
+        .hasCauseThat() // ConstraintViolationException
+        .hasCauseThat()
+        .hasMessageThat()
+        .contains(
+            "\"Domain_nsHostVKeys\" violates foreign key constraint \"fk_domain_nshostvkeys_host");
   }
 }

--- a/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
@@ -169,7 +169,6 @@ public class DomainBaseSqlTest {
         .hasCauseThat() // ConstraintViolationException
         .hasCauseThat()
         .hasMessageThat()
-        .contains(
-            "\"Domain_nsHostVKeys\" violates foreign key constraint \"fk_domain_nshostvkeys_host");
+        .contains("\"DomainHost\" violates foreign key constraint \"fk_domainhost_host");
   }
 }

--- a/db/src/main/resources/sql/flyway/V22__update_ns_hosts.sql
+++ b/db/src/main/resources/sql/flyway/V22__update_ns_hosts.sql
@@ -1,0 +1,54 @@
+-- Copyright 2020 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+create table "Domain_nsHostVKeys" (
+   domain_repo_id text not null,
+    ns_host_v_keys text
+);
+
+create table "HostResource" (
+   repo_id text not null,
+    creation_client_id text,
+    creation_time timestamptz,
+    current_sponsor_client_id text,
+    deletion_time timestamptz,
+    last_epp_update_client_id text,
+    last_epp_update_time timestamptz,
+    statuses text[],
+    fully_qualified_host_name text,
+    last_superordinate_change timestamptz,
+    last_transfer_time timestamptz,
+    superordinate_domain bytea,
+    primary key (repo_id)
+);
+
+create table "HostResource_inetAddresses" (
+   host_resource_repo_id text not null,
+    inet_addresses bytea
+);
+
+alter table if exists "Domain_nsHostVKeys"
+   add constraint FKfmi7bdink53swivs390m2btxg
+   foreign key (domain_repo_id)
+   references "Domain";
+
+alter table if exists "Domain_nsHostVKeys"
+  add constraint FK_Domain_nsHostVKeys_host_valid
+  foreign key (ns_host_v_keys)
+  references "HostResource";
+
+alter table if exists "HostResource_inetAddresses"
+   add constraint FK6unwhfkcu3oq6q347fxvpagv
+   foreign key (host_resource_repo_id)
+   references "HostResource";

--- a/db/src/main/resources/sql/flyway/V22__update_ns_hosts.sql
+++ b/db/src/main/resources/sql/flyway/V22__update_ns_hosts.sql
@@ -12,7 +12,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-create table "Domain_nsHostVKeys" (
+create table "DomainHost" (
    domain_repo_id text not null,
     ns_host_v_keys text
 );
@@ -38,13 +38,13 @@ create table "HostResource_inetAddresses" (
     inet_addresses bytea
 );
 
-alter table if exists "Domain_nsHostVKeys"
+alter table if exists "DomainHost"
    add constraint FKfmi7bdink53swivs390m2btxg
    foreign key (domain_repo_id)
    references "Domain";
 
-alter table if exists "Domain_nsHostVKeys"
-  add constraint FK_Domain_nsHostVKeys_host_valid
+alter table if exists "DomainHost"
+  add constraint FK_DomainHost_host_valid
   foreign key (ns_host_v_keys)
   references "HostResource";
 

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -67,7 +67,7 @@
         primary key (repo_id)
     );
 
-    create table "Domain_nsHostVKeys" (
+    create table "DomainHost" (
        domain_repo_id text not null,
         ns_host_v_keys text
     );
@@ -248,8 +248,8 @@ create index reservedlist_name_idx on "ReservedList" (name);
        foreign key (revision_id) 
        references "ClaimsList";
 
-    alter table if exists "Domain_nsHostVKeys" 
-       add constraint FKfmi7bdink53swivs390m2btxg 
+    alter table if exists "DomainHost" 
+       add constraint FKeq1guccbre1yk3oosgp2io554 
        foreign key (domain_repo_id) 
        references "Domain";
 

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -67,6 +67,11 @@
         primary key (repo_id)
     );
 
+    create table "Domain_nsHostVKeys" (
+       domain_repo_id text not null,
+        ns_host_v_keys text
+    );
+
     create table "GracePeriod" (
        id  bigserial not null,
         billing_event_one_time bytea,
@@ -75,6 +80,27 @@
         expiration_time timestamptz,
         type int4,
         primary key (id)
+    );
+
+    create table "HostResource" (
+       repo_id text not null,
+        creation_client_id text,
+        creation_time timestamptz,
+        current_sponsor_client_id text,
+        deletion_time timestamptz,
+        last_epp_update_client_id text,
+        last_epp_update_time timestamptz,
+        statuses text[],
+        fully_qualified_host_name text,
+        last_superordinate_change timestamptz,
+        last_transfer_time timestamptz,
+        superordinate_domain bytea,
+        primary key (repo_id)
+    );
+
+    create table "HostResource_inetAddresses" (
+       host_resource_repo_id text not null,
+        inet_addresses bytea
     );
 
     create table "Lock" (
@@ -221,6 +247,16 @@ create index reservedlist_name_idx on "ReservedList" (name);
        add constraint FK6sc6at5hedffc0nhdcab6ivuq 
        foreign key (revision_id) 
        references "ClaimsList";
+
+    alter table if exists "Domain_nsHostVKeys" 
+       add constraint FKfmi7bdink53swivs390m2btxg 
+       foreign key (domain_repo_id) 
+       references "Domain";
+
+    alter table if exists "HostResource_inetAddresses" 
+       add constraint FK6unwhfkcu3oq6q347fxvpagv 
+       foreign key (host_resource_repo_id) 
+       references "HostResource";
 
     alter table if exists "PremiumEntry" 
        add constraint FKo0gw90lpo1tuee56l0nb6y6g5 

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -117,10 +117,10 @@ CREATE TABLE public."Domain" (
 
 
 --
--- Name: Domain_nsHostVKeys; Type: TABLE; Schema: public; Owner: -
+-- Name: DomainHost; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public."Domain_nsHostVKeys" (
+CREATE TABLE public."DomainHost" (
     domain_repo_id text NOT NULL,
     ns_host_v_keys text
 );
@@ -619,18 +619,18 @@ ALTER TABLE ONLY public."HostResource_inetAddresses"
 
 
 --
--- Name: Domain_nsHostVKeys fk_domain_nshostvkeys_host_valid; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: DomainHost fk_domainhost_host_valid; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public."Domain_nsHostVKeys"
-    ADD CONSTRAINT fk_domain_nshostvkeys_host_valid FOREIGN KEY (ns_host_v_keys) REFERENCES public."HostResource"(repo_id);
+ALTER TABLE ONLY public."DomainHost"
+    ADD CONSTRAINT fk_domainhost_host_valid FOREIGN KEY (ns_host_v_keys) REFERENCES public."HostResource"(repo_id);
 
 
 --
--- Name: Domain_nsHostVKeys fkfmi7bdink53swivs390m2btxg; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: DomainHost fkfmi7bdink53swivs390m2btxg; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public."Domain_nsHostVKeys"
+ALTER TABLE ONLY public."DomainHost"
     ADD CONSTRAINT fkfmi7bdink53swivs390m2btxg FOREIGN KEY (domain_repo_id) REFERENCES public."Domain"(repo_id);
 
 

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -117,6 +117,46 @@ CREATE TABLE public."Domain" (
 
 
 --
+-- Name: Domain_nsHostVKeys; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."Domain_nsHostVKeys" (
+    domain_repo_id text NOT NULL,
+    ns_host_v_keys text
+);
+
+
+--
+-- Name: HostResource; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."HostResource" (
+    repo_id text NOT NULL,
+    creation_client_id text,
+    creation_time timestamp with time zone,
+    current_sponsor_client_id text,
+    deletion_time timestamp with time zone,
+    last_epp_update_client_id text,
+    last_epp_update_time timestamp with time zone,
+    statuses text[],
+    fully_qualified_host_name text,
+    last_superordinate_change timestamp with time zone,
+    last_transfer_time timestamp with time zone,
+    superordinate_domain bytea
+);
+
+
+--
+-- Name: HostResource_inetAddresses; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."HostResource_inetAddresses" (
+    host_resource_repo_id text NOT NULL,
+    inet_addresses bytea
+);
+
+
+--
 -- Name: Lock; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -391,6 +431,14 @@ ALTER TABLE ONLY public."Domain"
 
 
 --
+-- Name: HostResource HostResource_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."HostResource"
+    ADD CONSTRAINT "HostResource_pkey" PRIMARY KEY (repo_id);
+
+
+--
 -- Name: Lock Lock_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -560,6 +608,30 @@ ALTER TABLE ONLY public."RegistryLock"
 
 ALTER TABLE ONLY public."ClaimsEntry"
     ADD CONSTRAINT fk6sc6at5hedffc0nhdcab6ivuq FOREIGN KEY (revision_id) REFERENCES public."ClaimsList"(revision_id);
+
+
+--
+-- Name: HostResource_inetAddresses fk6unwhfkcu3oq6q347fxvpagv; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."HostResource_inetAddresses"
+    ADD CONSTRAINT fk6unwhfkcu3oq6q347fxvpagv FOREIGN KEY (host_resource_repo_id) REFERENCES public."HostResource"(repo_id);
+
+
+--
+-- Name: Domain_nsHostVKeys fk_domain_nshostvkeys_host_valid; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Domain_nsHostVKeys"
+    ADD CONSTRAINT fk_domain_nshostvkeys_host_valid FOREIGN KEY (ns_host_v_keys) REFERENCES public."HostResource"(repo_id);
+
+
+--
+-- Name: Domain_nsHostVKeys fkfmi7bdink53swivs390m2btxg; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Domain_nsHostVKeys"
+    ADD CONSTRAINT fkfmi7bdink53swivs390m2btxg FOREIGN KEY (domain_repo_id) REFERENCES public."Domain"(repo_id);
 
 
 --


### PR DESCRIPTION
Sending this pull request to illustrate how VKey persistence will work in the context of the DomainBase.nsHosts field.

This change depends on #538, which is not yet submitted, so that portion of the PR should go away once we get past that PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/541)
<!-- Reviewable:end -->
