### PR TITLE
Run the (Un)lockDomainCommand in an outer JPA txn

### DIFF
--- a/core/src/main/java/google/registry/tools/DomainLockUtils.java
+++ b/core/src/main/java/google/registry/tools/DomainLockUtils.java
@@ -117,7 +117,7 @@ public final class DomainLockUtils {
               RegistryLock newLock =
                   RegistryLockDao.save(lock.asBuilder().setLockCompletionTimestamp(now).build());
               setAsRelock(newLock);
-              tm().transact(() -> applyLockStatuses(newLock, now));
+              tm().transact(() -> applyLockStatuses(newLock, now, isAdmin));
               return newLock;
             });
   }
@@ -171,7 +171,7 @@ public final class DomainLockUtils {
                       createLockBuilder(domainName, registrarId, registrarPocId, isAdmin)
                           .setLockCompletionTimestamp(now)
                           .build());
-              tm().transact(() -> applyLockStatuses(newLock, now));
+              tm().transact(() -> applyLockStatuses(newLock, now, isAdmin));
               setAsRelock(newLock);
               return newLock;
             });
@@ -222,7 +222,7 @@ public final class DomainLockUtils {
       String domainName, String registrarId, @Nullable String registrarPocId, boolean isAdmin) {
     DateTime now = jpaTm().getTransactionTime();
     DomainBase domainBase = getDomain(domainName, registrarId, now);
-    verifyDomainNotLocked(domainBase);
+    verifyDomainNotLocked(domainBase, isAdmin);
 
     // Multiple pending actions are not allowed for non-admins
     RegistryLockDao.getMostRecentByRepoId(domainBase.getRepoId())
@@ -234,7 +234,6 @@ public final class DomainLockUtils {
                         || isAdmin,
                     "A pending or completed lock action already exists for %s",
                     previousLock.getDomainName()));
-
     return new RegistryLock.Builder()
         .setVerificationCode(stringGenerator.createString(VERIFICATION_CODE_LENGTH))
         .setDomainName(domainName)
@@ -251,6 +250,8 @@ public final class DomainLockUtils {
     Optional<RegistryLock> lockOptional =
         RegistryLockDao.getMostRecentVerifiedLockByRepoId(domainBase.getRepoId());
 
+    verifyDomainLocked(domainBase, isAdmin);
+
     RegistryLock.Builder newLockBuilder;
     if (isAdmin) {
       // Admins should always be able to unlock domains in case we get in a bad state
@@ -266,7 +267,6 @@ public final class DomainLockUtils {
                       .setLockCompletionTimestamp(now)
                       .setRegistrarId(registrarId));
     } else {
-      verifyDomainLocked(domainBase);
       RegistryLock lock =
           lockOptional.orElseThrow(
               () ->
@@ -294,16 +294,17 @@ public final class DomainLockUtils {
         .setRegistrarId(registrarId);
   }
 
-  private static void verifyDomainNotLocked(DomainBase domainBase) {
+  private static void verifyDomainNotLocked(DomainBase domainBase, boolean isAdmin) {
     checkArgument(
-        !domainBase.getStatusValues().containsAll(REGISTRY_LOCK_STATUSES),
+        isAdmin || !domainBase.getStatusValues().containsAll(REGISTRY_LOCK_STATUSES),
         "Domain %s is already locked",
         domainBase.getDomainName());
   }
 
-  private static void verifyDomainLocked(DomainBase domainBase) {
+  private static void verifyDomainLocked(DomainBase domainBase, boolean isAdmin) {
     checkArgument(
-        !Sets.intersection(domainBase.getStatusValues(), REGISTRY_LOCK_STATUSES).isEmpty(),
+        isAdmin || !Sets.intersection(domainBase.getStatusValues(), REGISTRY_LOCK_STATUSES)
+            .isEmpty(),
         "Domain %s is already unlocked",
         domainBase.getDomainName());
   }
@@ -312,7 +313,7 @@ public final class DomainLockUtils {
     DomainBase domain =
         loadByForeignKeyCached(DomainBase.class, domainName, now)
             .orElseThrow(
-                () -> new IllegalArgumentException(String.format("Unknown domain %s", domainName)));
+                () -> new IllegalArgumentException("Domain doesn't exist"));
     // The user must have specified either the correct registrar ID or the admin registrar ID
     checkArgument(
         registryAdminRegistrarId.equals(registrarId)
@@ -331,9 +332,9 @@ public final class DomainLockUtils {
                     String.format("Invalid verification code %s", verificationCode)));
   }
 
-  private void applyLockStatuses(RegistryLock lock, DateTime lockTime) {
+  private void applyLockStatuses(RegistryLock lock, DateTime lockTime, boolean isAdmin) {
     DomainBase domain = getDomain(lock.getDomainName(), lock.getRegistrarId(), lockTime);
-    verifyDomainNotLocked(domain);
+    verifyDomainNotLocked(domain, isAdmin);
 
     DomainBase newDomain =
         domain
@@ -346,9 +347,7 @@ public final class DomainLockUtils {
 
   private void removeLockStatuses(RegistryLock lock, boolean isAdmin, DateTime unlockTime) {
     DomainBase domain = getDomain(lock.getDomainName(), lock.getRegistrarId(), unlockTime);
-    if (!isAdmin) {
-      verifyDomainLocked(domain);
-    }
+    verifyDomainLocked(domain, isAdmin);
 
     DomainBase newDomain =
         domain

--- a/core/src/main/java/google/registry/tools/DomainLockUtils.java
+++ b/core/src/main/java/google/registry/tools/DomainLockUtils.java
@@ -224,13 +224,14 @@ public final class DomainLockUtils {
     DomainBase domainBase = getDomain(domainName, registrarId, now);
     verifyDomainNotLocked(domainBase);
 
-    // Multiple pending actions are not allowed
+    // Multiple pending actions are not allowed for non-admins
     RegistryLockDao.getMostRecentByRepoId(domainBase.getRepoId())
         .ifPresent(
             previousLock ->
                 checkArgument(
                     previousLock.isLockRequestExpired(now)
-                        || previousLock.getUnlockCompletionTimestamp().isPresent(),
+                        || previousLock.getUnlockCompletionTimestamp().isPresent()
+                        || isAdmin,
                     "A pending or completed lock action already exists for %s",
                     previousLock.getDomainName()));
 

--- a/core/src/main/java/google/registry/tools/LockDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/LockDomainCommand.java
@@ -14,15 +14,7 @@
 
 package google.registry.tools;
 
-import static google.registry.model.EppResourceUtils.loadByForeignKey;
-
 import com.beust.jcommander.Parameters;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-import com.google.common.flogger.FluentLogger;
-import google.registry.model.domain.DomainBase;
-import google.registry.model.eppcommon.StatusValue;
-import org.joda.time.DateTime;
 
 /**
  * A command to registry lock domain names.
@@ -31,25 +23,6 @@ import org.joda.time.DateTime;
  */
 @Parameters(separators = " =", commandDescription = "Registry lock a domain via EPP.")
 public class LockDomainCommand extends LockOrUnlockDomainCommand {
-
-  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
-
-  @Override
-  protected boolean shouldApplyToDomain(String domain, DateTime now) {
-    DomainBase domainBase =
-        loadByForeignKey(DomainBase.class, domain, now)
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        String.format("Domain '%s' does not exist or is deleted", domain)));
-    ImmutableSet<StatusValue> statusesToAdd =
-        Sets.difference(REGISTRY_LOCK_STATUSES, domainBase.getStatusValues()).immutableCopy();
-    if (statusesToAdd.isEmpty()) {
-      logger.atInfo().log("Domain '%s' is already locked and needs no updates.", domain);
-      return false;
-    }
-    return true;
-  }
 
   @Override
   protected void createAndApplyRequest(String domain) {

--- a/core/src/main/java/google/registry/tools/UnlockDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/UnlockDomainCommand.java
@@ -14,16 +14,8 @@
 
 package google.registry.tools;
 
-import static google.registry.model.EppResourceUtils.loadByForeignKey;
-
 import com.beust.jcommander.Parameters;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-import com.google.common.flogger.FluentLogger;
-import google.registry.model.domain.DomainBase;
-import google.registry.model.eppcommon.StatusValue;
 import java.util.Optional;
-import org.joda.time.DateTime;
 
 /**
  * A command to registry unlock domain names.
@@ -32,25 +24,6 @@ import org.joda.time.DateTime;
  */
 @Parameters(separators = " =", commandDescription = "Registry unlock a domain via EPP.")
 public class UnlockDomainCommand extends LockOrUnlockDomainCommand {
-
-  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
-
-  @Override
-  protected boolean shouldApplyToDomain(String domain, DateTime now) {
-    DomainBase domainBase =
-        loadByForeignKey(DomainBase.class, domain, now)
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        String.format("Domain '%s' does not exist or is deleted", domain)));
-    ImmutableSet<StatusValue> statusesToRemove =
-        Sets.intersection(domainBase.getStatusValues(), REGISTRY_LOCK_STATUSES).immutableCopy();
-    if (statusesToRemove.isEmpty()) {
-      logger.atInfo().log("Domain '%s' is already unlocked and needs no updates.", domain);
-      return false;
-    }
-    return true;
-  }
 
   @Override
   protected void createAndApplyRequest(String domain) {

--- a/core/src/test/java/google/registry/tools/DomainLockUtilsTest.java
+++ b/core/src/test/java/google/registry/tools/DomainLockUtilsTest.java
@@ -349,7 +349,7 @@ public final class DomainLockUtilsTest {
                     domainLockUtils.saveNewRegistryLockRequest(
                         "asdf.tld", "TheRegistrar", POC_ID, false)))
         .hasMessageThat()
-        .isEqualTo("Unknown domain asdf.tld");
+        .isEqualTo("Domain doesn't exist");
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/LockDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/LockDomainCommandTest.java
@@ -98,12 +98,9 @@ public class LockDomainCommandTest extends CommandTestCase<LockDomainCommand> {
   }
 
   @Test
-  public void testFailure_domainDoesntExist() {
-    IllegalArgumentException e =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> runCommandForced("--client=NewRegistrar", "missing.tld"));
-    assertThat(e).hasMessageThat().isEqualTo("Domain 'missing.tld' does not exist or is deleted");
+  public void testFailure_domainDoesntExist() throws Exception {
+    runCommandForced("--client=NewRegistrar", "missing.tld");
+    assertInStdout("Failed domains:\n[missing.tld (Unknown domain missing.tld)]");
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/LockDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/LockDomainCommandTest.java
@@ -100,7 +100,7 @@ public class LockDomainCommandTest extends CommandTestCase<LockDomainCommand> {
   @Test
   public void testFailure_domainDoesntExist() throws Exception {
     runCommandForced("--client=NewRegistrar", "missing.tld");
-    assertInStdout("Failed domains:\n[missing.tld (Unknown domain missing.tld)]");
+    assertInStdout("Failed domains:\n[missing.tld (Domain doesn't exist)]");
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/UnlockDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UnlockDomainCommandTest.java
@@ -43,9 +43,7 @@ import org.joda.time.Duration;
 import org.junit.Before;
 import org.junit.Test;
 
-/**
- * Unit tests for {@link UnlockDomainCommand}.
- */
+/** Unit tests for {@link UnlockDomainCommand}. */
 public class UnlockDomainCommandTest extends CommandTestCase<UnlockDomainCommand> {
 
   @Before
@@ -112,7 +110,7 @@ public class UnlockDomainCommandTest extends CommandTestCase<UnlockDomainCommand
   @Test
   public void testFailure_domainDoesntExist() throws Exception {
     runCommandForced("--client=NewRegistrar", "missing.tld");
-    assertInStdout("Failed domains:\n[missing.tld (Unknown domain missing.tld)]");
+    assertInStdout("Failed domains:\n[missing.tld (Domain doesn't exist)]");
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/UnlockDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UnlockDomainCommandTest.java
@@ -43,7 +43,9 @@ import org.joda.time.Duration;
 import org.junit.Before;
 import org.junit.Test;
 
-/** Unit tests for {@link UnlockDomainCommand}. */
+/**
+ * Unit tests for {@link UnlockDomainCommand}.
+ */
 public class UnlockDomainCommandTest extends CommandTestCase<UnlockDomainCommand> {
 
   @Before
@@ -108,19 +110,16 @@ public class UnlockDomainCommandTest extends CommandTestCase<UnlockDomainCommand
   }
 
   @Test
-  public void testFailure_domainDoesntExist() {
-    IllegalArgumentException e =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> runCommandForced("--client=TheRegistrar", "missing.tld"));
-    assertThat(e).hasMessageThat().isEqualTo("Domain 'missing.tld' does not exist or is deleted");
+  public void testFailure_domainDoesntExist() throws Exception {
+    runCommandForced("--client=NewRegistrar", "missing.tld");
+    assertInStdout("Failed domains:\n[missing.tld (Unknown domain missing.tld)]");
   }
 
   @Test
-  public void testSuccess_alreadyUnlockedDomain_performsNoAction() throws Exception {
+  public void testSuccess_alreadyUnlockedDomain_staysUnlocked() throws Exception {
     DomainBase domain = persistActiveDomain("example.tld");
     runCommandForced("--client=TheRegistrar", "example.tld");
-    assertThat(reloadResource(domain)).isEqualTo(domain);
+    assertThat(reloadResource(domain).getStatusValues()).containsNoneIn(REGISTRY_LOCK_STATUSES);
   }
 
   @Test

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistryLockPostActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistryLockPostActionTest.java
@@ -358,7 +358,7 @@ public final class RegistryLockPostActionTest {
                 "domainName", "bad.tld",
                 "isLock", true,
                 "password", "hi"));
-    assertFailureWithMessage(response, "Unknown domain bad.tld");
+    assertFailureWithMessage(response, "Domain doesn't exist");
   }
 
   @Test


### PR DESCRIPTION
There are a couple things going on here in this commit.

First, we add an external JPA transaction in the
LockOrUnlockDomainCommand class. This doesn't appear to do much, but it
avoids a situation similar to deadlock if an error occurs in Datastore
when saving the domain object (e.g. a contention issue). Specifically, DomainLockUtils relies on
the fact that any error in Datastore will be re-thrown in the JPA
transaction, meaning that any Datastore error will back out of the SQL
transaction as well. However, this is no longer true if we are already
in a Datastore transaction when calling DomainLockUtils (unless, again,
we are also in a JPA transaction). Basically, we require that the outer
transaction is the JPA one.

Secondly, this just allows for more breakglass operations in the lock or
unlock domain commands -- in a situation where things possibly go
haywire, we should allow admins to make sure with certainty that a
domain is locked or unlocked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/688)
<!-- Reviewable:end -->
