### PR TITLE
Add a property in Registry to disable invoicing

### DIFF
--- a/core/src/main/java/google/registry/beam/invoicing/sql/billing_events.sql
+++ b/core/src/main/java/google/registry/beam/invoicing/sql/billing_events.sql
@@ -57,8 +57,8 @@ FROM (
     WHERE
     -- TODO(b/18092292): Add a filter for tldState (not PDT/PREDELEGATION)
       tldType = 'REAL'
-    AND
-      disableInvoicing != true) ) AS BillingEvent
+    AND (disableInvoicing is null
+      OR disableInvoicing != true) ) ) AS BillingEvent
   -- Gather billing ID from registrar table
   -- This is a 'JOIN' as opposed to 'LEFT JOIN' to filter out
   -- non-billable registrars

--- a/core/src/main/java/google/registry/beam/invoicing/sql/billing_events.sql
+++ b/core/src/main/java/google/registry/beam/invoicing/sql/billing_events.sql
@@ -56,7 +56,9 @@ FROM (
       `%PROJECT_ID%.%DATASTORE_EXPORT_DATA_SET%.%REGISTRY_TABLE%`
     WHERE
     -- TODO(b/18092292): Add a filter for tldState (not PDT/PREDELEGATION)
-      tldType = 'REAL') ) AS BillingEvent
+      tldType = 'REAL'
+    AND
+      disableInvoicing != true) ) AS BillingEvent
   -- Gather billing ID from registrar table
   -- This is a 'JOIN' as opposed to 'LEFT JOIN' to filter out
   -- non-billable registrars

--- a/core/src/main/java/google/registry/beam/invoicing/sql/billing_events.sql
+++ b/core/src/main/java/google/registry/beam/invoicing/sql/billing_events.sql
@@ -57,8 +57,7 @@ FROM (
     WHERE
     -- TODO(b/18092292): Add a filter for tldState (not PDT/PREDELEGATION)
       tldType = 'REAL'
-    AND (disableInvoicing is null
-      OR disableInvoicing != true) ) ) AS BillingEvent
+    AND disableInvoicing is not TRUE) ) AS BillingEvent
   -- Gather billing ID from registrar table
   -- This is a 'JOIN' as opposed to 'LEFT JOIN' to filter out
   -- non-billable registrars

--- a/core/src/main/java/google/registry/model/registry/Registry.java
+++ b/core/src/main/java/google/registry/model/registry/Registry.java
@@ -340,6 +340,14 @@ public class Registry extends ImmutableObject implements Buildable {
   TldType tldType = TldType.REAL;
 
   /**
+   * Whether to disable invoicing for a {@link TldType#REAL} TLD.
+   *
+   * <p>Note that invoicing is always disabled for {@link TldType#TEST} TLDs. Setting this field has
+   * no effect for {@link TldType#TEST} TLDs.
+   */
+  boolean disableInvoicing = false;
+
+  /**
    * A property that transitions to different TldStates at different times. Stored as a list of
    * TldStateTransition embedded objects using the @Mapify annotation.
    */
@@ -634,6 +642,11 @@ public class Registry extends ImmutableObject implements Buildable {
 
     public Builder setTldType(TldType tldType) {
       getInstance().tldType = tldType;
+      return this;
+    }
+
+    public Builder setDisableInvoicing(boolean disableInvoicing) {
+      getInstance().disableInvoicing = disableInvoicing;
       return this;
     }
 

--- a/core/src/main/java/google/registry/tools/CreateOrUpdateTldCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdateTldCommand.java
@@ -118,6 +118,12 @@ abstract class CreateOrUpdateTldCommand extends MutatingCommand {
 
   @Nullable
   @Parameter(
+      names = "--disable_invoicing",
+      description = "Whether invoicing is disabled for a REAL tld.")
+  private Boolean disableInvoicing;
+
+  @Nullable
+  @Parameter(
       names = "--create_billing_cost",
       description = "Per-year billing cost for creating a domain")
   Money createBillingCost;
@@ -320,6 +326,7 @@ abstract class CreateOrUpdateTldCommand extends MutatingCommand {
       Optional.ofNullable(serverStatusChangeCost)
           .ifPresent(builder::setServerStatusChangeBillingCost);
       Optional.ofNullable(tldType).ifPresent(builder::setTldType);
+      Optional.ofNullable(disableInvoicing).ifPresent(builder::setDisableInvoicing);
       Optional.ofNullable(lordnUsername).ifPresent(u -> builder.setLordnUsername(u.orElse(null)));
       Optional.ofNullable(claimsPeriodEnd).ifPresent(builder::setClaimsPeriodEnd);
       Optional.ofNullable(numDnsPublishShards).ifPresent(builder::setNumDnsPublishLocks);

--- a/core/src/main/java/google/registry/tools/CreateOrUpdateTldCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdateTldCommand.java
@@ -119,7 +119,8 @@ abstract class CreateOrUpdateTldCommand extends MutatingCommand {
   @Nullable
   @Parameter(
       names = "--disable_invoicing",
-      description = "Whether invoicing is disabled for a REAL tld.")
+      description = "Whether invoicing is disabled for a REAL tld.",
+      arity = 1)
   private Boolean disableInvoicing;
 
   @Nullable

--- a/core/src/test/resources/google/registry/beam/invoicing/billing_events_test.sql
+++ b/core/src/test/resources/google/registry/beam/invoicing/billing_events_test.sql
@@ -57,8 +57,8 @@ FROM (
     WHERE
     -- TODO(b/18092292): Add a filter for tldState (not PDT/PREDELEGATION)
       tldType = 'REAL'
-    AND
-      disableInvoicing != true) ) AS BillingEvent
+    AND (disableInvoicing is null
+      OR disableInvoicing != true) ) ) AS BillingEvent
   -- Gather billing ID from registrar table
   -- This is a 'JOIN' as opposed to 'LEFT JOIN' to filter out
   -- non-billable registrars

--- a/core/src/test/resources/google/registry/beam/invoicing/billing_events_test.sql
+++ b/core/src/test/resources/google/registry/beam/invoicing/billing_events_test.sql
@@ -56,7 +56,9 @@ FROM (
       `my-project-id.latest_datastore_export.Registry`
     WHERE
     -- TODO(b/18092292): Add a filter for tldState (not PDT/PREDELEGATION)
-      tldType = 'REAL') ) AS BillingEvent
+      tldType = 'REAL'
+    AND
+      disableInvoicing != true) ) AS BillingEvent
   -- Gather billing ID from registrar table
   -- This is a 'JOIN' as opposed to 'LEFT JOIN' to filter out
   -- non-billable registrars

--- a/core/src/test/resources/google/registry/beam/invoicing/billing_events_test.sql
+++ b/core/src/test/resources/google/registry/beam/invoicing/billing_events_test.sql
@@ -57,8 +57,7 @@ FROM (
     WHERE
     -- TODO(b/18092292): Add a filter for tldState (not PDT/PREDELEGATION)
       tldType = 'REAL'
-    AND (disableInvoicing is null
-      OR disableInvoicing != true) ) ) AS BillingEvent
+    AND disableInvoicing is not TRUE) ) AS BillingEvent
   -- Gather billing ID from registrar table
   -- This is a 'JOIN' as opposed to 'LEFT JOIN' to filter out
   -- non-billable registrars

--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -494,6 +494,7 @@ enum google.registry.model.registrar.RegistrarContact$Type {
 class google.registry.model.registry.Registry {
   @Id java.lang.String tldStrId;
   @Parent com.googlecode.objectify.Key<google.registry.model.common.EntityGroupRoot> parent;
+  boolean disableInvoicing;
   boolean dnsPaused;
   boolean escrowEnabled;
   com.googlecode.objectify.Key<google.registry.model.registry.label.PremiumList> premiumList;


### PR DESCRIPTION
The added property will by default be `null` for existing entities and `false` for new entities. We could write a temporary MapReduce to set it to false for all existing ones, but it seems easier to just modify the query to account for the nullness of the column. The need to check for null won't exist once we migrate the `Registry` entity to Cloud SQL.

TESTED=deployed to alpha, set the property for tld zombo to true and triggered an export, verified that the column is null for all rows other than the row for zombo.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/644)
<!-- Reviewable:end -->
