### PR TITLE
Migrate SqlIntegrationTestSuite members  to Junit5

### DIFF
--- a/core/src/test/java/google/registry/model/EntityTestCase.java
+++ b/core/src/test/java/google/registry/model/EntityTestCase.java
@@ -42,22 +42,22 @@ import java.util.Set;
 import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Base class of all unit tests for entities which are persisted to Datastore via Objectify. */
-@RunWith(JUnit4.class)
 public abstract class EntityTestCase {
 
   protected FakeClock fakeClock = new FakeClock(DateTime.now(UTC));
 
-  @Rule
+  @Rule @RegisterExtension
   public final AppEngineRule appEngine =
       AppEngineRule.builder().withDatastoreAndCloudSql().withClock(fakeClock).build();
 
-  @Rule public InjectRule inject = new InjectRule();
+  @Rule @RegisterExtension public InjectRule inject = new InjectRule();
 
   @Before
+  @BeforeEach
   public void injectClock() {
     inject.setStaticField(Ofy.class, "clock", fakeClock);
   }

--- a/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
@@ -28,20 +28,17 @@ import google.registry.model.domain.secdns.DelegationSignerData;
 import google.registry.model.eppcommon.AuthInfo.PasswordAuth;
 import google.registry.model.eppcommon.StatusValue;
 import javax.persistence.EntityManager;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /** Verify that we can store/retrieve DomainBase objects from a SQL database. */
-@RunWith(JUnit4.class)
 public class DomainBaseSqlTest extends EntityTestCase {
 
   DomainBase domain;
   Key<ContactResource> contactKey;
   Key<ContactResource> contact2Key;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     contactKey = Key.create(ContactResource.class, "contact_id1");
     contact2Key = Key.create(ContactResource.class, "contact_id2");

--- a/core/src/test/java/google/registry/model/registry/RegistryLockDaoTest.java
+++ b/core/src/test/java/google/registry/model/registry/RegistryLockDaoTest.java
@@ -31,18 +31,15 @@ import google.registry.testing.AppEngineRule;
 import google.registry.testing.FakeClock;
 import java.util.Optional;
 import org.joda.time.Duration;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link RegistryLockDao}. */
-@RunWith(JUnit4.class)
 public final class RegistryLockDaoTest {
 
   private final FakeClock fakeClock = new FakeClock();
 
-  @Rule
+  @RegisterExtension
   public final AppEngineRule appEngine =
       AppEngineRule.builder().withDatastoreAndCloudSql().withClock(fakeClock).build();
 

--- a/core/src/test/java/google/registry/schema/registrar/RegistrarDaoTest.java
+++ b/core/src/test/java/google/registry/schema/registrar/RegistrarDaoTest.java
@@ -23,20 +23,17 @@ import google.registry.model.EntityTestCase;
 import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.RegistrarAddress;
 import google.registry.persistence.VKey;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link RegistrarDao}. */
-@RunWith(JUnit4.class)
+/** Unit tests for persisting {@link Registrar} entities. */
 public class RegistrarDaoTest extends EntityTestCase {
 
   private final VKey<Registrar> registrarKey = VKey.createSql(Registrar.class, "registrarId");
 
   private Registrar testRegistrar;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     testRegistrar =
         new Registrar.Builder()

--- a/core/src/test/java/google/registry/schema/server/LockDaoTest.java
+++ b/core/src/test/java/google/registry/schema/server/LockDaoTest.java
@@ -19,28 +19,25 @@ import static google.registry.testing.LogsSubject.assertAboutLogs;
 
 import com.google.common.testing.TestLogHandler;
 import google.registry.persistence.transaction.JpaTestRules;
-import google.registry.persistence.transaction.JpaTestRules.JpaIntegrationWithCoverageRule;
+import google.registry.persistence.transaction.JpaTestRules.JpaIntegrationWithCoverageExtension;
 import google.registry.testing.FakeClock;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.joda.time.Duration;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link Lock}. */
-@RunWith(JUnit4.class)
 public class LockDaoTest {
 
   private final FakeClock fakeClock = new FakeClock();
   private final TestLogHandler logHandler = new TestLogHandler();
   private final Logger loggerToIntercept = Logger.getLogger(LockDao.class.getCanonicalName());
 
-  @Rule
-  public final JpaIntegrationWithCoverageRule jpaRule =
-      new JpaTestRules.Builder().withClock(fakeClock).buildIntegrationWithCoverageRule();
+  @RegisterExtension
+  public final JpaIntegrationWithCoverageExtension jpa =
+      new JpaTestRules.Builder().withClock(fakeClock).buildIntegrationWithCoverageExtension();
 
   @Test
   public void save_worksSuccessfully() {

--- a/core/src/test/java/google/registry/schema/tld/PremiumListDaoTest.java
+++ b/core/src/test/java/google/registry/schema/tld/PremiumListDaoTest.java
@@ -34,19 +34,16 @@ import java.math.BigDecimal;
 import java.util.Optional;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link PremiumListDao}. */
-@RunWith(JUnit4.class)
 public class PremiumListDaoTest {
 
   private final FakeClock fakeClock = new FakeClock();
 
-  @Rule
+  @RegisterExtension
   public final AppEngineRule appEngine =
       AppEngineRule.builder().withDatastoreAndCloudSql().withClock(fakeClock).build();
 
@@ -124,7 +121,7 @@ public class PremiumListDaoTest {
 
   // TODO(b/147246613): Un-ignore this.
   @Test
-  @Ignore
+  @Disabled
   public void update_throwsWhenListDoesntExist() {
     IllegalArgumentException thrown =
         assertThrows(

--- a/core/src/test/java/google/registry/schema/tld/ReservedListDaoTest.java
+++ b/core/src/test/java/google/registry/schema/tld/ReservedListDaoTest.java
@@ -20,23 +20,20 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.registry.label.ReservationType;
 import google.registry.persistence.transaction.JpaTestRules;
-import google.registry.persistence.transaction.JpaTestRules.JpaIntegrationWithCoverageRule;
+import google.registry.persistence.transaction.JpaTestRules.JpaIntegrationWithCoverageExtension;
 import google.registry.schema.tld.ReservedList.ReservedEntry;
 import google.registry.testing.FakeClock;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link ReservedListDao}. */
-@RunWith(JUnit4.class)
 public class ReservedListDaoTest {
 
   private final FakeClock fakeClock = new FakeClock();
 
-  @Rule
-  public final JpaIntegrationWithCoverageRule jpaRule =
-      new JpaTestRules.Builder().withClock(fakeClock).buildIntegrationWithCoverageRule();
+  @RegisterExtension
+  public final JpaIntegrationWithCoverageExtension jpa =
+      new JpaTestRules.Builder().withClock(fakeClock).buildIntegrationWithCoverageExtension();
 
   private static final ImmutableMap<String, ReservedEntry> TEST_RESERVATIONS =
       ImmutableMap.of(

--- a/core/src/test/java/google/registry/schema/tmch/ClaimsListDaoTest.java
+++ b/core/src/test/java/google/registry/schema/tmch/ClaimsListDaoTest.java
@@ -18,22 +18,19 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import google.registry.persistence.transaction.JpaTestRules;
-import google.registry.persistence.transaction.JpaTestRules.JpaIntegrationWithCoverageRule;
+import google.registry.persistence.transaction.JpaTestRules.JpaIntegrationWithCoverageExtension;
 import google.registry.testing.FakeClock;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link ClaimsListDao}. */
-@RunWith(JUnit4.class)
 public class ClaimsListDaoTest {
 
   private final FakeClock fakeClock = new FakeClock();
 
-  @Rule
-  public final JpaIntegrationWithCoverageRule jpaRule =
-      new JpaTestRules.Builder().withClock(fakeClock).buildIntegrationWithCoverageRule();
+  @RegisterExtension
+  public final JpaIntegrationWithCoverageExtension jpa =
+      new JpaTestRules.Builder().withClock(fakeClock).buildIntegrationWithCoverageExtension();
 
   @Test
   public void trySave_insertsClaimsListSuccessfully() {

--- a/core/src/test/java/google/registry/testing/InjectRule.java
+++ b/core/src/test/java/google/registry/testing/InjectRule.java
@@ -22,6 +22,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.rules.ExternalResource;
 
 /**
@@ -44,9 +46,10 @@ import org.junit.rules.ExternalResource;
  * to be evil; but hopefully one day we'll be able to delete this class and do things
  * <i>properly</i> with <a href="http://square.github.io/dagger/">Dagger</a> dependency injection.
  *
- * <p>You use this class by declaring it as a {@link org.junit.Rule &#064;Rule} field and then
- * calling {@link #setStaticField} from either your {@link org.junit.Test &#064;Test} or {@link
- * org.junit.Before &#064;Before} methods. For example:
+ * <p>This class temporarily supports both JUnit4 and JUnit5. You use this class in JUnit4 by
+ * declaring it as a {@link org.junit.Rule &#064;Rule} field and then calling {@link
+ * #setStaticField} from either your {@link org.junit.Test &#064;Test} or {@link org.junit.Before
+ * &#064;Before} methods. For example:
  *
  * <pre>
  * // Doomsday.java
@@ -85,7 +88,7 @@ import org.junit.rules.ExternalResource;
  * @see google.registry.util.NonFinalForTesting
  * @see org.junit.rules.ExternalResource
  */
-public class InjectRule extends ExternalResource {
+public class InjectRule extends ExternalResource implements AfterEachCallback {
 
   private static class Change {
     private final Field field;
@@ -138,6 +141,11 @@ public class InjectRule extends ExternalResource {
     }
     changes.add(new Change(field, oldValue, newValue));
     injected.add(field);
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) throws Exception {
+    after();
   }
 
   @Override


### PR DESCRIPTION
Made InjectRule and EntityTestCase work with both JUnit4 and 5.

Note that "@RunWith(JUnit4.class)" is no longer needed on
JUnit4 test classes. Therefore, its removal from EntityTestCase
has no impact on child classes. All of them are still included in
tests.

Migrated remaining member classes in SqlIntegrationTestSuite to JUnit5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/550)
<!-- Reviewable:end -->
