### PR TITLE
Add a HostHistory and abstract EppHistory table

### DIFF
--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -66,6 +66,7 @@ import google.registry.model.registry.Registry;
 import google.registry.model.transfer.TransferData;
 import google.registry.model.transfer.TransferStatus;
 import google.registry.persistence.VKey;
+import google.registry.persistence.WithStringVKey;
 import google.registry.schema.replay.DatastoreAndSqlEntity;
 import google.registry.util.CollectionUtils;
 import java.util.HashSet;
@@ -107,6 +108,7 @@ import org.joda.time.Interval;
       @javax.persistence.Index(columnList = "tld")
     })
 @ExternalMessagingName("domain")
+@WithStringVKey
 public class DomainBase extends EppResource
     implements DatastoreAndSqlEntity, ForeignKeyedEppResource, ResourceWithTransferData {
 

--- a/core/src/main/java/google/registry/model/reporting/DomainTransactionRecord.java
+++ b/core/src/main/java/google/registry/model/reporting/DomainTransactionRecord.java
@@ -21,6 +21,8 @@ import com.google.common.collect.ImmutableSet;
 import com.googlecode.objectify.annotation.Embed;
 import google.registry.model.Buildable;
 import google.registry.model.ImmutableObject;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
 import org.joda.time.DateTime;
 
 /**
@@ -34,9 +36,11 @@ import org.joda.time.DateTime;
  * uses HistoryEntry.otherClientId because the losing party in a transfer is always the otherClient.
  */
 @Embed
+@Embeddable
 public class DomainTransactionRecord extends ImmutableObject implements Buildable {
 
   /** The TLD this record operates on. */
+  @Column(nullable = false)
   String tld;
 
   /**
@@ -50,9 +54,11 @@ public class DomainTransactionRecord extends ImmutableObject implements Buildabl
    *     href="https://www.icann.org/resources/unthemed-pages/registry-agmt-appc-10-2001-05-11-en">
    *     Grace period spec</a>
    */
+  @Column(nullable = false)
   DateTime reportingTime;
 
   /** The transaction report field we add reportAmount to for this registrar. */
+  @Column(nullable = false)
   TransactionReportField reportField;
 
   /**
@@ -67,6 +73,7 @@ public class DomainTransactionRecord extends ImmutableObject implements Buildabl
    * original SUCCESSFUL transfer counters. Finally, if we explicitly allow a transfer, the report
    * amount is 0, as we've already counted the transfer in the original request.
    */
+  @Column(nullable = false)
   Integer reportAmount;
 
   /**

--- a/core/src/main/java/google/registry/schema/history/EppHistory.java
+++ b/core/src/main/java/google/registry/schema/history/EppHistory.java
@@ -1,0 +1,190 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.schema.history;
+
+import static google.registry.util.CollectionUtils.nullToEmptyImmutableCopy;
+
+import com.google.common.collect.ImmutableSet;
+import google.registry.model.Buildable;
+import google.registry.model.CreateAutoTimestamp;
+import google.registry.model.ImmutableObject;
+import google.registry.model.eppcommon.Trid;
+import google.registry.model.reporting.DomainTransactionRecord;
+import google.registry.model.reporting.HistoryEntry;
+import java.util.Set;
+import javax.annotation.Nullable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import org.joda.time.DateTime;
+
+/**
+ * Common fields for history objects, added to all history objects in addition to the
+ * entity-specific fields.
+ */
+@MappedSuperclass
+public abstract class EppHistory extends ImmutableObject {
+
+  // Note: we don't reference the parent entity in this abstract class since we don't know the type
+  // and we might use different VKey types for different domain/contact/host types
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(nullable = false)
+  long revisionId;
+
+  /** The type of this history object. */
+  @Column(nullable = false)
+  HistoryEntry.Type type;
+
+  /** The id of the registrar that sent the command. */
+  @Column(nullable = false)
+  String registrarId;
+
+  /**
+   * For transfers, the id of the other registrar.
+   *
+   * <p>For requests and cancels, the other registrar is the losing party (because the registrar
+   * sending the EPP transfer command is the gaining party). For approves and rejects, the other
+   * registrar is the gaining party.
+   */
+  String otherRegistrarId;
+
+  @Column(nullable = false)
+  CreateAutoTimestamp creationTime = CreateAutoTimestamp.create(null);
+
+  byte[] xmlBytes;
+
+  /** Transaction id that made this change, or null if the entry was not created by a flow. */
+  Trid trid;
+
+  /** Whether this change was created by a superuser. */
+  boolean bySuperuser;
+
+  /** Reason for the change. */
+  String reason;
+
+  /** Whether this change was requested by a registrar. */
+  Boolean requestedByRegistrar;
+
+  /**
+   * Logging field for transaction reporting.
+   *
+   * <p>This will be empty for any HistoryEntry generated before this field was added. This will
+   * also be empty if the HistoryEntry refers to an EPP mutation that does not affect domain
+   * transaction counts (such as contact or host mutations).
+   */
+  @ElementCollection Set<DomainTransactionRecord> domainTransactionRecords;
+
+  public HistoryEntry.Type getType() {
+    return type;
+  }
+
+  public byte[] getXmlBytes() {
+    return xmlBytes;
+  }
+
+  public DateTime getCreationTime() {
+    return creationTime.getTimestamp();
+  }
+
+  public String getRegistrarId() {
+    return registrarId;
+  }
+
+  public String getOtherRegistrarId() {
+    return otherRegistrarId;
+  }
+
+  /** Returns the TRID, which may be null if the entry was not created by a normal flow. */
+  @Nullable
+  public Trid getTrid() {
+    return trid;
+  }
+
+  public boolean getBySuperuser() {
+    return bySuperuser;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+
+  public Boolean getRequestedByRegistrar() {
+    return requestedByRegistrar;
+  }
+
+  public ImmutableSet<DomainTransactionRecord> getDomainTransactionRecords() {
+    return nullToEmptyImmutableCopy(domainTransactionRecords);
+  }
+
+  protected abstract static class Builder<T extends EppHistory>
+      extends Buildable.Builder<T> {
+    public Builder() {}
+
+    public Builder(T instance) {
+      super(instance);
+    }
+
+    public Builder<T> setType(HistoryEntry.Type type) {
+      getInstance().type = type;
+      return this;
+    }
+
+    public Builder<T> setXmlBytes(byte[] xmlBytes) {
+      getInstance().xmlBytes = xmlBytes;
+      return this;
+    }
+
+    public Builder<T> setRegistrarId(String registrarId) {
+      getInstance().registrarId = registrarId;
+      return this;
+    }
+
+    public Builder<T> setOtherRegistrarId(String otherRegistrarId) {
+      getInstance().otherRegistrarId = otherRegistrarId;
+      return this;
+    }
+
+    public Builder<T> setTrid(Trid trid) {
+      getInstance().trid = trid;
+      return this;
+    }
+
+    public Builder<T> setBySuperuser(boolean bySuperuser) {
+      getInstance().bySuperuser = bySuperuser;
+      return this;
+    }
+
+    public Builder<T> setReason(String reason) {
+      getInstance().reason = reason;
+      return this;
+    }
+
+    public Builder<T> setRequestedByRegistrar(Boolean requestedByRegistrar) {
+      getInstance().requestedByRegistrar = requestedByRegistrar;
+      return this;
+    }
+
+    public Builder<T> setDomainTransactionRecords(
+        ImmutableSet<DomainTransactionRecord> domainTransactionRecords) {
+      getInstance().domainTransactionRecords = domainTransactionRecords;
+      return this;
+    }
+  }
+}

--- a/core/src/main/java/google/registry/schema/history/HostHistory.java
+++ b/core/src/main/java/google/registry/schema/history/HostHistory.java
@@ -1,0 +1,92 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.schema.history;
+
+import static google.registry.util.CollectionUtils.nullToEmptyImmutableCopy;
+
+import com.google.common.collect.ImmutableSet;
+import google.registry.model.domain.DomainBase;
+import google.registry.model.host.HostResource;
+import google.registry.persistence.VKey;
+import java.net.InetAddress;
+import java.util.Set;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.Index;
+import javax.persistence.Table;
+import org.joda.time.DateTime;
+
+/** A history of a host modification, including all the field from the host in question. */
+@Entity
+@Table(indexes = {@Index(columnList = "registrarId"), @Index(columnList = "creationTime")})
+public class HostHistory extends EppHistory {
+
+  VKey<HostResource> referencedEntity;
+
+  String fullyQualifiedHostName;
+
+  @ElementCollection Set<InetAddress> inetAddresses;
+
+  VKey<DomainBase> superordinateDomain;
+
+  DateTime lastTransferTime;
+
+  DateTime lastSuperordinateChange;
+
+  public VKey<HostResource> getReferencedEntity() {
+    return referencedEntity;
+  }
+
+  public String getFullyQualifiedHostName() {
+    return fullyQualifiedHostName;
+  }
+
+  public ImmutableSet<InetAddress> getInetAddresses() {
+    return nullToEmptyImmutableCopy(inetAddresses);
+  }
+
+  public VKey<DomainBase> getSuperordinateDomain() {
+    return superordinateDomain;
+  }
+
+  public DateTime getLastTransferTime() {
+    return lastTransferTime;
+  }
+
+  public DateTime getLastSuperordinateChange() {
+    return lastSuperordinateChange;
+  }
+
+  public static class Builder extends EppHistory.Builder<HostHistory> {
+    public Builder() {}
+
+    public Builder(HostHistory instance) {
+      super(instance);
+    }
+
+    public Builder setHostResource(HostResource hostResource) {
+      getInstance().referencedEntity = VKey.createSql(HostResource.class, hostResource.getRepoId());
+      getInstance().fullyQualifiedHostName = hostResource.getFullyQualifiedHostName();
+      getInstance().inetAddresses = hostResource.getInetAddresses();
+      if (hostResource.getSuperordinateDomain() != null) {
+        getInstance().superordinateDomain =
+            VKey.createOfy(DomainBase.class, hostResource.getSuperordinateDomain());
+      }
+      getInstance().lastTransferTime = hostResource.getLastTransferTime();
+      getInstance().lastSuperordinateChange = hostResource.getLastSuperordinateChange();
+      return this;
+    }
+  }
+}

--- a/core/src/main/resources/META-INF/persistence.xml
+++ b/core/src/main/resources/META-INF/persistence.xml
@@ -27,6 +27,7 @@
     <class>google.registry.schema.domain.RegistryLock</class>
     <class>google.registry.schema.tmch.ClaimsList</class>
     <class>google.registry.schema.cursor.Cursor</class>
+    <class>google.registry.schema.history.HostHistory</class>
     <class>google.registry.schema.server.Lock</class>
     <class>google.registry.schema.tld.PremiumList</class>
     <class>google.registry.schema.tld.PremiumEntry</class>
@@ -51,8 +52,9 @@
     <class>google.registry.persistence.converter.ZonedDateTimeConverter</class>
 
     <!-- Generated converters for VKey -->
-    <class>google.registry.model.host.VKeyConverter_HostResource</class>
     <class>google.registry.model.contact.VKeyConverter_ContactResource</class>
+    <class>google.registry.model.domain.VKeyConverter_DomainBase</class>
+    <class>google.registry.model.host.VKeyConverter_HostResource</class>
 
     <!-- TODO(weiminyu): check out application-layer validation. -->
     <validation-mode>NONE</validation-mode>

--- a/core/src/test/java/google/registry/model/ofy/DatastoreTransactionManagerTest.java
+++ b/core/src/test/java/google/registry/model/ofy/DatastoreTransactionManagerTest.java
@@ -28,8 +28,8 @@ import google.registry.testing.AppEngineRule;
 import google.registry.testing.FakeClock;
 import google.registry.testing.InjectRule;
 import java.util.NoSuchElementException;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class DatastoreTransactionManagerTest {
@@ -97,8 +97,7 @@ public class DatastoreTransactionManagerTest {
     assertThrows(
         RuntimeException.class,
         () ->
-            tm()
-                .transact(
+            tm().transact(
                     () -> {
                       tm().saveNew(theEntity);
                       throw new RuntimeException();

--- a/core/src/test/java/google/registry/schema/history/HostHistoryTest.java
+++ b/core/src/test/java/google/registry/schema/history/HostHistoryTest.java
@@ -1,0 +1,71 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.schema.history;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.SqlHelper.newHostResource;
+
+import com.google.common.collect.ImmutableSet;
+import google.registry.model.EntityTestCase;
+import google.registry.model.eppcommon.Trid;
+import google.registry.model.host.HostResource;
+import google.registry.model.reporting.HistoryEntry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link HostHistory}. */
+public class HostHistoryTest extends EntityTestCase {
+
+  private HostResource host;
+  private HostHistory hostHistory;
+
+  public HostHistoryTest() {
+    super(true);
+  }
+
+  @BeforeEach
+  public void setup() {
+    host = newHostResource("host1");
+    hostHistory =
+        new HostHistory.Builder()
+            .setHostResource(host)
+            .setBySuperuser(false)
+            .setRegistrarId("TheRegistrar")
+            .setReason("reason")
+            .setRequestedByRegistrar(true)
+            .setType(HistoryEntry.Type.HOST_UPDATE)
+            .setXmlBytes(new byte[] {1, 2, 3})
+            .setTrid(Trid.create("clientId", "serverId"))
+            .setDomainTransactionRecords(ImmutableSet.of())
+            .build();
+    jpaTm().transact(() -> jpaTm().saveNew(host));
+  }
+
+  @Test
+  public void testPersistence() {
+    long revisionId =
+        jpaTm().transact(() -> jpaTm().getEntityManager().merge(hostHistory)).revisionId;
+    jpaTm()
+        .transact(
+            () -> {
+              HostHistory fromDatabase =
+                  jpaTm().getEntityManager().find(HostHistory.class, revisionId);
+              hostHistory.creationTime = fromDatabase.creationTime;
+              hostHistory.revisionId = revisionId;
+              assertThat(fromDatabase).isEqualTo(hostHistory);
+            });
+  }
+}

--- a/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
+++ b/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
@@ -21,6 +21,7 @@ import google.registry.model.domain.DomainBaseSqlTest;
 import google.registry.model.registry.RegistryLockDaoTest;
 import google.registry.persistence.transaction.JpaEntityCoverage;
 import google.registry.schema.cursor.CursorDaoTest;
+import google.registry.schema.history.HostHistoryTest;
 import google.registry.schema.integration.SqlIntegrationTestSuite.AfterSuiteTest;
 import google.registry.schema.integration.SqlIntegrationTestSuite.BeforeSuiteTest;
 import google.registry.schema.registrar.RegistrarDaoTest;
@@ -72,6 +73,7 @@ import org.junit.runner.RunWith;
   ContactResourceTest.class,
   CursorDaoTest.class,
   DomainBaseSqlTest.class,
+  HostHistoryTest.class,
   LockDaoTest.class,
   PremiumListDaoTest.class,
   RegistrarDaoTest.class,

--- a/db/src/main/resources/sql/flyway/V25__create_host_history.sql
+++ b/db/src/main/resources/sql/flyway/V25__create_host_history.sql
@@ -1,0 +1,60 @@
+-- Copyright 2020 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+CREATE TABLE "HostHistory" (
+   revision_id  bigserial NOT NULL,
+    by_superuser boolean NOT NULL,
+    creation_time timestamptz NOT NULL,
+    other_registrar_id text,
+    reason text,
+    registrar_id text NOT NULL,
+    requested_by_registrar boolean,
+    client_transaction_id text,
+    server_transaction_id text,
+    type int4 NOT NULL,
+    xml_bytes bytea,
+    fully_qualified_host_name text,
+    last_superordinate_change timestamptz,
+    last_transfer_time timestamptz,
+    referenced_entity text,
+    superordinate_domain text,
+    PRIMARY KEY (revision_id)
+);
+
+CREATE TABLE "HostHistory_domainTransactionRecords" (
+   host_history_revision_id int8 NOT NULL,
+    report_amount int4 NOT NULL,
+    report_field int4 NOT NULL,
+    reporting_time timestamptz NOT NULL,
+    tld text NOT NULL,
+    PRIMARY KEY (host_history_revision_id, report_amount, report_field, reporting_time, tld)
+);
+
+CREATE TABLE "HostHistory_inetAddresses" (
+   host_history_revision_id int8 NOT NULL,
+    inet_addresses bytea
+);
+
+CREATE INDEX IDXnxei34hfrt20dyxtphh6j25mo ON "HostHistory" (registrar_id);
+CREATE INDEX IDXfg2nnjlujxo6cb9fha971bq2n ON "HostHistory" (creation_time);
+
+ALTER TABLE IF EXISTS "HostHistory_domainTransactionRecords"
+   ADD CONSTRAINT FKofp2dm4xd9my12aex1456rn7d
+   FOREIGN KEY (host_history_revision_id)
+   REFERENCES "HostHistory";
+       
+ALTER TABLE IF EXISTS "HostHistory_inetAddresses"
+   ADD CONSTRAINT FKdxdtvupo2b6xlqsq4og4nlo7k
+   FOREIGN KEY (host_history_revision_id)
+   REFERENCES "HostHistory";

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -135,6 +135,40 @@
         primary key (id)
     );
 
+    create table "HostHistory" (
+       revision_id  bigserial not null,
+        by_superuser boolean not null,
+        creation_time timestamptz not null,
+        other_registrar_id text,
+        reason text,
+        registrar_id text not null,
+        requested_by_registrar boolean,
+        client_transaction_id text,
+        server_transaction_id text,
+        type int4 not null,
+        xml_bytes bytea,
+        fully_qualified_host_name text,
+        last_superordinate_change timestamptz,
+        last_transfer_time timestamptz,
+        referenced_entity text,
+        superordinate_domain text,
+        primary key (revision_id)
+    );
+
+    create table "HostHistory_domainTransactionRecords" (
+       host_history_revision_id int8 not null,
+        report_amount int4 not null,
+        report_field int4 not null,
+        reporting_time timestamptz not null,
+        tld text not null,
+        primary key (host_history_revision_id, report_amount, report_field, reporting_time, tld)
+    );
+
+    create table "HostHistory_inetAddresses" (
+       host_history_revision_id int8 not null,
+        inet_addresses bytea
+    );
+
     create table "HostResource" (
        repo_id text not null,
         creation_client_id text not null,
@@ -292,6 +326,8 @@ create index IDX8ffrqm27qtj20jac056j7yq07 on "Domain" (current_sponsor_client_id
 create index IDX5mnf0wn20tno4b9do88j61klr on "Domain" (deletion_time);
 create index IDX1rcgkdd777bpvj0r94sltwd5y on "Domain" (fully_qualified_domain_name);
 create index IDXrwl38wwkli1j7gkvtywi9jokq on "Domain" (tld);
+create index IDXnxei34hfrt20dyxtphh6j25mo on "HostHistory" (registrar_id);
+create index IDXfg2nnjlujxo6cb9fha971bq2n on "HostHistory" (creation_time);
 create index premiumlist_name_idx on "PremiumList" (name);
 create index registrar_name_idx on "Registrar" (registrar_name);
 create index registrar_iana_identifier_idx on "Registrar" (iana_identifier);
@@ -312,6 +348,16 @@ create index reservedlist_name_idx on "ReservedList" (name);
        add constraint FKeq1guccbre1yk3oosgp2io554 
        foreign key (domain_repo_id) 
        references "Domain";
+
+    alter table if exists "HostHistory_domainTransactionRecords" 
+       add constraint FKofp2dm4xd9my12aex1456rn7d 
+       foreign key (host_history_revision_id) 
+       references "HostHistory";
+
+    alter table if exists "HostHistory_inetAddresses" 
+       add constraint FKdxdtvupo2b6xlqsq4og4nlo7k 
+       foreign key (host_history_revision_id) 
+       references "HostHistory";
 
     alter table if exists "HostResource_inetAddresses" 
        add constraint FK6unwhfkcu3oq6q347fxvpagv 

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -184,6 +184,72 @@ CREATE TABLE public."DomainHost" (
 
 
 --
+-- Name: HostHistory; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."HostHistory" (
+    revision_id bigint NOT NULL,
+    by_superuser boolean NOT NULL,
+    creation_time timestamp with time zone NOT NULL,
+    other_registrar_id text,
+    reason text,
+    registrar_id text NOT NULL,
+    requested_by_registrar boolean,
+    client_transaction_id text,
+    server_transaction_id text,
+    type integer NOT NULL,
+    xml_bytes bytea,
+    fully_qualified_host_name text,
+    last_superordinate_change timestamp with time zone,
+    last_transfer_time timestamp with time zone,
+    referenced_entity text,
+    superordinate_domain text
+);
+
+
+--
+-- Name: HostHistory_domainTransactionRecords; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."HostHistory_domainTransactionRecords" (
+    host_history_revision_id bigint NOT NULL,
+    report_amount integer NOT NULL,
+    report_field integer NOT NULL,
+    reporting_time timestamp with time zone NOT NULL,
+    tld text NOT NULL
+);
+
+
+--
+-- Name: HostHistory_inetAddresses; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."HostHistory_inetAddresses" (
+    host_history_revision_id bigint NOT NULL,
+    inet_addresses bytea
+);
+
+
+--
+-- Name: HostHistory_revision_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public."HostHistory_revision_id_seq"
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: HostHistory_revision_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public."HostHistory_revision_id_seq" OWNED BY public."HostHistory".revision_id;
+
+
+--
 -- Name: HostResource; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -435,6 +501,13 @@ ALTER TABLE ONLY public."ClaimsList" ALTER COLUMN revision_id SET DEFAULT nextva
 
 
 --
+-- Name: HostHistory revision_id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."HostHistory" ALTER COLUMN revision_id SET DEFAULT nextval('public."HostHistory_revision_id_seq"'::regclass);
+
+
+--
 -- Name: PremiumList revision_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -493,6 +566,22 @@ ALTER TABLE ONLY public."Cursor"
 
 ALTER TABLE ONLY public."Domain"
     ADD CONSTRAINT "Domain_pkey" PRIMARY KEY (repo_id);
+
+
+--
+-- Name: HostHistory_domainTransactionRecords HostHistory_domainTransactionRecords_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."HostHistory_domainTransactionRecords"
+    ADD CONSTRAINT "HostHistory_domainTransactionRecords_pkey" PRIMARY KEY (host_history_revision_id, report_amount, report_field, reporting_time, tld);
+
+
+--
+-- Name: HostHistory HostHistory_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."HostHistory"
+    ADD CONSTRAINT "HostHistory_pkey" PRIMARY KEY (revision_id);
 
 
 --
@@ -640,6 +729,13 @@ CREATE INDEX idxbn8t4wp85fgxjl8q4ctlscx55 ON public."Contact" USING btree (curre
 
 
 --
+-- Name: idxfg2nnjlujxo6cb9fha971bq2n; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idxfg2nnjlujxo6cb9fha971bq2n ON public."HostHistory" USING btree (creation_time);
+
+
+--
 -- Name: idxkjt9yaq92876dstimd93hwckh; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -651,6 +747,13 @@ CREATE INDEX idxkjt9yaq92876dstimd93hwckh ON public."Domain" USING btree (curren
 --
 
 CREATE INDEX idxn1f711wicdnooa2mqb7g1m55o ON public."Contact" USING btree (deletion_time);
+
+
+--
+-- Name: idxnxei34hfrt20dyxtphh6j25mo; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idxnxei34hfrt20dyxtphh6j25mo ON public."HostHistory" USING btree (registrar_id);
 
 
 --
@@ -792,6 +895,14 @@ ALTER TABLE ONLY public."DomainHost"
 
 
 --
+-- Name: HostHistory_inetAddresses fkdxdtvupo2b6xlqsq4og4nlo7k; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."HostHistory_inetAddresses"
+    ADD CONSTRAINT fkdxdtvupo2b6xlqsq4og4nlo7k FOREIGN KEY (host_history_revision_id) REFERENCES public."HostHistory"(revision_id);
+
+
+--
 -- Name: DomainHost fkfmi7bdink53swivs390m2btxg; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -829,6 +940,14 @@ ALTER TABLE ONLY public."Contact"
 
 ALTER TABLE ONLY public."PremiumEntry"
     ADD CONSTRAINT fko0gw90lpo1tuee56l0nb6y6g5 FOREIGN KEY (revision_id) REFERENCES public."PremiumList"(revision_id);
+
+
+--
+-- Name: HostHistory_domainTransactionRecords fkofp2dm4xd9my12aex1456rn7d; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."HostHistory_domainTransactionRecords"
+    ADD CONSTRAINT fkofp2dm4xd9my12aex1456rn7d FOREIGN KEY (host_history_revision_id) REFERENCES public."HostHistory"(revision_id);
 
 
 --


### PR DESCRIPTION
We will have separate history tables for domain, contact, and host
histories. Each will subclass EppHistory, which contains common fields
about the change itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/584)
<!-- Reviewable:end -->
