### PR TITLE
Add a test to verify JPA supports polymorphic VKey

### DIFF
--- a/core/src/main/java/google/registry/model/transfer/TransferData.java
+++ b/core/src/main/java/google/registry/model/transfer/TransferData.java
@@ -109,7 +109,6 @@ public abstract class TransferData<
   public B copyConstantFieldsToBuilder() {
     B newBuilder = new TypeInstantiator<B>(getClass()) {}.instantiate();
     newBuilder
-        // .setTransferPeriod(this.transferPeriod)
         .setTransferRequestTrid(this.transferRequestTrid)
         .setTransferRequestTime(this.transferRequestTime)
         .setGainingClientId(this.gainingClientId)


### PR DESCRIPTION
Added a test to verify that `jpaTm` can load the entity from a VKey with polymorphic type. For example, when we want to load a `PollMessage.OneTime` entity, we can use `VKey.createSql(PollMessage.class, id)`. Hibernate is able to figure out the exact type of the poll message by checking the `type` column in the schema. This makes sure that the vkey reconstructed by `VKeyTranslatorFactory` would not cause any problem when used for Cloud SQL.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/642)
<!-- Reviewable:end -->
