### PR TITLE
Disable JpaEntityCoverageCheck by default

### DIFF
--- a/core/src/test/java/google/registry/model/EntityTestCase.java
+++ b/core/src/test/java/google/registry/model/EntityTestCase.java
@@ -50,11 +50,22 @@ public abstract class EntityTestCase {
 
   protected FakeClock fakeClock = new FakeClock(DateTime.now(UTC));
 
-  @Rule @RegisterExtension
-  public final AppEngineRule appEngine =
-      AppEngineRule.builder().withDatastoreAndCloudSql().withClock(fakeClock).build();
+  @Rule @RegisterExtension public final AppEngineRule appEngine;
 
   @Rule @RegisterExtension public InjectRule inject = new InjectRule();
+
+  protected EntityTestCase() {
+    this(false);
+  }
+
+  protected EntityTestCase(boolean enableJpaEntityCheck) {
+    appEngine =
+        AppEngineRule.builder()
+            .withDatastoreAndCloudSql()
+            .enableJpaEntityCoverageCheck(enableJpaEntityCheck)
+            .withClock(fakeClock)
+            .build();
+  }
 
   @Before
   @BeforeEach

--- a/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
@@ -38,6 +38,10 @@ public class DomainBaseSqlTest extends EntityTestCase {
   Key<ContactResource> contactKey;
   Key<ContactResource> contact2Key;
 
+  public DomainBaseSqlTest() {
+    super(true);
+  }
+
   @BeforeEach
   public void setUp() {
     contactKey = Key.create(ContactResource.class, "contact_id1");

--- a/core/src/test/java/google/registry/model/registry/RegistryLockDaoTest.java
+++ b/core/src/test/java/google/registry/model/registry/RegistryLockDaoTest.java
@@ -41,7 +41,11 @@ public final class RegistryLockDaoTest {
 
   @RegisterExtension
   public final AppEngineRule appEngine =
-      AppEngineRule.builder().withDatastoreAndCloudSql().withClock(fakeClock).build();
+      AppEngineRule.builder()
+          .withDatastoreAndCloudSql()
+          .enableJpaEntityCoverageCheck(true)
+          .withClock(fakeClock)
+          .build();
 
   @Test
   public void testSaveAndLoad_success() {

--- a/core/src/test/java/google/registry/schema/cursor/CursorDaoTest.java
+++ b/core/src/test/java/google/registry/schema/cursor/CursorDaoTest.java
@@ -43,7 +43,11 @@ public class CursorDaoTest {
 
   @RegisterExtension
   public final AppEngineRule appEngine =
-      AppEngineRule.builder().withDatastoreAndCloudSql().withClock(fakeClock).build();
+      AppEngineRule.builder()
+          .withDatastoreAndCloudSql()
+          .enableJpaEntityCoverageCheck(true)
+          .withClock(fakeClock)
+          .build();
 
   @Test
   public void save_worksSuccessfullyOnNewCursor() {

--- a/core/src/test/java/google/registry/schema/registrar/RegistrarDaoTest.java
+++ b/core/src/test/java/google/registry/schema/registrar/RegistrarDaoTest.java
@@ -33,6 +33,10 @@ public class RegistrarDaoTest extends EntityTestCase {
 
   private Registrar testRegistrar;
 
+  public RegistrarDaoTest() {
+    super(true);
+  }
+
   @BeforeEach
   public void setUp() {
     testRegistrar =

--- a/core/src/test/java/google/registry/schema/tld/PremiumListDaoTest.java
+++ b/core/src/test/java/google/registry/schema/tld/PremiumListDaoTest.java
@@ -45,7 +45,11 @@ public class PremiumListDaoTest {
 
   @RegisterExtension
   public final AppEngineRule appEngine =
-      AppEngineRule.builder().withDatastoreAndCloudSql().withClock(fakeClock).build();
+      AppEngineRule.builder()
+          .withDatastoreAndCloudSql()
+          .enableJpaEntityCoverageCheck(true)
+          .withClock(fakeClock)
+          .build();
 
   private static final ImmutableMap<String, BigDecimal> TEST_PRICES =
       ImmutableMap.of(


### PR DESCRIPTION
Only members of SqlIntegrationTestSuite should enable the check,
which incurs per-test overhead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/555)
<!-- Reviewable:end -->
