### PR TITLE
Remove Registrar foreign key reference from Spec11ThreatMatch

### DIFF
--- a/db/src/main/resources/sql/flyway/V40__spec11threatmatch_remove_registrar_foreign_key.sql
+++ b/db/src/main/resources/sql/flyway/V40__spec11threatmatch_remove_registrar_foreign_key.sql
@@ -1,0 +1,16 @@
+-- Copyright 2020 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+alter table if exists "Spec11ThreatMatch"
+  drop constraint "fk_safebrowsing_threat_registrar_id";

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -1597,14 +1597,6 @@ ALTER TABLE ONLY public."Spec11ThreatMatch"
 
 
 --
--- Name: Spec11ThreatMatch fk_safebrowsing_threat_registrar_id; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Spec11ThreatMatch"
-    ADD CONSTRAINT fk_safebrowsing_threat_registrar_id FOREIGN KEY (registrar_id) REFERENCES public."Registrar"(registrar_id);
-
-
---
 -- Name: DomainHost fkfmi7bdink53swivs390m2btxg; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 


### PR DESCRIPTION
The Registrar table in SQL hasn't been migrated over from Datastore yet, so the foreign key reference to Registrar is temporarily removed so that the Spec11Pipeline can properly store new ThreatMatches into Spec11ThreatMatch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/715)
<!-- Reviewable:end -->
