### PR TITLE
Don't expect a renewal fee on restores when one isn't due

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainCheckFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCheckFlow.java
@@ -247,6 +247,7 @@ public final class DomainCheckFlow implements Flow {
             feeCheckItem,
             builder,
             domainNames.get(domainName),
+            Optional.empty(),
             feeCheck.getCurrency(),
             now,
             pricingLogic,

--- a/core/src/main/java/google/registry/flows/domain/DomainInfoFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainInfoFlow.java
@@ -158,6 +158,7 @@ public final class DomainInfoFlow implements Flow {
           feeInfo.get(),
           builder,
           InternetDomainName.from(targetId),
+          Optional.of(domain),
           null,
           now,
           pricingLogic,

--- a/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
@@ -659,6 +659,39 @@ public class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Dom
     doSuccessfulTest("domain_info_fee_restore_response.xml", false);
   }
 
+  @Test
+  public void testFeeExtension_restoreCommand_pendingDelete_noRenewal() throws Exception {
+    setEppInput(
+        "domain_info_fee.xml",
+        updateSubstitutions(SUBSTITUTION_BASE, "COMMAND", "restore", "PERIOD", "1"));
+    persistTestEntities(false);
+    persistResource(
+        domain
+            .asBuilder()
+            .setDeletionTime(clock.nowUtc().plusDays(25))
+            .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
+            .build());
+    doSuccessfulTest("domain_info_fee_restore_response_no_renewal.xml", false);
+  }
+
+  @Test
+  public void testFeeExtension_restoreCommand_pendingDelete_withRenewal() throws Exception {
+    createTld("example");
+    setEppInput(
+        "domain_info_fee.xml",
+        updateSubstitutions(
+            SUBSTITUTION_BASE, "NAME", "rich.example", "COMMAND", "restore", "PERIOD", "1"));
+    persistTestEntities("rich.example", false);
+    persistResource(
+        domain
+            .asBuilder()
+            .setDeletionTime(clock.nowUtc().plusDays(25))
+            .setRegistrationExpirationTime(clock.nowUtc().minusDays(1))
+            .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
+            .build());
+    doSuccessfulTest("domain_info_fee_restore_response_with_renewal.xml", false);
+  }
+
   /** Test create command on a premium label. */
   @Test
   public void testFeeExtension_createCommandPremium() throws Exception {

--- a/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
@@ -94,7 +94,8 @@ public class DomainRestoreRequestFlowTest
   }
 
   void persistPendingDeleteDomain() throws Exception {
-    persistPendingDeleteDomain(clock.nowUtc().plusYears(5).plusDays(45));
+    // The domain is now past what had been its expiration date at the time of deletion.
+    persistPendingDeleteDomain(clock.nowUtc().minusDays(5));
   }
 
   void persistPendingDeleteDomain(DateTime expirationTime) throws Exception {
@@ -286,6 +287,14 @@ public class DomainRestoreRequestFlowTest
   }
 
   @Test
+  public void testSuccess_fee_v06_noRenewal() throws Exception {
+    setEppInput("domain_update_restore_request_fee_no_renewal.xml", FEE_06_MAP);
+    persistPendingDeleteDomain(clock.nowUtc().plusMonths(6));
+    runFlowAssertResponse(
+        loadFile("domain_update_restore_request_response_fee_no_renewal.xml", FEE_06_MAP));
+  }
+
+  @Test
   public void testSuccess_fee_v11() throws Exception {
     setEppInput("domain_update_restore_request_fee.xml", FEE_11_MAP);
     persistPendingDeleteDomain();
@@ -408,6 +417,15 @@ public class DomainRestoreRequestFlowTest
     setEppInput("domain_update_restore_request_premium.xml");
     persistPendingDeleteDomain();
     runFlowAssertResponse(loadFile("domain_update_restore_request_response_premium.xml"));
+  }
+
+  @Test
+  public void testSuccess_premiumNotBlocked_andNoRenewal() throws Exception {
+    createTld("example");
+    setEppInput("domain_update_restore_request_premium_no_renewal.xml");
+    persistPendingDeleteDomain(clock.nowUtc().plusYears(2));
+    runFlowAssertResponse(
+        loadFile("domain_update_restore_request_response_fee_no_renewal.xml", FEE_12_MAP));
   }
 
   @Test

--- a/core/src/test/resources/google/registry/flows/domain/domain_info_fee_restore_response.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_info_fee_restore_response.xml
@@ -35,7 +35,6 @@
         <fee:currency>USD</fee:currency>
         <fee:command>restore</fee:command>
         <fee:period unit="y">1</fee:period>
-        <fee:fee description="renew">11.00</fee:fee>
         <fee:fee description="restore">17.00</fee:fee>
       </fee:infData>
     </extension>

--- a/core/src/test/resources/google/registry/flows/domain/domain_info_fee_restore_response_no_renewal.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_info_fee_restore_response_no_renewal.xml
@@ -6,9 +6,9 @@
     <resData>
       <domain:infData
        xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
-        <domain:name>rich.example</domain:name>
+        <domain:name>example.tld</domain:name>
         <domain:roid>%ROID%</domain:roid>
-        <domain:status s="ok"/>
+        <domain:status s="pendingDelete"/>
         <domain:registrant>jd1234</domain:registrant>
         <domain:contact type="admin">sh8013</domain:contact>
         <domain:contact type="tech">sh8013</domain:contact>
@@ -31,12 +31,14 @@
       </domain:infData>
     </resData>
     <extension>
+      <rgp:infData xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0">
+        <rgp:rgpStatus s="pendingDelete"/>
+      </rgp:infData>
       <fee:infData xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
         <fee:currency>USD</fee:currency>
         <fee:command>restore</fee:command>
         <fee:period unit="y">1</fee:period>
         <fee:fee description="restore">17.00</fee:fee>
-        <fee:class>premium</fee:class>
       </fee:infData>
     </extension>
     <trID>

--- a/core/src/test/resources/google/registry/flows/domain/domain_info_fee_restore_response_with_renewal.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_info_fee_restore_response_with_renewal.xml
@@ -8,7 +8,7 @@
        xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
         <domain:name>rich.example</domain:name>
         <domain:roid>%ROID%</domain:roid>
-        <domain:status s="ok"/>
+        <domain:status s="pendingDelete"/>
         <domain:registrant>jd1234</domain:registrant>
         <domain:contact type="admin">sh8013</domain:contact>
         <domain:contact type="tech">sh8013</domain:contact>
@@ -23,7 +23,7 @@
         <domain:crDate>1999-04-03T22:00:00.0Z</domain:crDate>
         <domain:upID>NewRegistrar</domain:upID>
         <domain:upDate>1999-12-03T09:00:00.0Z</domain:upDate>
-        <domain:exDate>2005-04-03T22:00:00.0Z</domain:exDate>
+        <domain:exDate>2005-03-02T22:00:00.000Z</domain:exDate>
         <domain:trDate>2000-04-08T09:00:00.0Z</domain:trDate>
         <domain:authInfo>
           <domain:pw>2fooBAR</domain:pw>
@@ -31,11 +31,15 @@
       </domain:infData>
     </resData>
     <extension>
+      <rgp:infData xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0">
+        <rgp:rgpStatus s="pendingDelete"/>
+      </rgp:infData>
       <fee:infData xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
         <fee:currency>USD</fee:currency>
         <fee:command>restore</fee:command>
         <fee:period unit="y">1</fee:period>
         <fee:fee description="restore">17.00</fee:fee>
+        <fee:fee description="renew">100.00</fee:fee>
         <fee:class>premium</fee:class>
       </fee:infData>
     </extension>

--- a/core/src/test/resources/google/registry/flows/domain/domain_update_restore_request_fee_no_renewal.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_update_restore_request_fee_no_renewal.xml
@@ -1,0 +1,21 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <command>
+    <update>
+      <domain:update
+       xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>example.tld</domain:name>
+        <domain:chg/>
+      </domain:update>
+    </update>
+    <extension>
+      <rgp:update xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0">
+        <rgp:restore op="request"/>
+      </rgp:update>
+      <fee:update xmlns:fee="urn:ietf:params:xml:ns:fee-%FEE_VERSION%">
+        <fee:currency>%CURRENCY%</fee:currency>
+        <fee:fee description="restore">17.00</fee:fee>
+      </fee:update>
+    </extension>
+    <clTRID>ABC-12345</clTRID>
+  </command>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain/domain_update_restore_request_premium_no_renewal.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_update_restore_request_premium_no_renewal.xml
@@ -1,0 +1,23 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <command>
+    <update>
+      <domain:update
+          xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>rich.example</domain:name>
+        <domain:chg/>
+      </domain:update>
+    </update>
+    <extension>
+      <rgp:update xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0">
+        <rgp:restore op="request"/>
+      </rgp:update>
+      <fee:update xmlns:fee="urn:ietf:params:xml:ns:fee-0.12">
+        <fee:currency>USD</fee:currency>
+        <fee:fee description="restore" refundable="true" grace-period="P0D" applied="immediate">
+          17.00
+        </fee:fee>
+      </fee:update>
+    </extension>
+    <clTRID>ABC-12345</clTRID>
+  </command>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain/domain_update_restore_request_response_fee_no_renewal.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_update_restore_request_response_fee_no_renewal.xml
@@ -1,0 +1,17 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <response>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
+    </result>
+    <extension>
+      <%FEE_NS%:updData xmlns:%FEE_NS%="urn:ietf:params:xml:ns:fee-%FEE_VERSION%">
+        <%FEE_NS%:currency>USD</%FEE_NS%:currency>
+        <%FEE_NS%:fee description="restore">17.00</%FEE_NS%:fee>
+      </%FEE_NS%:updData>
+    </extension>
+    <trID>
+      <clTRID>ABC-12345</clTRID>
+      <svTRID>server-trid</svTRID>
+    </trID>
+  </response>
+</epp>


### PR DESCRIPTION
This is a fix on top of #632 so that domain restore commands don't require
acking an illusory renewal fee for 1 year when that isn't actually happening
(i.e. if the domain isn't yet past its original expiration).

Unfortunately, there's still a problem remaining wherein the restore fee on a
domain check will always include the additional year even if it's not
necessary. We don't have a good solution to that. Also note that in versions of
the fee extension more recent than 0.6, the fee extension cannot be passed on a
domain info command at all, so the domain check command is the only way you have
to determine what the restore fee should be. So we definitely do want to get
that right so that the apparent restore fee on a check is the same as the actual
restore fee when running the restore command. We're not quite there yet though
and it's hard to say how we will get there, since we don't load domains during a
domain check command for performance reasons yet we would need to do so in order
to know the expiration date and thus whether the additional year of renewal
should be charged.

A problem for a future PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/637)
<!-- Reviewable:end -->
