### PR TITLE
Improve return value semantices for tm().load()

### DIFF
--- a/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
+++ b/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
@@ -22,6 +22,7 @@ import com.googlecode.objectify.Key;
 import google.registry.persistence.VKey;
 import google.registry.persistence.transaction.TransactionManager;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.StreamSupport;
@@ -136,8 +137,17 @@ public class DatastoreTransactionManager implements TransactionManager {
   // VKey instead of by ofy Key.  But ideally, there should be one set of TransactionManager
   // interface tests that are applied to both the datastore and SQL implementations.
   @Override
-  public <T> Optional<T> load(VKey<T> key) {
+  public <T> Optional<T> maybeLoad(VKey<T> key) {
     return Optional.of(getOfy().load().key(key.getOfyKey()).now());
+  }
+
+  @Override
+  public <T> T load(VKey<T> key) {
+    T result = getOfy().load().key(key.getOfyKey()).now();
+    if (result == null) {
+      throw new NoSuchElementException(key.toString());
+    }
+    return result;
   }
 
   @Override

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -232,10 +232,21 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   }
 
   @Override
-  public <T> Optional<T> load(VKey<T> key) {
+  public <T> Optional<T> maybeLoad(VKey<T> key) {
     checkArgumentNotNull(key, "key must be specified");
     assertInTransaction();
     return Optional.ofNullable(getEntityManager().find(key.getKind(), key.getSqlKey()));
+  }
+
+  @Override
+  public <T> T load(VKey<T> key) {
+    checkArgumentNotNull(key, "key must be specified");
+    assertInTransaction();
+    T result = getEntityManager().find(key.getKind(), key.getSqlKey());
+    if (result == null) {
+      throw new NoSuchElementException(key.toString());
+    }
+    return result;
   }
 
   @Override

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
@@ -108,7 +108,10 @@ public interface TransactionManager {
   <T> boolean checkExists(VKey<T> key);
 
   /** Loads the entity by its id, returns empty if the entity doesn't exist. */
-  <T> Optional<T> load(VKey<T> key);
+  <T> Optional<T> maybeLoad(VKey<T> key);
+
+  /** Loads the entity by its id, throws NoSuchElementException if it doesn't exist. */
+  <T> T load(VKey<T> key);
 
   /**
    * Leads the set of entities by their key id.

--- a/core/src/test/java/google/registry/model/contact/ContactResourceTest.java
+++ b/core/src/test/java/google/registry/model/contact/ContactResourceTest.java
@@ -140,8 +140,7 @@ public class ContactResourceTest extends EntityTestCase {
             .transact(
                 () ->
                     jpaTm()
-                        .load(VKey.createSql(ContactResource.class, originalContact.getRepoId())))
-            .get();
+                        .load(VKey.createSql(ContactResource.class, originalContact.getRepoId())));
     // TODO(b/153378849): Remove the hard code for postal info after resolving the issue that
     // @PostLoad doesn't work in Address
     ContactResource fixed =

--- a/core/src/test/java/google/registry/persistence/EntityCallbacksListenerTest.java
+++ b/core/src/test/java/google/registry/persistence/EntityCallbacksListenerTest.java
@@ -69,14 +69,14 @@ public class EntityCallbacksListenerTest {
     checkAll(updated, 0, 1, 0, 1);
 
     TestEntity testLoad =
-        jpaTm().transact(() -> jpaTm().load(VKey.createSql(TestEntity.class, "id"))).get();
+        jpaTm().transact(() -> jpaTm().load(VKey.createSql(TestEntity.class, "id")));
     checkAll(testLoad, 0, 0, 0, 1);
 
     TestEntity testRemove =
         jpaTm()
             .transact(
                 () -> {
-                  TestEntity removed = jpaTm().load(VKey.createSql(TestEntity.class, "id")).get();
+                  TestEntity removed = jpaTm().load(VKey.createSql(TestEntity.class, "id"));
                   jpaTm().getEntityManager().remove(removed);
                   return removed;
                 });

--- a/core/src/test/java/google/registry/schema/registrar/RegistrarDaoTest.java
+++ b/core/src/test/java/google/registry/schema/registrar/RegistrarDaoTest.java
@@ -78,7 +78,7 @@ public class RegistrarDaoTest {
   @Test
   public void update_worksSuccessfully() {
     jpaTm().transact(() -> jpaTm().saveNew(testRegistrar));
-    Registrar persisted = jpaTm().transact(() -> jpaTm().load(registrarKey)).get();
+    Registrar persisted = jpaTm().transact(() -> jpaTm().load(registrarKey));
     assertThat(persisted.getRegistrarName()).isEqualTo("registrarName");
     jpaTm()
         .transact(
@@ -86,7 +86,7 @@ public class RegistrarDaoTest {
                 jpaTm()
                     .update(
                         persisted.asBuilder().setRegistrarName("changedRegistrarName").build()));
-    Registrar updated = jpaTm().transact(() -> jpaTm().load(registrarKey)).get();
+    Registrar updated = jpaTm().transact(() -> jpaTm().load(registrarKey));
     assertThat(updated.getRegistrarName()).isEqualTo("changedRegistrarName");
   }
 
@@ -102,7 +102,7 @@ public class RegistrarDaoTest {
   public void load_worksSuccessfully() {
     assertThat(jpaTm().transact(() -> jpaTm().checkExists(testRegistrar))).isFalse();
     jpaTm().transact(() -> jpaTm().saveNew(testRegistrar));
-    Registrar persisted = jpaTm().transact(() -> jpaTm().load(registrarKey)).get();
+    Registrar persisted = jpaTm().transact(() -> jpaTm().load(registrarKey));
 
     assertThat(persisted.getClientId()).isEqualTo("registrarId");
     assertThat(persisted.getRegistrarName()).isEqualTo("registrarName");

--- a/core/src/test/java/google/registry/tools/UpdateRegistrarCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateRegistrarCommandTest.java
@@ -53,7 +53,6 @@ public class UpdateRegistrarCommandTest extends CommandTestCase<UpdateRegistrarC
     assertThat(
             jpaTm()
                 .transact(() -> jpaTm().load(VKey.createSql(Registrar.class, "NewRegistrar")))
-                .get()
                 .verifyPassword("some_password"))
         .isTrue();
   }


### PR DESCRIPTION
Since we rarely (if ever) want to check the result of a single element load,
make TransactionManager.load(VKey) return non-optional, non-nullable and just
throw a NoSuchElementException if the entity is not found.

Also add a maybeLoad() that does return an optional in case we ever want to do
this (exists() should suffice for an existence check).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/576)
<!-- Reviewable:end -->
