### PR TITLE
Fix broken RegistryCli

### DIFF
--- a/core/src/main/java/google/registry/tools/RegistryCli.java
+++ b/core/src/main/java/google/registry/tools/RegistryCli.java
@@ -29,7 +29,6 @@ import com.google.appengine.tools.remoteapi.RemoteApiOptions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import google.registry.backup.AppEngineEnvironment;
 import google.registry.config.RegistryConfig;
 import google.registry.model.ofy.ObjectifyService;
 import google.registry.persistence.transaction.TransactionManagerFactory;
@@ -179,7 +178,7 @@ final class RegistryCli implements AutoCloseable, CommandRunner {
             Iterables.getOnlyElement(jcommander.getCommands().get(parsedCommand).getObjects());
     loggingParams.configureLogging();  // Must be called after parameters are parsed.
 
-    try (AppEngineEnvironment env = new AppEngineEnvironment()) {
+    try {
       runCommand(command);
     } catch (RuntimeException ex) {
       if (Throwables.getRootCause(ex) instanceof LoginRequiredException) {


### PR DESCRIPTION
This PR removed the line `AppEngineEnvironment env = new AppEngineEnvironment()` which was introduced in #716. The created `env` object is not used by any of the subsequent code and during the course of its instantiation, `AppEngineEnvironment` sets up the AppEngine remote API which conflicts with the similar process that `RegistryCli` itself does. The symptom is when running a registry tool command using AppEngine remote API, we will get the below error:

```java
Exception in thread "main" com.google.apphosting.api.ApiProxy$CallNotFoundException: The API package 'urlfetch' or call 'Fetch()' was not found.
        at com.google.apphosting.api.ApiProxy.makeSyncCall(ApiProxy.java:111)
        at com.google.appengine.api.urlfetch.URLFetchServiceImpl.fetch(URLFetchServiceImpl.java:40)
        at com.google.appengine.repackaged.com.google.api.client.extensions.appengine.http.UrlFetchRequest.execute(UrlFetchRequest.java:74)
        at com.google.appengine.repackaged.com.google.api.client.http.HttpRequest.execute(HttpRequest.java:981)
        at com.google.appengine.tools.remoteapi.OAuthClient.get(OAuthClient.java:64)
        at com.google.appengine.tools.remoteapi.RemoteApiInstaller.getAppIdFromServer(RemoteApiInstaller.java:411)
        at com.google.appengine.tools.remoteapi.RemoteApiInstaller.loginImpl(RemoteApiInstaller.java:374)
        at com.google.appengine.tools.remoteapi.RemoteApiInstaller.login(RemoteApiInstaller.java:335)
        at com.google.appengine.tools.remoteapi.RemoteApiInstaller.install(RemoteApiInstaller.java:171)
        at google.registry.tools.RegistryCli.runCommand(RegistryCli.java:242)
        at google.registry.tools.RegistryCli.run(RegistryCli.java:182)
        at google.registry.tools.RegistryTool.main(RegistryTool.java:129)
```
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/728)
<!-- Reviewable:end -->
