### PR TITLE
Some more changes to make it possible to use Java 11 to compile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -308,9 +308,14 @@ subprojects {
     }
   }
 
-  javadocSource << project.sourceSets.main.allJava
-  javadocClasspath << project.sourceSets.main.compileClasspath
-  javadocDependentTasks << project.tasks.compileJava
+  // No need to produce javadoc for the docs subproject, which has no APIs to
+  // expose to users.
+  if (project.name != 'docs') {
+    javadocSource << project.sourceSets.main.allJava
+    javadocClasspath << project.sourceSets.main.compileClasspath
+    javadocClasspath << "${buildDir}/generated/sources/annotationProcessor/java/main"
+    javadocDependentTasks << project.tasks.compileJava
+  }
 }
 
 // If "-P verboseTestOutput=true" is passed in, configure all subprojects to dump all of their

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -404,7 +404,9 @@ task jaxbToJava {
         }
       }
     }
-    execInBash('find . -name *.java -exec sed -i /\\<p\\>\\$/d {} +', outputDir)
+    execInBash(
+        'find . -name *.java -exec sed -i /\\*\\ \\<p\\>\\$/d {} +',
+        generatedDir)
   }
 }
 

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -45,12 +45,16 @@ task flowDocsTool(type: JavaExec) {
 }
 
 tasks.compileJava {
-  options.compilerArgs = ["--add-exports", "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
-                          "--add-exports", "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-                          "--add-exports", "jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED"]
+  options.compilerArgs = ["--add-exports",
+                          "jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+                          "--add-exports",
+                          "jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+                          "--add-exports",
+                          "jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED"]
 
 }
 
 tasks.test {
-  jvmArgs = ['--add-exports', 'jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED']
+  jvmArgs = ['--add-exports',
+             'jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED']
 }

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -100,8 +100,12 @@ tasks.withType(JavaCompile).configureEach {
     // The -Werror flag causes Intellij to fail on deprecated api use.
     // Allow IDE user to turn off this flag by specifying a Gradle VM
     // option from inside the IDE.
-    if (System.getProperty('no_werror') != 'true') {
-        options.compilerArgs << "-Werror"
+    if (System.getProperty('no_werror') != 'true' &&
+        // The core project throws an warning about Gradle annotation processor
+        // not compatible with Java source version > 8. Re-assess once the
+        // warning is fixed.
+        getProject().name != 'core') {
+      options.compilerArgs << "-Werror"
     }
     options.errorprone.disableWarningsInGeneratedCode = true
     options.errorprone.errorproneArgumentProviders.add([


### PR DESCRIPTION
Add the class paths of the source files generated by annotation processors to
the javadoc task's class path so that it doesn't complain about missing
Dagger classes.

Also remove empty <p> tags in all generated source files, because jaxb
genrerates files in multiple locations.

Lastly, for unkown reasons when the source level is set to > 8, the core
subproject throws a warning about a Gradle internal annotator processor
that only supports up to Java 8 and cause the Java compliation to fail because
we set -Werror on all java compilation tasks. I don't think there is a
strong reason that we set -Werror anyway, so this commit removes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/732)
<!-- Reviewable:end -->
