### PR TITLE
Expand VKeyTranslatorFactory to support VKey of @EntitySubclass

### DIFF
--- a/core/src/main/java/google/registry/model/translators/AbstractSimpleTranslatorFactory.java
+++ b/core/src/main/java/google/registry/model/translators/AbstractSimpleTranslatorFactory.java
@@ -34,9 +34,9 @@ public abstract class AbstractSimpleTranslatorFactory<P, D> extends ValueTransla
   @Override
   protected final ValueTranslator<P, D> createSafe(
       Path path, Property property, Type type, CreateContext ctx) {
-    return new ValueTranslator<P, D>(path, new TypeInstantiator<D>(getClass()){}.getExactType()) {
+    return new ValueTranslator<P, D>(path, new TypeInstantiator<D>(getClass()) {}.getExactType()) {
 
-      SimpleTranslator<P, D> simpleTranslator = createTranslator();
+      SimpleTranslator<P, D> simpleTranslator = createTranslator(property);
 
       @Override
       protected P loadValue(D datastoreValue, LoadContext ctx) {
@@ -57,5 +57,5 @@ public abstract class AbstractSimpleTranslatorFactory<P, D> extends ValueTransla
     D saveValue(P pojoValue);
   }
 
-  abstract SimpleTranslator<P, D> createTranslator();
+  abstract SimpleTranslator<P, D> createTranslator(Property property);
 }

--- a/core/src/main/java/google/registry/model/translators/CidrAddressBlockTranslatorFactory.java
+++ b/core/src/main/java/google/registry/model/translators/CidrAddressBlockTranslatorFactory.java
@@ -14,6 +14,7 @@
 
 package google.registry.model.translators;
 
+import com.googlecode.objectify.impl.Property;
 import google.registry.util.CidrAddressBlock;
 
 /** Stores {@link CidrAddressBlock} as a canonicalized string. */
@@ -25,7 +26,7 @@ public class CidrAddressBlockTranslatorFactory
   }
 
   @Override
-  SimpleTranslator<CidrAddressBlock, String> createTranslator() {
+  SimpleTranslator<CidrAddressBlock, String> createTranslator(Property property) {
     return new SimpleTranslator<CidrAddressBlock, String>(){
       @Override
       public CidrAddressBlock loadValue(String datastoreValue) {

--- a/core/src/main/java/google/registry/model/translators/CreateAutoTimestampTranslatorFactory.java
+++ b/core/src/main/java/google/registry/model/translators/CreateAutoTimestampTranslatorFactory.java
@@ -18,6 +18,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static org.joda.time.DateTimeZone.UTC;
 
+import com.googlecode.objectify.impl.Property;
 import google.registry.model.CreateAutoTimestamp;
 import java.util.Date;
 import org.joda.time.DateTime;
@@ -31,7 +32,7 @@ public class CreateAutoTimestampTranslatorFactory
   }
 
   @Override
-  SimpleTranslator<CreateAutoTimestamp, Date> createTranslator() {
+  SimpleTranslator<CreateAutoTimestamp, Date> createTranslator(Property property) {
     return new SimpleTranslator<CreateAutoTimestamp, Date>() {
 
       /**

--- a/core/src/main/java/google/registry/model/translators/CurrencyUnitTranslatorFactory.java
+++ b/core/src/main/java/google/registry/model/translators/CurrencyUnitTranslatorFactory.java
@@ -14,6 +14,7 @@
 
 package google.registry.model.translators;
 
+import com.googlecode.objectify.impl.Property;
 import org.joda.money.CurrencyUnit;
 
 /** Stores {@link CurrencyUnit} as a canonicalized string. */
@@ -25,7 +26,7 @@ public class CurrencyUnitTranslatorFactory
   }
 
   @Override
-  SimpleTranslator<CurrencyUnit, String> createTranslator() {
+  SimpleTranslator<CurrencyUnit, String> createTranslator(Property property) {
     return new SimpleTranslator<CurrencyUnit, String>(){
       @Override
       public CurrencyUnit loadValue(String datastoreValue) {

--- a/core/src/main/java/google/registry/model/translators/DurationTranslatorFactory.java
+++ b/core/src/main/java/google/registry/model/translators/DurationTranslatorFactory.java
@@ -14,6 +14,7 @@
 
 package google.registry.model.translators;
 
+import com.googlecode.objectify.impl.Property;
 import org.joda.time.Duration;
 
 /** Stores {@link Duration} as a canonicalized string. */
@@ -24,7 +25,7 @@ public class DurationTranslatorFactory extends AbstractSimpleTranslatorFactory<D
   }
 
   @Override
-  protected SimpleTranslator<Duration, String> createTranslator() {
+  protected SimpleTranslator<Duration, String> createTranslator(Property property) {
     return new SimpleTranslator<Duration, String>() {
       @Override
       public Duration loadValue(String datastoreValue) {

--- a/core/src/main/java/google/registry/model/translators/InetAddressTranslatorFactory.java
+++ b/core/src/main/java/google/registry/model/translators/InetAddressTranslatorFactory.java
@@ -15,6 +15,7 @@
 package google.registry.model.translators;
 
 import com.google.common.net.InetAddresses;
+import com.googlecode.objectify.impl.Property;
 import java.net.InetAddress;
 
 /** Stores {@link InetAddress} as a canonicalized string. */
@@ -26,7 +27,7 @@ public class InetAddressTranslatorFactory
   }
 
   @Override
-  SimpleTranslator<InetAddress, String> createTranslator() {
+  SimpleTranslator<InetAddress, String> createTranslator(Property property) {
     return new SimpleTranslator<InetAddress, String>() {
       @Override
       public InetAddress loadValue(String datastoreValue) {

--- a/core/src/main/java/google/registry/model/translators/UpdateAutoTimestampTranslatorFactory.java
+++ b/core/src/main/java/google/registry/model/translators/UpdateAutoTimestampTranslatorFactory.java
@@ -17,6 +17,7 @@ package google.registry.model.translators;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static org.joda.time.DateTimeZone.UTC;
 
+import com.googlecode.objectify.impl.Property;
 import google.registry.model.UpdateAutoTimestamp;
 import java.util.Date;
 import org.joda.time.DateTime;
@@ -30,7 +31,7 @@ public class UpdateAutoTimestampTranslatorFactory
   }
 
   @Override
-  SimpleTranslator<UpdateAutoTimestamp, Date> createTranslator() {
+  SimpleTranslator<UpdateAutoTimestamp, Date> createTranslator(Property property) {
     return new SimpleTranslator<UpdateAutoTimestamp, Date>() {
 
       /**

--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -720,7 +720,7 @@ class google.registry.model.transfer.ContactTransferData {
   google.registry.model.transfer.TransferStatus transferStatus;
   java.lang.String gainingClientId;
   java.lang.String losingClientId;
-  java.util.Set<google.registry.persistence.VKey<? extends google.registry.model.transfer.TransferData$TransferServerApproveEntity>> serverApproveEntities;
+  java.util.Set<com.googlecode.objectify.Key<? extends google.registry.model.transfer.TransferData$TransferServerApproveEntity>> serverApproveEntities;
   org.joda.time.DateTime pendingTransferExpirationTime;
   org.joda.time.DateTime transferRequestTime;
 }
@@ -733,7 +733,7 @@ class google.registry.model.transfer.DomainTransferData {
   google.registry.persistence.VKey<google.registry.model.poll.PollMessage$Autorenew> serverApproveAutorenewPollMessage;
   java.lang.String gainingClientId;
   java.lang.String losingClientId;
-  java.util.Set<google.registry.persistence.VKey<? extends google.registry.model.transfer.TransferData$TransferServerApproveEntity>> serverApproveEntities;
+  java.util.Set<com.googlecode.objectify.Key<? extends google.registry.model.transfer.TransferData$TransferServerApproveEntity>> serverApproveEntities;
   org.joda.time.DateTime pendingTransferExpirationTime;
   org.joda.time.DateTime transferRequestTime;
   org.joda.time.DateTime transferredRegistrationExpirationTime;


### PR DESCRIPTION
Multiple entities annotated with `@EntitySubclass` share the same kind in the Objectify key string, e.g. both `Key<PollMessage.OneTime>` and `Key<PollMessage.AutoRenew>` would have the same value `PollMessage` as kind stored in the key. This means when we load a poll message key back from Datastore, we cannot know its exact type by just looking at the key, and this would break the approach used by `VKeyTranslatorFactory` to construct `VKey` from its Objectify `Key`. This PR solved this problem by using the property's type defined in the entity Java class to help determine the exact type of an `@EntitySubclass`. 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/638)
<!-- Reviewable:end -->
