### PR TITLE
Remove separate deployment of persistence.xml

### DIFF
--- a/appengine_war.gradle
+++ b/appengine_war.gradle
@@ -31,10 +31,6 @@ def coreResourcesDir = "${rootDir}/core/build/resources/main"
 war {
     webInf {
         from "../../core/src/main/java/google/registry/env/common/${project.name}/WEB-INF"
-
-        from("${coreResourcesDir}/META-INF/persistence.xml") {
-            into "classes/META-INF"
-        }
     }
 }
 


### PR DESCRIPTION
We added a step to explicitly copy persistence.xml because for some reason it
wasn't originally getting deployed to app-engine, resulting in failures on
startup.  However, this file is now included in core.jar and we are now
getting a warning about multiple persistence units with the same name as it
reads the files from both the filesystem and core.jar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/563)
<!-- Reviewable:end -->
