### PR TITLE
Add two folders of auto-generated Java classes to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,10 @@ nomulus.iml
 nomulus.ipr
 nomulus.iws
 
+# Auto-generated java classes by Intellij
+*/src/main/generated/
+*/src/test/generated_tests/
+
 # VScode
 .vscode
 


### PR DESCRIPTION
For some reason, Intellij 2020.1 puts some auto-generated Java classes to `${workspace}/core/src/test/generated_tests/` and `${workspace}/util/src/main/generated/` when running tests. So, add them to `.gitignore` to avoid interference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/679)
<!-- Reviewable:end -->
