### PR TITLE
Allow the `nomulus renew_domain` command to specify the client ID

### DIFF
--- a/core/src/main/java/google/registry/tools/RenewDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/RenewDomainCommand.java
@@ -15,6 +15,7 @@
 package google.registry.tools;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static google.registry.model.EppResourceUtils.loadByForeignKey;
 import static google.registry.util.CollectionUtils.findDuplicates;
 import static google.registry.util.PreconditionsUtils.checkArgumentPresent;
@@ -36,6 +37,13 @@ import org.joda.time.format.DateTimeFormatter;
 /** A command to renew domain(s) via EPP. */
 @Parameters(separators = " =", commandDescription = "Renew domain(s) via EPP.")
 final class RenewDomainCommand extends MutatingEppToolCommand {
+
+  @Parameter(
+      names = {"-c", "--client"},
+      description =
+          "The registrar to execute as and bill the renewal to; otherwise each domain's sponsoring"
+              + " registrar. Renewals by non-sponsoring registrars require --superuser as well.")
+  String clientId;
 
   @Parameter(
       names = {"-p", "--period"},
@@ -63,7 +71,7 @@ final class RenewDomainCommand extends MutatingEppToolCommand {
       setSoyTemplate(RenewDomainSoyInfo.getInstance(), RenewDomainSoyInfo.RENEWDOMAIN);
       DomainBase domain = domainOptional.get();
       addSoyRecord(
-          domain.getCurrentSponsorClientId(),
+          isNullOrEmpty(clientId) ? domain.getCurrentSponsorClientId() : clientId,
           new SoyMapData(
               "domainName", domain.getFullyQualifiedDomainName(),
               "expirationDate", domain.getRegistrationExpirationTime().toString(DATE_FORMATTER),


### PR DESCRIPTION
This means that a superuser can renew a domain and have the associated history
entry, one time billing event, and renewal grace period be recorded against a
specified registrar rather than the owning registrar of the domain.  This is
useful to e.g. renew a domain for free by "charging" the renewal to the
registry's fake registrar.  Since the grace period is written to the specified
cliend id as well, if the actual registrar deletes the domain, they don't get
back the money that they didn't pay in the first place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/567)
<!-- Reviewable:end -->
