### PR TITLE
Actually run JUnit 5 tests

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -646,6 +646,10 @@ artifacts {
  */
 class FilteringTest extends Test {
 
+  FilteringTest() {
+    useJUnitPlatform();
+  }
+
   private void applyTestFilter() {
     if (project.testFilter) {
       testNameIncludePatterns = project.testFilter.split(',')

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -72,6 +72,10 @@ dependencies {
     errorprone("com.google.errorprone:error_prone_core:2.3.3")
 }
 
+test {
+  useJUnitPlatform()
+}
+
 tasks.withType(JavaCompile).configureEach {
     // The -Werror flag causes Intellij to fail on deprecated api use.
     // Allow IDE user to turn off this flag by specifying a Gradle VM


### PR DESCRIPTION
In Gradle, JUnit 5 must be explicitly enabled with a call to
test.useJUnitPlatform().

The FilteringTest used in :core must also enable JUnit5 separately.

Fixed AppEngineRule to work with the few tests that have migrated
to JUnit5 (all in one of the two classes named PremiumListTest).

More work is needed with AppEngine before we can migrate tests
that actually use Cloud SQL.

For context, with @EnableRuleMigrationSupport, JUnit 5 runner calls
an external resource's before() and after() methods. TestRule.apply()
is not called, therefore any setup done their will be bypassed with
JUnit 5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/545)
<!-- Reviewable:end -->
