### PR TITLE
Resolve warnings in the Hibernate log

### DIFF
--- a/core/src/main/java/google/registry/schema/tld/PremiumEntry.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumEntry.java
@@ -14,6 +14,7 @@
 
 package google.registry.schema.tld;
 
+import google.registry.model.ImmutableObject;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import javax.persistence.Column;
@@ -26,7 +27,7 @@ import javax.persistence.Id;
  * <p>These are not persisted directly, but rather, using {@link PremiumList#getLabelsToPrices()}.
  */
 @Entity
-public class PremiumEntry implements Serializable {
+public class PremiumEntry extends ImmutableObject implements Serializable {
 
   @Id
   @Column(nullable = false)

--- a/core/src/main/resources/META-INF/orm.xml
+++ b/core/src/main/resources/META-INF/orm.xml
@@ -4,15 +4,10 @@
     xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence/orm
           http://xmlns.jcp.org/xml/ns/persistence/orm_2_2.xsd"
     version="2.2">
-  <embeddable class="org.joda.money.Money" access="FIELD">
-    <attributes>
-      <embedded name="money" access="FIELD"/>
-    </attributes>
-  </embeddable>
+  <embeddable class="org.joda.money.Money" access="FIELD" />
   <embeddable class="org.joda.money.BigMoney" access="FIELD">
     <attributes>
       <basic name="amount" access="FIELD"/>
-      <basic name="currency" access="FIELD"/>
     </attributes>
   </embeddable>
 </entity-mappings>


### PR DESCRIPTION
This PR resolved the warnings displayed when running a nomulus command:

```shell
Mar 27, 2020 5:07:56 PM org.hibernate.cfg.annotations.reflection.JPAOverriddenAnnotationReader checkForOrphanProperties
WARN: HHH000207: Property org.joda.money.Money.money not found in class but described in <mapping-file/> (possible typo error)
Mar 27, 2020 5:07:56 PM org.hibernate.cfg.annotations.reflection.JPAOverriddenAnnotationReader checkForOrphanProperties
WARN: HHH000207: Property org.joda.money.BigMoney.currency not found in class but described in <mapping-file/> (possible typo error)
Mar 27, 2020 5:07:56 PM org.hibernate.mapping.RootClass checkCompositeIdentifier
WARN: HHH000038: Composite-id class does not override equals(): google.registry.schema.tld.PremiumEntry
Mar 27, 2020 5:07:56 PM org.hibernate.mapping.RootClass checkCompositeIdentifier
WARN: HHH000039: Composite-id class does not override hashCode(): google.registry.schema.tld.PremiumEntry
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/542)
<!-- Reviewable:end -->
