### PR TITLE
Use the requested server host when creating the registry lock verification URL

### DIFF
--- a/core/src/test/java/google/registry/ui/server/registrar/RegistryLockPostActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistryLockPostActionTest.java
@@ -28,6 +28,7 @@ import static google.registry.ui.server.registrar.RegistryLockGetActionTest.user
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import com.google.appengine.api.users.User;
 import com.google.common.collect.ImmutableList;
@@ -56,6 +57,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import javax.mail.internet.InternetAddress;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.joda.time.Duration;
 import org.junit.Before;
@@ -74,7 +76,7 @@ public final class RegistryLockPostActionTest {
   private static final String EMAIL_MESSAGE_TEMPLATE =
       "Please click the link below to perform the lock \\/ unlock action on domain example.tld. "
           + "Note: this code will expire in one hour.\n\n"
-          + "https:\\/\\/localhost\\/registry-lock-verify\\?lockVerificationCode="
+          + "https:\\/\\/registrarconsole.tld\\/registry-lock-verify\\?lockVerificationCode="
           + "[0-9a-zA-Z_\\-]+&isLock=(true|false)";
 
   private final FakeClock clock = new FakeClock();
@@ -93,6 +95,7 @@ public final class RegistryLockPostActionTest {
   private RegistryLockPostAction action;
 
   @Mock SendEmailService emailService;
+  @Mock HttpServletRequest mockRequest;
   @Mock HttpServletResponse mockResponse;
 
   @Before
@@ -102,6 +105,8 @@ public final class RegistryLockPostActionTest {
     createTld("tld");
     domain = persistResource(newDomainBase("example.tld"));
     outgoingAddress = new InternetAddress("domain-registry@example.com");
+
+    when(mockRequest.getServerName()).thenReturn("registrarconsole.tld");
 
     action =
         createAction(
@@ -432,6 +437,7 @@ public final class RegistryLockPostActionTest {
             AsyncTaskEnqueuerTest.createForTesting(
                 mock(AppEngineServiceUtils.class), clock, Duration.ZERO));
     return new RegistryLockPostAction(
+        mockRequest,
         jsonActionRunner,
         authResult,
         registrarAccessor,


### PR DESCRIPTION
The app doesn't know about any external configuration that may point to
this app, so there's no way of finding out that, for instance,
registry.google points to the app. Thus, we have to use what the user
gives us so that, in our case, the registry-lock verification
emails can point to https://registry.google/registry-lock-verify instead
of https://domain-registry.appspot.com/registry-lock-verify. The former
is used by clients / users to authenticate, and unfortunately
authenticating on registry.google does not give authentication to
domain-registry.apspot.com.

Tested using the RDAP code that uses getServerName() -- in that case, if
you access registry.google/rdap/<>, it uses registry.google in the URLs
but if you use domain-registry.appspot.com/rdap/<>, it uses
domain-registry.appspot.com in the URLs.

Relatedly, frontend_config_prod-appengine.asciiproto in Piper
is what configures registry.google to point to
domain-registry.appspot.com

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/624)
<!-- Reviewable:end -->
