### PR TITLE
Create an ImmutableObjectSubject for comparing SQL objects

### DIFF
--- a/core/src/test/java/google/registry/model/ImmutableObjectSubject.java
+++ b/core/src/test/java/google/registry/model/ImmutableObjectSubject.java
@@ -1,0 +1,63 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.model;
+
+import static com.google.common.truth.Truth.assertAbout;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.truth.FailureMetadata;
+import com.google.common.truth.SimpleSubjectBuilder;
+import com.google.common.truth.Subject;
+import java.lang.reflect.Field;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Truth subject for asserting things about ImmutableObjects that are not built in. */
+public final class ImmutableObjectSubject extends Subject {
+
+  private final ImmutableObject actual;
+
+  protected ImmutableObjectSubject(FailureMetadata failureMetadata, ImmutableObject actual) {
+    super(failureMetadata, actual);
+    this.actual = actual;
+  }
+
+  public void isEqualExceptFields(ImmutableObject expected, String... ignoredFields) {
+    Map<Field, Object> actualFields = filterFields(actual, ignoredFields);
+    Map<Field, Object> expectedFields = filterFields(expected, ignoredFields);
+    assertThat(actualFields).containsExactlyEntriesIn(expectedFields);
+  }
+
+  public static SimpleSubjectBuilder<ImmutableObjectSubject, ImmutableObject>
+      assertAboutImmutableObjects() {
+    return assertAbout(ImmutableObjectSubject::new);
+  }
+
+  private static Map<Field, Object> filterFields(ImmutableObject original,
+      String... ignoredFields) {
+    Map<Field, Object> originalFields = ModelUtils.getFieldValues(original);
+    ImmutableSet<String> ignoredFieldSet = ImmutableSet.copyOf(ignoredFields);
+
+    // don't use ImmutableMap or a stream->collect model since we can have nulls
+    Map<Field, Object> result = new LinkedHashMap<>();
+    for (Map.Entry<Field, Object> entry : originalFields.entrySet()) {
+      if (!ignoredFieldSet.contains(entry.getKey().getName())) {
+        result.put(entry.getKey(), entry.getValue());
+      }
+    }
+    return result;
+  }
+}

--- a/core/src/test/java/google/registry/model/ImmutableObjectSubject.java
+++ b/core/src/test/java/google/registry/model/ImmutableObjectSubject.java
@@ -18,12 +18,16 @@ import static com.google.common.truth.Truth.assertAbout;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.truth.Correspondence;
+import com.google.common.truth.Correspondence.BinaryPredicate;
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.SimpleSubjectBuilder;
 import com.google.common.truth.Subject;
 import java.lang.reflect.Field;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nullable;
 
 /** Truth subject for asserting things about ImmutableObjects that are not built in. */
 public final class ImmutableObjectSubject extends Subject {
@@ -41,16 +45,44 @@ public final class ImmutableObjectSubject extends Subject {
     assertThat(actualFields).containsExactlyEntriesIn(expectedFields);
   }
 
+  public static Correspondence<ImmutableObject, ImmutableObject> immutableObjectCorrespondence(
+      String... ignoredFields) {
+    return Correspondence.from(
+        new ImmutableObjectBinaryPredicate(ignoredFields), "has all relevant fields equal to");
+  }
+
   public static SimpleSubjectBuilder<ImmutableObjectSubject, ImmutableObject>
       assertAboutImmutableObjects() {
     return assertAbout(ImmutableObjectSubject::new);
   }
 
-  private static Map<Field, Object> filterFields(ImmutableObject original,
-      String... ignoredFields) {
-    Map<Field, Object> originalFields = ModelUtils.getFieldValues(original);
-    ImmutableSet<String> ignoredFieldSet = ImmutableSet.copyOf(ignoredFields);
+  private static class ImmutableObjectBinaryPredicate
+      implements BinaryPredicate<ImmutableObject, ImmutableObject> {
 
+    private final String[] ignoredFields;
+
+    private ImmutableObjectBinaryPredicate(String... ignoredFields) {
+      this.ignoredFields = ignoredFields;
+    }
+
+    @Override
+    public boolean apply(@Nullable ImmutableObject actual, @Nullable ImmutableObject expected) {
+      if (actual == null && expected == null) {
+        return true;
+      }
+      if (actual == null || expected == null) {
+        return false;
+      }
+      Map<Field, Object> actualFields = filterFields(actual, ignoredFields);
+      Map<Field, Object> expectedFields = filterFields(expected, ignoredFields);
+      return Objects.equals(actualFields, expectedFields);
+    }
+  }
+
+  private static Map<Field, Object> filterFields(
+      ImmutableObject original, String... ignoredFields) {
+    ImmutableSet<String> ignoredFieldSet = ImmutableSet.copyOf(ignoredFields);
+    Map<Field, Object> originalFields = ModelUtils.getFieldValues(original);
     // don't use ImmutableMap or a stream->collect model since we can have nulls
     Map<Field, Object> result = new LinkedHashMap<>();
     for (Map.Entry<Field, Object> entry : originalFields.entrySet()) {

--- a/core/src/test/java/google/registry/model/history/HostHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/HostHistoryTest.java
@@ -14,7 +14,7 @@
 
 package google.registry.model.history;
 
-import static com.google.common.truth.Truth.assertThat;
+import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.testing.SqlHelper.saveRegistrar;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -74,14 +74,9 @@ public class HostHistoryTest extends EntityTestCase {
   }
 
   private void assertHostHistoriesEqual(HostHistory one, HostHistory two) {
-    // enough of the fields get changed during serialization that we can't depend on .equals()
-    assertThat(one.getClientId()).isEqualTo(two.getClientId());
-    assertThat(one.getHostRepoId()).isEqualTo(two.getHostRepoId());
-    assertThat(one.getBySuperuser()).isEqualTo(two.getBySuperuser());
-    assertThat(one.getRequestedByRegistrar()).isEqualTo(two.getRequestedByRegistrar());
-    assertThat(one.getReason()).isEqualTo(two.getReason());
-    assertThat(one.getTrid()).isEqualTo(two.getTrid());
-    assertThat(one.getType()).isEqualTo(two.getType());
-    assertThat(one.getHostBase().getHostName()).isEqualTo(two.getHostBase().getHostName());
+    assertAboutImmutableObjects().that(one).isEqualExceptFields(two, "hostBase");
+    assertAboutImmutableObjects()
+        .that(one.getHostBase())
+        .isEqualExceptFields(two.getHostBase(), "repoId");
   }
 }


### PR DESCRIPTION
Many times, when comparing objects that are loaded in from / saved to
SQL in tests, there are some fields we don't care about. Specifically,
we might not care about the last update time, revision ID, or other
things like that that are autoassigned by the DB. If we use this, we can
ignore those fields while still comparing the other ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/695)
<!-- Reviewable:end -->
