### PR TITLE
Fix a warning from Hibernate

### DIFF
--- a/core/src/main/java/google/registry/model/contact/ContactResource.java
+++ b/core/src/main/java/google/registry/model/contact/ContactResource.java
@@ -252,7 +252,7 @@ public class ContactResource extends EppResource
   }
 
   @Override
-  public final ContactTransferData getTransferData() {
+  public ContactTransferData getTransferData() {
     return Optional.ofNullable(transferData).orElse(ContactTransferData.EMPTY);
   }
 


### PR DESCRIPTION
Hibernate complained that `ContactResource.getTransferData()` should not be
final:
```shell
WARN: HHH000305: Could not create proxy factory
for:google.registry.model.contact.ContactResource
org.hibernate.HibernateException: Getter methods of lazy classes cannot
be final: google.registry.model.contact.ContactResource#getTransferData
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/645)
<!-- Reviewable:end -->
