### PR TITLE
Show price of reserved domains when using matching allocation token

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -555,7 +555,8 @@ public class DomainFlowUtils {
       @Nullable CurrencyUnit topLevelCurrency,
       DateTime currentDate,
       DomainPricingLogic pricingLogic,
-      Optional<AllocationToken> allocationToken)
+      Optional<AllocationToken> allocationToken,
+      boolean isAvailable)
       throws EppException {
     DateTime now = currentDate;
     // Use the custom effective date specified in the fee check request, if there is one.
@@ -587,7 +588,8 @@ public class DomainFlowUtils {
     ImmutableList<Fee> fees = ImmutableList.of();
     switch (feeRequest.getCommandName()) {
       case CREATE:
-        if (isReserved(domain, isSunrise)) { // Don't return a create price for reserved names.
+        // Don't return a create price for reserved names.
+        if (isReserved(domain, isSunrise) && !isAvailable) {
           builder.setClass("reserved"); // Override whatever class we've set above.
           builder.setAvailIfSupported(false);
           builder.setReasonIfSupported("reserved");

--- a/core/src/main/java/google/registry/flows/domain/DomainInfoFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainInfoFlow.java
@@ -164,7 +164,8 @@ public final class DomainInfoFlow implements Flow {
           null,
           now,
           pricingLogic,
-          Optional.empty());
+          Optional.empty(),
+          false);
       extensions.add(builder.build());
     }
     return extensions.build();

--- a/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
@@ -192,6 +192,21 @@ public class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFl
   }
 
   @Test
+  public void testSuccess_allocationTokenForReservedDomain_showsFee() throws Exception {
+    setEppInput("domain_check_allocationtoken_fee_specificuse.xml");
+    createTld("example");
+    persistResource(
+        new AllocationToken.Builder()
+            .setDomainName("specificuse.tld")
+            .setToken("abc123")
+            .setTokenType(SINGLE_USE)
+            .build());
+    // Fees are shown for all non-reserved domains and the reserved domain matching this
+    // allocation token.
+    runFlowAssertResponse(loadFile("domain_check_allocationtoken_fee_specificuse_response.xml"));
+  }
+
+  @Test
   public void testSuccess_oneExists_allocationTokenForWrongDomain() throws Exception {
     setEppInput("domain_check_allocationtoken.xml");
     persistActiveDomain("example1.tld");
@@ -440,7 +455,10 @@ public class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFl
   @Test
   public void testSuccess_duplicatesAllowed() throws Exception {
     setEppInput("domain_check_duplicates.xml");
-    doCheckTest(create(true, "example1.tld", null), create(true, "example1.tld", null));
+    doCheckTest(
+        create(true, "example1.tld", null),
+        create(true, "example2.tld", null),
+        create(true, "example1.tld", null));
   }
 
   @Test

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee_specificuse.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee_specificuse.xml
@@ -1,0 +1,48 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <command>
+    <check>
+      <domain:check
+          xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>example1.tld</domain:name>
+        <domain:name>example2.example</domain:name>
+        <domain:name>reserved.tld</domain:name>
+        <domain:name>specificuse.tld</domain:name>
+      </domain:check>
+    </check>
+    <extension>
+      <allocationToken:allocationToken
+          xmlns:allocationToken=
+              "urn:ietf:params:xml:ns:allocationToken-1.0">
+        abc123
+      </allocationToken:allocationToken>
+      <fee:check
+          xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
+        <fee:domain>
+          <fee:name>example1.tld</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">1</fee:period>
+        </fee:domain>
+        <fee:domain>
+          <fee:name>example2.example</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">1</fee:period>
+        </fee:domain>
+        <fee:domain>
+          <fee:name>reserved.tld</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">1</fee:period>
+        </fee:domain>
+        <fee:domain>
+          <fee:name>specificuse.tld</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">1</fee:period>
+        </fee:domain>
+      </fee:check>
+    </extension>
+    <clTRID>ABC-12345</clTRID>
+  </command>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee_specificuse_response.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee_specificuse_response.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<epp xmlns:launch="urn:ietf:params:xml:ns:launch-1.0" xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1" xmlns:host="urn:ietf:params:xml:ns:host-1.0" xmlns:fee11="urn:ietf:params:xml:ns:fee-0.11" xmlns:fee12="urn:ietf:params:xml:ns:fee-0.12" xmlns:fee="urn:ietf:params:xml:ns:fee-0.6" xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0" xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xmlns:contact="urn:ietf:params:xml:ns:contact-1.0">
+  <response>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
+    </result>
+    <resData>
+      <domain:chkData>
+        <domain:cd>
+          <domain:name avail="false">example1.tld</domain:name>
+          <domain:reason>Alloc token invalid for domain</domain:reason>
+        </domain:cd>
+        <domain:cd>
+          <domain:name avail="false">example2.example</domain:name>
+          <domain:reason>Alloc token invalid for domain</domain:reason>
+        </domain:cd>
+        <domain:cd>
+          <domain:name avail="false">reserved.tld</domain:name>
+          <domain:reason>Reserved</domain:reason>
+        </domain:cd>
+        <domain:cd>
+          <domain:name avail="true">specificuse.tld</domain:name>
+        </domain:cd>
+      </domain:chkData>
+    </resData>
+    <extension>
+      <fee:chkData>
+        <fee:cd>
+          <fee:name>example2.example</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:fee description="create">13.00</fee:fee>
+        </fee:cd>
+        <fee:cd>
+          <fee:name>example1.tld</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:fee description="create">13.00</fee:fee>
+        </fee:cd>
+        <fee:cd>
+          <fee:name>reserved.tld</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:class>reserved</fee:class>
+        </fee:cd>
+        <fee:cd>
+          <fee:name>specificuse.tld</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:fee description="create">13.00</fee:fee>
+        </fee:cd>
+      </fee:chkData>
+    </extension>
+    <trID>
+      <clTRID>ABC-12345</clTRID>
+      <svTRID>server-trid</svTRID>
+    </trID>
+  </response>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_duplicates.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_duplicates.xml
@@ -3,6 +3,7 @@
     <check>
       <domain:check xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
         <domain:name>example1.tld</domain:name>
+        <domain:name>example2.tld</domain:name>
         <domain:name>example1.tld</domain:name>
       </domain:check>
     </check>


### PR DESCRIPTION
When the registrar passes the fee extension, this shows the price of the domain
on a check command for reserved domains if the provided allocation token is a
match. Of course, the price is already always displayed on non-reserved names
(regardless of whether the specific provided token is a match or not).

This affects domain checks only; the price is already always displayed on domain
creates because you already by definition have access to register the domain in
question.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/632)
<!-- Reviewable:end -->
