### PR TITLE
Make JpaUnitTestRule not depend on the nomulus schema

### DIFF
--- a/core/src/test/java/google/registry/persistence/transaction/JpaTestRules.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTestRules.java
@@ -71,7 +71,7 @@ public class JpaTestRules {
         Optional<String> initScriptPath,
         ImmutableList<Class> extraEntityClasses,
         ImmutableMap<String, String> userProperties) {
-      super(clock, initScriptPath, extraEntityClasses, userProperties);
+      super(clock, initScriptPath, false, extraEntityClasses, userProperties);
     }
 
     @Override


### PR DESCRIPTION
We silently made `JpaUnitTestRule` bring in the nomulus tables when initializing the test db instance. This was not a problem until I tried to merge the `ReservedList` entities. The problem was that the merged `ReservedList` entity has a field `Key<EntityGroupRoot> parent = getCrossTldKey();` which requires the Datastore API environment when instantiating its object, so any test using `JpaUnitTestRule` will be broken because the nomulus schema was added to the test and Hibernate tried to instantiate the entity class. Removing the entity class from the `JpaUnitTestRule` fixed the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/613)
<!-- Reviewable:end -->
