### PR TITLE
Persist new threat matches

### DIFF
--- a/core/src/main/java/google/registry/beam/spec11/SafeBrowsingTransforms.java
+++ b/core/src/main/java/google/registry/beam/spec11/SafeBrowsingTransforms.java
@@ -141,7 +141,7 @@ public class SafeBrowsingTransforms {
     @ProcessElement
     public void processElement(ProcessContext context) {
       Subdomain subdomain = context.element();
-      subdomainBuffer.put(subdomain.fullyQualifiedDomainName(), subdomain);
+      subdomainBuffer.put(subdomain.domainName(), subdomain);
       if (subdomainBuffer.size() >= BATCH_SIZE) {
         ImmutableSet<KV<Subdomain, ThreatMatch>> results = evaluateAndFlush();
         results.forEach(context::output);
@@ -239,7 +239,7 @@ public class SafeBrowsingTransforms {
             String url = match.getJSONObject("threat").getString("url");
             Subdomain subdomain = subdomainBuffer.get(url);
             resultBuilder.add(
-                KV.of(subdomain, ThreatMatch.create(match, subdomain.fullyQualifiedDomainName())));
+                KV.of(subdomain, ThreatMatch.create(match, subdomain.domainName())));
           }
         }
       }

--- a/core/src/main/java/google/registry/beam/spec11/Spec11Pipeline.java
+++ b/core/src/main/java/google/registry/beam/spec11/Spec11Pipeline.java
@@ -22,8 +22,6 @@ import com.google.auto.value.AutoValue;
 import google.registry.beam.spec11.SafeBrowsingTransforms.EvaluateSafeBrowsingFn;
 import google.registry.config.CredentialModule.LocalCredential;
 import google.registry.config.RegistryConfig.Config;
-import google.registry.persistence.PersistenceModule.SocketFactoryJpaTm;
-import google.registry.persistence.transaction.JpaTransactionManager;
 import google.registry.util.GoogleCredentialsBundle;
 import google.registry.util.Retrier;
 import google.registry.util.SqlTemplate;

--- a/core/src/main/java/google/registry/beam/spec11/Spec11Pipeline.java
+++ b/core/src/main/java/google/registry/beam/spec11/Spec11Pipeline.java
@@ -207,7 +207,6 @@ public class Spec11Pipeline implements Serializable {
                         .setDomainRepoId(elem.getKey().domainRepoId())
                         .setRegistrarId(elem.getKey().registrarId())
                         .build();
-                // persist the ThreatMatch
                 jpaTm.saveNew(threatMatch);
                 return null;
               }

--- a/core/src/main/java/google/registry/beam/spec11/Spec11Pipeline.java
+++ b/core/src/main/java/google/registry/beam/spec11/Spec11Pipeline.java
@@ -207,7 +207,7 @@ public class Spec11Pipeline implements Serializable {
                         .setDomainRepoId(elem.getKey().domainRepoId())
                         .setRegistrarId(elem.getKey().registrarId())
                         .build();
-                //persist the ThreatMatch
+                // persist the ThreatMatch
                 jpaTm.saveNew(threatMatch);
                 return null;
               }

--- a/core/src/main/java/google/registry/beam/spec11/Spec11Pipeline.java
+++ b/core/src/main/java/google/registry/beam/spec11/Spec11Pipeline.java
@@ -19,9 +19,14 @@ import static google.registry.beam.BeamUtils.getQueryFromFile;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableSet;
 import google.registry.beam.spec11.SafeBrowsingTransforms.EvaluateSafeBrowsingFn;
 import google.registry.config.CredentialModule.LocalCredential;
 import google.registry.config.RegistryConfig.Config;
+import google.registry.model.reporting.Spec11ThreatMatch;
+import google.registry.model.reporting.Spec11ThreatMatch.ThreatType;
+import google.registry.persistence.PersistenceModule.SocketFactoryJpaTm;
+import google.registry.persistence.transaction.JpaTransactionManager;
 import google.registry.util.GoogleCredentialsBundle;
 import google.registry.util.Retrier;
 import google.registry.util.SqlTemplate;
@@ -37,6 +42,7 @@ import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.options.ValueProvider.NestedValueProvider;
+import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.ParDo;
@@ -46,6 +52,7 @@ import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.sdk.values.TypeDescriptors;
 import org.joda.time.LocalDate;
 import org.joda.time.YearMonth;
+import org.joda.time.format.ISODateTimeFormat;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -84,6 +91,7 @@ public class Spec11Pipeline implements Serializable {
   private final String beamStagingUrl;
   private final String spec11TemplateUrl;
   private final String reportingBucketUrl;
+  private final JpaTransactionManager jpaTm;
   private final GoogleCredentials googleCredentials;
   private final Retrier retrier;
 
@@ -93,12 +101,14 @@ public class Spec11Pipeline implements Serializable {
       @Config("beamStagingUrl") String beamStagingUrl,
       @Config("spec11TemplateUrl") String spec11TemplateUrl,
       @Config("reportingBucketUrl") String reportingBucketUrl,
+      @SocketFactoryJpaTm JpaTransactionManager jpaTm,
       @LocalCredential GoogleCredentialsBundle googleCredentialsBundle,
       Retrier retrier) {
     this.projectId = projectId;
     this.beamStagingUrl = beamStagingUrl;
     this.spec11TemplateUrl = spec11TemplateUrl;
     this.reportingBucketUrl = reportingBucketUrl;
+    this.jpaTm = jpaTm;
     this.googleCredentials = googleCredentialsBundle.getGoogleCredentials();
     this.retrier = retrier;
   }
@@ -163,7 +173,8 @@ public class Spec11Pipeline implements Serializable {
     evaluateUrlHealth(
         domains,
         new EvaluateSafeBrowsingFn(options.getSafeBrowsingApiKey(), retrier),
-        options.getDate());
+        options.getDate(),
+        jpaTm);
     p.run();
   }
 
@@ -175,14 +186,39 @@ public class Spec11Pipeline implements Serializable {
   void evaluateUrlHealth(
       PCollection<Subdomain> domains,
       EvaluateSafeBrowsingFn evaluateSafeBrowsingFn,
-      ValueProvider<String> dateProvider) {
+      ValueProvider<String> dateProvider,
+      JpaTransactionManager jpaTm) {
+
+    /* Store ThreatMatch objects in SQL. */
+    PCollection<KV<Subdomain, ThreatMatch>> subdomainsSql =
+        domains.apply("Run through SafeBrowsingAPI", ParDo.of(evaluateSafeBrowsingFn));
+    subdomainsSql.apply(
+        ParDo.of(
+            new DoFn<KV<Subdomain, ThreatMatch>, Void>() {
+              @ProcessElement
+              Void processElement(KV<Subdomain, ThreatMatch> elem) {
+                // create the Spec11ThreatMatch from Subdomain and ThreatMatch
+                Spec11ThreatMatch threatMatch =
+                    new Spec11ThreatMatch.Builder()
+                        .setThreatTypes(
+                            ImmutableSet.of(ThreatType.valueOf(elem.getValue().threatType())))
+                        .setCheckDate(LocalDate.parse(dateProvider.get(), ISODateTimeFormat.date()))
+                        .setDomainName(elem.getKey().domainName())
+                        .setDomainRepoId(elem.getKey().domainRepoId())
+                        .setRegistrarId(elem.getKey().registrarId())
+                        .build();
+                //persist the ThreatMatch
+                jpaTm.saveNew(threatMatch);
+                return null;
+              }
+            }));
 
     /* Store ThreatMatch objects in JSON. */
     PCollection<KV<Subdomain, ThreatMatch>> subdomainsJson =
         domains.apply("Run through SafeBrowsingAPI", ParDo.of(evaluateSafeBrowsingFn));
     subdomainsJson
         .apply(
-            "Map registrar client ID to email/ThreatMatch pair",
+            "Map registrar ID to email/ThreatMatch pair",
             MapElements.into(
                     TypeDescriptors.kvs(
                         TypeDescriptors.strings(), TypeDescriptor.of(EmailAndThreatMatch.class)))

--- a/core/src/main/java/google/registry/beam/spec11/Subdomain.java
+++ b/core/src/main/java/google/registry/beam/spec11/Subdomain.java
@@ -36,12 +36,14 @@ import org.apache.beam.sdk.io.gcp.bigquery.SchemaAndRecord;
 public abstract class Subdomain implements Serializable {
 
   private static final ImmutableList<String> FIELD_NAMES =
-      ImmutableList.of("fullyQualifiedDomainName", "registrarClientId", "registrarEmailAddress");
+      ImmutableList.of("domainName", "domainRepoId", "clientId", "registrarEmailAddress");
 
   /** Returns the fully qualified domain name. */
-  abstract String fullyQualifiedDomainName();
+  abstract String domainName();
+  /** Returns the domain repo ID (the primary key of the domain table). */
+  abstract String domainRepoId();
   /** Returns the client ID of the associated registrar for this domain. */
-  abstract String registrarClientId();
+  abstract String clientId();
   /** Returns the email address of the registrar associated with this domain. */
   abstract String registrarEmailAddress();
 
@@ -56,8 +58,9 @@ public abstract class Subdomain implements Serializable {
     checkFieldsNotNull(FIELD_NAMES, schemaAndRecord);
     GenericRecord record = schemaAndRecord.getRecord();
     return create(
-        extractField(record, "fullyQualifiedDomainName"),
-        extractField(record, "registrarClientId"),
+        extractField(record, "domainName"),
+        extractField(record, "domainRepoId"),
+        extractField(record, "clientId"),
         extractField(record, "registrarEmailAddress"));
   }
 
@@ -69,9 +72,11 @@ public abstract class Subdomain implements Serializable {
    */
   @VisibleForTesting
   static Subdomain create(
-      String fullyQualifiedDomainName, String registrarClientId, String registrarEmailAddress) {
+      String domainName,
+      String domainRepoId,
+      String clientId,
+      String registrarEmailAddress) {
     return new AutoValue_Subdomain(
-        fullyQualifiedDomainName, registrarClientId, registrarEmailAddress);
+        domainName, domainRepoId, clientId, registrarEmailAddress);
   }
 }
-

--- a/core/src/main/java/google/registry/beam/spec11/Subdomain.java
+++ b/core/src/main/java/google/registry/beam/spec11/Subdomain.java
@@ -36,14 +36,14 @@ import org.apache.beam.sdk.io.gcp.bigquery.SchemaAndRecord;
 public abstract class Subdomain implements Serializable {
 
   private static final ImmutableList<String> FIELD_NAMES =
-      ImmutableList.of("domainName", "domainRepoId", "clientId", "registrarEmailAddress");
+      ImmutableList.of("domainName", "domainRepoId", "registrarId", "registrarEmailAddress");
 
   /** Returns the fully qualified domain name. */
   abstract String domainName();
   /** Returns the domain repo ID (the primary key of the domain table). */
   abstract String domainRepoId();
-  /** Returns the client ID of the associated registrar for this domain. */
-  abstract String clientId();
+  /** Returns the registrar client ID of the associated registrar for this domain. */
+  abstract String registrarId();
   /** Returns the email address of the registrar associated with this domain. */
   abstract String registrarEmailAddress();
 
@@ -60,7 +60,7 @@ public abstract class Subdomain implements Serializable {
     return create(
         extractField(record, "domainName"),
         extractField(record, "domainRepoId"),
-        extractField(record, "clientId"),
+        extractField(record, "registrarId"),
         extractField(record, "registrarEmailAddress"));
   }
 
@@ -74,9 +74,9 @@ public abstract class Subdomain implements Serializable {
   static Subdomain create(
       String domainName,
       String domainRepoId,
-      String clientId,
+      String registrarId,
       String registrarEmailAddress) {
     return new AutoValue_Subdomain(
-        domainName, domainRepoId, clientId, registrarEmailAddress);
+        domainName, domainRepoId, registrarId, registrarEmailAddress);
   }
 }

--- a/core/src/main/java/google/registry/beam/spec11/Subdomain.java
+++ b/core/src/main/java/google/registry/beam/spec11/Subdomain.java
@@ -42,7 +42,7 @@ public abstract class Subdomain implements Serializable {
   abstract String domainName();
   /** Returns the domain repo ID (the primary key of the domain table). */
   abstract String domainRepoId();
-  /** Returns the registrar client ID of the associated registrar for this domain. */
+  /** Returns the registrar ID of the associated registrar for this domain. */
   abstract String registrarId();
   /** Returns the email address of the registrar associated with this domain. */
   abstract String registrarEmailAddress();

--- a/core/src/main/java/google/registry/beam/spec11/sql/subdomains.sql
+++ b/core/src/main/java/google/registry/beam/spec11/sql/subdomains.sql
@@ -19,11 +19,13 @@
   -- email address.
 
 SELECT
-  domain.fullyQualifiedDomainName AS fullyQualifiedDomainName,
-  registrar.clientId AS registrarClientId,
+  domain.fullyQualifiedDomainName AS domainName,
+  domain.__key__.name AS domainRepoId,
+  registrar.clientId AS clientId,
   COALESCE(registrar.emailAddress, '') AS registrarEmailAddress
 FROM ( (
     SELECT
+      __key__,
       fullyQualifiedDomainName,
       currentSponsorClientId,
       creationTime

--- a/core/src/main/java/google/registry/model/reporting/Spec11ThreatMatch.java
+++ b/core/src/main/java/google/registry/model/reporting/Spec11ThreatMatch.java
@@ -20,6 +20,7 @@ import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import google.registry.beam.spec11.ThreatMatch;
 import google.registry.model.Buildable;
 import google.registry.model.ImmutableObject;
 import google.registry.schema.replay.DatastoreEntity;

--- a/core/src/main/java/google/registry/model/reporting/Spec11ThreatMatch.java
+++ b/core/src/main/java/google/registry/model/reporting/Spec11ThreatMatch.java
@@ -20,7 +20,6 @@ import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import google.registry.beam.spec11.ThreatMatch;
 import google.registry.model.Buildable;
 import google.registry.model.ImmutableObject;
 import google.registry.schema.replay.DatastoreEntity;

--- a/core/src/main/java/google/registry/model/reporting/Spec11ThreatMatch.java
+++ b/core/src/main/java/google/registry/model/reporting/Spec11ThreatMatch.java
@@ -20,11 +20,13 @@ import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import google.registry.beam.spec11.ThreatMatch;
 import google.registry.model.Buildable;
 import google.registry.model.ImmutableObject;
 import google.registry.schema.replay.DatastoreEntity;
 import google.registry.schema.replay.SqlEntity;
 import google.registry.util.DomainNameUtils;
+import java.io.Serializable;
 import java.util.Set;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -42,7 +44,8 @@ import org.joda.time.LocalDate;
       @Index(name = "spec11threatmatch_tld_idx", columnList = "tld"),
       @Index(name = "spec11threatmatch_check_date_idx", columnList = "checkDate")
     })
-public class Spec11ThreatMatch extends ImmutableObject implements Buildable, SqlEntity {
+public class Spec11ThreatMatch extends ImmutableObject
+    implements Buildable, SqlEntity, Serializable {
 
   /** The type of threat detected. */
   public enum ThreatType {

--- a/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
+++ b/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
@@ -15,7 +15,6 @@
 package google.registry.beam.spec11;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -26,7 +25,6 @@ import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharStreams;
 import google.registry.beam.spec11.SafeBrowsingTransforms.EvaluateSafeBrowsingFn;
-import google.registry.persistence.transaction.JpaTransactionManager;
 import google.registry.testing.FakeClock;
 import google.registry.testing.FakeSleeper;
 import google.registry.util.GoogleCredentialsBundle;
@@ -90,14 +88,12 @@ public class Spec11PipelineTest {
   @Before
   public void initializePipeline() throws IOException {
     File beamTempFolder = tempFolder.newFolder();
-    JpaTransactionManager jpaTm = jpaTm();
     spec11Pipeline =
         new Spec11Pipeline(
             "test-project",
             beamTempFolder.getAbsolutePath() + "/staging",
             beamTempFolder.getAbsolutePath() + "/templates/invoicing",
             tempFolder.getRoot().getAbsolutePath(),
-            jpaTm,
             GoogleCredentialsBundle.create(GoogleCredentials.create(null)),
             retrier);
   }
@@ -147,8 +143,7 @@ public class Spec11PipelineTest {
 
     // Apply input and evaluation transforms
     PCollection<Subdomain> input = p.apply(Create.of(inputRows));
-    JpaTransactionManager jpaTm = jpaTm();
-    spec11Pipeline.evaluateUrlHealth(input, evalFn, StaticValueProvider.of("2018-06-01"), jpaTm);
+    spec11Pipeline.evaluateUrlHealth(input, evalFn, StaticValueProvider.of("2018-06-01"));
     p.run();
 
     // Verify header and 4 threat matches for 3 registrars are found


### PR DESCRIPTION
Creates Spec11ThreatMatch objects using Subdomains and ThreatMatches, and persists them using a JpaTransactionManager. Alter the existing test in Spec11PipelineTest to test for the persistence of them. This is so we can begin storing the new data from the daily runs using the SafeBrowsing API into our new SQL table.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/678)
<!-- Reviewable:end -->
