### PR TITLE
Add a Test workaround for certain Linux distro

### DIFF
--- a/core/src/nonprod/java/google/registry/tools/DumpGoldenSchemaCommand.java
+++ b/core/src/nonprod/java/google/registry/tools/DumpGoldenSchemaCommand.java
@@ -36,6 +36,9 @@ public class DumpGoldenSchemaCommand extends PostgresqlCommand {
   // The mount point in the container.
   private static final String CONTAINER_MOUNT_POINT = "/tmp/pg_dump.out";
 
+  // Temporary workaround to fix permission issues on certain Linux distro (e. g. Arch Linux).
+  private static final String CONTAINER_MOUNT_POINT_TMP = "/tmp/pg_dump.tmp";
+
   @Parameter(
       names = {"--output", "-o"},
       description = "Output file",
@@ -61,6 +64,11 @@ public class DumpGoldenSchemaCommand extends PostgresqlCommand {
     if (result.getExitCode() != 0) {
       throw new RuntimeException(result.toString());
     }
+    result = postgresContainer.execInContainer(
+        "cp", CONTAINER_MOUNT_POINT_TMP, CONTAINER_MOUNT_POINT);
+    if (result.getExitCode() != 0) {
+      throw new RuntimeException(result.toString());
+    }
   }
 
   @Override
@@ -79,7 +87,7 @@ public class DumpGoldenSchemaCommand extends PostgresqlCommand {
       "-U",
       username,
       "-f",
-      CONTAINER_MOUNT_POINT,
+      CONTAINER_MOUNT_POINT_TMP,
       "--schema-only",
       "--no-owner",
       "--no-privileges",


### PR DESCRIPTION
On Arch Linux, DumpGoldenSchemaCommandTest failed due to the follow
error:

java.lang.RuntimeException: Container.ExecResult(exitCode=1, stdout=, stderr=pg_dump: [archiver] could not open output file "/tmp/pg_dump.out": Is a directory)

However I cannot figure out why this permission error happens, as the
docker command is executed as root. Saving the pg_dump output to a
temporary file and copy it over the mapped file works, so I don't
know...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/552)
<!-- Reviewable:end -->
