### PR TITLE
Expand AckPollMessagesCommand to ack PollMessage.Autorenew

### DIFF
--- a/core/src/main/java/google/registry/flows/poll/PollAckFlow.java
+++ b/core/src/main/java/google/registry/flows/poll/PollAckFlow.java
@@ -14,8 +14,8 @@
 
 package google.registry.flows.poll;
 
-import static com.google.common.base.Preconditions.checkState;
 import static google.registry.flows.FlowUtils.validateClientIsLoggedIn;
+import static google.registry.flows.poll.PollFlowUtils.ackPollMessage;
 import static google.registry.flows.poll.PollFlowUtils.getPollMessagesQuery;
 import static google.registry.model.eppoutput.Result.Code.SUCCESS_WITH_NO_MESSAGES;
 import static google.registry.model.ofy.ObjectifyService.ofy;
@@ -100,27 +100,8 @@ public class PollAckFlow implements TransactionalFlow {
     // This keeps track of whether we should include the current acked message in the updated
     // message count that's returned to the user. The only case where we do so is if an autorenew
     // poll message is acked, but its next event is already ready to be delivered.
-    boolean includeAckedMessageInCount = false;
-    if (pollMessage instanceof PollMessage.OneTime) {
-      // One-time poll messages are deleted once acked.
-      ofy().delete().entity(pollMessage);
-    } else {
-      checkState(pollMessage instanceof PollMessage.Autorenew, "Unknown poll message type");
-      PollMessage.Autorenew autorenewPollMessage = (PollMessage.Autorenew) pollMessage;
+    boolean includeAckedMessageInCount = ackPollMessage(pollMessage, now);
 
-      // Move the eventTime of this autorenew poll message forward by a year.
-      DateTime nextEventTime = autorenewPollMessage.getEventTime().plusYears(1);
-
-      // If the next event falls within the bounds of the end time, then just update the eventTime
-      // and re-save it for future autorenew poll messages to be delivered. Otherwise, this
-      // autorenew poll message has no more events to deliver and should be deleted.
-      if (nextEventTime.isBefore(autorenewPollMessage.getAutorenewEndTime())) {
-        ofy().save().entity(autorenewPollMessage.asBuilder().setEventTime(nextEventTime).build());
-        includeAckedMessageInCount = isBeforeOrAt(nextEventTime, now);
-      } else {
-        ofy().delete().entity(autorenewPollMessage);
-      }
-    }
     // We need to return the new queue length. If this was the last message in the queue being
     // acked, then we return a special status code indicating that. Note that the query will
     // include the message being acked.

--- a/core/src/main/java/google/registry/flows/poll/PollAckFlow.java
+++ b/core/src/main/java/google/registry/flows/poll/PollAckFlow.java
@@ -100,7 +100,7 @@ public class PollAckFlow implements TransactionalFlow {
     // This keeps track of whether we should include the current acked message in the updated
     // message count that's returned to the user. The only case where we do so is if an autorenew
     // poll message is acked, but its next event is already ready to be delivered.
-    boolean includeAckedMessageInCount = ackPollMessage(pollMessage, now);
+    boolean includeAckedMessageInCount = ackPollMessage(pollMessage);
 
     // We need to return the new queue length. If this was the last message in the queue being
     // acked, then we return a special status code indicating that. Note that the query will

--- a/core/src/main/java/google/registry/flows/poll/PollFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/poll/PollFlowUtils.java
@@ -43,7 +43,7 @@ public final class PollFlowUtils {
    * do so is if an autorenew poll message is acked, but its next event is already ready to be
    * delivered.
    */
-  public static boolean ackPollMessage(PollMessage pollMessage, DateTime now) {
+  public static boolean ackPollMessage(PollMessage pollMessage) {
     boolean includeAckedMessageInCount = false;
     if (pollMessage instanceof PollMessage.OneTime) {
       // One-time poll messages are deleted once acked.
@@ -60,7 +60,7 @@ public final class PollFlowUtils {
       // autorenew poll message has no more events to deliver and should be deleted.
       if (nextEventTime.isBefore(autorenewPollMessage.getAutorenewEndTime())) {
         tm().saveNewOrUpdate(autorenewPollMessage.asBuilder().setEventTime(nextEventTime).build());
-        includeAckedMessageInCount = isBeforeOrAt(nextEventTime, now);
+        includeAckedMessageInCount = isBeforeOrAt(nextEventTime, tm().getTransactionTime());
       } else {
         tm().delete(autorenewPollMessage.createVKey());
       }

--- a/core/src/main/java/google/registry/tools/AckPollMessagesCommand.java
+++ b/core/src/main/java/google/registry/tools/AckPollMessagesCommand.java
@@ -16,7 +16,6 @@ package google.registry.tools;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static google.registry.flows.poll.PollFlowUtils.ackPollMessage;
 import static google.registry.flows.poll.PollFlowUtils.getPollMessagesQuery;
 import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.model.poll.PollMessageExternalKeyConverter.makePollMessageExternalId;
@@ -29,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.cmd.QueryKeys;
+import google.registry.flows.poll.PollFlowUtils;
 import google.registry.model.poll.PollMessage;
 import google.registry.model.poll.PollMessage.Autorenew;
 import google.registry.model.poll.PollMessage.OneTime;
@@ -96,7 +96,7 @@ final class AckPollMessagesCommand implements CommandWithRemoteApi {
                         .filter(pm -> isNullOrEmpty(message) || pm.getMsg().contains(message))
                         .collect(toImmutableList());
                 if (!dryRun) {
-                  pollMessages.forEach(pollMessage -> ackPollMessage(pollMessage, now));
+                  pollMessages.forEach(PollFlowUtils::ackPollMessage);
                 }
                 pollMessages.forEach(
                     pm ->

--- a/core/src/main/java/google/registry/tools/AckPollMessagesCommand.java
+++ b/core/src/main/java/google/registry/tools/AckPollMessagesCommand.java
@@ -35,7 +35,6 @@ import google.registry.model.poll.PollMessage.OneTime;
 import google.registry.util.Clock;
 import java.util.List;
 import javax.inject.Inject;
-import org.joda.time.DateTime;
 
 /**
  * Command to acknowledge one-time poll messages for a registrar.
@@ -85,8 +84,8 @@ final class AckPollMessagesCommand implements CommandWithRemoteApi {
 
   @Override
   public void run() {
-    DateTime now = clock.nowUtc();
-    QueryKeys<PollMessage> query = getPollMessagesQuery(clientId, now).keys();
+    QueryKeys<PollMessage> query = getPollMessagesQuery(clientId, clock.nowUtc()).keys();
+    // TODO(b/160325686): Remove the batch logic after db migration.
     for (List<Key<PollMessage>> keys : Iterables.partition(query, BATCH_SIZE)) {
       tm().transact(
               () -> {

--- a/core/src/test/java/google/registry/tools/AckPollMessagesCommandTest.java
+++ b/core/src/test/java/google/registry/tools/AckPollMessagesCommandTest.java
@@ -14,10 +14,12 @@
 
 package google.registry.tools;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatastoreHelper.persistResource;
 
+import com.google.common.collect.ImmutableList;
 import com.googlecode.objectify.Key;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.ofy.Ofy;
@@ -25,6 +27,7 @@ import google.registry.model.poll.PollMessage;
 import google.registry.model.poll.PollMessage.Autorenew;
 import google.registry.model.poll.PollMessage.OneTime;
 import google.registry.model.reporting.HistoryEntry;
+import google.registry.persistence.VKey;
 import google.registry.testing.FakeClock;
 import google.registry.testing.InjectRule;
 import org.joda.time.DateTime;
@@ -47,12 +50,17 @@ public class AckPollMessagesCommandTest extends CommandTestCase<AckPollMessagesC
 
   @Test
   public void testSuccess_doesntDeletePollMessagesInFuture() throws Exception {
-    OneTime pm1 = persistPollMessage(316L, DateTime.parse("2014-01-01T22:33:44Z"), "foobar");
-    OneTime pm2 = persistPollMessage(624L, DateTime.parse("2013-05-01T22:33:44Z"), "ninelives");
-    OneTime pm3 = persistPollMessage(791L, DateTime.parse("2015-01-08T22:33:44Z"), "ginger");
-    OneTime pm4 = persistPollMessage(123L, DateTime.parse("2015-09-01T22:33:44Z"), "notme");
+    VKey<OneTime> pm1 =
+        persistPollMessage(316L, DateTime.parse("2014-01-01T22:33:44Z"), "foobar").createVKey();
+    VKey<OneTime> pm2 =
+        persistPollMessage(624L, DateTime.parse("2013-05-01T22:33:44Z"), "ninelives").createVKey();
+    VKey<OneTime> pm3 =
+        persistPollMessage(791L, DateTime.parse("2015-01-08T22:33:44Z"), "ginger").createVKey();
+    OneTime futurePollMessage =
+        persistPollMessage(123L, DateTime.parse("2015-09-01T22:33:44Z"), "notme");
+    VKey<OneTime> pm4 = futurePollMessage.createVKey();
     runCommand("-c", "TheRegistrar");
-    assertThat(ofy().load().entities(pm1, pm2, pm3, pm4).values()).containsExactly(pm4);
+    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3, pm4))).containsExactly(futurePollMessage);
     assertInStdout(
         "1-FSDGS-TLD-2406-624-2013,2013-05-01T22:33:44.000Z,ninelives",
         "1-FSDGS-TLD-2406-316-2014,2014-01-01T22:33:44.000Z,foobar",
@@ -61,10 +69,12 @@ public class AckPollMessagesCommandTest extends CommandTestCase<AckPollMessagesC
   }
 
   @Test
-  public void testSuccess_doesntDeleteAutorenewPollMessages() throws Exception {
-    OneTime pm1 = persistPollMessage(316L, DateTime.parse("2014-01-01T22:33:44Z"), "foobar");
-    OneTime pm2 = persistPollMessage(624L, DateTime.parse("2013-05-01T22:33:44Z"), "ninelives");
-    Autorenew pm3 =
+  public void testSuccess_resavesAutorenewPollMessages() throws Exception {
+    VKey<OneTime> pm1 =
+        persistPollMessage(316L, DateTime.parse("2014-01-01T22:33:44Z"), "foobar").createVKey();
+    VKey<OneTime> pm2 =
+        persistPollMessage(624L, DateTime.parse("2013-05-01T22:33:44Z"), "ninelives").createVKey();
+    Autorenew autorenew =
         persistResource(
             new PollMessage.Autorenew.Builder()
                 .setId(624L)
@@ -73,26 +83,73 @@ public class AckPollMessagesCommandTest extends CommandTestCase<AckPollMessagesC
                         Key.create(DomainBase.class, "AAFSGS-TLD"), HistoryEntry.class, 99406L))
                 .setEventTime(DateTime.parse("2011-04-15T22:33:44Z"))
                 .setClientId("TheRegistrar")
+                .setMsg("autorenew")
                 .build());
+    Autorenew resaved =
+        autorenew.asBuilder().setEventTime(DateTime.parse("2012-04-15T22:33:44Z")).build();
+    VKey<Autorenew> pm3 = autorenew.createVKey();
     runCommand("-c", "TheRegistrar");
-    assertThat(ofy().load().entities(pm1, pm2, pm3).values()).containsExactly(pm3);
+    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3))).containsExactly(resaved);
+    assertInStdout(
+        "1-AAFSGS-TLD-99406-624-2011,2011-04-15T22:33:44.000Z,autorenew",
+        "1-FSDGS-TLD-2406-624-2013,2013-05-01T22:33:44.000Z,ninelives",
+        "1-FSDGS-TLD-2406-316-2014,2014-01-01T22:33:44.000Z,foobar");
+  }
+
+  @Test
+  public void testSuccess_deletesExpiredAutorenewPollMessages() throws Exception {
+    VKey<OneTime> pm1 =
+        persistPollMessage(316L, DateTime.parse("2014-01-01T22:33:44Z"), "foobar").createVKey();
+    VKey<OneTime> pm2 =
+        persistPollMessage(624L, DateTime.parse("2013-05-01T22:33:44Z"), "ninelives").createVKey();
+    Autorenew autorenew =
+        persistResource(
+            new PollMessage.Autorenew.Builder()
+                .setId(624L)
+                .setParentKey(
+                    Key.create(
+                        Key.create(DomainBase.class, "AAFSGS-TLD"), HistoryEntry.class, 99406L))
+                .setEventTime(DateTime.parse("2011-04-15T22:33:44Z"))
+                .setAutorenewEndTime(DateTime.parse("2012-01-01T22:33:44Z"))
+                .setClientId("TheRegistrar")
+                .setMsg("autorenew")
+                .build());
+    VKey<Autorenew> pm3 = autorenew.createVKey();
+    runCommand("-c", "TheRegistrar");
+    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3))).isEmpty();
+    assertInStdout(
+        "1-AAFSGS-TLD-99406-624-2011,2011-04-15T22:33:44.000Z,autorenew",
+        "1-FSDGS-TLD-2406-624-2013,2013-05-01T22:33:44.000Z,ninelives",
+        "1-FSDGS-TLD-2406-316-2014,2014-01-01T22:33:44.000Z,foobar");
   }
 
   @Test
   public void testSuccess_onlyDeletesPollMessagesMatchingMessage() throws Exception {
-    OneTime pm1 = persistPollMessage(316L, DateTime.parse("2014-01-01T22:33:44Z"), "food is good");
-    OneTime pm2 = persistPollMessage(624L, DateTime.parse("2013-05-01T22:33:44Z"), "theft is bad");
-    OneTime pm3 = persistPollMessage(791L, DateTime.parse("2015-01-08T22:33:44Z"), "mmmmmfood");
-    OneTime pm4 = persistPollMessage(123L, DateTime.parse("2015-09-01T22:33:44Z"), "time flies");
+    VKey<OneTime> pm1 =
+        persistPollMessage(316L, DateTime.parse("2014-01-01T22:33:44Z"), "food is good")
+            .createVKey();
+    OneTime notMatched1 =
+        persistPollMessage(624L, DateTime.parse("2013-05-01T22:33:44Z"), "theft is bad");
+    VKey<OneTime> pm2 = notMatched1.createVKey();
+    VKey<OneTime> pm3 =
+        persistPollMessage(791L, DateTime.parse("2015-01-08T22:33:44Z"), "mmmmmfood").createVKey();
+    OneTime notMatched2 =
+        persistPollMessage(123L, DateTime.parse("2015-09-01T22:33:44Z"), "time flies");
+    VKey<OneTime> pm4 = notMatched2.createVKey();
     runCommand("-c", "TheRegistrar", "-m", "food");
-    assertThat(ofy().load().entities(pm1, pm2, pm3, pm4).values()).containsExactly(pm2, pm4);
+    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3, pm4)))
+        .containsExactly(notMatched1, notMatched2);
   }
 
   @Test
   public void testSuccess_onlyDeletesPollMessagesMatchingClientId() throws Exception {
-    OneTime pm1 = persistPollMessage(316L, DateTime.parse("2014-01-01T22:33:44Z"), "food is good");
-    OneTime pm2 = persistPollMessage(624L, DateTime.parse("2013-05-01T22:33:44Z"), "theft is bad");
-    OneTime pm3 =
+    VKey<OneTime> pm1 =
+        persistPollMessage(316L, DateTime.parse("2014-01-01T22:33:44Z"), "food is good")
+            .createVKey();
+    VKey<OneTime> pm2 =
+        persistPollMessage(624L, DateTime.parse("2013-05-01T22:33:44Z"), "theft is bad")
+            .createVKey();
+    OneTime notMatched =
         persistResource(
             new PollMessage.OneTime.Builder()
                 .setId(2474L)
@@ -103,8 +160,9 @@ public class AckPollMessagesCommandTest extends CommandTestCase<AckPollMessagesC
                 .setEventTime(DateTime.parse("2013-06-01T22:33:44Z"))
                 .setMsg("baaaahh")
                 .build());
+    VKey<OneTime> pm3 = notMatched.createVKey();
     runCommand("-c", "TheRegistrar");
-    assertThat(ofy().load().entities(pm1, pm2, pm3).values()).containsExactly(pm3);
+    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3))).containsExactly(notMatched);
   }
 
   @Test
@@ -114,7 +172,11 @@ public class AckPollMessagesCommandTest extends CommandTestCase<AckPollMessagesC
     OneTime pm3 = persistPollMessage(791L, DateTime.parse("2015-01-08T22:33:44Z"), "ginger");
     OneTime pm4 = persistPollMessage(123L, DateTime.parse("2015-09-01T22:33:44Z"), "notme");
     runCommand("-c", "TheRegistrar", "-d");
-    assertThat(ofy().load().entities(pm1, pm2, pm3, pm4).values())
+    assertThat(
+            tm().load(
+                    ImmutableList.of(pm1, pm2, pm3, pm4).stream()
+                        .map(OneTime::createVKey)
+                        .collect(toImmutableList())))
         .containsExactly(pm1, pm2, pm3, pm4);
   }
 

--- a/core/src/test/java/google/registry/tools/AckPollMessagesCommandTest.java
+++ b/core/src/test/java/google/registry/tools/AckPollMessagesCommandTest.java
@@ -60,7 +60,8 @@ public class AckPollMessagesCommandTest extends CommandTestCase<AckPollMessagesC
         persistPollMessage(123L, DateTime.parse("2015-09-01T22:33:44Z"), "notme");
     VKey<OneTime> pm4 = futurePollMessage.createVKey();
     runCommand("-c", "TheRegistrar");
-    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3, pm4))).containsExactly(futurePollMessage);
+    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3, pm4)).values())
+        .containsExactly(futurePollMessage);
     assertInStdout(
         "1-FSDGS-TLD-2406-624-2013,2013-05-01T22:33:44.000Z,ninelives",
         "1-FSDGS-TLD-2406-316-2014,2014-01-01T22:33:44.000Z,foobar",
@@ -89,7 +90,7 @@ public class AckPollMessagesCommandTest extends CommandTestCase<AckPollMessagesC
         autorenew.asBuilder().setEventTime(DateTime.parse("2012-04-15T22:33:44Z")).build();
     VKey<Autorenew> pm3 = autorenew.createVKey();
     runCommand("-c", "TheRegistrar");
-    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3))).containsExactly(resaved);
+    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3)).values()).containsExactly(resaved);
     assertInStdout(
         "1-AAFSGS-TLD-99406-624-2011,2011-04-15T22:33:44.000Z,autorenew",
         "1-FSDGS-TLD-2406-624-2013,2013-05-01T22:33:44.000Z,ninelives",
@@ -137,7 +138,7 @@ public class AckPollMessagesCommandTest extends CommandTestCase<AckPollMessagesC
         persistPollMessage(123L, DateTime.parse("2015-09-01T22:33:44Z"), "time flies");
     VKey<OneTime> pm4 = notMatched2.createVKey();
     runCommand("-c", "TheRegistrar", "-m", "food");
-    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3, pm4)))
+    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3, pm4)).values())
         .containsExactly(notMatched1, notMatched2);
   }
 
@@ -162,7 +163,7 @@ public class AckPollMessagesCommandTest extends CommandTestCase<AckPollMessagesC
                 .build());
     VKey<OneTime> pm3 = notMatched.createVKey();
     runCommand("-c", "TheRegistrar");
-    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3))).containsExactly(notMatched);
+    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3)).values()).containsExactly(notMatched);
   }
 
   @Test
@@ -176,7 +177,8 @@ public class AckPollMessagesCommandTest extends CommandTestCase<AckPollMessagesC
             tm().load(
                     ImmutableList.of(pm1, pm2, pm3, pm4).stream()
                         .map(OneTime::createVKey)
-                        .collect(toImmutableList())))
+                        .collect(toImmutableList()))
+                .values())
         .containsExactly(pm1, pm2, pm3, pm4);
   }
 


### PR DESCRIPTION
This PR expanded `AckPollMessagesCommand` to support acknowledging `Autorenew` poll messages(see [here](https://b.corp.google.com/issues/159207551#comment9) for more context), and it also changed some of the `ofy()` calls to `tm()` in relevant code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/647)
<!-- Reviewable:end -->
