### PR TITLE
Fix JpaIntegrationRule in JUnit4

### DIFF
--- a/core/src/test/java/google/registry/beam/initsql/WriteToSqlTest.java
+++ b/core/src/test/java/google/registry/beam/initsql/WriteToSqlTest.java
@@ -26,6 +26,7 @@ import google.registry.model.registrar.Registrar;
 import google.registry.persistence.transaction.JpaTestRules;
 import google.registry.persistence.transaction.JpaTestRules.JpaIntegrationTestRule;
 import google.registry.testing.AppEngineRule;
+import google.registry.testing.DatastoreEntityExtension;
 import google.registry.testing.DatastoreHelper;
 import google.registry.testing.FakeClock;
 import google.registry.testing.InjectRule;
@@ -41,6 +42,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -54,9 +56,13 @@ public class WriteToSqlTest implements Serializable {
 
   @Rule public final transient InjectRule injectRule = new InjectRule();
 
-  @Rule
-  public transient JpaIntegrationTestRule jpaRule =
+  // For use in the RuleChain below. Saves a reference to retrieve Database connection config.
+  public final transient JpaIntegrationTestRule database =
       new JpaTestRules.Builder().withClock(fakeClock).buildIntegrationTestRule();
+
+  @Rule
+  public final transient RuleChain jpaRules =
+      RuleChain.outerRule(new DatastoreEntityExtension()).around(database);
 
   @Rule public transient TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -91,7 +97,9 @@ public class WriteToSqlTest implements Serializable {
     new PrintStream(credentialFile)
         .printf(
             "%s %s %s",
-            jpaRule.getDatabaseUrl(), jpaRule.getDatabaseUsername(), jpaRule.getDatabasePassword())
+            database.getDatabaseUrl(),
+            database.getDatabaseUsername(),
+            database.getDatabasePassword())
         .close();
   }
 

--- a/core/src/test/java/google/registry/testing/DatastoreEntityExtension.java
+++ b/core/src/test/java/google/registry/testing/DatastoreEntityExtension.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.rules.ExternalResource;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 /**
@@ -33,7 +34,8 @@ import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
  * href="https://junit.org/junit5/docs/current/user-guide/#extensions-registration-programmatic">
  * JUnit 5 User Guide</a> for details of extension ordering.
  */
-public class DatastoreEntityExtension implements BeforeEachCallback, AfterEachCallback {
+public class DatastoreEntityExtension extends ExternalResource
+    implements BeforeEachCallback, AfterEachCallback {
 
   private static final Environment PLACEHOLDER_ENV = new PlaceholderEnvironment();
 
@@ -46,6 +48,16 @@ public class DatastoreEntityExtension implements BeforeEachCallback, AfterEachCa
   public void afterEach(ExtensionContext context) {
     // Clear the cached instance.
     ApiProxy.setEnvironmentForCurrentThread(null);
+  }
+
+  @Override
+  protected void before() {
+    beforeEach(null);
+  }
+
+  @Override
+  protected void after() {
+    afterEach(null);
   }
 
   private static final class PlaceholderEnvironment implements Environment {


### PR DESCRIPTION
Made DatastoreExtension a JUnit4 Rule.

Nomulus model objects need Datastore API when manipulating Ofy keys.
As a result, JpaIntegrationTestRule must be used with AppEngineRule
or DatastoreExtension.

Also fixed WriteToSqlTest, which is the only JUnit4 test that uses
JpaIntegrationTestRule.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/687)
<!-- Reviewable:end -->
