### PR TITLE
Add SQL schema for GracePeriod

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -360,7 +360,8 @@ public class DomainCreateFlow implements TransactionalFlow {
                     command.getNameservers().stream().collect(toImmutableSet()))
             .setStatusValues(statuses.build())
             .setContacts(command.getContacts())
-            .addGracePeriod(GracePeriod.forBillingEvent(GracePeriodStatus.ADD, createBillingEvent))
+            .addGracePeriod(
+                GracePeriod.forBillingEvent(GracePeriodStatus.ADD, repoId, createBillingEvent))
             .build();
     entitiesToSave.add(
         newDomain,

--- a/core/src/main/java/google/registry/flows/domain/DomainDeleteFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainDeleteFlow.java
@@ -186,14 +186,18 @@ public final class DomainDeleteFlow implements TransactionalFlow {
       DateTime redemptionTime = now.plus(redemptionGracePeriodLength);
       asyncTaskEnqueuer.enqueueAsyncResave(
           existingDomain, now, ImmutableSortedSet.of(redemptionTime, deletionTime));
-      builder.setDeletionTime(deletionTime)
+      builder
+          .setDeletionTime(deletionTime)
           .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
           // Clear out all old grace periods and add REDEMPTION, which does not include a key to a
           // billing event because there isn't one for a domain delete.
-          .setGracePeriods(ImmutableSet.of(GracePeriod.createWithoutBillingEvent(
-              GracePeriodStatus.REDEMPTION,
-              redemptionTime,
-              clientId)));
+          .setGracePeriods(
+              ImmutableSet.of(
+                  GracePeriod.createWithoutBillingEvent(
+                      GracePeriodStatus.REDEMPTION,
+                      existingDomain.getRepoId(),
+                      redemptionTime,
+                      clientId)));
       // Note: The expiration time is unchanged, so if it's before the new deletion time, there will
       // be a "phantom autorenew" where the expiration time advances. No poll message will be
       // produced (since we are ending the autorenew recurrences at "now" below) and the billing

--- a/core/src/main/java/google/registry/flows/domain/DomainRenewFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRenewFlow.java
@@ -183,7 +183,8 @@ public final class DomainRenewFlow implements TransactionalFlow {
             .setAutorenewBillingEvent(newAutorenewEvent.createVKey())
             .setAutorenewPollMessage(newAutorenewPollMessage.createVKey())
             .addGracePeriod(
-                GracePeriod.forBillingEvent(GracePeriodStatus.RENEW, explicitRenewEvent))
+                GracePeriod.forBillingEvent(
+                    GracePeriodStatus.RENEW, existingDomain.getRepoId(), explicitRenewEvent))
             .build();
     EntityChanges entityChanges =
         flowCustomLogic.beforeSave(

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferApproveFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferApproveFlow.java
@@ -192,7 +192,10 @@ public final class DomainTransferApproveFlow implements TransactionalFlow {
             .setGracePeriods(
                 billingEvent.isPresent()
                     ? ImmutableSet.of(
-                        GracePeriod.forBillingEvent(GracePeriodStatus.TRANSFER, billingEvent.get()))
+                        GracePeriod.forBillingEvent(
+                            GracePeriodStatus.TRANSFER,
+                            existingDomain.getRepoId(),
+                            billingEvent.get()))
                     : ImmutableSet.of())
             .setLastEppUpdateTime(now)
             .setLastEppUpdateClientId(clientId)

--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -14,6 +14,7 @@
 
 package google.registry.model.domain;
 
+
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.annotation.Entity;
 import google.registry.model.EppResource;
@@ -27,9 +28,13 @@ import google.registry.schema.replay.DatastoreAndSqlEntity;
 import java.util.Set;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
+import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
+import javax.persistence.OneToMany;
 import org.joda.time.DateTime;
 
 /**
@@ -72,6 +77,17 @@ public class DomainBase extends DomainContent
   @Column(name = "host_repo_id")
   public Set<VKey<HostResource>> getNsHosts() {
     return super.nsHosts;
+  }
+
+  @Access(AccessType.PROPERTY)
+  @OneToMany(
+      cascade = {CascadeType.ALL},
+      fetch = FetchType.EAGER,
+      orphanRemoval = true)
+  @JoinColumn(name = "domainRepoId", referencedColumnName = "repoId")
+  @SuppressWarnings("UnusedMethod")
+  private Set<GracePeriod> getInternalGracePeriods() {
+    return gracePeriods;
   }
 
   @Override

--- a/core/src/main/java/google/registry/model/domain/GracePeriod.java
+++ b/core/src/main/java/google/registry/model/domain/GracePeriod.java
@@ -189,4 +189,15 @@ public class GracePeriod extends ImmutableObject {
         billingEvent.getClientId(),
         billingEvent.createVKey());
   }
+
+  /**
+   * Returns a clone of this {@link GracePeriod} with {@link #domainRepoId} set to the given value.
+   *
+   * <p>TODO(b/162739503): Remove this function after fully migrating to Cloud SQL.
+   */
+  public GracePeriod cloneWithDomainRepoId(String domainRepoId) {
+    GracePeriod clone = clone(this);
+    clone.domainRepoId = checkArgumentNotNull(domainRepoId);
+    return clone;
+  }
 }

--- a/core/src/main/java/google/registry/model/domain/GracePeriod.java
+++ b/core/src/main/java/google/registry/model/domain/GracePeriod.java
@@ -30,6 +30,8 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
+import javax.persistence.Index;
+import javax.persistence.Table;
 import org.joda.time.DateTime;
 
 /**
@@ -40,13 +42,19 @@ import org.joda.time.DateTime;
  */
 @Embed
 @javax.persistence.Entity
+@Table(indexes = @Index(columnList = "domainRepoId"))
 public class GracePeriod extends ImmutableObject {
 
+  /** Unique id required for hibernate representation. */
   @javax.persistence.Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Ignore
-  /** Unique id required for hibernate representation. */
   Long id;
+
+  /** Repository id for the domain which this grace period belongs to. */
+  @Ignore
+  @Column(nullable = false)
+  String domainRepoId;
 
   /** The type of grace period. */
   @Column(nullable = false)

--- a/core/src/main/java/google/registry/model/domain/GracePeriod.java
+++ b/core/src/main/java/google/registry/model/domain/GracePeriod.java
@@ -90,6 +90,10 @@ public class GracePeriod extends ImmutableObject {
     return type;
   }
 
+  public String getDomainRepoId() {
+    return domainRepoId;
+  }
+
   public DateTime getExpirationTime() {
     return expirationTime;
   }
@@ -121,6 +125,7 @@ public class GracePeriod extends ImmutableObject {
 
   private static GracePeriod createInternal(
       GracePeriodStatus type,
+      String domainRepoId,
       DateTime expirationTime,
       String clientId,
       @Nullable VKey<BillingEvent.OneTime> billingEventOneTime,
@@ -132,6 +137,7 @@ public class GracePeriod extends ImmutableObject {
         "Recurring billing events must be present on (and only on) autorenew grace periods");
     GracePeriod instance = new GracePeriod();
     instance.type = checkArgumentNotNull(type);
+    instance.domainRepoId = checkArgumentNotNull(domainRepoId);
     instance.expirationTime = checkArgumentNotNull(expirationTime);
     instance.clientId = checkArgumentNotNull(clientId);
     instance.billingEventOneTime = billingEventOneTime;
@@ -148,32 +154,39 @@ public class GracePeriod extends ImmutableObject {
    */
   public static GracePeriod create(
       GracePeriodStatus type,
+      String domainRepoId,
       DateTime expirationTime,
       String clientId,
       @Nullable VKey<BillingEvent.OneTime> billingEventOneTime) {
-    return createInternal(type, expirationTime, clientId, billingEventOneTime, null);
+    return createInternal(type, domainRepoId, expirationTime, clientId, billingEventOneTime, null);
   }
 
   /** Creates a GracePeriod for a Recurring billing event. */
   public static GracePeriod createForRecurring(
       GracePeriodStatus type,
+      String domainRepoId,
       DateTime expirationTime,
       String clientId,
       VKey<Recurring> billingEventRecurring) {
     checkArgumentNotNull(billingEventRecurring, "billingEventRecurring cannot be null");
-    return createInternal(type, expirationTime, clientId, null, billingEventRecurring);
+    return createInternal(
+        type, domainRepoId, expirationTime, clientId, null, billingEventRecurring);
   }
 
   /** Creates a GracePeriod with no billing event. */
   public static GracePeriod createWithoutBillingEvent(
-      GracePeriodStatus type, DateTime expirationTime, String clientId) {
-    return createInternal(type, expirationTime, clientId, null, null);
+      GracePeriodStatus type, String domainRepoId, DateTime expirationTime, String clientId) {
+    return createInternal(type, domainRepoId, expirationTime, clientId, null, null);
   }
 
   /** Constructs a GracePeriod of the given type from the provided one-time BillingEvent. */
   public static GracePeriod forBillingEvent(
-      GracePeriodStatus type, BillingEvent.OneTime billingEvent) {
+      GracePeriodStatus type, String domainRepoId, BillingEvent.OneTime billingEvent) {
     return create(
-        type, billingEvent.getBillingTime(), billingEvent.getClientId(), billingEvent.createVKey());
+        type,
+        domainRepoId,
+        billingEvent.getBillingTime(),
+        billingEvent.getClientId(),
+        billingEvent.createVKey());
   }
 }

--- a/core/src/main/java/google/registry/model/domain/GracePeriod.java
+++ b/core/src/main/java/google/registry/model/domain/GracePeriod.java
@@ -26,6 +26,8 @@ import google.registry.model.domain.rgp.GracePeriodStatus;
 import google.registry.persistence.VKey;
 import javax.annotation.Nullable;
 import javax.persistence.Column;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import org.joda.time.DateTime;
@@ -44,16 +46,19 @@ public class GracePeriod extends ImmutableObject {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Ignore
   /** Unique id required for hibernate representation. */
-  long id;
+  Long id;
 
   /** The type of grace period. */
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
   GracePeriodStatus type;
 
   /** When the grace period ends. */
+  @Column(nullable = false)
   DateTime expirationTime;
 
   /** The registrar to bill. */
-  @Column(name = "registrarId")
+  @Column(name = "registrarId", nullable = false)
   String clientId;
 
   /**
@@ -62,6 +67,7 @@ public class GracePeriod extends ImmutableObject {
    * billingEventRecurring}) or for redemption grace periods (since deletes have no cost).
    */
   // NB: Would @IgnoreSave(IfNull.class), but not allowed for @Embed collections.
+  @Column(name = "billing_event_id")
   VKey<BillingEvent.OneTime> billingEventOneTime = null;
 
   /**
@@ -69,6 +75,7 @@ public class GracePeriod extends ImmutableObject {
    * applicable - i.e. if the action was an autorenew - or null in all other cases.
    */
   // NB: Would @IgnoreSave(IfNull.class), but not allowed for @Embed collections.
+  @Column(name = "billing_recurrence_id")
   VKey<BillingEvent.Recurring> billingEventRecurring = null;
 
   public GracePeriodStatus getType() {

--- a/core/src/main/java/google/registry/model/domain/GracePeriod.java
+++ b/core/src/main/java/google/registry/model/domain/GracePeriod.java
@@ -18,18 +18,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
 import com.googlecode.objectify.annotation.Embed;
-import com.googlecode.objectify.annotation.Ignore;
-import google.registry.model.ImmutableObject;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Recurring;
 import google.registry.model.domain.rgp.GracePeriodStatus;
 import google.registry.persistence.VKey;
 import javax.annotation.Nullable;
-import javax.persistence.Column;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
+import javax.persistence.Entity;
 import javax.persistence.Index;
 import javax.persistence.Table;
 import org.joda.time.DateTime;
@@ -41,87 +35,9 @@ import org.joda.time.DateTime;
  * the resource is loaded from Datastore.
  */
 @Embed
-@javax.persistence.Entity
+@Entity
 @Table(indexes = @Index(columnList = "domainRepoId"))
-public class GracePeriod extends ImmutableObject {
-
-  /** Unique id required for hibernate representation. */
-  @javax.persistence.Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  @Ignore
-  Long id;
-
-  /** Repository id for the domain which this grace period belongs to. */
-  @Ignore
-  @Column(nullable = false)
-  String domainRepoId;
-
-  /** The type of grace period. */
-  @Column(nullable = false)
-  @Enumerated(EnumType.STRING)
-  GracePeriodStatus type;
-
-  /** When the grace period ends. */
-  @Column(nullable = false)
-  DateTime expirationTime;
-
-  /** The registrar to bill. */
-  @Column(name = "registrarId", nullable = false)
-  String clientId;
-
-  /**
-   * The one-time billing event corresponding to the action that triggered this grace period, or
-   * null if not applicable. Not set for autorenew grace periods (which instead use the field {@code
-   * billingEventRecurring}) or for redemption grace periods (since deletes have no cost).
-   */
-  // NB: Would @IgnoreSave(IfNull.class), but not allowed for @Embed collections.
-  @Column(name = "billing_event_id")
-  VKey<BillingEvent.OneTime> billingEventOneTime = null;
-
-  /**
-   * The recurring billing event corresponding to the action that triggered this grace period, if
-   * applicable - i.e. if the action was an autorenew - or null in all other cases.
-   */
-  // NB: Would @IgnoreSave(IfNull.class), but not allowed for @Embed collections.
-  @Column(name = "billing_recurrence_id")
-  VKey<BillingEvent.Recurring> billingEventRecurring = null;
-
-  public GracePeriodStatus getType() {
-    return type;
-  }
-
-  public String getDomainRepoId() {
-    return domainRepoId;
-  }
-
-  public DateTime getExpirationTime() {
-    return expirationTime;
-  }
-
-  public String getClientId() {
-    return clientId;
-  }
-
-  /** Returns true if this GracePeriod has an associated BillingEvent; i.e. if it's refundable. */
-  public boolean hasBillingEvent() {
-    return billingEventOneTime != null || billingEventRecurring != null;
-  }
-
-  /**
-   * Returns the one time billing event. The value will only be non-null if the type of this grace
-   * period is not AUTO_RENEW.
-   */
-  public VKey<BillingEvent.OneTime> getOneTimeBillingEvent() {
-    return billingEventOneTime;
-  }
-
-  /**
-   * Returns the recurring billing event. The value will only be non-null if the type of this grace
-   * period is AUTO_RENEW.
-   */
-  public VKey<BillingEvent.Recurring> getRecurringBillingEvent() {
-    return billingEventRecurring;
-  }
+public class GracePeriod extends GracePeriodBase {
 
   private static GracePeriod createInternal(
       GracePeriodStatus type,
@@ -200,4 +116,5 @@ public class GracePeriod extends ImmutableObject {
     clone.domainRepoId = checkArgumentNotNull(domainRepoId);
     return clone;
   }
+
 }

--- a/core/src/main/java/google/registry/model/domain/GracePeriodBase.java
+++ b/core/src/main/java/google/registry/model/domain/GracePeriodBase.java
@@ -1,0 +1,114 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.model.domain;
+
+import com.googlecode.objectify.annotation.Embed;
+import com.googlecode.objectify.annotation.Ignore;
+import google.registry.model.ImmutableObject;
+import google.registry.model.billing.BillingEvent;
+import google.registry.model.billing.BillingEvent.OneTime;
+import google.registry.model.domain.rgp.GracePeriodStatus;
+import google.registry.persistence.VKey;
+import javax.persistence.Column;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.MappedSuperclass;
+import org.joda.time.DateTime;
+
+/** Base class containing common fields and methods for {@link GracePeriod}. */
+@Embed
+@MappedSuperclass
+public class GracePeriodBase extends ImmutableObject {
+
+  /** Unique id required for hibernate representation. */
+  @javax.persistence.Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Ignore
+  Long id;
+
+  /** Repository id for the domain which this grace period belongs to. */
+  @Ignore
+  @Column(nullable = false)
+  String domainRepoId;
+
+  /** The type of grace period. */
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  GracePeriodStatus type;
+
+  /** When the grace period ends. */
+  @Column(nullable = false)
+  DateTime expirationTime;
+
+  /** The registrar to bill. */
+  @Column(name = "registrarId", nullable = false)
+  String clientId;
+
+  /**
+   * The one-time billing event corresponding to the action that triggered this grace period, or
+   * null if not applicable. Not set for autorenew grace periods (which instead use the field {@code
+   * billingEventRecurring}) or for redemption grace periods (since deletes have no cost).
+   */
+  // NB: Would @IgnoreSave(IfNull.class), but not allowed for @Embed collections.
+  @Column(name = "billing_event_id")
+  VKey<OneTime> billingEventOneTime = null;
+
+  /**
+   * The recurring billing event corresponding to the action that triggered this grace period, if
+   * applicable - i.e. if the action was an autorenew - or null in all other cases.
+   */
+  // NB: Would @IgnoreSave(IfNull.class), but not allowed for @Embed collections.
+  @Column(name = "billing_recurrence_id")
+  VKey<BillingEvent.Recurring> billingEventRecurring = null;
+
+  public GracePeriodStatus getType() {
+    return type;
+  }
+
+  public String getDomainRepoId() {
+    return domainRepoId;
+  }
+
+  public DateTime getExpirationTime() {
+    return expirationTime;
+  }
+
+  public String getClientId() {
+    return clientId;
+  }
+
+  /** Returns true if this GracePeriod has an associated BillingEvent; i.e. if it's refundable. */
+  public boolean hasBillingEvent() {
+    return billingEventOneTime != null || billingEventRecurring != null;
+  }
+
+  /**
+   * Returns the one time billing event. The value will only be non-null if the type of this grace
+   * period is not AUTO_RENEW.
+   */
+  public VKey<BillingEvent.OneTime> getOneTimeBillingEvent() {
+    return billingEventOneTime;
+  }
+
+  /**
+   * Returns the recurring billing event. The value will only be non-null if the type of this grace
+   * period is AUTO_RENEW.
+   */
+  public VKey<BillingEvent.Recurring> getRecurringBillingEvent() {
+    return billingEventRecurring;
+  }
+}

--- a/core/src/test/java/google/registry/batch/ResaveEntityActionTest.java
+++ b/core/src/test/java/google/registry/batch/ResaveEntityActionTest.java
@@ -117,9 +117,10 @@ public class ResaveEntityActionTest {
 
   @Test
   void test_domainPendingDeletion_isResavedAndReenqueued() {
+    DomainBase newDomain = newDomainBase("domain.tld");
     DomainBase domain =
         persistResource(
-            newDomainBase("domain.tld")
+            newDomain
                 .asBuilder()
                 .setDeletionTime(clock.nowUtc().plusDays(35))
                 .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
@@ -127,6 +128,7 @@ public class ResaveEntityActionTest {
                     ImmutableSet.of(
                         GracePeriod.createWithoutBillingEvent(
                             GracePeriodStatus.REDEMPTION,
+                            newDomain.getRepoId(),
                             clock.nowUtc().plusDays(30),
                             "TheRegistrar")))
                 .build());

--- a/core/src/test/java/google/registry/beam/initsql/DomainBaseUtilTest.java
+++ b/core/src/test/java/google/registry/beam/initsql/DomainBaseUtilTest.java
@@ -161,6 +161,7 @@ public class DomainBaseUtilTest {
                     .addGracePeriod(
                         GracePeriod.create(
                             GracePeriodStatus.ADD,
+                            "4-COM",
                             fakeClock.nowUtc().plusDays(1),
                             "registrar",
                             null))

--- a/core/src/test/java/google/registry/beam/initsql/InitSqlPipelineTest.java
+++ b/core/src/test/java/google/registry/beam/initsql/InitSqlPipelineTest.java
@@ -214,7 +214,11 @@ class InitSqlPipelineTest {
                   .setSmdId("smdid")
                   .addGracePeriod(
                       GracePeriod.create(
-                          GracePeriodStatus.ADD, fakeClock.nowUtc().plusDays(1), "registrar", null))
+                          GracePeriodStatus.ADD,
+                          "4-COM",
+                          fakeClock.nowUtc().plusDays(1),
+                          "registrar",
+                          null))
                   .build());
       exportDir = store.export(exportRootDir.getAbsolutePath(), ALL_KINDS, ImmutableSet.of());
       commitLogDir = Files.createDirectory(tmpDir.resolve("commits")).toFile();

--- a/core/src/test/java/google/registry/flows/FlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/FlowTestCase.java
@@ -185,6 +185,7 @@ public abstract class FlowTestCase<F extends Flow> {
       builder.put(
           GracePeriod.create(
               entry.getKey().getType(),
+              entry.getKey().getDomainRepoId(),
               entry.getKey().getExpirationTime(),
               entry.getKey().getClientId(),
               null),

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -325,7 +325,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     assertGracePeriods(
         domain.getGracePeriods(),
         ImmutableMap.of(
-            GracePeriod.create(GracePeriodStatus.ADD, billingTime, "TheRegistrar", null),
+            GracePeriod.create(
+                GracePeriodStatus.ADD, domain.getRepoId(), billingTime, "TheRegistrar", null),
             createBillingEvent));
     assertDnsTasksEnqueued(getUniqueIdFromCommand());
     assertEppResourceIndexEntityFor(domain);

--- a/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
@@ -195,6 +195,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
                     ImmutableSet.of(
                         GracePeriod.createForRecurring(
                             GracePeriodStatus.AUTO_RENEW,
+                            domain.getRepoId(),
                             A_MONTH_AGO.plusDays(45),
                             "TheRegistrar",
                             autorenewBillingEvent.createVKey())))
@@ -290,7 +291,8 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
   void testDryRun() throws Exception {
     setUpSuccessfulTest();
     setUpGracePeriods(
-        GracePeriod.create(GracePeriodStatus.ADD, TIME_BEFORE_FLOW.plusDays(1), "foo", null));
+        GracePeriod.create(
+            GracePeriodStatus.ADD, domain.getRepoId(), TIME_BEFORE_FLOW.plusDays(1), "foo", null));
     dryRunFlowAssertResponse(loadFile("generic_success_response.xml"));
   }
 
@@ -314,7 +316,8 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     setUpSuccessfulTest();
     BillingEvent.OneTime graceBillingEvent =
         persistResource(createBillingEvent(Reason.CREATE, Money.of(USD, 123)));
-    setUpGracePeriods(GracePeriod.forBillingEvent(gracePeriodStatus, graceBillingEvent));
+    setUpGracePeriods(
+        GracePeriod.forBillingEvent(gracePeriodStatus, domain.getRepoId(), graceBillingEvent));
     // We should see exactly one poll message, which is for the autorenew 1 month in the future.
     assertPollMessages(createAutorenewPollMessage("TheRegistrar").build());
     clock.advanceOneMilli();
@@ -388,9 +391,14 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     BillingEvent.OneTime renewBillingEvent =
         persistResource(createBillingEvent(Reason.RENEW, Money.of(USD, 456)));
     setUpGracePeriods(
-        GracePeriod.forBillingEvent(GracePeriodStatus.RENEW, renewBillingEvent),
+        GracePeriod.forBillingEvent(GracePeriodStatus.RENEW, domain.getRepoId(), renewBillingEvent),
         // This grace period has no associated billing event, so it won't cause a cancellation.
-        GracePeriod.create(GracePeriodStatus.TRANSFER, TIME_BEFORE_FLOW.plusDays(1), "foo", null));
+        GracePeriod.create(
+            GracePeriodStatus.TRANSFER,
+            domain.getRepoId(),
+            TIME_BEFORE_FLOW.plusDays(1),
+            "foo",
+            null));
     // We should see exactly one poll message, which is for the autorenew 1 month in the future.
     assertPollMessages(createAutorenewPollMessage("TheRegistrar").build());
     DateTime expectedExpirationTime = domain.getRegistrationExpirationTime().minusYears(2);
@@ -424,6 +432,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .containsExactly(
             GracePeriod.create(
                 GracePeriodStatus.REDEMPTION,
+                domain.getRepoId(),
                 clock.nowUtc().plus(Registry.get("tld").getRedemptionGracePeriodLength()),
                 "TheRegistrar",
                 null));
@@ -624,6 +633,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .containsExactly(
             GracePeriod.create(
                 GracePeriodStatus.REDEMPTION,
+                domain.getRepoId(),
                 clock.nowUtc().plus(Registry.get("tld").getRedemptionGracePeriodLength()),
                 "TheRegistrar",
                 null));
@@ -696,7 +706,8 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     BillingEvent.OneTime graceBillingEvent =
         persistResource(createBillingEvent(Reason.CREATE, Money.of(USD, 123)));
     // Use a grace period so that the delete is immediate, simplifying the assertions below.
-    setUpGracePeriods(GracePeriod.forBillingEvent(GracePeriodStatus.ADD, graceBillingEvent));
+    setUpGracePeriods(
+        GracePeriod.forBillingEvent(GracePeriodStatus.ADD, domain.getRepoId(), graceBillingEvent));
     // Add a nameserver.
     HostResource host = persistResource(newHostResource("ns1.example.tld"));
     persistResource(
@@ -1004,7 +1015,11 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     setUpSuccessfulTest();
     setUpGracePeriods(
         GracePeriod.create(
-            GracePeriodStatus.ADD, TIME_BEFORE_FLOW.plusDays(1), "TheRegistrar", null));
+            GracePeriodStatus.ADD,
+            domain.getRepoId(),
+            TIME_BEFORE_FLOW.plusDays(1),
+            "TheRegistrar",
+            null));
     setUpGracePeriodDurations();
     clock.advanceOneMilli();
     earlierHistoryEntry =
@@ -1027,7 +1042,11 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     setUpSuccessfulTest();
     setUpGracePeriods(
         GracePeriod.create(
-            GracePeriodStatus.ADD, TIME_BEFORE_FLOW.plusDays(1), "TheRegistrar", null));
+            GracePeriodStatus.ADD,
+            domain.getRepoId(),
+            TIME_BEFORE_FLOW.plusDays(1),
+            "TheRegistrar",
+            null));
     setUpGracePeriodDurations();
     clock.advanceOneMilli();
     earlierHistoryEntry =
@@ -1081,6 +1100,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .containsExactly(
             GracePeriod.create(
                 GracePeriodStatus.REDEMPTION,
+                domain.getRepoId(),
                 clock.nowUtc().plus(standardDays(15)),
                 "TheRegistrar",
                 null));
@@ -1127,6 +1147,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .containsExactly(
             GracePeriod.create(
                 GracePeriodStatus.REDEMPTION,
+                domain.getRepoId(),
                 clock.nowUtc().plus(standardDays(15)),
                 "TheRegistrar",
                 null));

--- a/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
@@ -308,7 +308,8 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
         domain
             .asBuilder()
             .addGracePeriod(
-                GracePeriod.create(gracePeriodStatus, clock.nowUtc().plusDays(1), "foo", null))
+                GracePeriod.create(
+                    gracePeriodStatus, domain.getRepoId(), clock.nowUtc().plusDays(1), "foo", null))
             .setCreationClientId("NewRegistrar")
             .setCreationTimeForTest(DateTime.parse("2003-11-26T22:00:00.0Z"))
             .setRegistrationExpirationTime(DateTime.parse("2005-11-26T22:00:00.0Z"))
@@ -337,7 +338,11 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
             .asBuilder()
             .addGracePeriod(
                 GracePeriod.createForRecurring(
-                    GracePeriodStatus.AUTO_RENEW, clock.nowUtc().plusDays(1), "foo", recurringVKey))
+                    GracePeriodStatus.AUTO_RENEW,
+                    domain.getRepoId(),
+                    clock.nowUtc().plusDays(1),
+                    "foo",
+                    recurringVKey))
             .build());
     doSuccessfulTest("domain_info_response_autorenewperiod.xml", false);
   }
@@ -352,7 +357,11 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
             .asBuilder()
             .addGracePeriod(
                 GracePeriod.create(
-                    GracePeriodStatus.REDEMPTION, clock.nowUtc().plusDays(1), "foo", null))
+                    GracePeriodStatus.REDEMPTION,
+                    domain.getRepoId(),
+                    clock.nowUtc().plusDays(1),
+                    "foo",
+                    null))
             .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
             .build());
     doSuccessfulTest("domain_info_response_redemptionperiod.xml", false);
@@ -367,7 +376,11 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
             .asBuilder()
             .addGracePeriod(
                 GracePeriod.create(
-                    GracePeriodStatus.RENEW, clock.nowUtc().plusDays(1), "foo", null))
+                    GracePeriodStatus.RENEW,
+                    domain.getRepoId(),
+                    clock.nowUtc().plusDays(1),
+                    "foo",
+                    null))
             .build());
     doSuccessfulTest("domain_info_response_renewperiod.xml", false);
   }
@@ -381,10 +394,18 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
             .asBuilder()
             .addGracePeriod(
                 GracePeriod.create(
-                    GracePeriodStatus.RENEW, clock.nowUtc().plusDays(1), "foo", null))
+                    GracePeriodStatus.RENEW,
+                    domain.getRepoId(),
+                    clock.nowUtc().plusDays(1),
+                    "foo",
+                    null))
             .addGracePeriod(
                 GracePeriod.create(
-                    GracePeriodStatus.RENEW, clock.nowUtc().plusDays(2), "foo", null))
+                    GracePeriodStatus.RENEW,
+                    domain.getRepoId(),
+                    clock.nowUtc().plusDays(2),
+                    "foo",
+                    null))
             .build());
     doSuccessfulTest("domain_info_response_renewperiod.xml", false);
   }
@@ -398,7 +419,11 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
             .asBuilder()
             .addGracePeriod(
                 GracePeriod.create(
-                    GracePeriodStatus.TRANSFER, clock.nowUtc().plusDays(1), "foo", null))
+                    GracePeriodStatus.TRANSFER,
+                    domain.getRepoId(),
+                    clock.nowUtc().plusDays(1),
+                    "foo",
+                    null))
             .build());
     doSuccessfulTest("domain_info_response_transferperiod.xml", false);
   }
@@ -421,10 +446,19 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
         domain
             .asBuilder()
             .addGracePeriod(
-                GracePeriod.create(GracePeriodStatus.ADD, clock.nowUtc().plusDays(1), "foo", null))
+                GracePeriod.create(
+                    GracePeriodStatus.ADD,
+                    domain.getRepoId(),
+                    clock.nowUtc().plusDays(1),
+                    "foo",
+                    null))
             .addGracePeriod(
                 GracePeriod.create(
-                    GracePeriodStatus.RENEW, clock.nowUtc().plusDays(2), "foo", null))
+                    GracePeriodStatus.RENEW,
+                    domain.getRepoId(),
+                    clock.nowUtc().plusDays(2),
+                    "foo",
+                    null))
             .build());
     doSuccessfulTest("domain_info_response_stackedaddrenewperiod.xml", false);
   }
@@ -437,7 +471,12 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
         domain
             .asBuilder()
             .addGracePeriod(
-                GracePeriod.create(GracePeriodStatus.ADD, clock.nowUtc().plusDays(1), "foo", null))
+                GracePeriod.create(
+                    GracePeriodStatus.ADD,
+                    domain.getRepoId(),
+                    clock.nowUtc().plusDays(1),
+                    "foo",
+                    null))
             .setDsData(
                 ImmutableSet.of(
                     DelegationSignerData.create(

--- a/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
@@ -236,6 +236,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, DomainBa
         ImmutableMap.of(
             GracePeriod.create(
                 GracePeriodStatus.RENEW,
+                domain.getRepoId(),
                 clock.nowUtc().plus(Registry.get("tld").getRenewGracePeriodLength()),
                 renewalClientId,
                 null),

--- a/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
@@ -112,7 +112,11 @@ class DomainRestoreRequestFlowTest
             .setDeletionTime(clock.nowUtc().plusDays(35))
             .addGracePeriod(
                 GracePeriod.create(
-                    GracePeriodStatus.REDEMPTION, clock.nowUtc().plusDays(1), "foo", null))
+                    GracePeriodStatus.REDEMPTION,
+                    domain.getRepoId(),
+                    clock.nowUtc().plusDays(1),
+                    "foo",
+                    null))
             .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
             .setDeletePollMessage(
                 persistResource(

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
@@ -288,6 +288,7 @@ class DomainTransferApproveFlowTest
         ImmutableMap.of(
             GracePeriod.create(
                 GracePeriodStatus.TRANSFER,
+                domain.getRepoId(),
                 clock.nowUtc().plus(registry.getTransferGracePeriodLength()),
                 "NewRegistrar",
                 null),
@@ -649,6 +650,7 @@ class DomainTransferApproveFlowTest
                 .addGracePeriod(
                     GracePeriod.createForRecurring(
                         GracePeriodStatus.AUTO_RENEW,
+                        domain.getRepoId(),
                         autorenewTime.plus(Registry.get("tld").getAutoRenewGracePeriodLength()),
                         "TheRegistrar",
                         existingAutorenewEvent))

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
@@ -332,6 +332,7 @@ class DomainTransferRequestFlowTest
           ImmutableMap.of(
               GracePeriod.create(
                   GracePeriodStatus.TRANSFER,
+                  domain.getRepoId(),
                   implicitTransferTime.plus(registry.getTransferGracePeriodLength()),
                   "NewRegistrar",
                   null),
@@ -962,6 +963,7 @@ class DomainTransferRequestFlowTest
                 .addGracePeriod(
                     GracePeriod.createForRecurring(
                         GracePeriodStatus.AUTO_RENEW,
+                        domain.getRepoId(),
                         autorenewTime.plus(Registry.get("tld").getAutoRenewGracePeriodLength()),
                         "TheRegistrar",
                         existingAutorenewEvent))
@@ -1088,6 +1090,7 @@ class DomainTransferRequestFlowTest
                 .addGracePeriod(
                     GracePeriod.createForRecurring(
                         GracePeriodStatus.AUTO_RENEW,
+                        domain.getRepoId(),
                         autorenewTime.plus(Registry.get("tld").getAutoRenewGracePeriodLength()),
                         "TheRegistrar",
                         domain.getAutorenewBillingEvent()))
@@ -1117,6 +1120,7 @@ class DomainTransferRequestFlowTest
                 .addGracePeriod(
                     GracePeriod.createForRecurring(
                         GracePeriodStatus.AUTO_RENEW,
+                        domain.getRepoId(),
                         autorenewTime.plus(Registry.get("tld").getAutoRenewGracePeriodLength()),
                         "TheRegistrar",
                         existingAutorenewEvent))

--- a/core/src/test/java/google/registry/model/billing/BillingEventTest.java
+++ b/core/src/test/java/google/registry/model/billing/BillingEventTest.java
@@ -385,10 +385,11 @@ public class BillingEventTest extends EntityTestCase {
 
   @Test
   void testSuccess_cancellation_forGracePeriod_withOneTime() {
-    BillingEvent.Cancellation newCancellation = BillingEvent.Cancellation.forGracePeriod(
-        GracePeriod.forBillingEvent(GracePeriodStatus.ADD, oneTime),
-        historyEntry2,
-        "foo.tld");
+    BillingEvent.Cancellation newCancellation =
+        BillingEvent.Cancellation.forGracePeriod(
+            GracePeriod.forBillingEvent(GracePeriodStatus.ADD, domain.getRepoId(), oneTime),
+            historyEntry2,
+            "foo.tld");
     // Set ID to be the same to ignore for the purposes of comparison.
     newCancellation = newCancellation.asBuilder().setId(cancellationOneTime.getId()).build();
     assertThat(newCancellation).isEqualTo(cancellationOneTime);
@@ -400,6 +401,7 @@ public class BillingEventTest extends EntityTestCase {
         BillingEvent.Cancellation.forGracePeriod(
             GracePeriod.createForRecurring(
                 GracePeriodStatus.AUTO_RENEW,
+                domain.getRepoId(),
                 now.plusYears(1).plusDays(45),
                 "a registrar",
                 recurring.createVKey()),
@@ -418,7 +420,10 @@ public class BillingEventTest extends EntityTestCase {
             () ->
                 BillingEvent.Cancellation.forGracePeriod(
                     GracePeriod.createWithoutBillingEvent(
-                        GracePeriodStatus.REDEMPTION, now.plusDays(1), "a registrar"),
+                        GracePeriodStatus.REDEMPTION,
+                        domain.getRepoId(),
+                        now.plusDays(1),
+                        "a registrar"),
                     historyEntry,
                     "foo.tld"));
     assertThat(thrown).hasMessageThat().contains("grace period without billing event");

--- a/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
@@ -18,6 +18,7 @@ import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableO
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.testing.SqlHelper.assertThrowForeignKeyViolation;
 import static google.registry.testing.SqlHelper.saveRegistrar;
+import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.joda.time.DateTimeZone.UTC;
 
@@ -25,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.DesignatedContact.Type;
 import google.registry.model.domain.launch.LaunchNotice;
+import google.registry.model.domain.rgp.GracePeriodStatus;
 import google.registry.model.domain.secdns.DelegationSignerData;
 import google.registry.model.eppcommon.AuthInfo.PasswordAuth;
 import google.registry.model.eppcommon.StatusValue;
@@ -100,6 +102,8 @@ public class DomainBaseSqlTest {
             .setLaunchNotice(
                 LaunchNotice.create("tcnid", "validatorId", START_OF_TIME, START_OF_TIME))
             .setSmdId("smdid")
+            .addGracePeriod(
+                GracePeriod.create(GracePeriodStatus.ADD, "4-COM", END_OF_TIME, "registrar1", null))
             .build();
 
     host =

--- a/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
@@ -154,6 +154,7 @@ public class DomainBaseTest extends EntityTestCase {
                     .addGracePeriod(
                         GracePeriod.create(
                             GracePeriodStatus.ADD,
+                            "4-COM",
                             fakeClock.nowUtc().plusDays(1),
                             "registrar",
                             null))
@@ -371,7 +372,11 @@ public class DomainBaseTest extends EntityTestCase {
                 // Okay for billing event to be null since the point of this grace period is just
                 // to check that the transfer will clear all existing grace periods.
                 GracePeriod.create(
-                    GracePeriodStatus.ADD, fakeClock.nowUtc().plusDays(100), "foo", null))
+                    GracePeriodStatus.ADD,
+                    domain.getRepoId(),
+                    fakeClock.nowUtc().plusDays(100),
+                    "foo",
+                    null))
             .build();
     DomainBase afterTransfer = domain.cloneProjectedAtTime(fakeClock.nowUtc().plusDays(1));
     DateTime newExpirationTime = oldExpirationTime.plusYears(1);
@@ -382,6 +387,7 @@ public class DomainBaseTest extends EntityTestCase {
         .containsExactly(
             GracePeriod.create(
                 GracePeriodStatus.TRANSFER,
+                domain.getRepoId(),
                 fakeClock
                     .nowUtc()
                     .plusDays(1)
@@ -499,9 +505,24 @@ public class DomainBaseTest extends EntityTestCase {
   void testStackedGracePeriods() {
     ImmutableList<GracePeriod> gracePeriods =
         ImmutableList.of(
-            GracePeriod.create(GracePeriodStatus.ADD, fakeClock.nowUtc().plusDays(3), "foo", null),
-            GracePeriod.create(GracePeriodStatus.ADD, fakeClock.nowUtc().plusDays(2), "bar", null),
-            GracePeriod.create(GracePeriodStatus.ADD, fakeClock.nowUtc().plusDays(1), "baz", null));
+            GracePeriod.create(
+                GracePeriodStatus.ADD,
+                domain.getRepoId(),
+                fakeClock.nowUtc().plusDays(3),
+                "foo",
+                null),
+            GracePeriod.create(
+                GracePeriodStatus.ADD,
+                domain.getRepoId(),
+                fakeClock.nowUtc().plusDays(2),
+                "bar",
+                null),
+            GracePeriod.create(
+                GracePeriodStatus.ADD,
+                domain.getRepoId(),
+                fakeClock.nowUtc().plusDays(1),
+                "baz",
+                null));
     domain = domain.asBuilder().setGracePeriods(ImmutableSet.copyOf(gracePeriods)).build();
     for (int i = 1; i < 3; ++i) {
       assertThat(domain.cloneProjectedAtTime(fakeClock.nowUtc().plusDays(i)).getGracePeriods())
@@ -513,14 +534,32 @@ public class DomainBaseTest extends EntityTestCase {
   void testGracePeriodsByType() {
     ImmutableSet<GracePeriod> addGracePeriods =
         ImmutableSet.of(
-            GracePeriod.create(GracePeriodStatus.ADD, fakeClock.nowUtc().plusDays(3), "foo", null),
-            GracePeriod.create(GracePeriodStatus.ADD, fakeClock.nowUtc().plusDays(1), "baz", null));
+            GracePeriod.create(
+                GracePeriodStatus.ADD,
+                domain.getRepoId(),
+                fakeClock.nowUtc().plusDays(3),
+                "foo",
+                null),
+            GracePeriod.create(
+                GracePeriodStatus.ADD,
+                domain.getRepoId(),
+                fakeClock.nowUtc().plusDays(1),
+                "baz",
+                null));
     ImmutableSet<GracePeriod> renewGracePeriods =
         ImmutableSet.of(
             GracePeriod.create(
-                GracePeriodStatus.RENEW, fakeClock.nowUtc().plusDays(3), "foo", null),
+                GracePeriodStatus.RENEW,
+                domain.getRepoId(),
+                fakeClock.nowUtc().plusDays(3),
+                "foo",
+                null),
             GracePeriod.create(
-                GracePeriodStatus.RENEW, fakeClock.nowUtc().plusDays(1), "baz", null));
+                GracePeriodStatus.RENEW,
+                domain.getRepoId(),
+                fakeClock.nowUtc().plusDays(1),
+                "baz",
+                null));
     domain =
         domain
             .asBuilder()
@@ -589,6 +628,7 @@ public class DomainBaseTest extends EntityTestCase {
         .containsExactly(
             GracePeriod.createForRecurring(
                 GracePeriodStatus.AUTO_RENEW,
+                domain.getRepoId(),
                 oldExpirationTime
                     .plusYears(2)
                     .plus(Registry.get("com").getAutoRenewGracePeriodLength()),
@@ -757,6 +797,7 @@ public class DomainBaseTest extends EntityTestCase {
                     ImmutableSet.of(
                         GracePeriod.createForRecurring(
                             GracePeriodStatus.AUTO_RENEW,
+                            domain.getRepoId(),
                             now.plusDays(1),
                             "NewRegistrar",
                             recurringBillKey)))

--- a/core/src/test/java/google/registry/model/domain/GracePeriodTest.java
+++ b/core/src/test/java/google/registry/model/domain/GracePeriodTest.java
@@ -63,8 +63,9 @@ public class GracePeriodTest {
 
   @Test
   void testSuccess_forBillingEvent() {
-    GracePeriod gracePeriod = GracePeriod.forBillingEvent(GracePeriodStatus.ADD, onetime);
+    GracePeriod gracePeriod = GracePeriod.forBillingEvent(GracePeriodStatus.ADD, "1-TEST", onetime);
     assertThat(gracePeriod.getType()).isEqualTo(GracePeriodStatus.ADD);
+    assertThat(gracePeriod.getDomainRepoId()).isEqualTo("1-TEST");
     assertThat(gracePeriod.getOneTimeBillingEvent()).isEqualTo(onetime.createVKey());
     assertThat(gracePeriod.getRecurringBillingEvent()).isNull();
     assertThat(gracePeriod.getClientId()).isEqualTo("TheRegistrar");
@@ -74,9 +75,11 @@ public class GracePeriodTest {
 
   @Test
   void testSuccess_createWithoutBillingEvent() {
-    GracePeriod gracePeriod = GracePeriod.createWithoutBillingEvent(
-        GracePeriodStatus.REDEMPTION, now, "TheRegistrar");
+    GracePeriod gracePeriod =
+        GracePeriod.createWithoutBillingEvent(
+            GracePeriodStatus.REDEMPTION, "1-TEST", now, "TheRegistrar");
     assertThat(gracePeriod.getType()).isEqualTo(GracePeriodStatus.REDEMPTION);
+    assertThat(gracePeriod.getDomainRepoId()).isEqualTo("1-TEST");
     assertThat(gracePeriod.getOneTimeBillingEvent()).isNull();
     assertThat(gracePeriod.getRecurringBillingEvent()).isNull();
     assertThat(gracePeriod.getClientId()).isEqualTo("TheRegistrar");
@@ -89,7 +92,7 @@ public class GracePeriodTest {
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> GracePeriod.forBillingEvent(GracePeriodStatus.AUTO_RENEW, onetime));
+            () -> GracePeriod.forBillingEvent(GracePeriodStatus.AUTO_RENEW, "1-TEST", onetime));
     assertThat(thrown).hasMessageThat().contains("autorenew");
   }
 
@@ -101,6 +104,7 @@ public class GracePeriodTest {
             () ->
                 GracePeriod.createForRecurring(
                     GracePeriodStatus.RENEW,
+                    "1-TEST",
                     now.plusDays(1),
                     "TheRegistrar",
                     VKey.create(Recurring.class, 12345)));

--- a/core/src/test/java/google/registry/rde/DomainBaseToXjcConverterTest.java
+++ b/core/src/test/java/google/registry/rde/DomainBaseToXjcConverterTest.java
@@ -278,6 +278,7 @@ public class DomainBaseToXjcConverterTest {
                 ImmutableSet.of(
                     GracePeriod.forBillingEvent(
                         GracePeriodStatus.RENEW,
+                        domain.getRepoId(),
                         persistResource(
                             new BillingEvent.OneTime.Builder()
                                 .setReason(Reason.RENEW)
@@ -291,6 +292,7 @@ public class DomainBaseToXjcConverterTest {
                                 .build())),
                     GracePeriod.create(
                         GracePeriodStatus.TRANSFER,
+                        domain.getRepoId(),
                         DateTime.parse("1920-01-01T00:00:00Z"),
                         "foo",
                         null)))

--- a/core/src/test/java/google/registry/rde/RdeFixtures.java
+++ b/core/src/test/java/google/registry/rde/RdeFixtures.java
@@ -122,6 +122,7 @@ final class RdeFixtures {
                 ImmutableSet.of(
                     GracePeriod.forBillingEvent(
                         GracePeriodStatus.RENEW,
+                        domain.getRepoId(),
                         persistResource(
                             new BillingEvent.OneTime.Builder()
                                 .setReason(Reason.RENEW)
@@ -135,6 +136,7 @@ final class RdeFixtures {
                                 .build())),
                     GracePeriod.create(
                         GracePeriodStatus.TRANSFER,
+                        domain.getRepoId(),
                         DateTime.parse("1992-01-01T00:00:00Z"),
                         "foo",
                         null)))

--- a/core/src/test/java/google/registry/testing/DatastoreHelper.java
+++ b/core/src/test/java/google/registry/testing/DatastoreHelper.java
@@ -504,9 +504,10 @@ public class DatastoreHelper {
       DateTime creationTime,
       DateTime expirationTime) {
     String domainName = String.format("%s.%s", label, tld);
+    String repoId = generateNewDomainRoid(tld);
     DomainBase domain =
         new DomainBase.Builder()
-            .setRepoId(generateNewDomainRoid(tld))
+            .setRepoId(repoId)
             .setDomainName(domainName)
             .setPersistedCurrentSponsorClientId("TheRegistrar")
             .setCreationClientId("TheRegistrar")
@@ -519,7 +520,7 @@ public class DatastoreHelper {
                     DesignatedContact.create(Type.TECH, contact.createVKey())))
             .setAuthInfo(DomainAuthInfo.create(PasswordAuth.create("fooBAR")))
             .addGracePeriod(
-                GracePeriod.create(GracePeriodStatus.ADD, now.plusDays(10), "foo", null))
+                GracePeriod.create(GracePeriodStatus.ADD, repoId, now.plusDays(10), "foo", null))
             .build();
     HistoryEntry historyEntryDomainCreate =
         persistResource(

--- a/core/src/test/java/google/registry/whois/DomainWhoisResponseTest.java
+++ b/core/src/test/java/google/registry/whois/DomainWhoisResponseTest.java
@@ -228,11 +228,12 @@ class DomainWhoisResponseTest {
     VKey<ContactResource> adminResourceKey = adminContact.createVKey();
     VKey<ContactResource> techResourceKey = techContact.createVKey();
 
+    String repoId = "3-TLD";
     domainBase =
         persistResource(
             new DomainBase.Builder()
                 .setDomainName("example.tld")
-                .setRepoId("3-TLD")
+                .setRepoId(repoId)
                 .setLastEppUpdateTime(DateTime.parse("2009-05-29T20:13:00Z"))
                 .setCreationTimeForTest(DateTime.parse("2000-10-08T00:45:00Z"))
                 .setRegistrationExpirationTime(DateTime.parse("2010-10-08T00:44:59Z"))
@@ -252,8 +253,9 @@ class DomainWhoisResponseTest {
                 .setDsData(ImmutableSet.of(DelegationSignerData.create(1, 2, 3, "deadface")))
                 .setGracePeriods(
                     ImmutableSet.of(
-                        GracePeriod.create(GracePeriodStatus.ADD, END_OF_TIME, "", null),
-                        GracePeriod.create(GracePeriodStatus.TRANSFER, END_OF_TIME, "", null)))
+                        GracePeriod.create(GracePeriodStatus.ADD, repoId, END_OF_TIME, "", null),
+                        GracePeriod.create(
+                            GracePeriodStatus.TRANSFER, repoId, END_OF_TIME, "", null)))
                 .build());
   }
 

--- a/db/src/main/resources/sql/flyway/V42__add_join_table_for_grace_period.sql
+++ b/db/src/main/resources/sql/flyway/V42__add_join_table_for_grace_period.sql
@@ -1,0 +1,52 @@
+-- Copyright 2020 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+create table "GracePeriod" (
+    id  bigserial not null,
+    billing_event_id int8,
+    billing_recurrence_id int8,
+    registrar_id text not null,
+    expiration_time timestamptz not null,
+    type text not null,
+    primary key (id)
+);
+
+alter table if exists "GracePeriod"
+   add constraint fk_grace_period_billing_event_id
+   foreign key (billing_event_id)
+   references "BillingEvent";
+
+alter table if exists "GracePeriod"
+   add constraint fk_grace_period_billing_recurrence_id
+   foreign key (billing_recurrence_id)
+   references "BillingRecurrence";
+
+create table "DomainGracePeriod" (
+   domain_repo_id text not null,
+   grace_period_id int8 not null,
+   primary key (domain_repo_id, grace_period_id)
+);
+
+alter table if exists "DomainGracePeriod"
+    add constraint UK_cn4v4atanwosjiksnstk59ghc unique (grace_period_id);
+
+alter table if exists "DomainGracePeriod"
+   add constraint FK6csolg92mour3qpgscatqpt50
+   foreign key (grace_period_id)
+   references "GracePeriod";
+
+alter table if exists "DomainGracePeriod"
+   add constraint FK66qes7q8o6cnckskb2bxdlw6c
+   foreign key (domain_repo_id)
+   references "Domain";

--- a/db/src/main/resources/sql/flyway/V43__add_grace_period_table.sql
+++ b/db/src/main/resources/sql/flyway/V43__add_grace_period_table.sql
@@ -17,10 +17,16 @@ create table "GracePeriod" (
     billing_event_id int8,
     billing_recurrence_id int8,
     registrar_id text not null,
+    domain_repo_id text not null,
     expiration_time timestamptz not null,
     type text not null,
     primary key (id)
 );
+
+alter table if exists "GracePeriod"
+   add constraint fk_grace_period_domain_repo_id
+   foreign key (domain_repo_id)
+   references "Domain";
 
 alter table if exists "GracePeriod"
    add constraint fk_grace_period_billing_event_id
@@ -32,21 +38,5 @@ alter table if exists "GracePeriod"
    foreign key (billing_recurrence_id)
    references "BillingRecurrence";
 
-create table "DomainGracePeriod" (
-   domain_repo_id text not null,
-   grace_period_id int8 not null,
-   primary key (domain_repo_id, grace_period_id)
-);
+create index IDXj1mtx98ndgbtb1bkekahms18w on "GracePeriod" (domain_repo_id);
 
-alter table if exists "DomainGracePeriod"
-    add constraint UK_cn4v4atanwosjiksnstk59ghc unique (grace_period_id);
-
-alter table if exists "DomainGracePeriod"
-   add constraint FK6csolg92mour3qpgscatqpt50
-   foreign key (grace_period_id)
-   references "GracePeriod";
-
-alter table if exists "DomainGracePeriod"
-   add constraint FK66qes7q8o6cnckskb2bxdlw6c
-   foreign key (domain_repo_id)
-   references "Domain";

--- a/db/src/main/resources/sql/flyway/V45__add_grace_period_table.sql
+++ b/db/src/main/resources/sql/flyway/V45__add_grace_period_table.sql
@@ -24,7 +24,7 @@ create table "GracePeriod" (
 );
 
 alter table if exists "GracePeriod"
-   add constraint fk_grace_period_domain_repo_id
+   add constraint FK2mys4hojm6ev2g9tmy5aq6m7g
    foreign key (domain_repo_id)
    references "Domain";
 
@@ -39,4 +39,3 @@ alter table if exists "GracePeriod"
    references "BillingRecurrence";
 
 create index IDXj1mtx98ndgbtb1bkekahms18w on "GracePeriod" (domain_repo_id);
-

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -339,11 +339,12 @@ create sequence history_id_sequence start 1 increment 1;
 
     create table "GracePeriod" (
        id  bigserial not null,
-        billing_event_one_time int8,
-        billing_event_recurring int8,
-        registrar_id text,
-        expiration_time timestamptz,
-        type int4,
+        billing_event_id int8,
+        billing_recurrence_id int8,
+        registrar_id text not null,
+        domain_repo_id text not null,
+        expiration_time timestamptz not null,
+        type text not null,
         primary key (id)
     );
 
@@ -596,6 +597,7 @@ create index IDXrh4xmrot9bd63o382ow9ltfig on "DomainHistory" (creation_time);
 create index IDXaro1omfuaxjwmotk3vo00trwm on "DomainHistory" (history_registrar_id);
 create index IDXsu1nam10cjes9keobapn5jvxj on "DomainHistory" (history_type);
 create index IDX6w3qbtgce93cal2orjg1tw7b7 on "DomainHistory" (history_modification_time);
+create index IDXj1mtx98ndgbtb1bkekahms18w on "GracePeriod" (domain_repo_id);
 create index IDXfg2nnjlujxo6cb9fha971bq2n on "HostHistory" (creation_time);
 create index IDX1iy7njgb7wjmj9piml4l2g0qi on "HostHistory" (history_registrar_id);
 create index IDXkkwbwcwvrdkkqothkiye4jiff on "HostHistory" (host_name);
@@ -629,6 +631,11 @@ create index spec11threatmatch_check_date_idx on "Spec11ThreatMatch" (check_date
 
     alter table if exists "DomainHost" 
        add constraint FKeq1guccbre1yk3oosgp2io554 
+       foreign key (domain_repo_id) 
+       references "Domain";
+
+    alter table if exists "GracePeriod" 
+       add constraint FK2mys4hojm6ev2g9tmy5aq6m7g 
        foreign key (domain_repo_id) 
        references "Domain";
 

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -489,6 +489,40 @@ CREATE TABLE public."DomainHost" (
 
 
 --
+-- Name: GracePeriod; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."GracePeriod" (
+    id bigint NOT NULL,
+    billing_event_id bigint,
+    billing_recurrence_id bigint,
+    registrar_id text NOT NULL,
+    domain_repo_id text NOT NULL,
+    expiration_time timestamp with time zone NOT NULL,
+    type text NOT NULL
+);
+
+
+--
+-- Name: GracePeriod_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public."GracePeriod_id_seq"
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: GracePeriod_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public."GracePeriod_id_seq" OWNED BY public."GracePeriod".id;
+
+
+--
 -- Name: HostHistory; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -901,6 +935,13 @@ ALTER TABLE ONLY public."ClaimsList" ALTER COLUMN revision_id SET DEFAULT nextva
 
 
 --
+-- Name: GracePeriod id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."GracePeriod" ALTER COLUMN id SET DEFAULT nextval('public."GracePeriod_id_seq"'::regclass);
+
+
+--
 -- Name: PollMessage poll_message_id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1020,6 +1061,14 @@ ALTER TABLE ONLY public."DomainHistory"
 
 ALTER TABLE ONLY public."Domain"
     ADD CONSTRAINT "Domain_pkey" PRIMARY KEY (repo_id);
+
+
+--
+-- Name: GracePeriod GracePeriod_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."GracePeriod"
+    ADD CONSTRAINT "GracePeriod_pkey" PRIMARY KEY (id);
 
 
 --
@@ -1311,6 +1360,13 @@ CREATE INDEX idxhp33wybmb6tbpr1bq7ttwk8je ON public."ContactHistory" USING btree
 
 
 --
+-- Name: idxj1mtx98ndgbtb1bkekahms18w; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idxj1mtx98ndgbtb1bkekahms18w ON public."GracePeriod" USING btree (domain_repo_id);
+
+
+--
 -- Name: idxj77pfwhui9f0i7wjq6lmibovj; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1486,6 +1542,14 @@ ALTER TABLE ONLY public."Domain"
 
 ALTER TABLE ONLY public."RegistryLock"
     ADD CONSTRAINT fk2lhcwpxlnqijr96irylrh1707 FOREIGN KEY (relock_revision_id) REFERENCES public."RegistryLock"(revision_id);
+
+
+--
+-- Name: GracePeriod fk2mys4hojm6ev2g9tmy5aq6m7g; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."GracePeriod"
+    ADD CONSTRAINT fk2mys4hojm6ev2g9tmy5aq6m7g FOREIGN KEY (domain_repo_id) REFERENCES public."Domain"(repo_id);
 
 
 --
@@ -1726,6 +1790,22 @@ ALTER TABLE ONLY public."Domain"
 
 ALTER TABLE ONLY public."DomainHost"
     ADD CONSTRAINT fk_domainhost_host_valid FOREIGN KEY (host_repo_id) REFERENCES public."HostResource"(repo_id);
+
+
+--
+-- Name: GracePeriod fk_grace_period_billing_event_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."GracePeriod"
+    ADD CONSTRAINT fk_grace_period_billing_event_id FOREIGN KEY (billing_event_id) REFERENCES public."BillingEvent"(billing_event_id);
+
+
+--
+-- Name: GracePeriod fk_grace_period_billing_recurrence_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."GracePeriod"
+    ADD CONSTRAINT fk_grace_period_billing_recurrence_id FOREIGN KEY (billing_recurrence_id) REFERENCES public."BillingRecurrence"(billing_recurrence_id);
 
 
 --


### PR DESCRIPTION
We created a new sql table for `GracePeriod` instead of embedding it into `DomainBase`(like what we do for Datastore) because it is possible that a domain can have multiple `GracePeriod` attached to it, e.g. if a domain gets renewed multiple times within 5 days, it will have the same number of `GracePeriod.RENEW` associated to it because each `GracePeriod.RENEW` lasts 5 days.

Also, given that most types of `GracePeriod` only last a few days and they will be deleted after expiration, we can expect the size of the `GracePeriod` is relatively small. So, we set to eagerly load the associated `GracePeriod` records when the domain is loaded. 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/709)
<!-- Reviewable:end -->
