### PR TITLE
Double the # of pubapi instances to better handle traffic spikes

### DIFF
--- a/core/src/main/java/google/registry/env/production/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/pubapi/WEB-INF/appengine-web.xml
@@ -7,7 +7,7 @@
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <manual-scaling>
-    <instances>10</instances>
+    <instances>20</instances>
   </manual-scaling>
 
   <system-properties>


### PR DESCRIPTION
We may also consider switching to an automatic scaling mode soon, on the hope
that it's working better than the last time we tried it (it would help to keep
resource costs down at least).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/671)
<!-- Reviewable:end -->
