### PR TITLE
Fix some SQL credential issues identified when deploying Beam pipelines

### DIFF
--- a/core/src/main/java/google/registry/beam/initsql/BeamJpaModule.java
+++ b/core/src/main/java/google/registry/beam/initsql/BeamJpaModule.java
@@ -42,6 +42,7 @@ import javax.annotation.Nullable;
 import javax.inject.Singleton;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResourceId;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
 
 /**
  * Provides bindings for {@link JpaTransactionManager} to Cloud SQL.
@@ -100,6 +101,7 @@ public class BeamJpaModule {
   }
 
   String readOnlyLineFromCredentialFile() {
+    FileSystems.setDefaultPipelineOptions(PipelineOptionsFactory.create());
     try {
       ResourceId resourceId = FileSystems.matchSingleFileSpec(credentialFilePath).resourceId();
       try (BufferedReader reader =

--- a/core/src/main/java/google/registry/beam/initsql/BeamJpaModule.java
+++ b/core/src/main/java/google/registry/beam/initsql/BeamJpaModule.java
@@ -42,7 +42,6 @@ import javax.annotation.Nullable;
 import javax.inject.Singleton;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResourceId;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 
 /**
  * Provides bindings for {@link JpaTransactionManager} to Cloud SQL.
@@ -101,7 +100,6 @@ public class BeamJpaModule {
   }
 
   String readOnlyLineFromCredentialFile() {
-    FileSystems.setDefaultPipelineOptions(PipelineOptionsFactory.create());
     try {
       ResourceId resourceId = FileSystems.matchSingleFileSpec(credentialFilePath).resourceId();
       try (BufferedReader reader =

--- a/core/src/main/java/google/registry/tools/RegistryCli.java
+++ b/core/src/main/java/google/registry/tools/RegistryCli.java
@@ -66,6 +66,12 @@ final class RegistryCli implements AutoCloseable, CommandRunner {
               + "If not set, credentials saved by running `nomulus login' will be used.")
   private String credentialJson = null;
 
+  @Parameter(
+      names = {"--sql_access_info"},
+      description = "Name of a file containing space-separated SQL access info used when deploying "
+          + "Beam pipelines")
+  private String sqlAccessInfoFile = null;
+
   // Do not make this final - compile-time constant inlining may interfere with JCommander.
   @ParametersDelegate
   private LoggingParameters loggingParams = new LoggingParameters();
@@ -161,7 +167,7 @@ final class RegistryCli implements AutoCloseable, CommandRunner {
     component =
         DaggerRegistryToolComponent.builder()
             .credentialFilePath(credentialJson)
-            .beamJpaModule(new BeamJpaModule(credentialJson))
+            .beamJpaModule(new BeamJpaModule(sqlAccessInfoFile))
             .build();
 
     // JCommander stores sub-commands as nested JCommander objects containing a list of user objects


### PR DESCRIPTION
There are two issues fixed here.
1. Without calling `FileSystems.setDefaultPipelineOptions(PipelineOptionsFactory.create()), the Nomulus tool doesn't know how to handle gs:// scheme files. Thus, if you try to deploy (for instance) the Spec11 pipeline using a GCS credential file, it fails.
2. There was a misunderstanding before about what the credential file
actually refers to -- there is a credential file in JSON format that is
used for gcloud authorization, and there is a space-delimited SQL access
info file that has the instance name, username, and password. These are
separate options and should have separate command-line params.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/706)
<!-- Reviewable:end -->
