### PR TITLE
Use rearranged sql credentials in flyway task

### DIFF
--- a/db/build.gradle
+++ b/db/build.gradle
@@ -25,16 +25,11 @@ ext {
   Set allDbEnv =
       [ 'alpha', 'crash' ].plus(restrictedDbEnv).asUnmodifiable()
 
-  def appNameProperty = 'appName'
   def dbServerProperty = 'dbServer'
   def dbNameProperty = 'dbName'
 
   def dbServer = findProperty(dbServerProperty).toString().toLowerCase()
   def dbName = findProperty(dbNameProperty)
-  def appName = "domain-registry"
-  if (hasProperty(appNameProperty)) {
-    appName = findProperty(appNameProperty)
-  }
 
   isCloudSql = {
     return allDbEnv.contains(dbServer)
@@ -80,7 +75,8 @@ ext {
   getCloudSqlCredential = { env, role ->
     def devProject = project.hasProperty('devProject')
         ? project.getProperty('devProject') : rootProject.devProject
-    def gcpProject = env == 'production' ? appName : "${appName}-${env}"
+    def gcpProject = project.hasProperty('gcpProject')
+        ? project.getProperty('gcpProject') : rootProject.gcpProject
     def keyProject = env in restrictedDbEnv? devProject : gcpProject
     def command =
         """gsutil cp \

--- a/db/build.gradle
+++ b/db/build.gradle
@@ -25,17 +25,23 @@ ext {
   Set allDbEnv =
       [ 'alpha', 'crash' ].plus(restrictedDbEnv).asUnmodifiable()
 
+  def appNameProperty = 'appName'
   def dbServerProperty = 'dbServer'
   def dbNameProperty = 'dbName'
 
   def dbServer = findProperty(dbServerProperty).toString().toLowerCase()
   def dbName = findProperty(dbNameProperty)
+  def appName = "domain-registry"
+  if (hasProperty(appNameProperty)) {
+    appName = findProperty(appNameProperty)
+  }
 
   isCloudSql = {
     return allDbEnv.contains(dbServer)
   }
 
   getAccessInfoByHostPort = { hostAndPort ->
+    println "Database set to ${hostAndPort}."
     return [
         url: "jdbc:postgresql://${hostAndPort}/${dbName}",
         user: findProperty('dbUser'),
@@ -45,6 +51,7 @@ ext {
   getSocketFactoryAccessInfo = { env ->
     def cred = getCloudSqlCredential(env, 'admin').split(' ')
     def sqlInstance = cred[0]
+    println "Database set to Cloud SQL instance ${sqlInstance}."
     return [
         url: """\
                    jdbc:postgresql://google/${dbName}?cloudSqlInstance=
@@ -73,14 +80,16 @@ ext {
   getCloudSqlCredential = { env, role ->
     def devProject = project.hasProperty('devProject')
         ? project.getProperty('devProject') : rootProject.devProject
+    def gcpProject = env == 'production' ? appName : "${appName}-${env}"
+    def keyProject = env in restrictedDbEnv? devProject : gcpProject
     def command =
         """gsutil cp \
-           gs://${devProject}-deploy/cloudsql-credentials/${env}/${role}_credential.enc - | \
+           gs://${gcpProject}-beam/cloudsql/${role}_credential.enc - | \
            base64 -d | \
            gcloud kms decrypt --location global --keyring nomulus-tool-keyring \
            --key nomulus-tool-key --plaintext-file=- \
            --ciphertext-file=- \
-           --project=${devProject}"""
+           --project=${keyProject}"""
 
     return execInBash(command, '/tmp')
   }


### PR DESCRIPTION
Let the flyway tasks use the sql credential files set up for BEAM
pipelines. 

Credential files have been created for each environment in GCS
at gs://${project}-beam/cloudsql/admin_credential.enc. They are
meant for the BEAM pipeline runner accounts in each project.

Alpha and crash accounts use the 'nomulus-tools-key' in their own project to
decrypt the credential file.

Sandbox and production accounts use the 'nomulus-tools-key' in
domain-registry-dev to decrypt the credential file.

Previously all flyway tasks use the 'nomulus-tools-key' in
domain-registry-dev, which was meant for the Cloud Build tasks.
It is a little cleaner to limit this key to sandbox and production.

Note that this setup is temporary. It will become obsolete once
we migrate to Cloud Secret Manager for secret storage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/712)
<!-- Reviewable:end -->
