### PR TITLE
Delete screenshots folder in fragile test first

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -705,6 +705,10 @@ task fragileTest(type: FilteringTest) {
 
   // Run every test class in a freshly started process.
   forkEvery 1
+
+  doFirst {
+    new File(screenshotsDir).deleteDir()
+  }
 }
 
 task outcastTest(type: FilteringTest) {
@@ -897,10 +901,6 @@ task standardTest(type: FilteringTest) {
 
   systemProperty 'test.projectRoot', rootProject.projectRootDir
   systemProperty 'test.resourcesDir', resourcesDir
-
-  doFirst {
-    new File(screenshotsDir).deleteDir()
-  }
 }
 
 test {


### PR DESCRIPTION
It is not clear to me why this folder is deleted in standardTest first,
presumably this is done when the webdriver tests were part of
standardTest?

Also not clear to me is why screenshots are only deleted in presubmits
but not locally. At least on my workstation standardTest runs after
fragileTest, just like in kokoro, so it should have deleted the screenshots
folder, but it didn't.

Regardless, the correct thing to do is to delete this folder first in
fragileTest so that it doesn't interfere with the results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/735)
<!-- Reviewable:end -->
