### PR TITLE
Disambiguate injected Cloud SQL parameter names

### DIFF
--- a/core/src/main/java/google/registry/beam/initsql/BeamJpaModule.java
+++ b/core/src/main/java/google/registry/beam/initsql/BeamJpaModule.java
@@ -156,6 +156,12 @@ public class BeamJpaModule {
     return "nomulus-tool-keyring";
   }
 
+  @Provides
+  @Config("beamHibernateHikariMaximumPoolSize")
+  static int getBeamHibernateHikariMaximumPoolSize() {
+    return 4;
+  }
+
   @Module
   interface BindModule {
 

--- a/core/src/main/java/google/registry/beam/initsql/BeamJpaModule.java
+++ b/core/src/main/java/google/registry/beam/initsql/BeamJpaModule.java
@@ -19,7 +19,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
 import dagger.Binds;
 import dagger.Component;
 import dagger.Lazy;
@@ -45,7 +44,6 @@ import java.nio.channels.Channels;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import javax.annotation.Nullable;
-import javax.inject.Named;
 import javax.inject.Singleton;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResourceId;
@@ -156,18 +154,6 @@ public class BeamJpaModule {
   @Config("beamCloudKmsKeyRing")
   static String keyRingName() {
     return "nomulus-tool-keyring";
-  }
-
-  @Provides
-  @Config("beamDefaultCredentialOauthScopes")
-  static ImmutableList<String> defaultCredentialOauthScopes() {
-    return ImmutableList.of("https://www.googleapis.com/auth/cloud-platform");
-  }
-
-  @Provides
-  @Named("beamTransientFailureRetries")
-  static int transientFailureRetries() {
-    return 12;
   }
 
   @Module

--- a/core/src/main/java/google/registry/beam/initsql/BeamJpaModule.java
+++ b/core/src/main/java/google/registry/beam/initsql/BeamJpaModule.java
@@ -25,9 +25,9 @@ import dagger.Component;
 import dagger.Lazy;
 import dagger.Module;
 import dagger.Provides;
-import google.registry.beam.initsql.BeamJpaModule.BindModule;
 import google.registry.config.CredentialModule;
 import google.registry.config.RegistryConfig.Config;
+import google.registry.config.RegistryConfig.ConfigModule;
 import google.registry.keyring.kms.KmsModule;
 import google.registry.persistence.PersistenceModule;
 import google.registry.persistence.PersistenceModule.JdbcJpaTm;
@@ -37,12 +37,14 @@ import google.registry.util.Clock;
 import google.registry.util.Sleeper;
 import google.registry.util.SystemClock;
 import google.registry.util.SystemSleeper;
+import google.registry.util.UtilsModule;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.channels.Channels;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import org.apache.beam.sdk.io.FileSystems;
@@ -53,27 +55,31 @@ import org.apache.beam.sdk.io.fs.ResourceId;
  *
  * <p>This module is intended for use in BEAM pipelines, and uses a BEAM utility to access GCS like
  * a regular file system.
- *
- * <p>Note that {@link google.registry.config.RegistryConfig.ConfigModule} cannot be used here,
- * since many bindings, especially KMS-related ones, are different.
  */
-@Module(includes = {BindModule.class})
-class BeamJpaModule {
+@Module
+public class BeamJpaModule {
 
   private static final String GCS_SCHEME = "gs://";
 
-  private final String credentialFilePath;
+  @Nullable private final String credentialFilePath;
 
   /**
    * Constructs a new instance of {@link BeamJpaModule}.
+   *
+   * <p>Note: it is an unfortunately necessary antipattern to check for the validity of
+   * credentialFilePath in {@link #provideCloudSqlAccessInfo} rather than in the constructor.
+   * Unfortunately, this is a restriction imposed upon us by Dagger. Specifically, because we use
+   * this in at least one 1 {@link google.registry.tools.RegistryTool} command(s), it must be
+   * instantiated in {@link google.registry.tools.RegistryToolComponent} for all possible commands;
+   * Dagger doesn't permit it to ever be null. For the vast majority of commands, it will never be
+   * used (so a null credential file path is fine in those cases).
    *
    * @param credentialFilePath the path to a Cloud SQL credential file. This must refer to either a
    *     real encrypted file on GCS as returned by {@link
    *     BackupPaths#getCloudSQLCredentialFilePatterns} or an unencrypted file on local filesystem
    *     with credentials to a test database.
    */
-  BeamJpaModule(String credentialFilePath) {
-    checkArgument(!isNullOrEmpty(credentialFilePath), "Null or empty credentialFilePath");
+  public BeamJpaModule(@Nullable String credentialFilePath) {
     this.credentialFilePath = credentialFilePath;
   }
 
@@ -85,6 +91,7 @@ class BeamJpaModule {
   @Provides
   @Singleton
   SqlAccessInfo provideCloudSqlAccessInfo(Lazy<CloudSqlCredentialDecryptor> lazyDecryptor) {
+    checkArgument(!isNullOrEmpty(credentialFilePath), "Null or empty credentialFilePath");
     String line = readOnlyLineFromCredentialFile();
     if (isCloudSqlCredential()) {
       line = lazyDecryptor.get().decrypt(line);
@@ -114,13 +121,13 @@ class BeamJpaModule {
   }
 
   @Provides
-  @Config("cloudSqlJdbcUrl")
+  @Config("beamCloudSqlJdbcUrl")
   String provideJdbcUrl(SqlAccessInfo sqlAccessInfo) {
     return sqlAccessInfo.jdbcUrl();
   }
 
   @Provides
-  @Config("cloudSqlInstanceConnectionName")
+  @Config("beamCloudSqlInstanceConnectionName")
   String provideSqlInstanceName(SqlAccessInfo sqlAccessInfo) {
     return sqlAccessInfo
         .cloudSqlInstanceName()
@@ -128,37 +135,37 @@ class BeamJpaModule {
   }
 
   @Provides
-  @Config("cloudSqlUsername")
+  @Config("beamCloudSqlUsername")
   String provideSqlUsername(SqlAccessInfo sqlAccessInfo) {
     return sqlAccessInfo.user();
   }
 
   @Provides
-  @Config("cloudSqlPassword")
+  @Config("beamCloudSqlPassword")
   String provideSqlPassword(SqlAccessInfo sqlAccessInfo) {
     return sqlAccessInfo.password();
   }
 
   @Provides
-  @Config("cloudKmsProjectId")
+  @Config("beamCloudKmsProjectId")
   static String kmsProjectId() {
     return "domain-registry-dev";
   }
 
   @Provides
-  @Config("cloudKmsKeyRing")
+  @Config("beamCloudKmsKeyRing")
   static String keyRingName() {
     return "nomulus-tool-keyring";
   }
 
   @Provides
-  @Config("defaultCredentialOauthScopes")
+  @Config("beamDefaultCredentialOauthScopes")
   static ImmutableList<String> defaultCredentialOauthScopes() {
     return ImmutableList.of("https://www.googleapis.com/auth/cloud-platform");
   }
 
   @Provides
-  @Named("transientFailureRetries")
+  @Named("beamTransientFailureRetries")
   static int transientFailureRetries() {
     return 12;
   }
@@ -176,10 +183,12 @@ class BeamJpaModule {
   @Singleton
   @Component(
       modules = {
+        ConfigModule.class,
         CredentialModule.class,
         BeamJpaModule.class,
         KmsModule.class,
-        PersistenceModule.class
+        PersistenceModule.class,
+        UtilsModule.class
       })
   public interface JpaTransactionManagerComponent {
     @SocketFactoryJpaTm

--- a/core/src/main/java/google/registry/beam/initsql/BeamJpaModule.java
+++ b/core/src/main/java/google/registry/beam/initsql/BeamJpaModule.java
@@ -68,7 +68,7 @@ public class BeamJpaModule {
    * credentialFilePath in {@link #provideCloudSqlAccessInfo} rather than in the constructor.
    * Unfortunately, this is a restriction imposed upon us by Dagger. Specifically, because we use
    * this in at least one 1 {@link google.registry.tools.RegistryTool} command(s), it must be
-   * instantiated in {@link google.registry.tools.RegistryToolComponent} for all possible commands;
+   * instantiated in {@code google.registry.tools.RegistryToolComponent} for all possible commands;
    * Dagger doesn't permit it to ever be null. For the vast majority of commands, it will never be
    * used (so a null credential file path is fine in those cases).
    *

--- a/core/src/main/java/google/registry/beam/initsql/CloudSqlCredentialDecryptor.java
+++ b/core/src/main/java/google/registry/beam/initsql/CloudSqlCredentialDecryptor.java
@@ -18,11 +18,11 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.api.services.cloudkms.v1.model.DecryptRequest;
 import com.google.common.base.Strings;
+import google.registry.config.RegistryConfig.Config;
 import google.registry.keyring.kms.KmsConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import javax.inject.Inject;
-import javax.inject.Named;
 
 /**
  * Decrypts data using Cloud KMS, with the same crypto key with which Cloud SQL credential files on
@@ -35,7 +35,7 @@ public class CloudSqlCredentialDecryptor {
   private final KmsConnection kmsConnection;
 
   @Inject
-  CloudSqlCredentialDecryptor(@Named("beamKmsConnection") KmsConnection kmsConnection) {
+  CloudSqlCredentialDecryptor(@Config("beamKmsConnection") KmsConnection kmsConnection) {
     this.kmsConnection = kmsConnection;
   }
 

--- a/core/src/main/java/google/registry/beam/initsql/CloudSqlCredentialDecryptor.java
+++ b/core/src/main/java/google/registry/beam/initsql/CloudSqlCredentialDecryptor.java
@@ -22,6 +22,7 @@ import google.registry.keyring.kms.KmsConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import javax.inject.Inject;
+import javax.inject.Named;
 
 /**
  * Decrypts data using Cloud KMS, with the same crypto key with which Cloud SQL credential files on
@@ -34,7 +35,7 @@ public class CloudSqlCredentialDecryptor {
   private final KmsConnection kmsConnection;
 
   @Inject
-  CloudSqlCredentialDecryptor(KmsConnection kmsConnection) {
+  CloudSqlCredentialDecryptor(@Named("defaultKmsConnection") KmsConnection kmsConnection) {
     this.kmsConnection = kmsConnection;
   }
 

--- a/core/src/main/java/google/registry/beam/initsql/CloudSqlCredentialDecryptor.java
+++ b/core/src/main/java/google/registry/beam/initsql/CloudSqlCredentialDecryptor.java
@@ -35,7 +35,7 @@ public class CloudSqlCredentialDecryptor {
   private final KmsConnection kmsConnection;
 
   @Inject
-  CloudSqlCredentialDecryptor(@Named("defaultKmsConnection") KmsConnection kmsConnection) {
+  CloudSqlCredentialDecryptor(@Named("beamKmsConnection") KmsConnection kmsConnection) {
     this.kmsConnection = kmsConnection;
   }
 

--- a/core/src/main/java/google/registry/beam/spec11/Spec11Pipeline.java
+++ b/core/src/main/java/google/registry/beam/spec11/Spec11Pipeline.java
@@ -94,8 +94,7 @@ public class Spec11Pipeline implements Serializable {
       @Config("spec11TemplateUrl") String spec11TemplateUrl,
       @Config("reportingBucketUrl") String reportingBucketUrl,
       @LocalCredential GoogleCredentialsBundle googleCredentialsBundle,
-      Retrier retrier
-  ) {
+      Retrier retrier) {
     this.projectId = projectId;
     this.beamStagingUrl = beamStagingUrl;
     this.spec11TemplateUrl = spec11TemplateUrl;

--- a/core/src/main/java/google/registry/keyring/kms/KmsConnectionImpl.java
+++ b/core/src/main/java/google/registry/keyring/kms/KmsConnectionImpl.java
@@ -25,11 +25,9 @@ import com.google.api.services.cloudkms.v1.model.DecryptRequest;
 import com.google.api.services.cloudkms.v1.model.EncryptRequest;
 import com.google.api.services.cloudkms.v1.model.KeyRing;
 import com.google.api.services.cloudkms.v1.model.UpdateCryptoKeyPrimaryVersionRequest;
-import google.registry.config.RegistryConfig.Config;
 import google.registry.keyring.api.KeyringException;
 import google.registry.util.Retrier;
 import java.io.IOException;
-import javax.inject.Inject;
 
 /** The {@link KmsConnection} which talks to Cloud KMS. */
 class KmsConnectionImpl implements KmsConnection {
@@ -44,12 +42,7 @@ class KmsConnectionImpl implements KmsConnection {
   private final String projectId;
   private final Retrier retrier;
 
-  @Inject
-  KmsConnectionImpl(
-      @Config("cloudKmsProjectId") String projectId,
-      @Config("cloudKmsKeyRing") String kmsKeyRingName,
-      Retrier retrier,
-      CloudKMS kms) {
+  KmsConnectionImpl(String projectId, String kmsKeyRingName, Retrier retrier, CloudKMS kms) {
     this.projectId = projectId;
     this.kmsKeyRingName = kmsKeyRingName;
     this.retrier = retrier;

--- a/core/src/main/java/google/registry/keyring/kms/KmsKeyring.java
+++ b/core/src/main/java/google/registry/keyring/kms/KmsKeyring.java
@@ -27,6 +27,7 @@ import google.registry.keyring.api.KeyringException;
 import google.registry.model.server.KmsSecret;
 import java.io.IOException;
 import javax.inject.Inject;
+import javax.inject.Named;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPKeyPair;
 import org.bouncycastle.openpgp.PGPPrivateKey;
@@ -86,7 +87,7 @@ public class KmsKeyring implements Keyring {
   private final KmsConnection kmsConnection;
 
   @Inject
-  KmsKeyring(KmsConnection kmsConnection) {
+  KmsKeyring(@Named("defaultKmsConnection") KmsConnection kmsConnection) {
     this.kmsConnection = kmsConnection;
   }
 

--- a/core/src/main/java/google/registry/keyring/kms/KmsKeyring.java
+++ b/core/src/main/java/google/registry/keyring/kms/KmsKeyring.java
@@ -21,13 +21,13 @@ import static google.registry.model.common.EntityGroupRoot.getCrossTldKey;
 import static google.registry.model.ofy.ObjectifyService.ofy;
 
 import com.googlecode.objectify.Key;
+import google.registry.config.RegistryConfig.Config;
 import google.registry.keyring.api.KeySerializer;
 import google.registry.keyring.api.Keyring;
 import google.registry.keyring.api.KeyringException;
 import google.registry.model.server.KmsSecret;
 import java.io.IOException;
 import javax.inject.Inject;
-import javax.inject.Named;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPKeyPair;
 import org.bouncycastle.openpgp.PGPPrivateKey;
@@ -87,7 +87,7 @@ public class KmsKeyring implements Keyring {
   private final KmsConnection kmsConnection;
 
   @Inject
-  KmsKeyring(@Named("defaultKmsConnection") KmsConnection kmsConnection) {
+  KmsKeyring(@Config("defaultKmsConnection") KmsConnection kmsConnection) {
     this.kmsConnection = kmsConnection;
   }
 

--- a/core/src/main/java/google/registry/keyring/kms/KmsModule.java
+++ b/core/src/main/java/google/registry/keyring/kms/KmsModule.java
@@ -24,6 +24,8 @@ import google.registry.config.CredentialModule.DefaultCredential;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.keyring.api.Keyring;
 import google.registry.util.GoogleCredentialsBundle;
+import google.registry.util.Retrier;
+import javax.inject.Named;
 
 /** Dagger module for Cloud KMS. */
 @Module
@@ -32,9 +34,22 @@ public abstract class KmsModule {
   public static final String NAME = "KMS";
 
   @Provides
+  @Named("defaultKms")
   static CloudKMS provideKms(
       @DefaultCredential GoogleCredentialsBundle credentialsBundle,
       @Config("cloudKmsProjectId") String projectId) {
+    return createKms(credentialsBundle, projectId);
+  }
+
+  @Provides
+  @Named("beamKms")
+  static CloudKMS provideBeamKms(
+      @DefaultCredential GoogleCredentialsBundle credentialsBundle,
+      @Config("beamCloudKmsProjectId") String projectId) {
+    return createKms(credentialsBundle, projectId);
+  }
+
+  private static CloudKMS createKms(GoogleCredentialsBundle credentialsBundle, String projectId) {
     return new CloudKMS.Builder(
             credentialsBundle.getHttpTransport(),
             credentialsBundle.getJsonFactory(),
@@ -43,11 +58,28 @@ public abstract class KmsModule {
         .build();
   }
 
+  @Provides
+  @Named("defaultKmsConnection")
+  static KmsConnection provideKmsConnection(
+      @Config("cloudKmsProjectId") String projectId,
+      @Config("cloudKmsKeyRing") String keyringName,
+      Retrier retrier,
+      @Named("defaultKms") CloudKMS defaultKms) {
+    return new KmsConnectionImpl(projectId, keyringName, retrier, defaultKms);
+  }
+
+  @Provides
+  @Named("beamKmsConnection")
+  static KmsConnection provideBeamKmsConnection(
+      @Config("beamCloudKmsProjectId") String projectId,
+      @Config("beamCloudKmsKeyRing") String keyringName,
+      Retrier retrier,
+      @Named("beamKms") CloudKMS defaultKms) {
+    return new KmsConnectionImpl(projectId, keyringName, retrier, defaultKms);
+  }
+
   @Binds
   @IntoMap
   @StringKey(NAME)
   abstract Keyring provideKeyring(KmsKeyring keyring);
-
-  @Binds
-  abstract KmsConnection provideKmsConnection(KmsConnectionImpl kmsConnectionImpl);
 }

--- a/core/src/main/java/google/registry/keyring/kms/KmsModule.java
+++ b/core/src/main/java/google/registry/keyring/kms/KmsModule.java
@@ -25,7 +25,6 @@ import google.registry.config.RegistryConfig.Config;
 import google.registry.keyring.api.Keyring;
 import google.registry.util.GoogleCredentialsBundle;
 import google.registry.util.Retrier;
-import javax.inject.Named;
 
 /** Dagger module for Cloud KMS. */
 @Module
@@ -34,7 +33,7 @@ public abstract class KmsModule {
   public static final String NAME = "KMS";
 
   @Provides
-  @Named("defaultKms")
+  @Config("defaultKms")
   static CloudKMS provideKms(
       @DefaultCredential GoogleCredentialsBundle credentialsBundle,
       @Config("cloudKmsProjectId") String projectId) {
@@ -42,7 +41,7 @@ public abstract class KmsModule {
   }
 
   @Provides
-  @Named("beamKms")
+  @Config("beamKms")
   static CloudKMS provideBeamKms(
       @DefaultCredential GoogleCredentialsBundle credentialsBundle,
       @Config("beamCloudKmsProjectId") String projectId) {
@@ -59,22 +58,22 @@ public abstract class KmsModule {
   }
 
   @Provides
-  @Named("defaultKmsConnection")
+  @Config("defaultKmsConnection")
   static KmsConnection provideKmsConnection(
       @Config("cloudKmsProjectId") String projectId,
       @Config("cloudKmsKeyRing") String keyringName,
       Retrier retrier,
-      @Named("defaultKms") CloudKMS defaultKms) {
+      @Config("defaultKms") CloudKMS defaultKms) {
     return new KmsConnectionImpl(projectId, keyringName, retrier, defaultKms);
   }
 
   @Provides
-  @Named("beamKmsConnection")
+  @Config("beamKmsConnection")
   static KmsConnection provideBeamKmsConnection(
       @Config("beamCloudKmsProjectId") String projectId,
       @Config("beamCloudKmsKeyRing") String keyringName,
       Retrier retrier,
-      @Named("beamKms") CloudKMS defaultKms) {
+      @Config("beamKms") CloudKMS defaultKms) {
     return new KmsConnectionImpl(projectId, keyringName, retrier, defaultKms);
   }
 

--- a/core/src/main/java/google/registry/keyring/kms/KmsUpdater.java
+++ b/core/src/main/java/google/registry/keyring/kms/KmsUpdater.java
@@ -39,6 +39,7 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
 import com.google.common.collect.ImmutableMap;
+import google.registry.config.RegistryConfig.Config;
 import google.registry.keyring.api.KeySerializer;
 import google.registry.keyring.kms.KmsKeyring.PrivateKeyLabel;
 import google.registry.keyring.kms.KmsKeyring.PublicKeyLabel;
@@ -50,7 +51,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.inject.Inject;
-import javax.inject.Named;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPKeyPair;
 import org.bouncycastle.openpgp.PGPPublicKey;
@@ -65,7 +65,7 @@ public final class KmsUpdater {
   private final HashMap<String, byte[]> secretValues;
 
   @Inject
-  public KmsUpdater(@Named("defaultKmsConnection") KmsConnection kmsConnection) {
+  public KmsUpdater(@Config("defaultKmsConnection") KmsConnection kmsConnection) {
     this.kmsConnection = kmsConnection;
 
     // Use LinkedHashMap to preserve insertion order on update() to simplify testing and debugging

--- a/core/src/main/java/google/registry/keyring/kms/KmsUpdater.java
+++ b/core/src/main/java/google/registry/keyring/kms/KmsUpdater.java
@@ -50,6 +50,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import javax.inject.Inject;
+import javax.inject.Named;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPKeyPair;
 import org.bouncycastle.openpgp.PGPPublicKey;
@@ -64,7 +65,7 @@ public final class KmsUpdater {
   private final HashMap<String, byte[]> secretValues;
 
   @Inject
-  public KmsUpdater(KmsConnection kmsConnection) {
+  public KmsUpdater(@Named("defaultKmsConnection") KmsConnection kmsConnection) {
     this.kmsConnection = kmsConnection;
 
     // Use LinkedHashMap to preserve insertion order on update() to simplify testing and debugging

--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -152,11 +152,13 @@ public class PersistenceModule {
   static JpaTransactionManager provideSocketFactoryJpaTm(
       @Config("beamCloudSqlUsername") String username,
       @Config("beamCloudSqlPassword") String password,
+      @Config("beamHibernateHikariMaximumPoolSize") int hikariMaximumPoolSize,
       @BeamPipelineCloudSqlConfigs ImmutableMap<String, String> cloudSqlConfigs,
       Clock clock) {
     HashMap<String, String> overrides = Maps.newHashMap(cloudSqlConfigs);
     overrides.put(Environment.USER, username);
     overrides.put(Environment.PASS, password);
+    overrides.put(HIKARI_MAXIMUM_POOL_SIZE, String.valueOf(hikariMaximumPoolSize));
     return new JpaTransactionManagerImpl(create(overrides), clock);
   }
 

--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -152,7 +152,7 @@ public class PersistenceModule {
   static JpaTransactionManager provideSocketFactoryJpaTm(
       @Config("beamCloudSqlUsername") String username,
       @Config("beamCloudSqlPassword") String password,
-      @PartialCloudSqlConfigs ImmutableMap<String, String> cloudSqlConfigs,
+      @BeamPipelineCloudSqlConfigs ImmutableMap<String, String> cloudSqlConfigs,
       Clock clock) {
     HashMap<String, String> overrides = Maps.newHashMap(cloudSqlConfigs);
     overrides.put(Environment.USER, username);

--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -94,6 +94,21 @@ public class PersistenceModule {
       @Config("cloudSqlJdbcUrl") String jdbcUrl,
       @Config("cloudSqlInstanceConnectionName") String instanceConnectionName,
       @DefaultHibernateConfigs ImmutableMap<String, String> defaultConfigs) {
+    return createPartialSqlConfigs(jdbcUrl, instanceConnectionName, defaultConfigs);
+  }
+
+  @Provides
+  @Singleton
+  @BeamPipelineCloudSqlConfigs
+  static ImmutableMap<String, String> provideBeamPipelineCloudSqlConfigs(
+      @Config("beamCloudSqlJdbcUrl") String jdbcUrl,
+      @Config("beamCloudSqlInstanceConnectionName") String instanceConnectionName,
+      @DefaultHibernateConfigs ImmutableMap<String, String> defaultConfigs) {
+    return createPartialSqlConfigs(jdbcUrl, instanceConnectionName, defaultConfigs);
+  }
+
+  private static ImmutableMap<String, String> createPartialSqlConfigs(
+      String jdbcUrl, String instanceConnectionName, ImmutableMap<String, String> defaultConfigs) {
     HashMap<String, String> overrides = Maps.newHashMap(defaultConfigs);
     overrides.put(Environment.URL, jdbcUrl);
     overrides.put(HIKARI_DS_SOCKET_FACTORY, "com.google.cloud.sql.postgres.SocketFactory");
@@ -135,8 +150,8 @@ public class PersistenceModule {
   @Singleton
   @SocketFactoryJpaTm
   static JpaTransactionManager provideSocketFactoryJpaTm(
-      @Config("cloudSqlUsername") String username,
-      @Config("cloudSqlPassword") String password,
+      @Config("beamCloudSqlUsername") String username,
+      @Config("beamCloudSqlPassword") String password,
       @PartialCloudSqlConfigs ImmutableMap<String, String> cloudSqlConfigs,
       Clock clock) {
     HashMap<String, String> overrides = Maps.newHashMap(cloudSqlConfigs);
@@ -149,9 +164,9 @@ public class PersistenceModule {
   @Singleton
   @JdbcJpaTm
   static JpaTransactionManager provideLocalJpaTm(
-      @Config("cloudSqlJdbcUrl") String jdbcUrl,
-      @Config("cloudSqlUsername") String username,
-      @Config("cloudSqlPassword") String password,
+      @Config("beamCloudSqlJdbcUrl") String jdbcUrl,
+      @Config("beamCloudSqlUsername") String username,
+      @Config("beamCloudSqlPassword") String password,
       @DefaultHibernateConfigs ImmutableMap<String, String> defaultConfigs,
       Clock clock) {
     HashMap<String, String> overrides = Maps.newHashMap(defaultConfigs);
@@ -217,6 +232,11 @@ public class PersistenceModule {
   @Qualifier
   @Documented
   @interface PartialCloudSqlConfigs {}
+
+  /** Dagger qualifier for the Cloud SQL configs used by Beam pipelines. */
+  @Qualifier
+  @Documented
+  @interface BeamPipelineCloudSqlConfigs {}
 
   /** Dagger qualifier for the default Hibernate configurations. */
   // TODO(shicong): Change annotations in this class to none public or put them in a top level

--- a/core/src/main/java/google/registry/tools/AuthModule.java
+++ b/core/src/main/java/google/registry/tools/AuthModule.java
@@ -50,7 +50,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import javax.annotation.Nullable;
-import javax.inject.Named;
 import javax.inject.Qualifier;
 import javax.inject.Singleton;
 
@@ -151,7 +150,7 @@ public class AuthModule {
   public static String provideLocalCredentialJson(
       Lazy<GoogleClientSecrets> clientSecrets,
       @StoredCredential Lazy<Credential> credential,
-      @Nullable @Named("credentialFilePath") String credentialFilePath) {
+      @Nullable @Config("credentialFilePath") String credentialFilePath) {
     try {
       if (credentialFilePath != null) {
         return new String(Files.readAllBytes(Paths.get(credentialFilePath)), UTF_8);

--- a/core/src/main/java/google/registry/tools/AuthModule.java
+++ b/core/src/main/java/google/registry/tools/AuthModule.java
@@ -151,10 +151,10 @@ public class AuthModule {
   public static String provideLocalCredentialJson(
       Lazy<GoogleClientSecrets> clientSecrets,
       @StoredCredential Lazy<Credential> credential,
-      @Nullable @Named("credentialFileName") String credentialFilename) {
+      @Nullable @Named("credentialFilePath") String credentialFilePath) {
     try {
-      if (credentialFilename != null) {
-        return new String(Files.readAllBytes(Paths.get(credentialFilename)), UTF_8);
+      if (credentialFilePath != null) {
+        return new String(Files.readAllBytes(Paths.get(credentialFilePath)), UTF_8);
       } else {
         return new Gson()
             .toJson(

--- a/core/src/main/java/google/registry/tools/RegistryCli.java
+++ b/core/src/main/java/google/registry/tools/RegistryCli.java
@@ -29,6 +29,7 @@ import com.google.appengine.tools.remoteapi.RemoteApiOptions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import google.registry.beam.initsql.BeamJpaModule;
 import google.registry.config.RegistryConfig;
 import google.registry.model.ofy.ObjectifyService;
 import google.registry.persistence.transaction.TransactionManagerFactory;
@@ -153,11 +154,15 @@ final class RegistryCli implements AutoCloseable, CommandRunner {
       return;
     }
 
-    checkState(RegistryToolEnvironment.get() == environment,
+    checkState(
+        RegistryToolEnvironment.get() == environment,
         "RegistryToolEnvironment argument pre-processing kludge failed.");
 
     component =
-        DaggerRegistryToolComponent.builder().credentialFilename(credentialJson).build();
+        DaggerRegistryToolComponent.builder()
+            .credentialFilePath(credentialJson)
+            .beamJpaModule(new BeamJpaModule(credentialJson))
+            .build();
 
     // JCommander stores sub-commands as nested JCommander objects containing a list of user objects
     // to be populated.  Extract the subcommand by getting the JCommander wrapper and then

--- a/core/src/main/java/google/registry/tools/RegistryToolComponent.java
+++ b/core/src/main/java/google/registry/tools/RegistryToolComponent.java
@@ -21,6 +21,7 @@ import google.registry.batch.BatchModule;
 import google.registry.beam.initsql.BeamJpaModule;
 import google.registry.bigquery.BigqueryModule;
 import google.registry.config.CredentialModule.LocalCredentialJson;
+import google.registry.config.RegistryConfig.Config;
 import google.registry.config.RegistryConfig.ConfigModule;
 import google.registry.dns.writer.VoidDnsWriterModule;
 import google.registry.dns.writer.clouddns.CloudDnsWriterModule;
@@ -43,7 +44,6 @@ import google.registry.tools.AuthModule.LocalCredentialModule;
 import google.registry.util.UtilsModule;
 import google.registry.whois.WhoisModule;
 import javax.annotation.Nullable;
-import javax.inject.Named;
 import javax.inject.Singleton;
 
 /**
@@ -132,7 +132,7 @@ interface RegistryToolComponent {
   @Component.Builder
   interface Builder {
     @BindsInstance
-    Builder credentialFilePath(@Nullable @Named("credentialFilePath") String credentialFilePath);
+    Builder credentialFilePath(@Nullable @Config("credentialFilePath") String credentialFilePath);
 
     Builder beamJpaModule(BeamJpaModule beamJpaModule);
 

--- a/core/src/main/java/google/registry/tools/RegistryToolComponent.java
+++ b/core/src/main/java/google/registry/tools/RegistryToolComponent.java
@@ -18,6 +18,7 @@ import dagger.BindsInstance;
 import dagger.Component;
 import dagger.Lazy;
 import google.registry.batch.BatchModule;
+import google.registry.beam.initsql.BeamJpaModule;
 import google.registry.bigquery.BigqueryModule;
 import google.registry.config.CredentialModule.LocalCredentialJson;
 import google.registry.config.RegistryConfig.ConfigModule;
@@ -57,6 +58,7 @@ import javax.inject.Singleton;
       AppEngineAdminApiModule.class,
       AuthModule.class,
       BatchModule.class,
+      BeamJpaModule.class,
       BigqueryModule.class,
       ConfigModule.class,
       CloudDnsWriterModule.class,
@@ -130,7 +132,9 @@ interface RegistryToolComponent {
   @Component.Builder
   interface Builder {
     @BindsInstance
-    Builder credentialFilename(@Nullable @Named("credentialFileName") String credentialFilename);
+    Builder credentialFilePath(@Nullable @Named("credentialFilePath") String credentialFilePath);
+
+    Builder beamJpaModule(BeamJpaModule beamJpaModule);
 
     RegistryToolComponent build();
   }


### PR DESCRIPTION
This allows us to also inject the BeamJpaModule into RegistryTool, which
allows us to use the SocketJpaTransactionManager in Beam pipelines.

Some side effects of this include:
- duplication of KMS connections -- one standard, one Beam
- duplication of the creation of the partial Hibernate SQL configs
- removal of ambiguity between credentialFileName, credentialFilename,
and credentialFilePath -- we now use the latter.
- Performing the credential null check when instantiating the SQL
connection rather than when instantiating the module object. See the code
comments for more details on this.

I verified that this compiles and the tests run successfully when
injecting a @SocketFactoryJpaTm into a Beam pipeline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/657)
<!-- Reviewable:end -->
