### PR TITLE
Revert "Remove minimumIdle config in HikariCP (#557)"

### DIFF
--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -1512,9 +1512,19 @@ public final class RegistryConfig {
     return CONFIG_SETTINGS.get().hibernate.hikariConnectionTimeout;
   }
 
+  /** Returns the minimum idle connections for HikariCP. */
+  public static String getHibernateHikariMinimumIdle() {
+    return CONFIG_SETTINGS.get().hibernate.hikariMinimumIdle;
+  }
+
   /** Returns the maximum pool size for HikariCP. */
   public static String getHibernateHikariMaximumPoolSize() {
     return CONFIG_SETTINGS.get().hibernate.hikariMaximumPoolSize;
+  }
+
+  /** Returns the idle timeout for HikariCP. */
+  public static String getHibernateHikariIdleTimeout() {
+    return CONFIG_SETTINGS.get().hibernate.hikariIdleTimeout;
   }
 
   /** Returns the roid suffix to be used for the roids of all contacts and hosts. */

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -112,7 +112,9 @@ public class RegistryConfigSettings {
     public String connectionIsolation;
     public String logSqlQueries;
     public String hikariConnectionTimeout;
+    public String hikariMinimumIdle;
     public String hikariMaximumPoolSize;
+    public String hikariIdleTimeout;
   }
 
   /** Configuration for Cloud SQL. */

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -207,17 +207,21 @@ hibernate:
 
   # Connection pool configurations.
   hikariConnectionTimeout: 20000
-
   # We occasionally received "Connection is not available, request timed out"
   # exception when setting minimumIdle to 0 and it turned out it is a bug (See
-  # https://github.com/brettwooldridge/HikariCP/issues/1212) in HikariCP and
-  # the workaround is to use a fixed size connection pool.
+  # https://github.com/brettwooldridge/HikariCP/issues/1212) in HikariCP.
+  #
+  # We tried to use a fixed size pool but ran into an issue(See b/155383029),
+  # so we need further investigation to figure out the proper size of the pool.
   #
   # HikariCP also recommends not setting minimumIdle for maximum performance
   # and responsiveness to spike demands (See
   # https://github.com/brettwooldridge/HikariCP).
-  # TODO(b/154720215): Experiment with a smaller pool size.
-  hikariMaximumPoolSize: 20
+  #
+  # TODO(b/154720215): Investigate the long term fix.
+  hikariMinimumIdle: 1
+  hikariMaximumPoolSize: 10
+  hikariIdleTimeout: 300000
 
 cloudSql:
   # jdbc url for the Cloud SQL database.

--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -17,7 +17,9 @@ package google.registry.persistence;
 import static com.google.common.base.Preconditions.checkState;
 import static google.registry.config.RegistryConfig.getHibernateConnectionIsolation;
 import static google.registry.config.RegistryConfig.getHibernateHikariConnectionTimeout;
+import static google.registry.config.RegistryConfig.getHibernateHikariIdleTimeout;
 import static google.registry.config.RegistryConfig.getHibernateHikariMaximumPoolSize;
+import static google.registry.config.RegistryConfig.getHibernateHikariMinimumIdle;
 import static google.registry.config.RegistryConfig.getHibernateLogSqlQueries;
 
 import com.google.api.client.auth.oauth2.Credential;
@@ -48,7 +50,10 @@ public class PersistenceModule {
   // This name must be the same as the one defined in persistence.xml.
   public static final String PERSISTENCE_UNIT_NAME = "nomulus";
   public static final String HIKARI_CONNECTION_TIMEOUT = "hibernate.hikari.connectionTimeout";
+  public static final String HIKARI_MINIMUM_IDLE = "hibernate.hikari.minimumIdle";
   public static final String HIKARI_MAXIMUM_POOL_SIZE = "hibernate.hikari.maximumPoolSize";
+  public static final String HIKARI_IDLE_TIMEOUT = "hibernate.hikari.idleTimeout";
+
   public static final String HIKARI_DS_SOCKET_FACTORY = "hibernate.hikari.dataSource.socketFactory";
   public static final String HIKARI_DS_CLOUD_SQL_INSTANCE =
       "hibernate.hikari.dataSource.cloudSqlInstance";
@@ -74,7 +79,9 @@ public class PersistenceModule {
     properties.put(Environment.ISOLATION, getHibernateConnectionIsolation());
     properties.put(Environment.SHOW_SQL, getHibernateLogSqlQueries());
     properties.put(HIKARI_CONNECTION_TIMEOUT, getHibernateHikariConnectionTimeout());
+    properties.put(HIKARI_MINIMUM_IDLE, getHibernateHikariMinimumIdle());
     properties.put(HIKARI_MAXIMUM_POOL_SIZE, getHibernateHikariMaximumPoolSize());
+    properties.put(HIKARI_IDLE_TIMEOUT, getHibernateHikariIdleTimeout());
     properties.put(Environment.DIALECT, NomulusPostgreSQLDialect.class.getName());
     return properties.build();
   }


### PR DESCRIPTION
Reverts commit d8066ca752ec662249a344a2cc13199029121836 because it caused b/155383029.

This PR reduced the `hikariMaximumPoolSize` to 10 based on the fact that our Cloud SQL instance can only handle 600 concurrent connections and we can have ~50 instances running at the same time during peak.

Also, To mitigate the issue that #557 tried to fix, `hikariMinimumIdle` was increased from 0 to 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/573)
<!-- Reviewable:end -->
