### PR TITLE
Fix cookie processing for RDAP URL update

### DIFF
--- a/core/src/main/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsAction.java
+++ b/core/src/main/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsAction.java
@@ -101,7 +101,8 @@ public final class UpdateRegistrarRdapBaseUrlsAction implements Runnable {
     HttpResponse response = request.execute();
 
     Optional<HttpCookie> idCookie =
-        HttpCookie.parse(response.getHeaders().getFirstHeaderStringValue("Set-Cookie")).stream()
+        response.getHeaders().getHeaderStringValues("Set-Cookie").stream()
+            .flatMap(value -> HttpCookie.parse(value).stream())
             .filter(cookie -> cookie.getName().equals(COOKIE_ID))
             .findAny();
     checkState(

--- a/core/src/test/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsActionTest.java
+++ b/core/src/test/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsActionTest.java
@@ -321,6 +321,10 @@ public final class UpdateRegistrarRdapBaseUrlsActionTest extends ShardableTestCa
     MockLowLevelHttpResponse loginResponse = new MockLowLevelHttpResponse();
     loginResponse.addHeader(
         "Set-Cookie",
+        "JSESSIONID=bogusid; "
+            + "Expires=Tue, 11-Jun-2019 16:34:21 GMT; Path=/; Secure; HttpOnly");
+    loginResponse.addHeader(
+        "Set-Cookie",
         "id=myAuthenticationId; "
             + "Expires=Tue, 11-Jun-2019 16:34:21 GMT; Path=/mosapi/v1/app; Secure; HttpOnly");
 


### PR DESCRIPTION
The existing code only does cookie processing on the _first_ Set-Cookie
header.  Therefore, if the "id" cookie used for authentication is defined in
anything other than the first Set-Cookie header (as it now is), we don't find
it.

Replace the cookie processing stanza with a line that processes all cookies in
all Set-Cookie headers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/630)
<!-- Reviewable:end -->
