### PR TITLE
Add JUnit5 extension to run test twice against different databases

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -880,6 +880,9 @@ task standardTest(type: FilteringTest) {
   // forkEvery 1
 
   // Sets the maximum number of test executors that may exist at the same time.
+  // Also, Gradle executes tests in 1 thread and some of our test infrastructures
+  // depend on that, e.g. DualDatabaseTestInvocationContextProvider injects
+  // different implementation of TransactionManager into TransactionManagerFactory.
   maxParallelForks 5
 
   systemProperty 'test.projectRoot', rootProject.projectRootDir

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerImplTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerImplTest.java
@@ -37,7 +37,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link JpaTransactionManagerImpl}. */
+/**
+ * Unit tests for SQL only APIs defined in {@link JpaTransactionManagerImpl}. Note that the tests
+ * for common APIs in {@link TransactionManager} are added in {@link TransactionManagerTest}.
+ *
+ * <p>TODO(shicong): Remove duplicate tests that covered by TransactionManagerTest by refactoring
+ * the test schema.
+ */
 @RunWith(JUnit4.class)
 public class JpaTransactionManagerImplTest {
 
@@ -61,29 +67,6 @@ public class JpaTransactionManagerImplTest {
           .withClock(fakeClock)
           .withEntityClass(TestEntity.class, TestCompoundIdEntity.class)
           .buildUnitTestRule();
-
-  @Test
-  public void inTransaction_returnsCorrespondingResult() {
-    assertThat(jpaTm().inTransaction()).isFalse();
-    jpaTm().transact(() -> assertThat(jpaTm().inTransaction()).isTrue());
-    assertThat(jpaTm().inTransaction()).isFalse();
-  }
-
-  @Test
-  public void assertInTransaction_throwsExceptionWhenNotInTransaction() {
-    assertThrows(IllegalStateException.class, () -> jpaTm().assertInTransaction());
-    jpaTm().transact(() -> jpaTm().assertInTransaction());
-    assertThrows(IllegalStateException.class, () -> jpaTm().assertInTransaction());
-  }
-
-  @Test
-  public void getTransactionTime_throwsExceptionWhenNotInTransaction() {
-    FakeClock txnClock = fakeClock;
-    txnClock.advanceOneMilli();
-    assertThrows(IllegalStateException.class, () -> jpaTm().getTransactionTime());
-    jpaTm().transact(() -> assertThat(jpaTm().getTransactionTime()).isEqualTo(txnClock.nowUtc()));
-    assertThrows(IllegalStateException.class, () -> jpaTm().getTransactionTime());
-  }
 
   @Test
   public void transact_succeeds() {

--- a/core/src/test/java/google/registry/testing/AppEngineRule.java
+++ b/core/src/test/java/google/registry/testing/AppEngineRule.java
@@ -210,12 +210,12 @@ public final class AppEngineRule extends ExternalResource
     @SafeVarargs
     public final Builder withOfyTestEntities(Class<?>... entities) {
       ofyTestEntities.add(entities);
-      rule.withJpaUnitTest = true;
       return this;
     }
 
     public Builder withJpaUnitTestEntities(Class<?>... entities) {
       jpaTestEntities.add(entities);
+      rule.withJpaUnitTest = true;
       return this;
     }
 
@@ -225,10 +225,10 @@ public final class AppEngineRule extends ExternalResource
           "withJpaEntityCoverageCheck enabled without Cloud SQL");
       checkState(
           !rule.withJpaUnitTest || rule.withDatastoreAndCloudSql,
-          "withOfyTestEntities enabled without Cloud SQL");
+          "withJpaUnitTestEntities enabled without Cloud SQL");
       checkState(
           !rule.withJpaUnitTest || !rule.enableJpaEntityCoverageCheck,
-          "withOfyTestEntities cannot be set when enableJpaEntityCoverageCheck");
+          "withJpaUnitTestEntities cannot be set when enableJpaEntityCoverageCheck");
       rule.ofyTestEntities = this.ofyTestEntities.build();
       rule.jpaTestEntities = this.jpaTestEntities.build();
       return rule;

--- a/core/src/test/java/google/registry/testing/AppEngineRule.java
+++ b/core/src/test/java/google/registry/testing/AppEngineRule.java
@@ -17,6 +17,8 @@ package google.registry.testing;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static google.registry.testing.DatastoreHelper.persistSimpleResources;
+import static google.registry.testing.DualDatabaseTestInvocationContextProvider.injectTmForDualDatabaseTest;
+import static google.registry.testing.DualDatabaseTestInvocationContextProvider.restoreTmAfterDualDatabaseTest;
 import static google.registry.util.ResourceUtils.readResourceUtf8;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.json.XML.toJSONObject;
@@ -45,6 +47,7 @@ import google.registry.persistence.transaction.JpaTestRules;
 import google.registry.persistence.transaction.JpaTestRules.JpaIntegrationTestRule;
 import google.registry.persistence.transaction.JpaTestRules.JpaIntegrationWithCoverageExtension;
 import google.registry.persistence.transaction.JpaTestRules.JpaIntegrationWithCoverageRule;
+import google.registry.persistence.transaction.JpaTestRules.JpaUnitTestRule;
 import google.registry.util.Clock;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -118,8 +121,11 @@ public final class AppEngineRule extends ExternalResource
    */
   JpaIntegrationWithCoverageExtension jpaIntegrationWithCoverageExtension = null;
 
+  JpaUnitTestRule jpaUnitTestRule;
+
   private boolean withDatastoreAndCloudSql;
   private boolean enableJpaEntityCoverageCheck;
+  private boolean withJpaUnitTest;
   private boolean withLocalModules;
   private boolean withTaskQueue;
   private boolean withUserService;
@@ -131,12 +137,14 @@ public final class AppEngineRule extends ExternalResource
 
   // Test Objectify entity classes to be used with this AppEngineRule instance.
   private ImmutableList<Class<?>> ofyTestEntities;
+  private ImmutableList<Class<?>> jpaTestEntities;
 
   /** Builder for {@link AppEngineRule}. */
   public static class Builder {
 
     private AppEngineRule rule = new AppEngineRule();
-    private ImmutableList.Builder<Class<?>> ofyTestEntities = new ImmutableList.Builder();
+    private ImmutableList.Builder<Class<?>> ofyTestEntities = new ImmutableList.Builder<>();
+    private ImmutableList.Builder<Class<?>> jpaTestEntities = new ImmutableList.Builder<>();
 
     /** Turn on the Datastore service and the Cloud SQL service. */
     public Builder withDatastoreAndCloudSql() {
@@ -202,6 +210,12 @@ public final class AppEngineRule extends ExternalResource
     @SafeVarargs
     public final Builder withOfyTestEntities(Class<?>... entities) {
       ofyTestEntities.add(entities);
+      rule.withJpaUnitTest = true;
+      return this;
+    }
+
+    public Builder withJpaUnitTestEntities(Class<?>... entities) {
+      jpaTestEntities.add(entities);
       return this;
     }
 
@@ -209,7 +223,14 @@ public final class AppEngineRule extends ExternalResource
       checkState(
           !rule.enableJpaEntityCoverageCheck || rule.withDatastoreAndCloudSql,
           "withJpaEntityCoverageCheck enabled without Cloud SQL");
+      checkState(
+          !rule.withJpaUnitTest || rule.withDatastoreAndCloudSql,
+          "withOfyTestEntities enabled without Cloud SQL");
+      checkState(
+          !rule.withJpaUnitTest || !rule.enableJpaEntityCoverageCheck,
+          "withOfyTestEntities cannot be set when enableJpaEntityCoverageCheck");
       rule.ofyTestEntities = this.ofyTestEntities.build();
+      rule.jpaTestEntities = this.jpaTestEntities.build();
       return rule;
     }
   }
@@ -328,11 +349,18 @@ public final class AppEngineRule extends ExternalResource
       if (enableJpaEntityCoverageCheck) {
         jpaIntegrationWithCoverageExtension = builder.buildIntegrationWithCoverageExtension();
         jpaIntegrationWithCoverageExtension.beforeEach(context);
+      } else if (withJpaUnitTest) {
+        jpaUnitTestRule =
+            builder
+                .withEntityClass(jpaTestEntities.toArray(new Class[jpaTestEntities.size()]))
+                .buildUnitTestRule();
+        jpaUnitTestRule.before();
       } else {
         jpaIntegrationTestRule = builder.buildIntegrationTestRule();
         jpaIntegrationTestRule.before();
       }
     }
+    injectTmForDualDatabaseTest(context);
   }
 
   /** Called after each test method. JUnit 5 only. */
@@ -341,11 +369,14 @@ public final class AppEngineRule extends ExternalResource
     if (withDatastoreAndCloudSql) {
       if (enableJpaEntityCoverageCheck) {
         jpaIntegrationWithCoverageExtension.afterEach(context);
+      } else if (withJpaUnitTest) {
+        jpaUnitTestRule.after();
       } else {
         jpaIntegrationTestRule.after();
       }
     }
     after();
+    restoreTmAfterDualDatabaseTest(context);
   }
 
   /**
@@ -559,5 +590,9 @@ public final class AppEngineRule extends ExternalResource
             makeRegistrar2(),
             makeRegistrarContact2(),
             makeRegistrarContact3()));
+  }
+
+  boolean isWithDatastoreAndCloudSql() {
+    return withDatastoreAndCloudSql;
   }
 }

--- a/core/src/test/java/google/registry/testing/DualDatabaseTest.java
+++ b/core/src/test/java/google/registry/testing/DualDatabaseTest.java
@@ -1,0 +1,28 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.testing;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/** Annotation to add {@link DualDatabaseTestInvocationContextProvider} for the annotated test. */
+@Target({TYPE})
+@Retention(RUNTIME)
+@ExtendWith(DualDatabaseTestInvocationContextProvider.class)
+public @interface DualDatabaseTest {}

--- a/core/src/test/java/google/registry/testing/DualDatabaseTestInvocationContextProvider.java
+++ b/core/src/test/java/google/registry/testing/DualDatabaseTestInvocationContextProvider.java
@@ -1,0 +1,125 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.testing;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+
+import com.google.common.collect.ImmutableList;
+import google.registry.persistence.transaction.TransactionManager;
+import google.registry.persistence.transaction.TransactionManagerFactory;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+
+/**
+ * Implementation of {@link TestTemplateInvocationContextProvider} to execute tests against
+ * different database. The test annotated with {@link TestTemplate} will be executed twice against
+ * Datastore and PostgresQL respectively.
+ */
+class DualDatabaseTestInvocationContextProvider implements TestTemplateInvocationContextProvider {
+  private static final Namespace NAMESPACE =
+      Namespace.create(DualDatabaseTestInvocationContextProvider.class);
+  private static final String INJECTED_TM_SUPPLIER_KEY = "injected_tm_supplier_key";
+  private static final String ORIGINAL_TM_KEY = "original_tm_key";
+
+  @Override
+  public boolean supportsTestTemplate(ExtensionContext context) {
+    return true;
+  }
+
+  @Override
+  public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
+      ExtensionContext context) {
+    return Stream.of(
+        createInvocationContext("Test Datastore", TransactionManagerFactory::ofyTm),
+        createInvocationContext("Test PostgreSQL", TransactionManagerFactory::jpaTm));
+  }
+
+  private TestTemplateInvocationContext createInvocationContext(
+      String name, Supplier<? extends TransactionManager> tmSupplier) {
+    return new TestTemplateInvocationContext() {
+      @Override
+      public String getDisplayName(int invocationIndex) {
+        return name;
+      }
+
+      @Override
+      public List<Extension> getAdditionalExtensions() {
+        return ImmutableList.of(new DatabaseSwitchInvocationContext(tmSupplier));
+      }
+    };
+  }
+
+  private static class DatabaseSwitchInvocationContext implements TestInstancePostProcessor {
+
+    private Supplier<? extends TransactionManager> tmSupplier;
+
+    private DatabaseSwitchInvocationContext(Supplier<? extends TransactionManager> tmSupplier) {
+      this.tmSupplier = tmSupplier;
+    }
+
+    @Override
+    public void postProcessTestInstance(Object testInstance, ExtensionContext context)
+        throws Exception {
+      List<Field> appEngineRuleFields =
+          Stream.of(testInstance.getClass().getFields())
+              .filter(field -> field.getType().isAssignableFrom(AppEngineRule.class))
+              .collect(toImmutableList());
+      if (appEngineRuleFields.size() != 1) {
+        throw new IllegalStateException(
+            "@DualDatabaseTest test must have only 1 AppEngineRule field");
+      }
+      appEngineRuleFields.get(0).setAccessible(true);
+      AppEngineRule appEngineRule = (AppEngineRule) appEngineRuleFields.get(0).get(testInstance);
+      if (!appEngineRule.isWithDatastoreAndCloudSql()) {
+        throw new IllegalStateException(
+            "AppEngineRule in @DualDatabaseTest test must set withDatastoreAndCloudSql()");
+      }
+      context.getStore(NAMESPACE).put(INJECTED_TM_SUPPLIER_KEY, tmSupplier);
+    }
+  }
+
+  static void injectTmForDualDatabaseTest(ExtensionContext context) {
+    if (isDualDatabaseTest(context)) {
+      context.getStore(NAMESPACE).put(ORIGINAL_TM_KEY, tm());
+      Supplier<? extends TransactionManager> tmSupplier =
+          (Supplier<? extends TransactionManager>)
+              context.getStore(NAMESPACE).get(INJECTED_TM_SUPPLIER_KEY);
+      TransactionManagerFactory.setTm(tmSupplier.get());
+    }
+  }
+
+  static void restoreTmAfterDualDatabaseTest(ExtensionContext context) {
+    if (isDualDatabaseTest(context)) {
+      TransactionManager original =
+          (TransactionManager) context.getStore(NAMESPACE).get(ORIGINAL_TM_KEY);
+      TransactionManagerFactory.setTm(original);
+    }
+  }
+
+  private static boolean isDualDatabaseTest(ExtensionContext context) {
+    Object testInstance = context.getTestInstance().orElseThrow(RuntimeException::new);
+    return testInstance.getClass().isAnnotationPresent(DualDatabaseTest.class);
+  }
+}


### PR DESCRIPTION
This PR added a JUint 5 extension `DualDatabaseTestInvocationContextProvider` which can execute annotated test twice against different databases, i.g. Datastore and PostgresQL.

This helps us easily expand the existing Datastore tests to work with both Datastore and PostgresQL.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/588)
<!-- Reviewable:end -->
