### PR TITLE
Fix test failures on certain machines

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -707,7 +707,10 @@ task outcastTest(type: FilteringTest) {
   tests = outcastTestPatterns
 
   // Sets the maximum number of test executors that may exist at the same time.
-  maxParallelForks 5
+  // Note that this number appears to contribute to NoClassDefFoundError
+  // exceptions on certain machines and distros. The root cause is unclear.
+  // Try reducing this number if you experience similar problems.
+  maxParallelForks 3
 }
 
 // Whitebox test verifying that RegistryTool can be instantiated. Note the


### PR DESCRIPTION
On certain machines (one of mine) the outcastTest consistently fails due
to the following error:

java.lang.NoClassDefFoundError: Could not initialize class
google.registry.persistence.transaction.JpaTestRules$JpaIntegrationTestRule

If I reduce maxparallelForks to 3 it consistently passes. This issue was
mentioned here:

https://discuss.gradle.org/t/junit-test-fails-with-noclassdeffounderror-only-when-maxparallelforks-1/6047

But this post was 8 years old and no solution was identified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/571)
<!-- Reviewable:end -->
