### PR TITLE
Allow a --token option when checking a domain

### DIFF
--- a/core/src/main/java/google/registry/tools/CheckDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/CheckDomainCommand.java
@@ -14,6 +14,8 @@
 
 package google.registry.tools;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.common.collect.Multimap;
@@ -39,6 +41,11 @@ final class CheckDomainCommand extends NonMutatingEppToolCommand {
       required = true)
   private List<String> mainParameters;
 
+  @Parameter(
+      names = {"-t", "--token"},
+      description = "Allocation token to use in the command, if desired")
+  private String allocationToken;
+
   @Inject
   @Config("registryAdminClientId")
   String registryAdminClientId;
@@ -53,7 +60,11 @@ final class CheckDomainCommand extends NonMutatingEppToolCommand {
     Multimap<String, String> domainNameMap = validateAndGroupDomainNamesByTld(mainParameters);
     for (Collection<String> values : domainNameMap.asMap().values()) {
       setSoyTemplate(DomainCheckSoyInfo.getInstance(), DomainCheckSoyInfo.DOMAINCHECK);
-      addSoyRecord(clientId, new SoyMapData("domainNames", values));
+      SoyMapData soyMapData = new SoyMapData("domainNames", values);
+      if (!isNullOrEmpty(allocationToken)) {
+        soyMapData.put("allocationToken", allocationToken);
+      }
+      addSoyRecord(clientId, soyMapData);
     }
   }
 }

--- a/core/src/main/resources/google/registry/tools/soy/DomainCheck.soy
+++ b/core/src/main/resources/google/registry/tools/soy/DomainCheck.soy
@@ -19,6 +19,7 @@
  */
 {template .domaincheck stricthtml="false"}
 {@param domainNames: list<string>}
+{@param? allocationToken: string|null}
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
   <command>
@@ -39,6 +40,12 @@
         </fee:domain>
       {/for}
       </fee:check>
+      {if isNonnull($allocationToken)}
+        <allocationToken:allocationToken
+            xmlns:allocationToken="urn:ietf:params:xml:ns:allocationToken-1.0">
+          {$allocationToken}
+        </allocationToken:allocationToken>
+      {/if}
     </extension>
     <clTRID>RegistryTool</clTRID>
   </command>

--- a/core/src/test/java/google/registry/tools/CheckDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CheckDomainCommandTest.java
@@ -77,6 +77,12 @@ public class CheckDomainCommandTest extends EppToolCommandTestCase<CheckDomainCo
   }
 
   @Test
+  public void testSuccess_allocationToken_reserved() throws Exception {
+    runCommand("--client=NewRegistrar", "--token=abc123", "example.tld");
+    eppVerifier.expectDryRun().verifySent("domain_check_fee_allocationtoken.xml");
+  }
+
+  @Test
   public void testFailure_NoMainParameter() {
     assertThrows(ParameterException.class, () -> runCommand("--client=NewRegistrar"));
   }

--- a/core/src/test/resources/google/registry/tools/server/domain_check_fee_allocationtoken.xml
+++ b/core/src/test/resources/google/registry/tools/server/domain_check_fee_allocationtoken.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <command>
+    <check>
+      <domain:check xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>example.tld</domain:name>
+      </domain:check>
+    </check>
+    <extension>
+      <fee:check xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
+        <fee:domain>
+          <fee:name>example.tld</fee:name>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">1</fee:period>
+        </fee:domain>
+      </fee:check>
+      <allocationToken:allocationToken
+          xmlns:allocationToken="urn:ietf:params:xml:ns:allocationToken-1.0">
+        abc123
+      </allocationToken:allocationToken>
+    </extension>
+    <clTRID>RegistryTool</clTRID>
+  </command>
+</epp>


### PR DESCRIPTION
This isn't strictly necessary and can be done via the raw EPP xml command, but it'll make things easier to test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/556)
<!-- Reviewable:end -->
