### PR TITLE
Rename client_id to registrar_id in SQL

### DIFF
--- a/core/src/main/java/google/registry/model/EppResource.java
+++ b/core/src/main/java/google/registry/model/EppResource.java
@@ -68,11 +68,11 @@ public abstract class EppResource extends BackupGroupRoot implements Buildable {
 
   /** The ID of the registrar that is currently sponsoring this resource. */
   @Index
-  @Column(nullable = false)
+  @Column(name = "currentSponsorRegistrarId", nullable = false)
   String currentSponsorClientId;
 
   /** The ID of the registrar that created this resource. */
-  @Column(nullable = false)
+  @Column(name = "creationRegistrarId", nullable = false)
   String creationClientId;
 
   /**
@@ -82,6 +82,7 @@ public abstract class EppResource extends BackupGroupRoot implements Buildable {
    * edits; it only includes EPP-visible modifications such as {@literal <update>}. Can be null if
    * the resource has never been modified.
    */
+  @Column(name = "lastEppUpdateRegistrarId")
   String lastEppUpdateClientId;
 
   /** The time when this resource was created. */

--- a/core/src/main/java/google/registry/model/billing/BillingEvent.java
+++ b/core/src/main/java/google/registry/model/billing/BillingEvent.java
@@ -116,7 +116,7 @@ public abstract class BillingEvent extends ImmutableObject
 
   /** The registrar to bill. */
   @Index
-  @Column(nullable = false)
+  @Column(name = "registrarId", nullable = false)
   String clientId;
 
   /** Revision id of the entry in DomainHistory table that ths bill belongs to. */
@@ -267,7 +267,7 @@ public abstract class BillingEvent extends ImmutableObject
   @javax.persistence.Entity(name = "BillingEvent")
   @javax.persistence.Table(
       indexes = {
-        @javax.persistence.Index(columnList = "clientId"),
+        @javax.persistence.Index(columnList = "registrarId"),
         @javax.persistence.Index(columnList = "eventTime"),
         @javax.persistence.Index(columnList = "billingTime"),
         @javax.persistence.Index(columnList = "syntheticCreationTime"),
@@ -440,7 +440,7 @@ public abstract class BillingEvent extends ImmutableObject
   @javax.persistence.Entity(name = "BillingRecurrence")
   @javax.persistence.Table(
       indexes = {
-        @javax.persistence.Index(columnList = "clientId"),
+        @javax.persistence.Index(columnList = "registrarId"),
         @javax.persistence.Index(columnList = "eventTime"),
         @javax.persistence.Index(columnList = "recurrenceEndTime"),
         @javax.persistence.Index(columnList = "recurrence_time_of_year")
@@ -531,7 +531,7 @@ public abstract class BillingEvent extends ImmutableObject
   @javax.persistence.Entity(name = "BillingCancellation")
   @javax.persistence.Table(
       indexes = {
-        @javax.persistence.Index(columnList = "clientId"),
+        @javax.persistence.Index(columnList = "registrarId"),
         @javax.persistence.Index(columnList = "eventTime"),
         @javax.persistence.Index(columnList = "billingTime")
       })

--- a/core/src/main/java/google/registry/model/contact/ContactResource.java
+++ b/core/src/main/java/google/registry/model/contact/ContactResource.java
@@ -56,7 +56,7 @@ import org.joda.time.DateTime;
     name = "Contact",
     indexes = {
       @javax.persistence.Index(columnList = "creationTime"),
-      @javax.persistence.Index(columnList = "currentSponsorClientId"),
+      @javax.persistence.Index(columnList = "currentSponsorRegistrarId"),
       @javax.persistence.Index(columnList = "deletionTime"),
       @javax.persistence.Index(columnList = "contactId", unique = true),
       @javax.persistence.Index(columnList = "searchName")

--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -102,7 +102,7 @@ import org.joda.time.Interval;
     name = "Domain",
     indexes = {
       @javax.persistence.Index(columnList = "creationTime"),
-      @javax.persistence.Index(columnList = "currentSponsorClientId"),
+      @javax.persistence.Index(columnList = "currentSponsorRegistrarId"),
       @javax.persistence.Index(columnList = "deletionTime"),
       @javax.persistence.Index(columnList = "fullyQualifiedDomainName"),
       @javax.persistence.Index(columnList = "tld")

--- a/core/src/main/java/google/registry/model/domain/GracePeriod.java
+++ b/core/src/main/java/google/registry/model/domain/GracePeriod.java
@@ -24,6 +24,7 @@ import google.registry.model.ImmutableObject;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.domain.rgp.GracePeriodStatus;
 import javax.annotation.Nullable;
+import javax.persistence.Column;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import org.joda.time.DateTime;
@@ -51,6 +52,7 @@ public class GracePeriod extends ImmutableObject {
   DateTime expirationTime;
 
   /** The registrar to bill. */
+  @Column(name = "registrarId")
   String clientId;
 
   /**

--- a/core/src/main/java/google/registry/model/registrar/Registrar.java
+++ b/core/src/main/java/google/registry/model/registrar/Registrar.java
@@ -236,7 +236,7 @@ public class Registrar extends ImmutableObject
    */
   @Id
   @javax.persistence.Id
-  @Column(name = "client_id", nullable = false)
+  @Column(name = "registrarId", nullable = false)
   String clientIdentifier;
 
   /**

--- a/db/src/main/resources/sql/flyway/V30__client_id_to_registrar_id.sql
+++ b/db/src/main/resources/sql/flyway/V30__client_id_to_registrar_id.sql
@@ -1,0 +1,34 @@
+-- Copyright 2020 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+ALTER TABLE IF EXISTS "Domain" RENAME creation_client_id TO creation_registrar_id;
+ALTER TABLE IF EXISTS "Domain" RENAME current_sponsor_client_id TO current_sponsor_registrar_id;
+ALTER TABLE IF EXISTS "Domain" RENAME last_epp_update_client_id TO last_epp_update_registrar_id;
+
+ALTER TABLE IF EXISTS "Contact" RENAME creation_client_id TO creation_registrar_id;
+ALTER TABLE IF EXISTS "Contact" RENAME current_sponsor_client_id TO current_sponsor_registrar_id;
+ALTER TABLE IF EXISTS "Contact" RENAME last_epp_update_client_id TO last_epp_update_registrar_id;
+
+ALTER TABLE IF EXISTS "HostResource" RENAME creation_client_id TO creation_registrar_id;
+ALTER TABLE IF EXISTS "HostResource" RENAME current_sponsor_client_id TO current_sponsor_registrar_id;
+ALTER TABLE IF EXISTS "HostResource" RENAME last_epp_update_client_id TO last_epp_update_registrar_id;
+
+ALTER TABLE IF EXISTS "Registrar" RENAME client_id TO registrar_id;
+
+ALTER TABLE IF EXISTS "BillingCancellation" RENAME client_id TO registrar_id;
+ALTER TABLE IF EXISTS "BillingCancellation" RENAME CONSTRAINT fk_billing_cancellation_client_id TO fk_billing_cancellation_registrar_id;
+ALTER TABLE IF EXISTS "BillingEvent" RENAME client_id TO registrar_id;
+ALTER TABLE IF EXISTS "BillingEvent" RENAME CONSTRAINT fk_billing_event_client_id TO fk_billing_event_registrar_id;
+ALTER TABLE IF EXISTS "BillingRecurrence" RENAME client_id TO registrar_id;
+ALTER TABLE IF EXISTS "BillingRecurrence" RENAME CONSTRAINT fk_billing_recurrence_client_id TO fk_billing_recurrence_registrar_id;

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -14,7 +14,7 @@
 
     create table "BillingCancellation" (
        billing_cancellation_id  bigserial not null,
-        client_id text not null,
+        registrar_id text not null,
         domain_history_revision_id int8 not null,
         domain_repo_id text not null,
         event_time timestamptz not null,
@@ -29,7 +29,7 @@
 
     create table "BillingEvent" (
        billing_event_id  bigserial not null,
-        client_id text not null,
+        registrar_id text not null,
         domain_history_revision_id int8 not null,
         domain_repo_id text not null,
         event_time timestamptz not null,
@@ -48,7 +48,7 @@
 
     create table "BillingRecurrence" (
        billing_recurrence_id  bigserial not null,
-        client_id text not null,
+        registrar_id text not null,
         domain_history_revision_id int8 not null,
         domain_repo_id text not null,
         event_time timestamptz not null,
@@ -76,11 +76,11 @@
 
     create table "Contact" (
        repo_id text not null,
-        creation_client_id text not null,
+        creation_registrar_id text not null,
         creation_time timestamptz not null,
-        current_sponsor_client_id text not null,
+        current_sponsor_registrar_id text not null,
         deletion_time timestamptz,
-        last_epp_update_client_id text,
+        last_epp_update_registrar_id text,
         last_epp_update_time timestamptz,
         statuses text[],
         auth_info_repo_id text,
@@ -157,11 +157,11 @@
 
     create table "Domain" (
        repo_id text not null,
-        creation_client_id text not null,
+        creation_registrar_id text not null,
         creation_time timestamptz not null,
-        current_sponsor_client_id text not null,
+        current_sponsor_registrar_id text not null,
         deletion_time timestamptz,
-        last_epp_update_client_id text,
+        last_epp_update_registrar_id text,
         last_epp_update_time timestamptz,
         statuses text[],
         admin_contact text,
@@ -209,7 +209,7 @@
        id  bigserial not null,
         billing_event_one_time bytea,
         billing_event_recurring bytea,
-        client_id text,
+        registrar_id text,
         expiration_time timestamptz,
         type int4,
         primary key (id)
@@ -217,11 +217,11 @@
 
     create table "HostResource" (
        repo_id text not null,
-        creation_client_id text not null,
+        creation_registrar_id text not null,
         creation_time timestamptz not null,
-        current_sponsor_client_id text not null,
+        current_sponsor_registrar_id text not null,
         deletion_time timestamptz,
-        last_epp_update_client_id text,
+        last_epp_update_registrar_id text,
         last_epp_update_time timestamptz,
         statuses text[],
         fully_qualified_host_name text,
@@ -292,7 +292,7 @@
     );
 
     create table "Registrar" (
-       client_id text not null,
+       registrar_id text not null,
         allowed_tlds text[],
         billing_account_map hstore,
         billing_identifier int8,
@@ -337,7 +337,7 @@
         type text not null,
         url text,
         whois_server text,
-        primary key (client_id)
+        primary key (registrar_id)
     );
 
     create table "RegistrarPoc" (
@@ -390,27 +390,27 @@
         should_publish boolean not null,
         primary key (revision_id)
     );
-create index IDXeokttmxtpq2hohcioe5t2242b on "BillingCancellation" (client_id);
+create index IDXih4b2tea127p5rb61gje6e1y2 on "BillingCancellation" (registrar_id);
 create index IDX2exdfbx6oiiwnhr8j6gjpqt2j on "BillingCancellation" (event_time);
 create index IDXqa3g92jc17e8dtiaviy4fet4x on "BillingCancellation" (billing_time);
-create index IDX73l103vc5900ig3p4odf0cngt on "BillingEvent" (client_id);
+create index IDXqspv57gj2led8ly42fq01t7m7 on "BillingEvent" (registrar_id);
 create index IDX5yfbr88439pxw0v3j86c74fp8 on "BillingEvent" (event_time);
 create index IDX6py6ocrab0ivr76srcd2okpnq on "BillingEvent" (billing_time);
 create index IDXplxf9v56p0wg8ws6qsvd082hk on "BillingEvent" (synthetic_creation_time);
 create index IDXhmv411mdqo5ibn4vy7ykxpmlv on "BillingEvent" (allocation_token_id);
-create index IDXn898pb9mwcg359cdwvolb11ck on "BillingRecurrence" (client_id);
+create index IDXd3gxhkh0jk694pjvh9pyn7wjc on "BillingRecurrence" (registrar_id);
 create index IDX6syykou4nkc7hqa5p8r92cpch on "BillingRecurrence" (event_time);
 create index IDXp3usbtvk0v1m14i5tdp4xnxgc on "BillingRecurrence" (recurrence_end_time);
 create index IDXjny8wuot75b5e6p38r47wdawu on "BillingRecurrence" (recurrence_time_of_year);
 create index IDX3y752kr9uh4kh6uig54vemx0l on "Contact" (creation_time);
-create index IDXbn8t4wp85fgxjl8q4ctlscx55 on "Contact" (current_sponsor_client_id);
+create index IDXtm415d6fe1rr35stm33s5mg18 on "Contact" (current_sponsor_registrar_id);
 create index IDXn1f711wicdnooa2mqb7g1m55o on "Contact" (deletion_time);
 create index IDX1p3esngcwwu6hstyua6itn6ff on "Contact" (search_name);
 
     alter table if exists "Contact" 
        add constraint UKoqd7n4hbx86hvlgkilq75olas unique (contact_id);
 create index IDX8nr0ke9mrrx4ewj6pd2ag4rmr on "Domain" (creation_time);
-create index IDX8ffrqm27qtj20jac056j7yq07 on "Domain" (current_sponsor_client_id);
+create index IDXhsjqiy2lyobfymplb28nm74lm on "Domain" (current_sponsor_registrar_id);
 create index IDX5mnf0wn20tno4b9do88j61klr on "Domain" (deletion_time);
 create index IDX1rcgkdd777bpvj0r94sltwd5y on "Domain" (fully_qualified_domain_name);
 create index IDXrwl38wwkli1j7gkvtywi9jokq on "Domain" (tld);

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -40,7 +40,7 @@ SET default_with_oids = false;
 
 CREATE TABLE public."BillingCancellation" (
     billing_cancellation_id bigint NOT NULL,
-    client_id text NOT NULL,
+    registrar_id text NOT NULL,
     domain_history_revision_id bigint NOT NULL,
     domain_repo_id text NOT NULL,
     event_time timestamp with time zone NOT NULL,
@@ -78,7 +78,7 @@ ALTER SEQUENCE public."BillingCancellation_billing_cancellation_id_seq" OWNED BY
 
 CREATE TABLE public."BillingEvent" (
     billing_event_id bigint NOT NULL,
-    client_id text NOT NULL,
+    registrar_id text NOT NULL,
     domain_history_revision_id bigint NOT NULL,
     domain_repo_id text NOT NULL,
     event_time timestamp with time zone NOT NULL,
@@ -120,7 +120,7 @@ ALTER SEQUENCE public."BillingEvent_billing_event_id_seq" OWNED BY public."Billi
 
 CREATE TABLE public."BillingRecurrence" (
     billing_recurrence_id bigint NOT NULL,
-    client_id text NOT NULL,
+    registrar_id text NOT NULL,
     domain_history_revision_id bigint NOT NULL,
     domain_repo_id text NOT NULL,
     event_time timestamp with time zone NOT NULL,
@@ -198,11 +198,11 @@ ALTER SEQUENCE public."ClaimsList_revision_id_seq" OWNED BY public."ClaimsList".
 
 CREATE TABLE public."Contact" (
     repo_id text NOT NULL,
-    creation_client_id text NOT NULL,
+    creation_registrar_id text NOT NULL,
     creation_time timestamp with time zone NOT NULL,
-    current_sponsor_client_id text NOT NULL,
+    current_sponsor_registrar_id text NOT NULL,
     deletion_time timestamp with time zone,
-    last_epp_update_client_id text,
+    last_epp_update_registrar_id text,
     last_epp_update_time timestamp with time zone,
     statuses text[],
     auth_info_repo_id text,
@@ -279,11 +279,11 @@ CREATE TABLE public."Cursor" (
 
 CREATE TABLE public."Domain" (
     repo_id text NOT NULL,
-    creation_client_id text NOT NULL,
+    creation_registrar_id text NOT NULL,
     creation_time timestamp with time zone NOT NULL,
-    current_sponsor_client_id text NOT NULL,
+    current_sponsor_registrar_id text NOT NULL,
     deletion_time timestamp with time zone,
-    last_epp_update_client_id text,
+    last_epp_update_registrar_id text,
     last_epp_update_time timestamp with time zone,
     statuses text[],
     auth_info_repo_id text,
@@ -338,11 +338,11 @@ CREATE TABLE public."DomainHost" (
 
 CREATE TABLE public."HostResource" (
     repo_id text NOT NULL,
-    creation_client_id text,
+    creation_registrar_id text,
     creation_time timestamp with time zone,
-    current_sponsor_client_id text,
+    current_sponsor_registrar_id text,
     deletion_time timestamp with time zone,
-    last_epp_update_client_id text,
+    last_epp_update_registrar_id text,
     last_epp_update_time timestamp with time zone,
     statuses text[],
     fully_qualified_host_name text,
@@ -476,7 +476,7 @@ ALTER SEQUENCE public."PremiumList_revision_id_seq" OWNED BY public."PremiumList
 --
 
 CREATE TABLE public."Registrar" (
-    client_id text NOT NULL,
+    registrar_id text NOT NULL,
     allowed_tlds text[],
     billing_account_map public.hstore,
     billing_identifier bigint,
@@ -802,7 +802,7 @@ ALTER TABLE ONLY public."RegistrarPoc"
 --
 
 ALTER TABLE ONLY public."Registrar"
-    ADD CONSTRAINT "Registrar_pkey" PRIMARY KEY (client_id);
+    ADD CONSTRAINT "Registrar_pkey" PRIMARY KEY (registrar_id);
 
 
 --
@@ -905,7 +905,7 @@ CREATE INDEX idx6syykou4nkc7hqa5p8r92cpch ON public."BillingRecurrence" USING bt
 -- Name: idx73l103vc5900ig3p4odf0cngt; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX idx73l103vc5900ig3p4odf0cngt ON public."BillingEvent" USING btree (client_id);
+CREATE INDEX idx73l103vc5900ig3p4odf0cngt ON public."BillingEvent" USING btree (registrar_id);
 
 
 --
@@ -940,7 +940,7 @@ CREATE INDEX idxaydgox62uno9qx8cjlj5lauye ON public."PollMessage" USING btree (e
 -- Name: idxbn8t4wp85fgxjl8q4ctlscx55; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX idxbn8t4wp85fgxjl8q4ctlscx55 ON public."Contact" USING btree (current_sponsor_client_id);
+CREATE INDEX idxbn8t4wp85fgxjl8q4ctlscx55 ON public."Contact" USING btree (current_sponsor_registrar_id);
 
 
 --
@@ -954,7 +954,7 @@ CREATE INDEX idxe7wu46c7wpvfmfnj4565abibp ON public."PollMessage" USING btree (r
 -- Name: idxeokttmxtpq2hohcioe5t2242b; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX idxeokttmxtpq2hohcioe5t2242b ON public."BillingCancellation" USING btree (client_id);
+CREATE INDEX idxeokttmxtpq2hohcioe5t2242b ON public."BillingCancellation" USING btree (registrar_id);
 
 
 --
@@ -975,7 +975,7 @@ CREATE INDEX idxjny8wuot75b5e6p38r47wdawu ON public."BillingRecurrence" USING bt
 -- Name: idxkjt9yaq92876dstimd93hwckh; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX idxkjt9yaq92876dstimd93hwckh ON public."Domain" USING btree (current_sponsor_client_id);
+CREATE INDEX idxkjt9yaq92876dstimd93hwckh ON public."Domain" USING btree (current_sponsor_registrar_id);
 
 
 --
@@ -989,7 +989,7 @@ CREATE INDEX idxn1f711wicdnooa2mqb7g1m55o ON public."Contact" USING btree (delet
 -- Name: idxn898pb9mwcg359cdwvolb11ck; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX idxn898pb9mwcg359cdwvolb11ck ON public."BillingRecurrence" USING btree (client_id);
+CREATE INDEX idxn898pb9mwcg359cdwvolb11ck ON public."BillingRecurrence" USING btree (registrar_id);
 
 
 --
@@ -1060,7 +1060,7 @@ CREATE INDEX reservedlist_name_idx ON public."ReservedList" USING btree (name);
 --
 
 ALTER TABLE ONLY public."Contact"
-    ADD CONSTRAINT fk1sfyj7o7954prbn1exk7lpnoe FOREIGN KEY (creation_client_id) REFERENCES public."Registrar"(client_id);
+    ADD CONSTRAINT fk1sfyj7o7954prbn1exk7lpnoe FOREIGN KEY (creation_registrar_id) REFERENCES public."Registrar"(registrar_id);
 
 
 --
@@ -1068,7 +1068,7 @@ ALTER TABLE ONLY public."Contact"
 --
 
 ALTER TABLE ONLY public."Domain"
-    ADD CONSTRAINT fk2jc69qyg2tv9hhnmif6oa1cx1 FOREIGN KEY (creation_client_id) REFERENCES public."Registrar"(client_id);
+    ADD CONSTRAINT fk2jc69qyg2tv9hhnmif6oa1cx1 FOREIGN KEY (creation_registrar_id) REFERENCES public."Registrar"(registrar_id);
 
 
 --
@@ -1084,7 +1084,7 @@ ALTER TABLE ONLY public."RegistryLock"
 --
 
 ALTER TABLE ONLY public."Domain"
-    ADD CONSTRAINT fk2u3srsfbei272093m3b3xwj23 FOREIGN KEY (current_sponsor_client_id) REFERENCES public."Registrar"(client_id);
+    ADD CONSTRAINT fk2u3srsfbei272093m3b3xwj23 FOREIGN KEY (current_sponsor_registrar_id) REFERENCES public."Registrar"(registrar_id);
 
 
 --
@@ -1108,7 +1108,7 @@ ALTER TABLE ONLY public."HostResource_inetAddresses"
 --
 
 ALTER TABLE ONLY public."Contact"
-    ADD CONSTRAINT fk93c185fx7chn68uv7nl6uv2s0 FOREIGN KEY (current_sponsor_client_id) REFERENCES public."Registrar"(client_id);
+    ADD CONSTRAINT fk93c185fx7chn68uv7nl6uv2s0 FOREIGN KEY (current_sponsor_registrar_id) REFERENCES public."Registrar"(registrar_id);
 
 
 --
@@ -1128,11 +1128,11 @@ ALTER TABLE ONLY public."BillingCancellation"
 
 
 --
--- Name: BillingCancellation fk_billing_cancellation_client_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: BillingCancellation fk_billing_cancellation_registrar_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public."BillingCancellation"
-    ADD CONSTRAINT fk_billing_cancellation_client_id FOREIGN KEY (client_id) REFERENCES public."Registrar"(client_id);
+    ADD CONSTRAINT fk_billing_cancellation_registrar_id FOREIGN KEY (registrar_id) REFERENCES public."Registrar"(registrar_id);
 
 
 --
@@ -1144,19 +1144,19 @@ ALTER TABLE ONLY public."BillingEvent"
 
 
 --
--- Name: BillingEvent fk_billing_event_client_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: BillingEvent fk_billing_event_registrar_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public."BillingEvent"
-    ADD CONSTRAINT fk_billing_event_client_id FOREIGN KEY (client_id) REFERENCES public."Registrar"(client_id);
+    ADD CONSTRAINT fk_billing_event_registrar_id FOREIGN KEY (registrar_id) REFERENCES public."Registrar"(registrar_id);
 
 
 --
--- Name: BillingRecurrence fk_billing_recurrence_client_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+-- Name: BillingRecurrence fk_billing_recurrence_registrar_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public."BillingRecurrence"
-    ADD CONSTRAINT fk_billing_recurrence_client_id FOREIGN KEY (client_id) REFERENCES public."Registrar"(client_id);
+    ADD CONSTRAINT fk_billing_recurrence_registrar_id FOREIGN KEY (registrar_id) REFERENCES public."Registrar"(registrar_id);
 
 
 --
@@ -1164,7 +1164,7 @@ ALTER TABLE ONLY public."BillingRecurrence"
 --
 
 ALTER TABLE ONLY public."Contact"
-    ADD CONSTRAINT fk_contact_transfer_gaining_registrar_id FOREIGN KEY (transfer_gaining_registrar_id) REFERENCES public."Registrar"(client_id);
+    ADD CONSTRAINT fk_contact_transfer_gaining_registrar_id FOREIGN KEY (transfer_gaining_registrar_id) REFERENCES public."Registrar"(registrar_id);
 
 
 --
@@ -1172,7 +1172,7 @@ ALTER TABLE ONLY public."Contact"
 --
 
 ALTER TABLE ONLY public."Contact"
-    ADD CONSTRAINT fk_contact_transfer_losing_registrar_id FOREIGN KEY (transfer_losing_registrar_id) REFERENCES public."Registrar"(client_id);
+    ADD CONSTRAINT fk_contact_transfer_losing_registrar_id FOREIGN KEY (transfer_losing_registrar_id) REFERENCES public."Registrar"(registrar_id);
 
 
 --
@@ -1236,7 +1236,7 @@ ALTER TABLE ONLY public."Domain"
 --
 
 ALTER TABLE ONLY public."Domain"
-    ADD CONSTRAINT fk_domain_transfer_gaining_registrar_id FOREIGN KEY (transfer_gaining_registrar_id) REFERENCES public."Registrar"(client_id);
+    ADD CONSTRAINT fk_domain_transfer_gaining_registrar_id FOREIGN KEY (transfer_gaining_registrar_id) REFERENCES public."Registrar"(registrar_id);
 
 
 --
@@ -1244,7 +1244,7 @@ ALTER TABLE ONLY public."Domain"
 --
 
 ALTER TABLE ONLY public."Domain"
-    ADD CONSTRAINT fk_domain_transfer_losing_registrar_id FOREIGN KEY (transfer_losing_registrar_id) REFERENCES public."Registrar"(client_id);
+    ADD CONSTRAINT fk_domain_transfer_losing_registrar_id FOREIGN KEY (transfer_losing_registrar_id) REFERENCES public."Registrar"(registrar_id);
 
 
 --
@@ -1292,7 +1292,7 @@ ALTER TABLE ONLY public."PollMessage"
 --
 
 ALTER TABLE ONLY public."PollMessage"
-    ADD CONSTRAINT fk_poll_message_registrar_id FOREIGN KEY (registrar_id) REFERENCES public."Registrar"(client_id);
+    ADD CONSTRAINT fk_poll_message_registrar_id FOREIGN KEY (registrar_id) REFERENCES public."Registrar"(registrar_id);
 
 
 --
@@ -1300,7 +1300,7 @@ ALTER TABLE ONLY public."PollMessage"
 --
 
 ALTER TABLE ONLY public."PollMessage"
-    ADD CONSTRAINT fk_poll_message_transfer_response_gaining_registrar_id FOREIGN KEY (transfer_response_gaining_registrar_id) REFERENCES public."Registrar"(client_id);
+    ADD CONSTRAINT fk_poll_message_transfer_response_gaining_registrar_id FOREIGN KEY (transfer_response_gaining_registrar_id) REFERENCES public."Registrar"(registrar_id);
 
 
 --
@@ -1308,7 +1308,7 @@ ALTER TABLE ONLY public."PollMessage"
 --
 
 ALTER TABLE ONLY public."PollMessage"
-    ADD CONSTRAINT fk_poll_message_transfer_response_losing_registrar_id FOREIGN KEY (transfer_response_losing_registrar_id) REFERENCES public."Registrar"(client_id);
+    ADD CONSTRAINT fk_poll_message_transfer_response_losing_registrar_id FOREIGN KEY (transfer_response_losing_registrar_id) REFERENCES public."Registrar"(registrar_id);
 
 
 --
@@ -1332,7 +1332,7 @@ ALTER TABLE ONLY public."ReservedEntry"
 --
 
 ALTER TABLE ONLY public."Domain"
-    ADD CONSTRAINT fkjc0r9r5y1lfbt4gpbqw4wsuvq FOREIGN KEY (last_epp_update_client_id) REFERENCES public."Registrar"(client_id);
+    ADD CONSTRAINT fkjc0r9r5y1lfbt4gpbqw4wsuvq FOREIGN KEY (last_epp_update_registrar_id) REFERENCES public."Registrar"(registrar_id);
 
 
 --
@@ -1340,7 +1340,7 @@ ALTER TABLE ONLY public."Domain"
 --
 
 ALTER TABLE ONLY public."Contact"
-    ADD CONSTRAINT fkmb7tdiv85863134w1wogtxrb2 FOREIGN KEY (last_epp_update_client_id) REFERENCES public."Registrar"(client_id);
+    ADD CONSTRAINT fkmb7tdiv85863134w1wogtxrb2 FOREIGN KEY (last_epp_update_registrar_id) REFERENCES public."Registrar"(registrar_id);
 
 
 --


### PR DESCRIPTION
We'll eventually want to shift everything over to using registrar_id and
registrarId rather than client_id and clientId but for the sake of the
Datastore schema and existing code, we won't change the Java identifier
for now. Once we're completely and only on SQL, we can rename the Java
field easily.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/619)
<!-- Reviewable:end -->
