### PR TITLE
Output PO number in detailed report

### DIFF
--- a/core/src/main/java/google/registry/beam/invoicing/BillingEvent.java
+++ b/core/src/main/java/google/registry/beam/invoicing/BillingEvent.java
@@ -235,6 +235,7 @@ public abstract class BillingEvent implements Serializable {
                 DATE_TIME_FORMATTER.format(eventTime()),
                 registrarId(),
                 billingId(),
+                poNumber(),
                 tld(),
                 action(),
                 domain(),

--- a/core/src/test/java/google/registry/beam/invoicing/BillingEventTest.java
+++ b/core/src/test/java/google/registry/beam/invoicing/BillingEventTest.java
@@ -133,7 +133,17 @@ public class BillingEventTest {
     BillingEvent event = BillingEvent.parseFromRecord(schemaAndRecord);
     assertThat(event.toCsv())
         .isEqualTo("1,2017-10-24 09:06:03 UTC,2017-01-19 23:59:43 UTC,myRegistrar,"
-            + "12345-CRRHELLO,test,RENEW,example.test,123456,5,USD,20.50,AUTO_RENEW");
+            + "12345-CRRHELLO,,test,RENEW,example.test,123456,5,USD,20.50,AUTO_RENEW");
+  }
+
+  @Test
+  public void testConvertBillingEvent_nonNullPoNumber_toCsv() {
+    GenericRecord record = createRecord();
+    record.put("poNumber", "905610");
+    BillingEvent event = BillingEvent.parseFromRecord(new SchemaAndRecord(record, null));
+    assertThat(event.toCsv())
+        .isEqualTo("1,2017-10-24 09:06:03 UTC,2017-01-19 23:59:43 UTC,myRegistrar,"
+            + "12345-CRRHELLO,905610,test,RENEW,example.test,123456,5,USD,20.50,AUTO_RENEW");
   }
 
   @Test

--- a/core/src/test/java/google/registry/beam/invoicing/InvoicingPipelineTest.java
+++ b/core/src/test/java/google/registry/beam/invoicing/InvoicingPipelineTest.java
@@ -157,21 +157,21 @@ public class InvoicingPipelineTest {
     return ImmutableMap.of(
         "invoice_details_2017-10_theRegistrar_test.csv",
         ImmutableList.of(
-            "1,2017-10-04 00:00:00 UTC,2017-10-04 00:00:00 UTC,theRegistrar,234,"
+            "1,2017-10-04 00:00:00 UTC,2017-10-04 00:00:00 UTC,theRegistrar,234,,"
                 + "test,RENEW,mydomain2.test,REPO-ID,3,USD,20.50,",
-            "1,2017-10-04 00:00:00 UTC,2017-10-04 00:00:00 UTC,theRegistrar,234,"
+            "1,2017-10-04 00:00:00 UTC,2017-10-04 00:00:00 UTC,theRegistrar,234,,"
                 + "test,RENEW,mydomain.test,REPO-ID,3,USD,20.50,"),
         "invoice_details_2017-10_theRegistrar_hello.csv",
         ImmutableList.of(
-            "1,2017-10-02 00:00:00 UTC,2017-09-29 00:00:00 UTC,theRegistrar,234,"
+            "1,2017-10-02 00:00:00 UTC,2017-09-29 00:00:00 UTC,theRegistrar,234,,"
                 + "hello,CREATE,mydomain3.hello,REPO-ID,5,JPY,70.75,"),
         "invoice_details_2017-10_bestdomains_test.csv",
         ImmutableList.of(
-            "1,2017-10-04 00:00:00 UTC,2017-10-04 00:00:00 UTC,bestdomains,456,"
+            "1,2017-10-04 00:00:00 UTC,2017-10-04 00:00:00 UTC,bestdomains,456,116688,"
                 + "test,RENEW,mydomain4.test,REPO-ID,1,USD,20.50,"),
         "invoice_details_2017-10_anotherRegistrar_test.csv",
         ImmutableList.of(
-            "1,2017-10-04 00:00:00 UTC,2017-10-04 00:00:00 UTC,anotherRegistrar,789,"
+            "1,2017-10-04 00:00:00 UTC,2017-10-04 00:00:00 UTC,anotherRegistrar,789,,"
                 + "test,CREATE,mydomain5.test,REPO-ID,1,USD,0.00,SUNRISE ANCHOR_TENANT"));
   }
 


### PR DESCRIPTION
The PO number header was added during the beam migration but we forgot
to print the actual data in the corresponding column. This resulted in a
misalignment of columns in the detailed report.

This PR fixes it. Note that we cannot drop PO number from the header (as is not
useful in the detailed report) because the header represents all fields
that are to be parsed from the SQL query results, and PO number *is*
needed when generating the invoice itself. By dual-purposing the header
(both as the required fields in the parser and the first line in the
detailed report) we have to include the value of PO number in the
detailed report CSV as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/659)
<!-- Reviewable:end -->
