### PR TITLE
Use an enum instead of boolean in EntityTestCase constructor

### DIFF
--- a/core/src/test/java/google/registry/model/EntityTestCase.java
+++ b/core/src/test/java/google/registry/model/EntityTestCase.java
@@ -49,6 +49,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 /** Base class of all unit tests for entities which are persisted to Datastore via Objectify. */
 public abstract class EntityTestCase {
 
+  protected enum JpaEntityCheck {
+    ENABLED, DISABLED;
+  }
+
   protected FakeClock fakeClock = new FakeClock(DateTime.now(UTC));
 
   @Rule @RegisterExtension public final AppEngineRule appEngine;
@@ -56,14 +60,14 @@ public abstract class EntityTestCase {
   @Rule @RegisterExtension public InjectRule inject = new InjectRule();
 
   protected EntityTestCase() {
-    this(false);
+    this(JpaEntityCheck.DISABLED);
   }
 
-  protected EntityTestCase(boolean enableJpaEntityCheck) {
+  protected EntityTestCase(JpaEntityCheck jpaEntityCheck) {
     appEngine =
         AppEngineRule.builder()
             .withDatastoreAndCloudSql()
-            .enableJpaEntityCoverageCheck(enableJpaEntityCheck)
+            .enableJpaEntityCoverageCheck(jpaEntityCheck == JpaEntityCheck.ENABLED)
             .withClock(fakeClock)
             .build();
   }

--- a/core/src/test/java/google/registry/model/EntityTestCase.java
+++ b/core/src/test/java/google/registry/model/EntityTestCase.java
@@ -49,8 +49,14 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 /** Base class of all unit tests for entities which are persisted to Datastore via Objectify. */
 public abstract class EntityTestCase {
 
-  protected enum JpaEntityCheck {
-    ENABLED, DISABLED;
+  protected enum JpaEntityCoverageCheck {
+    /**
+     * The test will contribute to the coverage checks in {@link
+     * google.registry.schema.integration.SqlIntegrationTestSuite}.
+     */
+    ENABLED,
+    /** The test is not relevant for JPA coverage checks. */
+    DISABLED;
   }
 
   protected FakeClock fakeClock = new FakeClock(DateTime.now(UTC));
@@ -60,14 +66,14 @@ public abstract class EntityTestCase {
   @Rule @RegisterExtension public InjectRule inject = new InjectRule();
 
   protected EntityTestCase() {
-    this(JpaEntityCheck.DISABLED);
+    this(JpaEntityCoverageCheck.DISABLED);
   }
 
-  protected EntityTestCase(JpaEntityCheck jpaEntityCheck) {
+  protected EntityTestCase(JpaEntityCoverageCheck jpaEntityCoverageCheck) {
     appEngine =
         AppEngineRule.builder()
             .withDatastoreAndCloudSql()
-            .enableJpaEntityCoverageCheck(jpaEntityCheck == JpaEntityCheck.ENABLED)
+            .enableJpaEntityCoverageCheck(jpaEntityCoverageCheck == JpaEntityCoverageCheck.ENABLED)
             .withClock(fakeClock)
             .build();
   }

--- a/core/src/test/java/google/registry/model/billing/BillingEventTest.java
+++ b/core/src/test/java/google/registry/model/billing/BillingEventTest.java
@@ -51,7 +51,7 @@ public class BillingEventTest extends EntityTestCase {
   private final DateTime now = DateTime.now(UTC);
 
   public BillingEventTest() {
-    super(true);
+    super(JpaEntityCheck.ENABLED);
   }
 
   HistoryEntry historyEntry;

--- a/core/src/test/java/google/registry/model/billing/BillingEventTest.java
+++ b/core/src/test/java/google/registry/model/billing/BillingEventTest.java
@@ -51,7 +51,7 @@ public class BillingEventTest extends EntityTestCase {
   private final DateTime now = DateTime.now(UTC);
 
   public BillingEventTest() {
-    super(JpaEntityCheck.ENABLED);
+    super(JpaEntityCoverageCheck.ENABLED);
   }
 
   HistoryEntry historyEntry;

--- a/core/src/test/java/google/registry/model/contact/ContactResourceTest.java
+++ b/core/src/test/java/google/registry/model/contact/ContactResourceTest.java
@@ -49,7 +49,7 @@ public class ContactResourceTest extends EntityTestCase {
   ContactResource contactResource;
 
   public ContactResourceTest() {
-    super(true);
+    super(JpaEntityCheck.ENABLED);
   }
 
   @BeforeEach

--- a/core/src/test/java/google/registry/model/contact/ContactResourceTest.java
+++ b/core/src/test/java/google/registry/model/contact/ContactResourceTest.java
@@ -49,7 +49,7 @@ public class ContactResourceTest extends EntityTestCase {
   ContactResource contactResource;
 
   public ContactResourceTest() {
-    super(JpaEntityCheck.ENABLED);
+    super(JpaEntityCoverageCheck.ENABLED);
   }
 
   @BeforeEach

--- a/core/src/test/java/google/registry/model/history/ContactHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/ContactHistoryTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 public class ContactHistoryTest extends EntityTestCase {
 
   public ContactHistoryTest() {
-    super(true);
+    super(JpaEntityCheck.ENABLED);
   }
 
   @Test

--- a/core/src/test/java/google/registry/model/history/ContactHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/ContactHistoryTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 public class ContactHistoryTest extends EntityTestCase {
 
   public ContactHistoryTest() {
-    super(JpaEntityCheck.ENABLED);
+    super(JpaEntityCoverageCheck.ENABLED);
   }
 
   @Test

--- a/core/src/test/java/google/registry/model/history/HostHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/HostHistoryTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 public class HostHistoryTest extends EntityTestCase {
 
   public HostHistoryTest() {
-    super(JpaEntityCheck.ENABLED);
+    super(JpaEntityCoverageCheck.ENABLED);
   }
 
   @Test

--- a/core/src/test/java/google/registry/model/history/HostHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/HostHistoryTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 public class HostHistoryTest extends EntityTestCase {
 
   public HostHistoryTest() {
-    super(true);
+    super(JpaEntityCheck.ENABLED);
   }
 
   @Test

--- a/core/src/test/java/google/registry/model/poll/PollMessageTest.java
+++ b/core/src/test/java/google/registry/model/poll/PollMessageTest.java
@@ -39,7 +39,7 @@ public class PollMessageTest extends EntityTestCase {
   PollMessage.Autorenew autoRenew;
 
   public PollMessageTest() {
-    super(JpaEntityCheck.ENABLED);
+    super(JpaEntityCoverageCheck.ENABLED);
   }
 
   @BeforeEach

--- a/core/src/test/java/google/registry/model/poll/PollMessageTest.java
+++ b/core/src/test/java/google/registry/model/poll/PollMessageTest.java
@@ -39,7 +39,7 @@ public class PollMessageTest extends EntityTestCase {
   PollMessage.Autorenew autoRenew;
 
   public PollMessageTest() {
-    super(true);
+    super(JpaEntityCheck.ENABLED);
   }
 
   @BeforeEach

--- a/core/src/test/java/google/registry/model/registry/RegistryLockDaoTest.java
+++ b/core/src/test/java/google/registry/model/registry/RegistryLockDaoTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 public final class RegistryLockDaoTest extends EntityTestCase {
 
   public RegistryLockDaoTest() {
-    super(JpaEntityCheck.ENABLED);
+    super(JpaEntityCoverageCheck.ENABLED);
   }
 
   @Test

--- a/core/src/test/java/google/registry/model/registry/RegistryLockDaoTest.java
+++ b/core/src/test/java/google/registry/model/registry/RegistryLockDaoTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 public final class RegistryLockDaoTest extends EntityTestCase {
 
   public RegistryLockDaoTest() {
-    super(true);
+    super(JpaEntityCheck.ENABLED);
   }
 
   @Test

--- a/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchTest.java
+++ b/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchTest.java
@@ -47,7 +47,7 @@ public class Spec11ThreatMatchTest extends EntityTestCase {
   private ContactResource registrantContact;
 
   public Spec11ThreatMatchTest() {
-    super(true);
+    super(JpaEntityCheck.ENABLED);
   }
 
   @BeforeEach

--- a/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchTest.java
+++ b/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchTest.java
@@ -47,7 +47,7 @@ public class Spec11ThreatMatchTest extends EntityTestCase {
   private ContactResource registrantContact;
 
   public Spec11ThreatMatchTest() {
-    super(JpaEntityCheck.ENABLED);
+    super(JpaEntityCoverageCheck.ENABLED);
   }
 
   @BeforeEach


### PR DESCRIPTION
It's more clear to use an enum rather than just a simple boolean

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/669)
<!-- Reviewable:end -->
