### PR TITLE
Clarify un-avail reason on allocation-token-reserved domains

### DIFF
--- a/core/src/main/java/google/registry/model/registry/label/ReservationType.java
+++ b/core/src/main/java/google/registry/model/registry/label/ReservationType.java
@@ -38,10 +38,10 @@ public enum ReservationType {
   ALLOWED_IN_SUNRISE("Reserved", 0),
 
   /** The domain can only be registered by providing a specific token. */
-  RESERVED_FOR_SPECIFIC_USE("Allocation token required", 1),
+  RESERVED_FOR_SPECIFIC_USE("Reserved; alloc. token required", 1),
 
   /** The domain is for an anchor tenant and can only be registered using a specific token. */
-  RESERVED_FOR_ANCHOR_TENANT("Allocation token required", 2),
+  RESERVED_FOR_ANCHOR_TENANT("Reserved; alloc. token required", 2),
 
   /**
    * The domain can only be registered during sunrise for defensive purposes, and will never

--- a/core/src/test/java/google/registry/flows/CheckApiActionTest.java
+++ b/core/src/test/java/google/registry/flows/CheckApiActionTest.java
@@ -277,7 +277,7 @@ class CheckApiActionTest {
             "tier", "premium",
             "status", "success",
             "available", false,
-            "reason", "Allocation token required");
+            "reason", "Reserved; alloc. token required");
 
     verifySuccessMetric(PREMIUM, RESERVED);
   }

--- a/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
@@ -143,7 +143,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
         create(false, "example1.tld", "In use"),
         create(false, "example2.tld", "The allocation token is invalid"),
         create(false, "reserved.tld", "Reserved"),
-        create(false, "specificuse.tld", "Allocation token required"));
+        create(false, "specificuse.tld", "Reserved; alloc. token required"));
   }
 
   @Test
@@ -156,7 +156,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
         create(false, "example1.tld", "In use"),
         create(true, "example2.tld", null),
         create(false, "reserved.tld", "Reserved"),
-        create(false, "specificuse.tld", "Allocation token required"));
+        create(false, "specificuse.tld", "Reserved; alloc. token required"));
   }
 
   @Test
@@ -173,7 +173,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
         create(false, "example1.tld", "In use"),
         create(false, "example2.tld", "Alloc token was already redeemed"),
         create(false, "reserved.tld", "Reserved"),
-        create(false, "specificuse.tld", "Allocation token required"));
+        create(false, "specificuse.tld", "Reserved; alloc. token required"));
   }
 
   @Test
@@ -222,7 +222,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
         create(false, "example1.tld", "In use"),
         create(false, "example2.tld", "Alloc token invalid for domain"),
         create(false, "reserved.tld", "Reserved"),
-        create(false, "specificuse.tld", "Allocation token required"));
+        create(false, "specificuse.tld", "Reserved; alloc. token required"));
   }
 
   @Test
@@ -276,7 +276,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
     doCheckTest(
         create(false, "collision.tld", "Cannot be delegated"),
         create(false, "reserved.tld", "Reserved"),
-        create(false, "anchor.tld", "Allocation token required"),
+        create(false, "anchor.tld", "Reserved; alloc. token required"),
         create(false, "allowedinsunrise.tld", "Reserved"),
         create(false, "premiumcollision.tld", "Cannot be delegated"));
   }
@@ -410,7 +410,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
   @Test
   void testSuccess_anchorTenantReserved() throws Exception {
     setEppInput("domain_check_anchor.xml");
-    doCheckTest(create(false, "anchor.tld", "Allocation token required"));
+    doCheckTest(create(false, "anchor.tld", "Reserved; alloc. token required"));
   }
 
   @Test


### PR DESCRIPTION
Apparently, in domain check responses, `avail=false, reason=Allocation token
required` was not sufficiently understood by all registrars. This changes it to
`avail=false, reason=Reserved; alloc. token required` to hopefully make it
crystal clear that the domain in question is reserved, i.e. if you were supposed
to be able to register this domain you'd already know it because we'd have
already given you the requisite allocation token.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/725)
<!-- Reviewable:end -->
