### PR TITLE
Add SqlEntity and DatastoreEntity interfaces

### DIFF
--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -66,6 +66,7 @@ import google.registry.model.registry.Registry;
 import google.registry.model.transfer.TransferData;
 import google.registry.model.transfer.TransferStatus;
 import google.registry.persistence.VKey;
+import google.registry.schema.replay.DatastoreAndSqlEntity;
 import google.registry.util.CollectionUtils;
 import java.util.HashSet;
 import java.util.Objects;
@@ -107,7 +108,7 @@ import org.joda.time.Interval;
     })
 @ExternalMessagingName("domain")
 public class DomainBase extends EppResource
-    implements ForeignKeyedEppResource, ResourceWithTransferData {
+    implements ForeignKeyedEppResource, ResourceWithTransferData, DatastoreAndSqlEntity {
 
   /** The max number of years that a domain can be registered for, as set by ICANN policy. */
   public static final int MAX_REGISTRATION_YEARS = 10;

--- a/core/src/main/java/google/registry/model/registrar/Registrar.java
+++ b/core/src/main/java/google/registry/model/registrar/Registrar.java
@@ -73,6 +73,7 @@ import google.registry.model.annotations.ReportedOn;
 import google.registry.model.common.EntityGroupRoot;
 import google.registry.model.registrar.Registrar.BillingAccountEntry.CurrencyMapper;
 import google.registry.model.registry.Registry;
+import google.registry.schema.replay.DatastoreAndSqlEntity;
 import google.registry.util.CidrAddressBlock;
 import java.security.cert.CertificateParsingException;
 import java.util.Comparator;
@@ -107,11 +108,12 @@ import org.joda.time.DateTime;
           columnList = "ianaIdentifier",
           name = "registrar_iana_identifier_idx"),
     })
-public class Registrar extends ImmutableObject implements Buildable, Jsonifiable {
+public class Registrar extends ImmutableObject
+    implements Buildable, Jsonifiable, DatastoreAndSqlEntity {
 
   /** Represents the type of a registrar entity. */
   public enum Type {
-    /** A real-world, third-party registrar.  Should have non-null IANA and billing IDs. */
+    /** A real-world, third-party registrar. Should have non-null IANA and billing IDs. */
     REAL(Objects::nonNull),
 
     /**

--- a/core/src/main/java/google/registry/schema/replay/DatastoreAndSqlEntity.java
+++ b/core/src/main/java/google/registry/schema/replay/DatastoreAndSqlEntity.java
@@ -1,0 +1,31 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.schema.replay;
+
+import com.google.common.collect.ImmutableList;
+
+/** An entity that has the same Java object representation in SQL and Datastore. */
+public interface DatastoreAndSqlEntity extends DatastoreEntity, SqlEntity {
+
+  @Override
+  default ImmutableList<DatastoreEntity> toDatastoreEntities() {
+    return ImmutableList.of(this);
+  }
+
+  @Override
+  default ImmutableList<SqlEntity> toSqlEntities() {
+    return ImmutableList.of(this);
+  }
+}

--- a/core/src/main/java/google/registry/schema/replay/DatastoreEntity.java
+++ b/core/src/main/java/google/registry/schema/replay/DatastoreEntity.java
@@ -1,0 +1,30 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.schema.replay;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * An object that can be stored in Datastore and serialized using Objectify's {@link
+ * com.googlecode.objectify.cmd.Saver#toEntity(Object)} code.
+ *
+ * <p>This is used when replaying {@link google.registry.model.ofy.CommitLogManifest}s to import
+ * transactions and data into the secondary SQL store during the first, Datastore-primary, phase of
+ * the migration.
+ */
+public interface DatastoreEntity {
+
+  ImmutableList<SqlEntity> toSqlEntities();
+}

--- a/core/src/main/java/google/registry/schema/replay/SqlEntity.java
+++ b/core/src/main/java/google/registry/schema/replay/SqlEntity.java
@@ -1,0 +1,29 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.schema.replay;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * An object that can be stored in Cloud SQL using {@link
+ * javax.persistence.EntityManager#persist(Object)}
+ *
+ * <p>This will be used when replaying SQL transactions into Datastore, during the second,
+ * SQL-primary, phase of the migration from Datastore to SQL.
+ */
+public interface SqlEntity {
+
+  ImmutableList<DatastoreEntity> toDatastoreEntities();
+}

--- a/core/src/test/java/google/registry/schema/replay/EntityTest.java
+++ b/core/src/test/java/google/registry/schema/replay/EntityTest.java
@@ -14,9 +14,12 @@
 
 package google.registry.schema.replay;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.ImmutableSet;
 import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
 import io.github.classgraph.ClassInfoList;
 import io.github.classgraph.ScanResult;
 import org.junit.Ignore;
@@ -32,18 +35,31 @@ public class EntityTest {
   public void testSqlEntityPersistence() {
     try (ScanResult scanResult =
         new ClassGraph().enableAnnotationInfo().whitelistPackages("google.registry").scan()) {
-      // All javax.persistence entities must implement SqlEntity
-      ClassInfoList failingJavaxEntities =
-          scanResult
-              .getClassesWithAnnotation(javax.persistence.Entity.class.getName())
-              .filter(info -> !info.implementsInterface(SqlEntity.class.getName()));
-      assertThat(failingJavaxEntities).isEmpty();
-      // All com.googlecode.objectify.annotation.Entity classes must implement DatastoreEntity
-      ClassInfoList failingObjectifyEntries =
-          scanResult
-              .getClassesWithAnnotation(com.googlecode.objectify.annotation.Entity.class.getName())
-              .filter(info -> !info.implementsInterface(DatastoreEntity.class.getName()));
-      assertThat(failingObjectifyEntries).isEmpty();
+      // All javax.persistence entities must implement SqlEntity and vice versa
+      ImmutableSet<String> javaxPersistenceClasses =
+          getClassNames(
+              scanResult.getClassesWithAnnotation(javax.persistence.Entity.class.getName()));
+      ImmutableSet<String> sqlEntityClasses =
+          getClassNames(scanResult.getClassesImplementing(SqlEntity.class.getName()));
+      assertThat(javaxPersistenceClasses).isEqualTo(sqlEntityClasses);
+
+      // All com.googlecode.objectify.annotation.Entity classes must implement DatastoreEntity and
+      // vice versa
+      ImmutableSet<String> objectifyClasses =
+          getClassNames(
+              scanResult.getClassesWithAnnotation(
+                  com.googlecode.objectify.annotation.Entity.class.getName()));
+      ImmutableSet<String> datastoreEntityClasses =
+          getClassNames(scanResult.getClassesImplementing(DatastoreEntity.class.getName()));
+      assertThat(objectifyClasses).isEqualTo(datastoreEntityClasses);
     }
+  }
+
+  private ImmutableSet<String> getClassNames(ClassInfoList classInfoList) {
+    return classInfoList.stream()
+        .filter(ClassInfo::isStandardClass)
+        .map(ClassInfo::loadClass)
+        .map(Class::getName)
+        .collect(toImmutableSet());
   }
 }

--- a/core/src/test/java/google/registry/schema/replay/EntityTest.java
+++ b/core/src/test/java/google/registry/schema/replay/EntityTest.java
@@ -1,0 +1,49 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.schema.replay;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfoList;
+import io.github.classgraph.ScanResult;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Test to verify classes implement {@link SqlEntity} and {@link DatastoreEntity} when they should.
+ */
+public class EntityTest {
+
+  @Test
+  @Ignore("This won't be done until b/152410794 is done, since it requires many entity changes")
+  public void testSqlEntityPersistence() {
+    try (ScanResult scanResult =
+        new ClassGraph().enableAnnotationInfo().whitelistPackages("google.registry").scan()) {
+      // All javax.persistence entities must implement SqlEntity
+      ClassInfoList failingJavaxEntities =
+          scanResult
+              .getClassesWithAnnotation(javax.persistence.Entity.class.getName())
+              .filter(info -> !info.implementsInterface(SqlEntity.class.getName()));
+      assertThat(failingJavaxEntities).isEmpty();
+      // All com.googlecode.objectify.annotation.Entity classes must implement DatastoreEntity
+      ClassInfoList failingObjectifyEntries =
+          scanResult
+              .getClassesWithAnnotation(com.googlecode.objectify.annotation.Entity.class.getName())
+              .filter(info -> !info.implementsInterface(DatastoreEntity.class.getName()));
+      assertThat(failingObjectifyEntries).isEmpty();
+    }
+  }
+}


### PR DESCRIPTION
These will be used when replaying transactions from either the Datastore
commit logs or the SQL Transaction objects.

When Datastore is the primary database, we will read in the
Datastore commit logs, convert each saved entity to however many SQL
entities, then save those SQL entities in SQL.

When SQL is the primary database, we will read in the SQL objects from a
yet-to-be-created SQL table, convert them to however many Datastore
entities, then save those Datastore entities in Datastore.

This PR includes an example of how this will work for entities that are
saveable in both SQL and Datastore (the simple case).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/562)
<!-- Reviewable:end -->
