### PR TITLE
Implement remaining methods in JpaTransactionManager

### DIFF
--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -122,32 +122,35 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
 
   @Override
   public <T> T transactNew(Supplier<T> work) {
-    // TODO(shicong): Implements the functionality to start a new transaction.
-    throw new UnsupportedOperationException();
+    return transact(work);
   }
 
   @Override
   public void transactNew(Runnable work) {
-    // TODO(shicong): Implements the functionality to start a new transaction.
-    throw new UnsupportedOperationException();
+    transact(work);
   }
 
   @Override
   public <T> T transactNewReadOnly(Supplier<T> work) {
-    // TODO(shicong): Implements read only transaction.
-    throw new UnsupportedOperationException();
+    return transact(
+        () -> {
+          getEntityManager().createNativeQuery("SET TRANSACTION READ ONLY").executeUpdate();
+          return work.get();
+        });
   }
 
   @Override
   public void transactNewReadOnly(Runnable work) {
-    // TODO(shicong): Implements read only transaction.
-    throw new UnsupportedOperationException();
+    transactNewReadOnly(
+        () -> {
+          work.run();
+          return null;
+        });
   }
 
   @Override
   public <T> T doTransactionless(Supplier<T> work) {
-    // TODO(shicong): Implements doTransactionless.
-    throw new UnsupportedOperationException();
+    return transact(work);
   }
 
   @Override

--- a/core/src/test/java/google/registry/persistence/transaction/TransactionManagerTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/TransactionManagerTest.java
@@ -117,6 +117,30 @@ public class TransactionManagerTest {
   }
 
   @TestTemplate
+  void transactNew_succeeds() {
+    assertEntityNotExist(theEntity);
+    tm().transactNew(() -> tm().saveNew(theEntity));
+    assertEntityExists(theEntity);
+  }
+
+  @TestTemplate
+  void transactNewReadOnly_succeeds() {
+    assertEntityNotExist(theEntity);
+    tm().transact(() -> tm().saveNew(theEntity));
+    assertEntityExists(theEntity);
+    TestEntity persisted = tm().transactNewReadOnly(() -> tm().load(theEntity.key()));
+    assertThat(persisted).isEqualTo(theEntity);
+  }
+
+  @TestTemplate
+  void transactNewReadOnly_throwsWhenWritingEntity() {
+    assertEntityNotExist(theEntity);
+    assertThrows(
+        RuntimeException.class, () -> tm().transactNewReadOnly(() -> tm().saveNew(theEntity)));
+    assertEntityNotExist(theEntity);
+  }
+
+  @TestTemplate
   void saveNew_succeeds() {
     assertEntityNotExist(theEntity);
     tm().transact(() -> tm().saveNew(theEntity));


### PR DESCRIPTION
For all `JpaTransactionManager.transactNew()` methods, we just call `JpaTransactionManager.transact()` to reuse the current transaction if it exists. This is because Postgresql's transaction doesn't have the limitation that Datastore's transaction has(See [here](https://cloud.google.com/datastore/docs/concepts/transactions#what_can_be_done_in_a_transaction)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/633)
<!-- Reviewable:end -->
