### PR TITLE
Convert all VKeys to symmetric VKeys

### DIFF
--- a/core/src/main/java/google/registry/batch/DeleteContactsAndHostsAction.java
+++ b/core/src/main/java/google/registry/batch/DeleteContactsAndHostsAction.java
@@ -85,7 +85,6 @@ import google.registry.model.poll.PendingActionNotificationResponse.HostPendingA
 import google.registry.model.poll.PollMessage;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.server.Lock;
-import google.registry.persistence.VKey;
 import google.registry.request.Action;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -285,7 +284,7 @@ public class DeleteContactsAndHostsAction implements Runnable {
       if (resourceKey.getKind().equals(KIND_CONTACT)) {
         return domain
             .getReferencedContacts()
-            .contains(VKey.createOfy(ContactResource.class, (Key<ContactResource>) resourceKey));
+            .contains(ContactResource.createVKey((Key<ContactResource>) resourceKey));
       } else if (resourceKey.getKind().equals(KIND_HOST)) {
         return domain
             .getNameservers()

--- a/core/src/main/java/google/registry/batch/DeleteContactsAndHostsAction.java
+++ b/core/src/main/java/google/registry/batch/DeleteContactsAndHostsAction.java
@@ -85,6 +85,7 @@ import google.registry.model.poll.PendingActionNotificationResponse.HostPendingA
 import google.registry.model.poll.PollMessage;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.server.Lock;
+import google.registry.persistence.VKey;
 import google.registry.request.Action;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -284,11 +285,9 @@ public class DeleteContactsAndHostsAction implements Runnable {
       if (resourceKey.getKind().equals(KIND_CONTACT)) {
         return domain
             .getReferencedContacts()
-            .contains(ContactResource.createVKey((Key<ContactResource>) resourceKey));
+            .contains(VKey.from((Key<ContactResource>) resourceKey));
       } else if (resourceKey.getKind().equals(KIND_HOST)) {
-        return domain
-            .getNameservers()
-            .contains(HostResource.createVKey((Key<HostResource>) resourceKey));
+        return domain.getNameservers().contains(VKey.from((Key<HostResource>) resourceKey));
       } else {
         throw new IllegalStateException("EPP resource key of unknown type: " + resourceKey);
       }

--- a/core/src/main/java/google/registry/batch/DeleteContactsAndHostsAction.java
+++ b/core/src/main/java/google/registry/batch/DeleteContactsAndHostsAction.java
@@ -289,7 +289,7 @@ public class DeleteContactsAndHostsAction implements Runnable {
       } else if (resourceKey.getKind().equals(KIND_HOST)) {
         return domain
             .getNameservers()
-            .contains(VKey.createOfy(HostResource.class, (Key<HostResource>) resourceKey));
+            .contains(HostResource.createVKey((Key<HostResource>) resourceKey));
       } else {
         throw new IllegalStateException("EPP resource key of unknown type: " + resourceKey);
       }

--- a/core/src/main/java/google/registry/batch/RefreshDnsOnHostRenameAction.java
+++ b/core/src/main/java/google/registry/batch/RefreshDnsOnHostRenameAction.java
@@ -52,6 +52,7 @@ import google.registry.mapreduce.inputs.NullInput;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.host.HostResource;
 import google.registry.model.server.Lock;
+import google.registry.persistence.VKey;
 import google.registry.request.Action;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -206,7 +207,7 @@ public class RefreshDnsOnHostRenameAction implements Runnable {
       Key<HostResource> referencingHostKey = null;
       for (DnsRefreshRequest request : refreshRequests) {
         if (isActive(domain, request.lastUpdateTime())
-            && domain.getNameservers().contains(HostResource.createVKey(request.hostKey()))) {
+            && domain.getNameservers().contains(VKey.from(request.hostKey()))) {
           referencingHostKey = request.hostKey();
           break;
         }

--- a/core/src/main/java/google/registry/batch/RefreshDnsOnHostRenameAction.java
+++ b/core/src/main/java/google/registry/batch/RefreshDnsOnHostRenameAction.java
@@ -52,7 +52,6 @@ import google.registry.mapreduce.inputs.NullInput;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.host.HostResource;
 import google.registry.model.server.Lock;
-import google.registry.persistence.VKey;
 import google.registry.request.Action;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -207,9 +206,7 @@ public class RefreshDnsOnHostRenameAction implements Runnable {
       Key<HostResource> referencingHostKey = null;
       for (DnsRefreshRequest request : refreshRequests) {
         if (isActive(domain, request.lastUpdateTime())
-            && domain
-                .getNameservers()
-                .contains(VKey.createOfy(HostResource.class, request.hostKey()))) {
+            && domain.getNameservers().contains(HostResource.createVKey(request.hostKey()))) {
           referencingHostKey = request.hostKey();
           break;
         }

--- a/core/src/main/java/google/registry/model/billing/BillingEvent.java
+++ b/core/src/main/java/google/registry/model/billing/BillingEvent.java
@@ -347,11 +347,27 @@ public abstract class BillingEvent extends ImmutableObject
 
     @Override
     public VKey<OneTime> createVKey() {
-      return VKey.create(getClass(), getId(), Key.create(this));
+      return VKey.create(
+          getClass(),
+          parent.getParent().getName() + "/" + parent.getId() + "/" + getId(),
+          Key.create(this));
     }
 
     public static VKey<OneTime> createVKey(Key<OneTime> key) {
-      return VKey.create(OneTime.class, key.getId(), key);
+      // TODO(b/159207551): As it stands, the SQL key generated here doesn't mesh with the primary
+      // key type for the table, which is a single long integer.
+      if (key == null) {
+        return null;
+      }
+      Key parent = key.getParent();
+      Key grandparent = (parent != null) ? parent.getParent() : null;
+      String path =
+          (grandparent != null ? grandparent.getName() : "")
+              + "/"
+              + (parent != null ? parent.getId() : "")
+              + "/"
+              + key.getId();
+      return VKey.create(OneTime.class, path, key);
     }
 
     @Override
@@ -489,11 +505,21 @@ public abstract class BillingEvent extends ImmutableObject
 
     @Override
     public VKey<Recurring> createVKey() {
-      return VKey.create(getClass(), getId(), Key.create(this));
+      return VKey.create(
+          getClass(),
+          parent.getParent().getName() + "/" + parent.getId() + "/" + getId(),
+          Key.create(this));
     }
 
     public static VKey<Recurring> createVKey(Key<Recurring> key) {
-      return VKey.create(Recurring.class, key.getId(), key);
+      // TODO(b/159207551): As it stands, the SQL key generated here doesn't mesh with the primary
+      // key type for the table, which is a single long integer.
+      if (key == null) {
+        return null;
+      }
+      String path =
+          key.getParent().getParent().getName() + "/" + key.getParent().getId() + "/" + key.getId();
+      return VKey.create(Recurring.class, path, key);
     }
 
     @Override
@@ -604,22 +630,30 @@ public abstract class BillingEvent extends ImmutableObject
           .setParent(historyEntry);
       // Set the grace period's billing event using the appropriate Cancellation builder method.
       if (gracePeriod.getOneTimeBillingEvent() != null) {
-        builder.setOneTimeEventKey(
-            BillingEvent.OneTime.createVKey(gracePeriod.getOneTimeBillingEvent()));
+        builder.setOneTimeEventKey(VKey.from(gracePeriod.getOneTimeBillingEvent()));
       } else if (gracePeriod.getRecurringBillingEvent() != null) {
-        builder.setRecurringEventKey(
-            BillingEvent.Recurring.createVKey(gracePeriod.getRecurringBillingEvent()));
+        builder.setRecurringEventKey(VKey.from(gracePeriod.getRecurringBillingEvent()));
       }
       return builder.build();
     }
 
     @Override
     public VKey<Cancellation> createVKey() {
-      return VKey.create(getClass(), getId(), Key.create(this));
+      return VKey.create(
+          getClass(),
+          parent.getParent().getName() + "/" + parent.getId() + "/" + getId(),
+          Key.create(this));
     }
 
     public static VKey<Cancellation> createVKey(Key<Cancellation> key) {
-      return VKey.create(Cancellation.class, key.getId(), key);
+      // TODO(b/159207551): As it stands, the SQL key generated here doesn't mesh with the primary
+      // key type for the table, which is a single long integer.
+      if (key == null) {
+        return null;
+      }
+      String path =
+          key.getParent().getParent().getName() + "/" + key.getParent().getId() + "/" + key.getId();
+      return VKey.create(Cancellation.class, path, key);
     }
 
     @Override
@@ -699,11 +733,21 @@ public abstract class BillingEvent extends ImmutableObject
 
     @Override
     public VKey<Modification> createVKey() {
-      return VKey.create(getClass(), getId(), Key.create(this));
+      return VKey.create(
+          getClass(),
+          parent.getParent().getName() + "/" + parent.getId() + "/" + getId(),
+          Key.create(this));
     }
 
     public static VKey<Modification> createVKey(Key<Modification> key) {
-      return VKey.create(Modification.class, key.getId(), key);
+      // TODO(b/159207551): As it stands, the SQL key generated here doesn't mesh with the primary
+      // key type for the table, which is a single long integer.
+      if (key == null) {
+        return null;
+      }
+      String path =
+          key.getParent().getParent().getName() + "/" + key.getParent().getId() + "/" + key.getId();
+      return VKey.create(Modification.class, path, key);
     }
 
     /**

--- a/core/src/main/java/google/registry/model/billing/BillingEvent.java
+++ b/core/src/main/java/google/registry/model/billing/BillingEvent.java
@@ -347,7 +347,11 @@ public abstract class BillingEvent extends ImmutableObject
 
     @Override
     public VKey<OneTime> createVKey() {
-      return VKey.createOfy(getClass(), Key.create(this));
+      return VKey.create(getClass(), getId(), Key.create(this));
+    }
+
+    public static VKey<OneTime> createVKey(Key<OneTime> key) {
+      return VKey.create(OneTime.class, key.getId(), key);
     }
 
     @Override
@@ -485,7 +489,11 @@ public abstract class BillingEvent extends ImmutableObject
 
     @Override
     public VKey<Recurring> createVKey() {
-      return VKey.createOfy(getClass(), Key.create(this));
+      return VKey.create(getClass(), getId(), Key.create(this));
+    }
+
+    public static VKey<Recurring> createVKey(Key<Recurring> key) {
+      return VKey.create(Recurring.class, key.getId(), key);
     }
 
     @Override
@@ -597,17 +605,21 @@ public abstract class BillingEvent extends ImmutableObject
       // Set the grace period's billing event using the appropriate Cancellation builder method.
       if (gracePeriod.getOneTimeBillingEvent() != null) {
         builder.setOneTimeEventKey(
-            VKey.createOfy(BillingEvent.OneTime.class, gracePeriod.getOneTimeBillingEvent()));
+            BillingEvent.OneTime.createVKey(gracePeriod.getOneTimeBillingEvent()));
       } else if (gracePeriod.getRecurringBillingEvent() != null) {
         builder.setRecurringEventKey(
-            VKey.createOfy(BillingEvent.Recurring.class, gracePeriod.getRecurringBillingEvent()));
+            BillingEvent.Recurring.createVKey(gracePeriod.getRecurringBillingEvent()));
       }
       return builder.build();
     }
 
     @Override
     public VKey<Cancellation> createVKey() {
-      return VKey.createOfy(getClass(), Key.create(this));
+      return VKey.create(getClass(), getId(), Key.create(this));
+    }
+
+    public static VKey<Cancellation> createVKey(Key<Cancellation> key) {
+      return VKey.create(Cancellation.class, key.getId(), key);
     }
 
     @Override
@@ -687,7 +699,11 @@ public abstract class BillingEvent extends ImmutableObject
 
     @Override
     public VKey<Modification> createVKey() {
-      return VKey.createOfy(this.getClass(), Key.create(this));
+      return VKey.create(getClass(), getId(), Key.create(this));
+    }
+
+    public static VKey<Modification> createVKey(Key<Modification> key) {
+      return VKey.create(Modification.class, key.getId(), key);
     }
 
     /**

--- a/core/src/main/java/google/registry/model/contact/ContactResource.java
+++ b/core/src/main/java/google/registry/model/contact/ContactResource.java
@@ -200,8 +200,11 @@ public class ContactResource extends EppResource
 
   @Override
   public VKey<ContactResource> createVKey() {
-    // TODO(mmuller): create symmetric keys if we can ever reload both sides.
-    return VKey.createOfy(ContactResource.class, Key.create(this));
+    return VKey.create(ContactResource.class, getRepoId(), Key.create(this));
+  }
+
+  public static VKey<ContactResource> createVKey(Key<ContactResource> key) {
+    return VKey.create(ContactResource.class, key.getName(), key);
   }
 
   @Override

--- a/core/src/main/java/google/registry/model/contact/ContactResource.java
+++ b/core/src/main/java/google/registry/model/contact/ContactResource.java
@@ -203,10 +203,6 @@ public class ContactResource extends EppResource
     return VKey.create(ContactResource.class, getRepoId(), Key.create(this));
   }
 
-  public static VKey<ContactResource> createVKey(Key<ContactResource> key) {
-    return VKey.create(ContactResource.class, key.getName(), key);
-  }
-
   @Override
   @javax.persistence.Id
   @Access(AccessType.PROPERTY)

--- a/core/src/main/java/google/registry/model/domain/DesignatedContact.java
+++ b/core/src/main/java/google/registry/model/domain/DesignatedContact.java
@@ -85,6 +85,6 @@ public class DesignatedContact extends ImmutableObject {
   }
 
   public DesignatedContact reconstitute() {
-    return create(type, ContactResource.createVKey(contact));
+    return create(type, VKey.from(contact));
   }
 }

--- a/core/src/main/java/google/registry/model/domain/DesignatedContact.java
+++ b/core/src/main/java/google/registry/model/domain/DesignatedContact.java
@@ -85,6 +85,6 @@ public class DesignatedContact extends ImmutableObject {
   }
 
   public DesignatedContact reconstitute() {
-    return create(type, VKey.createOfy(ContactResource.class, contact));
+    return create(type, ContactResource.createVKey(contact));
   }
 }

--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -643,10 +643,6 @@ public class DomainBase extends EppResource
     return VKey.create(DomainBase.class, getRepoId(), Key.create(this));
   }
 
-  public static VKey<DomainBase> createVKey(Key key) {
-    return VKey.create(DomainBase.class, key.getName(), key);
-  }
-
   /** Predicate to determine if a given {@link DesignatedContact} is the registrant. */
   private static final Predicate<DesignatedContact> IS_REGISTRANT =
       (DesignatedContact contact) -> DesignatedContact.Type.REGISTRANT.equals(contact.type);

--- a/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
+++ b/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
@@ -183,7 +183,11 @@ public class AllocationToken extends BackupGroupRoot implements Buildable {
   }
 
   public VKey<AllocationToken> createVKey() {
-    return VKey.createOfy(getClass(), Key.create(this));
+    return VKey.create(getClass(), getToken(), Key.create(this));
+  }
+
+  public static VKey<AllocationToken> createVKey(Key<AllocationToken> key) {
+    return VKey.create(AllocationToken.class, key.getName(), key);
   }
 
   @Override

--- a/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
+++ b/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
@@ -186,10 +186,6 @@ public class AllocationToken extends BackupGroupRoot implements Buildable {
     return VKey.create(getClass(), getToken(), Key.create(this));
   }
 
-  public static VKey<AllocationToken> createVKey(Key<AllocationToken> key) {
-    return VKey.create(AllocationToken.class, key.getName(), key);
-  }
-
   @Override
   public Builder asBuilder() {
     return new Builder(clone(this));

--- a/core/src/main/java/google/registry/model/host/HostBase.java
+++ b/core/src/main/java/google/registry/model/host/HostBase.java
@@ -126,7 +126,7 @@ public class HostBase extends EppResource {
 
   @Override
   public VKey<? extends EppResource> createVKey() {
-    return VKey.createOfy(HostBase.class, Key.create(this));
+    return VKey.create(HostBase.class, getRepoId(), Key.create(this));
   }
 
   @Deprecated

--- a/core/src/main/java/google/registry/model/host/HostHistory.java
+++ b/core/src/main/java/google/registry/model/host/HostHistory.java
@@ -83,7 +83,8 @@ public class HostHistory extends HistoryEntry {
     @Override
     public Builder setParent(Key<? extends EppResource> parent) {
       super.setParent(parent);
-      getInstance().hostRepoId = VKey.createOfy(HostResource.class, (Key<HostResource>) parent);
+      getInstance().hostRepoId =
+          VKey.create(HostResource.class, parent.getName(), (Key<HostResource>) parent);
       return this;
     }
   }

--- a/core/src/main/java/google/registry/model/host/HostResource.java
+++ b/core/src/main/java/google/registry/model/host/HostResource.java
@@ -51,10 +51,6 @@ public class HostResource extends HostBase
     return VKey.create(HostResource.class, getRepoId(), Key.create(this));
   }
 
-  public static VKey<HostResource> createVKey(Key<HostResource> key) {
-    return VKey.create(HostResource.class, key.getName(), key);
-  }
-
   @Override
   public Builder asBuilder() {
     return new Builder(clone(this));

--- a/core/src/main/java/google/registry/model/host/HostResource.java
+++ b/core/src/main/java/google/registry/model/host/HostResource.java
@@ -48,8 +48,11 @@ public class HostResource extends HostBase
 
   @Override
   public VKey<HostResource> createVKey() {
-    // TODO(mmuller): create symmetric keys if we can ever reload both sides.
-    return VKey.createOfy(HostResource.class, Key.create(this));
+    return VKey.create(HostResource.class, getRepoId(), Key.create(this));
+  }
+
+  public static VKey<HostResource> createVKey(Key<HostResource> key) {
+    return VKey.create(HostResource.class, key.getName(), key);
   }
 
   @Override

--- a/core/src/main/java/google/registry/model/poll/PollMessage.java
+++ b/core/src/main/java/google/registry/model/poll/PollMessage.java
@@ -154,6 +154,18 @@ public abstract class PollMessage extends ImmutableObject
   @Override
   public abstract VKey<? extends PollMessage> createVKey();
 
+  public static VKey<PollMessage> createVKey(Key<PollMessage> key) {
+    // TODO(b/159207551): As it stands, the SQL key generated here doesn't mesh with the primary key
+    // type for the table, which is a single long integer.  Also note that the class id is not
+    // correct here and as such the resulting key will not be loadable from SQL.
+    if (key == null) {
+      return null;
+    }
+    String path =
+        key.getParent().getParent().getName() + "/" + key.getParent().getId() + key.getId();
+    return VKey.create(PollMessage.class, path, key);
+  }
+
   /** Override Buildable.asBuilder() to give this method stronger typing. */
   @Override
   public abstract Builder<?, ?> asBuilder();
@@ -300,10 +312,6 @@ public abstract class PollMessage extends ImmutableObject
       return VKey.create(this.getClass(), getId(), Key.create(this));
     }
 
-    public static VKey<OneTime> createVKey(Key<OneTime> key) {
-      return VKey.create(OneTime.class, key.getId(), key);
-    }
-
     @Override
     public Builder asBuilder() {
       return new Builder(clone(this));
@@ -403,10 +411,6 @@ public abstract class PollMessage extends ImmutableObject
     @Override
     public VKey<Autorenew> createVKey() {
       return VKey.create(this.getClass(), getId(), Key.create(this));
-    }
-
-    public static VKey<Autorenew> createVKey(Key<Autorenew> key) {
-      return VKey.create(Autorenew.class, key.getId(), key);
     }
 
     @Override

--- a/core/src/main/java/google/registry/model/poll/PollMessage.java
+++ b/core/src/main/java/google/registry/model/poll/PollMessage.java
@@ -297,7 +297,11 @@ public abstract class PollMessage extends ImmutableObject
 
     @Override
     public VKey<OneTime> createVKey() {
-      return VKey.createOfy(this.getClass(), Key.create(this));
+      return VKey.create(this.getClass(), getId(), Key.create(this));
+    }
+
+    public static VKey<OneTime> createVKey(Key<OneTime> key) {
+      return VKey.create(OneTime.class, key.getId(), key);
     }
 
     @Override
@@ -398,7 +402,11 @@ public abstract class PollMessage extends ImmutableObject
 
     @Override
     public VKey<Autorenew> createVKey() {
-      return VKey.createOfy(this.getClass(), Key.create(this));
+      return VKey.create(this.getClass(), getId(), Key.create(this));
+    }
+
+    public static VKey<Autorenew> createVKey(Key<Autorenew> key) {
+      return VKey.create(Autorenew.class, key.getId(), key);
     }
 
     @Override

--- a/core/src/main/java/google/registry/model/reporting/HistoryEntry.java
+++ b/core/src/main/java/google/registry/model/reporting/HistoryEntry.java
@@ -236,7 +236,7 @@ public class HistoryEntry extends ImmutableObject implements Buildable {
   }
 
   public static VKey<HistoryEntry> createVKey(Key<HistoryEntry> key) {
-    // TODO(b/158837942): This will likely need some revision.  As it stands, this method was
+    // TODO(b/159207551): This will likely need some revision.  As it stands, this method was
     // introduced purely to facilitate testing of VKey specialization in VKeyTranslatorFactory.
     // This class will likely require that functionality, though perhaps not this implementation of
     // it.

--- a/core/src/main/java/google/registry/model/reporting/HistoryEntry.java
+++ b/core/src/main/java/google/registry/model/reporting/HistoryEntry.java
@@ -30,6 +30,7 @@ import google.registry.model.ImmutableObject;
 import google.registry.model.annotations.ReportedOn;
 import google.registry.model.domain.Period;
 import google.registry.model.eppcommon.Trid;
+import google.registry.persistence.VKey;
 import java.util.Set;
 import javax.annotation.Nullable;
 import javax.persistence.AttributeOverride;
@@ -232,6 +233,19 @@ public class HistoryEntry extends ImmutableObject implements Buildable {
 
   public ImmutableSet<DomainTransactionRecord> getDomainTransactionRecords() {
     return nullToEmptyImmutableCopy(domainTransactionRecords);
+  }
+
+  public static VKey<HistoryEntry> createVKey(Key<HistoryEntry> key) {
+    // TODO(b/158837942): This will likely need some revision.  As it stands, this method was
+    // introduced purely to facilitate testing of VKey specialization in VKeyTranslatorFactory.
+    // This class will likely require that functionality, though perhaps not this implementation of
+    // it.
+    // For now, just assume that the primary key of a history entry is comprised of the parent
+    // type, key and the object identifer.
+    return VKey.create(
+        HistoryEntry.class,
+        key.getParent().getKind() + "/" + key.getParent().getName() + "/" + key.getId(),
+        key);
   }
 
   @Override

--- a/core/src/main/java/google/registry/model/translators/VKeyTranslatorFactory.java
+++ b/core/src/main/java/google/registry/model/translators/VKeyTranslatorFactory.java
@@ -67,9 +67,17 @@ public class VKeyTranslatorFactory extends AbstractSimpleTranslatorFactory<VKey,
           clazz.getDeclaredMethod("createVKey", com.googlecode.objectify.Key.class);
       return (VKey<T>) createVKeyMethod.invoke(null, new Object[] {key});
     } catch (NoSuchMethodException e) {
-      // Revert to an ofy vkey for now.  TODO(mmuller): remove this when all classes with VKeys have
-      // converters.
-      return VKey.createOfy(clazz, key);
+      checkArgument(
+          key.getParent() == null,
+          "Cannot auto-convert key %s of kind %s because it has a parent.  Add a createVKey(Key) "
+              + "method for it.",
+          key,
+          key.getKind());
+      if (key.getName() != null) {
+        return VKey.create(clazz, key.getName(), key);
+      } else {
+        return VKey.create(clazz, key.getId(), key);
+      }
     } catch (IllegalAccessException | InvocationTargetException e) {
       // If we have a createVKey(Key) method with incorrect permissions or that is non-static, this
       // is probably an error so let's reported.

--- a/core/src/main/java/google/registry/persistence/VKey.java
+++ b/core/src/main/java/google/registry/persistence/VKey.java
@@ -19,6 +19,7 @@ import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
 import com.googlecode.objectify.Key;
 import google.registry.model.ImmutableObject;
+import google.registry.model.translators.VKeyTranslatorFactory;
 import java.io.Serializable;
 import java.util.Optional;
 
@@ -117,5 +118,10 @@ public class VKey<T> extends ImmutableObject implements Serializable {
   /** Returns the objectify key if it exists. */
   public Optional<com.googlecode.objectify.Key<T>> maybeGetOfyKey() {
     return Optional.ofNullable(this.ofyKey);
+  }
+
+  /** Convenience method to construct a VKey from an objectify Key. */
+  public static <T> VKey<T> from(Key<T> key) {
+    return VKeyTranslatorFactory.createVKey(key);
   }
 }

--- a/core/src/main/java/google/registry/persistence/VKey.java
+++ b/core/src/main/java/google/registry/persistence/VKey.java
@@ -47,36 +47,15 @@ public class VKey<T> extends ImmutableObject implements Serializable {
     this.primaryKey = primaryKey;
   }
 
-  /** Creates a {@link VKey} which only contains the sql primary key. */
+  /**
+   * Creates a {@link VKey} which only contains the sql primary key.
+   *
+   * <p>Deprecated. Create symmetric keys with create() instead.
+   */
   public static <T> VKey<T> createSql(Class<? extends T> kind, Object sqlKey) {
     checkArgumentNotNull(kind, "kind must not be null");
     checkArgumentNotNull(sqlKey, "sqlKey must not be null");
     return new VKey(kind, null, sqlKey);
-  }
-
-  /** Creates a {@link VKey} which only contains the ofy primary key. */
-  public static <T> VKey<T> createOfy(
-      Class<? extends T> kind, com.googlecode.objectify.Key<? extends T> ofyKey) {
-    checkArgumentNotNull(kind, "kind must not be null");
-    checkArgumentNotNull(ofyKey, "ofyKey must not be null");
-    return new VKey(kind, ofyKey, null);
-  }
-
-  /**
-   * Creates a {@link VKey} which only contains the ofy primary key by specifying the id of the
-   * {@link Key}.
-   */
-  public static <T> VKey<T> createOfy(Class<? extends T> kind, long id) {
-    return createOfy(kind, Key.create(kind, id));
-  }
-
-  /**
-   * Creates a {@link VKey} which only contains the ofy primary key by specifying the name of the
-   * {@link Key}.
-   */
-  public static <T> VKey<T> createOfy(Class<? extends T> kind, String name) {
-    checkArgumentNotNull(kind, "name must not be null");
-    return createOfy(kind, Key.create(kind, name));
   }
 
   /** Creates a {@link VKey} which only contains both sql and ofy primary key. */

--- a/core/src/main/java/google/registry/persistence/VKey.java
+++ b/core/src/main/java/google/registry/persistence/VKey.java
@@ -87,6 +87,11 @@ public class VKey<T> extends ImmutableObject implements Serializable {
     return new VKey(kind, ofyKey, sqlKey);
   }
 
+  /** Creates a symmetric {@link VKey} in which both sql and ofy keys are {@code id}. */
+  public static <T> VKey<T> create(Class<? extends T> kind, long id) {
+    return new VKey(kind, Key.create(kind, id), id);
+  }
+
   /** Returns the type of the entity. */
   public Class<? extends T> getKind() {
     return this.kind;

--- a/core/src/main/java/google/registry/rdap/RdapDomainSearchAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapDomainSearchAction.java
@@ -295,7 +295,7 @@ public class RdapDomainSearchAction extends RdapSearchActionBase {
       query = query.filter("currentSponsorClientId", desiredRegistrar.get());
     }
     return StreamSupport.stream(query.keys().spliterator(), false)
-        .map(key -> VKey.createOfy(HostResource.class, key))
+        .map(key -> HostResource.createVKey(key))
         .collect(toImmutableSet());
   }
 
@@ -406,7 +406,7 @@ public class RdapDomainSearchAction extends RdapSearchActionBase {
     }
     return searchByNameserverRefs(
         StreamSupport.stream(query.keys().spliterator(), false)
-            .map(key -> VKey.createOfy(HostResource.class, key))
+            .map(key -> HostResource.createVKey(key))
             .collect(toImmutableSet()));
   }
 

--- a/core/src/main/java/google/registry/rdap/RdapDomainSearchAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapDomainSearchAction.java
@@ -295,7 +295,7 @@ public class RdapDomainSearchAction extends RdapSearchActionBase {
       query = query.filter("currentSponsorClientId", desiredRegistrar.get());
     }
     return StreamSupport.stream(query.keys().spliterator(), false)
-        .map(key -> HostResource.createVKey(key))
+        .map(key -> VKey.from(key))
         .collect(toImmutableSet());
   }
 
@@ -406,7 +406,7 @@ public class RdapDomainSearchAction extends RdapSearchActionBase {
     }
     return searchByNameserverRefs(
         StreamSupport.stream(query.keys().spliterator(), false)
-            .map(key -> HostResource.createVKey(key))
+            .map(key -> VKey.from(key))
             .collect(toImmutableSet()));
   }
 

--- a/core/src/test/java/google/registry/flows/EppTestCase.java
+++ b/core/src/test/java/google/registry/flows/EppTestCase.java
@@ -41,7 +41,6 @@ import google.registry.model.registry.Registry;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.reporting.HistoryEntry.Type;
 import google.registry.monitoring.whitebox.EppMetric;
-import google.registry.persistence.VKey;
 import google.registry.testing.FakeClock;
 import google.registry.testing.FakeHttpSession;
 import google.registry.testing.FakeResponse;
@@ -341,7 +340,7 @@ public class EppTestCase extends ShardableTestCase {
         .setClientId(domain.getCurrentSponsorClientId())
         .setEventTime(deleteTime)
         .setOneTimeEventKey(
-            VKey.createOfy(OneTime.class, findKeyToActualOneTimeBillingEvent(billingEventToCancel)))
+            OneTime.createVKey(findKeyToActualOneTimeBillingEvent(billingEventToCancel)))
         .setBillingTime(createTime.plus(Registry.get(domain.getTld()).getAddGracePeriodLength()))
         .setReason(Reason.CREATE)
         .setParent(getOnlyHistoryEntryOfType(domain, Type.DOMAIN_DELETE))
@@ -356,7 +355,7 @@ public class EppTestCase extends ShardableTestCase {
         .setClientId(domain.getCurrentSponsorClientId())
         .setEventTime(deleteTime)
         .setOneTimeEventKey(
-            VKey.createOfy(OneTime.class, findKeyToActualOneTimeBillingEvent(billingEventToCancel)))
+            OneTime.createVKey(findKeyToActualOneTimeBillingEvent(billingEventToCancel)))
         .setBillingTime(renewTime.plus(Registry.get(domain.getTld()).getRenewGracePeriodLength()))
         .setReason(Reason.RENEW)
         .setParent(getOnlyHistoryEntryOfType(domain, Type.DOMAIN_DELETE))

--- a/core/src/test/java/google/registry/flows/EppTestCase.java
+++ b/core/src/test/java/google/registry/flows/EppTestCase.java
@@ -41,6 +41,7 @@ import google.registry.model.registry.Registry;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.reporting.HistoryEntry.Type;
 import google.registry.monitoring.whitebox.EppMetric;
+import google.registry.persistence.VKey;
 import google.registry.testing.FakeClock;
 import google.registry.testing.FakeHttpSession;
 import google.registry.testing.FakeResponse;
@@ -339,8 +340,7 @@ public class EppTestCase extends ShardableTestCase {
         .setTargetId(domain.getDomainName())
         .setClientId(domain.getCurrentSponsorClientId())
         .setEventTime(deleteTime)
-        .setOneTimeEventKey(
-            OneTime.createVKey(findKeyToActualOneTimeBillingEvent(billingEventToCancel)))
+        .setOneTimeEventKey(VKey.from(findKeyToActualOneTimeBillingEvent(billingEventToCancel)))
         .setBillingTime(createTime.plus(Registry.get(domain.getTld()).getAddGracePeriodLength()))
         .setReason(Reason.CREATE)
         .setParent(getOnlyHistoryEntryOfType(domain, Type.DOMAIN_DELETE))
@@ -354,8 +354,7 @@ public class EppTestCase extends ShardableTestCase {
         .setTargetId(domain.getDomainName())
         .setClientId(domain.getCurrentSponsorClientId())
         .setEventTime(deleteTime)
-        .setOneTimeEventKey(
-            OneTime.createVKey(findKeyToActualOneTimeBillingEvent(billingEventToCancel)))
+        .setOneTimeEventKey(VKey.from(findKeyToActualOneTimeBillingEvent(billingEventToCancel)))
         .setBillingTime(renewTime.plus(Registry.get(domain.getTld()).getRenewGracePeriodLength()))
         .setReason(Reason.RENEW)
         .setParent(getOnlyHistoryEntryOfType(domain, Type.DOMAIN_DELETE))

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
@@ -71,6 +71,7 @@ import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.transfer.DomainTransferData;
 import google.registry.model.transfer.TransferResponse.DomainTransferResponse;
 import google.registry.model.transfer.TransferStatus;
+import google.registry.persistence.VKey;
 import java.util.Arrays;
 import java.util.stream.Stream;
 import org.joda.money.Money;
@@ -402,8 +403,7 @@ public class DomainTransferApproveFlowTest
             .setEventTime(clock.nowUtc()) // The cancellation happens at the moment of transfer.
             .setBillingTime(
                 oldExpirationTime.plus(Registry.get("tld").getAutoRenewGracePeriodLength()))
-            .setRecurringEventKey(
-                BillingEvent.Recurring.createVKey(domain.getAutorenewBillingEvent())));
+            .setRecurringEventKey(VKey.from(domain.getAutorenewBillingEvent())));
   }
 
   @Test

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
@@ -71,7 +71,6 @@ import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.transfer.DomainTransferData;
 import google.registry.model.transfer.TransferResponse.DomainTransferResponse;
 import google.registry.model.transfer.TransferStatus;
-import google.registry.persistence.VKey;
 import java.util.Arrays;
 import java.util.stream.Stream;
 import org.joda.money.Money;
@@ -404,7 +403,7 @@ public class DomainTransferApproveFlowTest
             .setBillingTime(
                 oldExpirationTime.plus(Registry.get("tld").getAutoRenewGracePeriodLength()))
             .setRecurringEventKey(
-                VKey.createOfy(BillingEvent.Recurring.class, domain.getAutorenewBillingEvent())));
+                BillingEvent.Recurring.createVKey(domain.getAutorenewBillingEvent())));
   }
 
   @Test

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
@@ -1144,8 +1144,7 @@ public class DomainTransferRequestFlowTest
             .setEventTime(clock.nowUtc().plus(Registry.get("tld").getAutomaticTransferLength()))
             .setBillingTime(autorenewTime.plus(Registry.get("tld").getAutoRenewGracePeriodLength()))
             // The cancellation should refer to the old autorenew billing event.
-            .setRecurringEventKey(
-                VKey.createOfy(BillingEvent.Recurring.class, existingAutorenewEvent)));
+            .setRecurringEventKey(BillingEvent.Recurring.createVKey(existingAutorenewEvent)));
   }
 
   @Test
@@ -1173,8 +1172,7 @@ public class DomainTransferRequestFlowTest
             .setBillingTime(
                 expirationTime.plus(Registry.get("tld").getAutoRenewGracePeriodLength()))
             // The cancellation should refer to the old autorenew billing event.
-            .setRecurringEventKey(
-                VKey.createOfy(BillingEvent.Recurring.class, existingAutorenewEvent)));
+            .setRecurringEventKey(BillingEvent.Recurring.createVKey(existingAutorenewEvent)));
   }
 
   @Test

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
@@ -1144,7 +1144,7 @@ public class DomainTransferRequestFlowTest
             .setEventTime(clock.nowUtc().plus(Registry.get("tld").getAutomaticTransferLength()))
             .setBillingTime(autorenewTime.plus(Registry.get("tld").getAutoRenewGracePeriodLength()))
             // The cancellation should refer to the old autorenew billing event.
-            .setRecurringEventKey(BillingEvent.Recurring.createVKey(existingAutorenewEvent)));
+            .setRecurringEventKey(VKey.from(existingAutorenewEvent)));
   }
 
   @Test
@@ -1172,7 +1172,7 @@ public class DomainTransferRequestFlowTest
             .setBillingTime(
                 expirationTime.plus(Registry.get("tld").getAutoRenewGracePeriodLength()))
             // The cancellation should refer to the old autorenew billing event.
-            .setRecurringEventKey(BillingEvent.Recurring.createVKey(existingAutorenewEvent)));
+            .setRecurringEventKey(VKey.from(existingAutorenewEvent)));
   }
 
   @Test

--- a/core/src/test/java/google/registry/model/contact/ContactResourceTest.java
+++ b/core/src/test/java/google/registry/model/contact/ContactResourceTest.java
@@ -113,7 +113,7 @@ public class ContactResourceTest extends EntityTestCase {
                     .setLosingClientId("losing")
                     .setPendingTransferExpirationTime(fakeClock.nowUtc())
                     .setServerApproveEntities(
-                        ImmutableSet.of(VKey.createOfy(BillingEvent.OneTime.class, 1)))
+                        ImmutableSet.of(VKey.create(BillingEvent.OneTime.class, 1)))
                     .setTransferRequestTime(fakeClock.nowUtc())
                     .setTransferStatus(TransferStatus.SERVER_APPROVED)
                     .setTransferRequestTrid(Trid.create("client-trid", "server-trid"))

--- a/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
@@ -76,7 +76,7 @@ public class DomainBaseTest extends EntityTestCase {
         persistResource(
                 new HostResource.Builder()
                     .setHostName("ns1.example.com")
-                    .setSuperordinateDomain(DomainBase.createVKey(domainKey))
+                    .setSuperordinateDomain(VKey.from(domainKey))
                     .setRepoId("1-COM")
                     .build())
             .createVKey();
@@ -139,15 +139,12 @@ public class DomainBaseTest extends EntityTestCase {
                             .setPendingTransferExpirationTime(fakeClock.nowUtc())
                             .setServerApproveEntities(
                                 ImmutableSet.of(
-                                    BillingEvent.OneTime.createVKey(oneTimeBillKey),
-                                    BillingEvent.Recurring.createVKey(recurringBillKey),
-                                    PollMessage.Autorenew.createVKey(autorenewPollKey)))
-                            .setServerApproveBillingEvent(
-                                BillingEvent.OneTime.createVKey(oneTimeBillKey))
-                            .setServerApproveAutorenewEvent(
-                                BillingEvent.Recurring.createVKey(recurringBillKey))
-                            .setServerApproveAutorenewPollMessage(
-                                PollMessage.Autorenew.createVKey(autorenewPollKey))
+                                    VKey.from(oneTimeBillKey),
+                                    VKey.from(recurringBillKey),
+                                    VKey.from(autorenewPollKey)))
+                            .setServerApproveBillingEvent(VKey.from(oneTimeBillKey))
+                            .setServerApproveAutorenewEvent(VKey.from(recurringBillKey))
+                            .setServerApproveAutorenewPollMessage(VKey.from(autorenewPollKey))
                             .setTransferRequestTime(fakeClock.nowUtc().plusDays(1))
                             .setTransferStatus(TransferStatus.SERVER_APPROVED)
                             .setTransferRequestTrid(Trid.create("client-trid", "server-trid"))
@@ -750,8 +747,8 @@ public class DomainBaseTest extends EntityTestCase {
             .setPendingTransferExpirationTime(transferExpirationTime)
             .setTransferStatus(TransferStatus.PENDING)
             .setGainingClientId("TheRegistrar")
-            .setServerApproveAutorenewEvent(BillingEvent.Recurring.createVKey(recurringBillKey))
-            .setServerApproveBillingEvent(BillingEvent.OneTime.createVKey(oneTimeBillKey))
+            .setServerApproveAutorenewEvent(VKey.from(recurringBillKey))
+            .setServerApproveBillingEvent(VKey.from(oneTimeBillKey))
             .build();
     domain =
         persistResource(

--- a/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
@@ -141,13 +141,13 @@ public class DomainBaseTest extends EntityTestCase {
                                 ImmutableSet.of(
                                     BillingEvent.OneTime.createVKey(oneTimeBillKey),
                                     BillingEvent.Recurring.createVKey(recurringBillKey),
-                                    VKey.createOfy(PollMessage.Autorenew.class, autorenewPollKey)))
+                                    PollMessage.Autorenew.createVKey(autorenewPollKey)))
                             .setServerApproveBillingEvent(
                                 BillingEvent.OneTime.createVKey(oneTimeBillKey))
                             .setServerApproveAutorenewEvent(
                                 BillingEvent.Recurring.createVKey(recurringBillKey))
                             .setServerApproveAutorenewPollMessage(
-                                VKey.createOfy(PollMessage.Autorenew.class, autorenewPollKey))
+                                PollMessage.Autorenew.createVKey(autorenewPollKey))
                             .setTransferRequestTime(fakeClock.nowUtc().plusDays(1))
                             .setTransferStatus(TransferStatus.SERVER_APPROVED)
                             .setTransferRequestTrid(Trid.create("client-trid", "server-trid"))

--- a/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
@@ -76,7 +76,7 @@ public class DomainBaseTest extends EntityTestCase {
         persistResource(
                 new HostResource.Builder()
                     .setHostName("ns1.example.com")
-                    .setSuperordinateDomain(VKey.createOfy(DomainBase.class, domainKey))
+                    .setSuperordinateDomain(DomainBase.createVKey(domainKey))
                     .setRepoId("1-COM")
                     .build())
             .createVKey();
@@ -139,13 +139,13 @@ public class DomainBaseTest extends EntityTestCase {
                             .setPendingTransferExpirationTime(fakeClock.nowUtc())
                             .setServerApproveEntities(
                                 ImmutableSet.of(
-                                    VKey.createOfy(BillingEvent.OneTime.class, oneTimeBillKey),
-                                    VKey.createOfy(BillingEvent.Recurring.class, recurringBillKey),
+                                    BillingEvent.OneTime.createVKey(oneTimeBillKey),
+                                    BillingEvent.Recurring.createVKey(recurringBillKey),
                                     VKey.createOfy(PollMessage.Autorenew.class, autorenewPollKey)))
                             .setServerApproveBillingEvent(
-                                VKey.createOfy(BillingEvent.OneTime.class, oneTimeBillKey))
+                                BillingEvent.OneTime.createVKey(oneTimeBillKey))
                             .setServerApproveAutorenewEvent(
-                                VKey.createOfy(BillingEvent.Recurring.class, recurringBillKey))
+                                BillingEvent.Recurring.createVKey(recurringBillKey))
                             .setServerApproveAutorenewPollMessage(
                                 VKey.createOfy(PollMessage.Autorenew.class, autorenewPollKey))
                             .setTransferRequestTime(fakeClock.nowUtc().plusDays(1))
@@ -750,10 +750,8 @@ public class DomainBaseTest extends EntityTestCase {
             .setPendingTransferExpirationTime(transferExpirationTime)
             .setTransferStatus(TransferStatus.PENDING)
             .setGainingClientId("TheRegistrar")
-            .setServerApproveAutorenewEvent(
-                VKey.createOfy(BillingEvent.Recurring.class, recurringBillKey))
-            .setServerApproveBillingEvent(
-                VKey.createOfy(BillingEvent.OneTime.class, oneTimeBillKey))
+            .setServerApproveAutorenewEvent(BillingEvent.Recurring.createVKey(recurringBillKey))
+            .setServerApproveBillingEvent(BillingEvent.OneTime.createVKey(oneTimeBillKey))
             .build();
     domain =
         persistResource(

--- a/core/src/test/java/google/registry/model/host/HostResourceTest.java
+++ b/core/src/test/java/google/registry/model/host/HostResourceTest.java
@@ -63,7 +63,7 @@ public class HostResourceTest extends EntityTestCase {
                         .setLosingClientId("losing")
                         .setPendingTransferExpirationTime(fakeClock.nowUtc())
                         .setServerApproveEntities(
-                            ImmutableSet.of(VKey.createOfy(BillingEvent.OneTime.class, 1)))
+                            ImmutableSet.of(VKey.create(BillingEvent.OneTime.class, 1)))
                         .setTransferRequestTime(fakeClock.nowUtc())
                         .setTransferStatus(TransferStatus.SERVER_APPROVED)
                         .setTransferRequestTrid(Trid.create("client-trid", "server-trid"))

--- a/core/src/test/java/google/registry/model/transfer/TransferDataTest.java
+++ b/core/src/test/java/google/registry/model/transfer/TransferDataTest.java
@@ -48,11 +48,11 @@ public class TransferDataTest {
 
   @Before
   public void setUp() {
-    transferBillingEventKey = VKey.createOfy(BillingEvent.OneTime.class, 12345);
-    otherServerApproveBillingEventKey = VKey.createOfy(BillingEvent.Cancellation.class, 2468);
-    recurringBillingEventKey = VKey.createOfy(BillingEvent.Recurring.class, 13579);
-    autorenewPollMessageKey = VKey.createOfy(PollMessage.Autorenew.class, 67890);
-    otherServerApprovePollMessageKey = VKey.createOfy(PollMessage.OneTime.class, 314159);
+    transferBillingEventKey = VKey.create(BillingEvent.OneTime.class, 12345);
+    otherServerApproveBillingEventKey = VKey.create(BillingEvent.Cancellation.class, 2468);
+    recurringBillingEventKey = VKey.create(BillingEvent.Recurring.class, 13579);
+    autorenewPollMessageKey = VKey.create(PollMessage.Autorenew.class, 67890);
+    otherServerApprovePollMessageKey = VKey.create(PollMessage.OneTime.class, 314159);
   }
 
   @Test

--- a/core/src/test/java/google/registry/persistence/VKeyTest.java
+++ b/core/src/test/java/google/registry/persistence/VKeyTest.java
@@ -42,8 +42,6 @@ public class VKeyTest {
     assertThat(key.maybeGetSqlKey().isPresent()).isTrue();
     assertThat(key.maybeGetOfyKey().isPresent()).isTrue();
 
-    Key<TestObject> ofyKey = Key.create(TestObject.create("foo"));
-    assertThat(VKey.createOfy(TestObject.class, ofyKey).maybeGetOfyKey().get()).isEqualTo(ofyKey);
     assertThat(VKey.createSql(TestObject.class, "foo").maybeGetSqlKey().get()).isEqualTo("foo");
   }
 }


### PR DESCRIPTION
Replace all of the calls that currently create asymmetric (ofy-only) VKeys with calls to do complete symmetric key creation.  Add code to VKeyTranslatorFactory that will automatically create symmetric keys from non-hierarchical ofy keys, removing the static createVKey() method from classes that don't need it and adding it to the hierarchical (BillingEvent and PollMessage) types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/641)
<!-- Reviewable:end -->
