### PR TITLE
Replay Cloud SQL transactions against datastore

### DIFF
--- a/core/src/main/java/google/registry/model/EntityClasses.java
+++ b/core/src/main/java/google/registry/model/EntityClasses.java
@@ -52,6 +52,7 @@ import google.registry.model.tmch.ClaimsListShard;
 import google.registry.model.tmch.ClaimsListShard.ClaimsListRevision;
 import google.registry.model.tmch.ClaimsListShard.ClaimsListSingleton;
 import google.registry.model.tmch.TmchCrl;
+import google.registry.schema.replay.LastSqlTransaction;
 
 /** Sets of classes of the Objectify-registered entities in use throughout the model. */
 public final class EntityClasses {
@@ -90,6 +91,7 @@ public final class EntityClasses {
           HostResource.class,
           KmsSecret.class,
           KmsSecretRevision.class,
+          LastSqlTransaction.class,
           Lock.class,
           PollMessage.class,
           PollMessage.Autorenew.class,

--- a/core/src/main/java/google/registry/model/ofy/Ofy.java
+++ b/core/src/main/java/google/registry/model/ofy/Ofy.java
@@ -116,7 +116,7 @@ public class Ofy {
     return ofy().getTransaction() != null;
   }
 
-  void assertInTransaction() {
+  public void assertInTransaction() {
     checkState(inTransaction(), "Must be called in a transaction");
   }
 

--- a/core/src/main/java/google/registry/persistence/transaction/Transaction.java
+++ b/core/src/main/java/google/registry/persistence/transaction/Transaction.java
@@ -86,7 +86,7 @@ public class Transaction extends ImmutableObject implements Buildable {
     }
   }
 
-  static Transaction deserialize(byte[] serializedTransaction) throws IOException {
+  public static Transaction deserialize(byte[] serializedTransaction) throws IOException {
     ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(serializedTransaction));
 
     // Verify that the data is what we expect.

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionEntity.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionEntity.java
@@ -34,9 +34,9 @@ public class TransactionEntity implements SqlEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  long id;
+  private long id;
 
-  byte[] contents;
+  private byte[] contents;
 
   TransactionEntity() {}
 
@@ -47,5 +47,13 @@ public class TransactionEntity implements SqlEntity {
   @Override
   public Optional<DatastoreEntity> toDatastoreEntity() {
     return Optional.empty(); // Not persisted in Datastore per se
+  }
+
+  public long getId() {
+    return id;
+  }
+
+  public byte[] getContents() {
+    return contents;
   }
 }

--- a/core/src/main/java/google/registry/schema/replay/LastSqlTransaction.java
+++ b/core/src/main/java/google/registry/schema/replay/LastSqlTransaction.java
@@ -22,9 +22,7 @@ import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import google.registry.model.ImmutableObject;
 
-/**
- * Datastore entity to keep track of the last SQL transaction imported into the datastore.
- */
+/** Datastore entity to keep track of the last SQL transaction imported into the datastore. */
 @Entity
 public class LastSqlTransaction extends ImmutableObject {
 
@@ -37,17 +35,19 @@ public class LastSqlTransaction extends ImmutableObject {
 
   private long transactionId;
 
-  LastSqlTransaction() {
-    transactionId = -1;
+  LastSqlTransaction() {}
+
+  private LastSqlTransaction(long newTransactionId) {
+    transactionId = newTransactionId;
   }
 
-  void setTransactionId(long transactionId) {
+  LastSqlTransaction withNewTransactionId(long transactionId) {
     checkArgument(
         transactionId > this.transactionId,
         "New transaction id (%s) must be greater than the current transaction id (%s)",
         transactionId,
         this.transactionId);
-    this.transactionId = transactionId;
+    return new LastSqlTransaction(transactionId);
   }
 
   long getTransactionId() {
@@ -66,11 +66,12 @@ public class LastSqlTransaction extends ImmutableObject {
     return result == null ? new LastSqlTransaction() : result;
   }
 
-  /** Stores the instance in datastore.
+  /**
+   * Stores the instance in datastore.
    *
    * <p>Must be called within the same transaction as load().
    */
   void store() {
-    ofy().saveWithoutBackup().entity(this);
+    ofy().save().entity(this);
   }
 }

--- a/core/src/main/java/google/registry/schema/replay/LastSqlTransaction.java
+++ b/core/src/main/java/google/registry/schema/replay/LastSqlTransaction.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public class LastSqlTransaction extends ImmutableObject implements DatastoreOnly
     transactionId = newTransactionId;
   }
 
-  LastSqlTransaction withNewTransactionId(long transactionId) {
+  LastSqlTransaction cloneWithNewTransactionId(long transactionId) {
     checkArgument(
         transactionId > this.transactionId,
         "New transaction id (%s) must be greater than the current transaction id (%s)",
@@ -59,11 +59,12 @@ public class LastSqlTransaction extends ImmutableObject implements DatastoreOnly
   /**
    * Loads the instance.
    *
-   * <p>Must be called within a transaction.
+   * <p>Must be called within an Ofy transaction.
    *
-   * <p>Creates a new instance of the singleton if it is not already present in the datastore,
+   * <p>Creates a new instance of the singleton if it is not already present in Cloud Datastore,
    */
   static LastSqlTransaction load() {
+    ofy().assertInTransaction();
     LastSqlTransaction result = ofy().load().key(KEY).now();
     return result == null ? new LastSqlTransaction() : result;
   }

--- a/core/src/main/java/google/registry/schema/replay/LastSqlTransaction.java
+++ b/core/src/main/java/google/registry/schema/replay/LastSqlTransaction.java
@@ -17,6 +17,7 @@ package google.registry.schema.replay;
 import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.model.ofy.ObjectifyService.ofy;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
@@ -37,7 +38,8 @@ public class LastSqlTransaction extends ImmutableObject {
 
   LastSqlTransaction() {}
 
-  private LastSqlTransaction(long newTransactionId) {
+  @VisibleForTesting
+  LastSqlTransaction(long newTransactionId) {
     transactionId = newTransactionId;
   }
 

--- a/core/src/main/java/google/registry/schema/replay/LastSqlTransaction.java
+++ b/core/src/main/java/google/registry/schema/replay/LastSqlTransaction.java
@@ -25,7 +25,7 @@ import google.registry.model.ImmutableObject;
 
 /** Datastore entity to keep track of the last SQL transaction imported into the datastore. */
 @Entity
-public class LastSqlTransaction extends ImmutableObject {
+public class LastSqlTransaction extends ImmutableObject implements DatastoreOnlyEntity {
 
   /** The key for this singleton. */
   public static final Key<LastSqlTransaction> KEY = Key.create(LastSqlTransaction.class, 1);

--- a/core/src/main/java/google/registry/schema/replay/LastSqlTransaction.java
+++ b/core/src/main/java/google/registry/schema/replay/LastSqlTransaction.java
@@ -1,0 +1,76 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.schema.replay;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static google.registry.model.ofy.ObjectifyService.ofy;
+
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+import google.registry.model.ImmutableObject;
+
+/**
+ * Datastore entity to keep track of the last SQL transaction imported into the datastore.
+ */
+@Entity
+public class LastSqlTransaction extends ImmutableObject {
+
+  /** The key for this singleton. */
+  public static final Key<LastSqlTransaction> KEY = Key.create(LastSqlTransaction.class, 1);
+
+  @SuppressWarnings("unused")
+  @Id
+  private long id = 1;
+
+  private long transactionId;
+
+  LastSqlTransaction() {
+    transactionId = -1;
+  }
+
+  void setTransactionId(long transactionId) {
+    checkArgument(
+        transactionId > this.transactionId,
+        "New transaction id (%s) must be greater than the current transaction id (%s)",
+        transactionId,
+        this.transactionId);
+    this.transactionId = transactionId;
+  }
+
+  long getTransactionId() {
+    return transactionId;
+  }
+
+  /**
+   * Loads the instance.
+   *
+   * <p>Must be called within a transaction.
+   *
+   * <p>Creates a new instance of the singleton if it is not already present in the datastore,
+   */
+  static LastSqlTransaction load() {
+    LastSqlTransaction result = ofy().load().key(KEY).now();
+    return result == null ? new LastSqlTransaction() : result;
+  }
+
+  /** Stores the instance in datastore.
+   *
+   * <p>Must be called within the same transaction as load().
+   */
+  void store() {
+    ofy().saveWithoutBackup().entity(this);
+  }
+}

--- a/core/src/main/java/google/registry/schema/replay/LastSqlTransaction.java
+++ b/core/src/main/java/google/registry/schema/replay/LastSqlTransaction.java
@@ -65,13 +65,4 @@ public class LastSqlTransaction extends ImmutableObject {
     LastSqlTransaction result = ofy().load().key(KEY).now();
     return result == null ? new LastSqlTransaction() : result;
   }
-
-  /**
-   * Stores the instance in datastore.
-   *
-   * <p>Must be called within the same transaction as load().
-   */
-  void store() {
-    ofy().save().entity(this);
-  }
 }

--- a/core/src/main/java/google/registry/schema/replay/ReplicateToDatastoreAction.java
+++ b/core/src/main/java/google/registry/schema/replay/ReplicateToDatastoreAction.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/core/src/main/java/google/registry/schema/replay/ReplicateToDatastoreAction.java
+++ b/core/src/main/java/google/registry/schema/replay/ReplicateToDatastoreAction.java
@@ -1,0 +1,65 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.schema.replay;
+
+import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.ofyTm;
+import static google.registry.request.Action.Method.GET;
+
+import google.registry.persistence.transaction.Transaction;
+import google.registry.persistence.transaction.TransactionEntity;
+import google.registry.request.Action;
+import google.registry.request.auth.Auth;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Cron task to replicate from Cloud SQL to datastore.
+ */
+@Action(
+    service = Action.Service.BACKEND,
+    path = ReplicateToDatastoreAction.PATH,
+    method = GET,
+    automaticallyPrintOk = true,
+    auth = Auth.AUTH_INTERNAL_OR_ADMIN)
+class ReplicateToDatastoreAction implements Runnable {
+  public static final String PATH = "/_dr/cron/replicateToDatastore";
+
+  @Override
+  public void run() {
+    ofyTm().transact(() -> {
+          LastSqlTransaction lastSqlTxn = LastSqlTransaction.load();
+
+          // Get all entries that we haven't processed yet.
+          List transactions = jpaTm().transact(() ->
+            jpaTm().getEntityManager().createQuery(
+                    "SELECT txn FROM TransactionEntity txn WHERE id > :lastId ORDER BY id")
+                .setParameter("lastId", lastSqlTxn.getTransactionId())
+                .getResultList());
+
+          // Write them all to datastore.
+          for (TransactionEntity txnEntity : (List<TransactionEntity>) transactions) {
+            try {
+              Transaction.deserialize(txnEntity.getContents()).writeToDatastore();
+            } catch (IOException e) {
+              throw new RuntimeException(e);
+            }
+            lastSqlTxn.setTransactionId(txnEntity.getId());
+          }
+
+          lastSqlTxn.store();
+        });
+  }
+}

--- a/core/src/main/java/google/registry/schema/replay/ReplicateToDatastoreAction.java
+++ b/core/src/main/java/google/registry/schema/replay/ReplicateToDatastoreAction.java
@@ -14,6 +14,7 @@
 
 package google.registry.schema.replay;
 
+import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.ofyTm;
 import static google.registry.request.Action.Method.GET;
@@ -78,7 +79,7 @@ class ReplicateToDatastoreAction implements Runnable {
               newTransactionId = txnEntity.getId();
 
               // Write the updated last transaction id to datastore.
-              lastSqlTxn.withNewTransactionId(newTransactionId).store();
+              ofy().save().entity(lastSqlTxn.withNewTransactionId(newTransactionId));
               return true;
             });
   }

--- a/core/src/test/java/google/registry/persistence/transaction/TransactionTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/TransactionTest.java
@@ -112,7 +112,7 @@ class TransactionTest {
               });
       TransactionEntity txnEnt =
           jpaTm().transact(() -> jpaTm().loadByKey(VKey.createSql(TransactionEntity.class, 1L)));
-      Transaction txn = Transaction.deserialize(txnEnt.contents);
+      Transaction txn = Transaction.deserialize(txnEnt.getContents());
       txn.writeToDatastore();
       ofyTm()
           .transact(

--- a/core/src/test/java/google/registry/schema/replay/ReplicateToDatastoreActionTest.java
+++ b/core/src/test/java/google/registry/schema/replay/ReplicateToDatastoreActionTest.java
@@ -1,4 +1,4 @@
-// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/core/src/test/java/google/registry/schema/replay/ReplicateToDatastoreActionTest.java
+++ b/core/src/test/java/google/registry/schema/replay/ReplicateToDatastoreActionTest.java
@@ -72,9 +72,12 @@ public class ReplicateToDatastoreActionTest {
     assertThat(ofyTm().transact(() -> ofyTm().load(bar.key()))).isEqualTo(bar);
     assertThat(ofyTm().transact(() -> ofyTm().maybeLoad(baz.key())).isPresent()).isFalse();
 
-    jpaTm().transact(() -> {
-          jpaTm().delete(bar.key()); jpaTm().saveNew(baz);
-        });
+    jpaTm()
+        .transact(
+            () -> {
+              jpaTm().delete(bar.key());
+              jpaTm().saveNew(baz);
+            });
     task.run();
 
     assertThat(ofyTm().transact(() -> ofyTm().maybeLoad(bar.key()).isPresent())).isFalse();
@@ -102,7 +105,6 @@ public class ReplicateToDatastoreActionTest {
     assertThat(ofyTm().transact(() -> ofyTm().load(bar.key()))).isEqualTo(bar);
     assertThat(ofyTm().transact(() -> ofyTm().maybeLoad(foo.key()).isPresent())).isFalse();
   }
-
 
   @Entity(name = "ReplicationTestEntity")
   @javax.persistence.Entity(name = "TestEntity")

--- a/core/src/test/java/google/registry/schema/replay/ReplicateToDatastoreActionTest.java
+++ b/core/src/test/java/google/registry/schema/replay/ReplicateToDatastoreActionTest.java
@@ -1,0 +1,122 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.schema.replay;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.ofyTm;
+
+import com.googlecode.objectify.Key;
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+import google.registry.config.RegistryConfig;
+import google.registry.model.ImmutableObject;
+import google.registry.persistence.VKey;
+import google.registry.testing.AppEngineExtension;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class ReplicateToDatastoreActionTest {
+
+  @RegisterExtension
+  public final AppEngineExtension appEngine =
+      AppEngineExtension.builder()
+          .withDatastoreAndCloudSql()
+          .withOfyTestEntities(TestEntity.class)
+          .withJpaUnitTestEntities(TestEntity.class)
+          .build();
+
+  ReplicateToDatastoreAction task = new ReplicateToDatastoreAction();
+
+  public ReplicateToDatastoreActionTest() {}
+
+  @BeforeEach
+  public void setUp() {
+    RegistryConfig.overrideCloudSqlReplicateTransactions(true);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    RegistryConfig.overrideCloudSqlReplicateTransactions(false);
+  }
+
+  @Test
+  public void testReplication() {
+    TestEntity foo = new TestEntity("foo");
+    TestEntity bar = new TestEntity("bar");
+    TestEntity baz = new TestEntity("baz");
+
+    jpaTm()
+        .transact(
+            () -> {
+              jpaTm().saveNew(foo);
+              jpaTm().saveNew(bar);
+            });
+    task.run();
+
+    assertThat(ofyTm().transact(() -> ofyTm().load(foo.key()))).isEqualTo(foo);
+    assertThat(ofyTm().transact(() -> ofyTm().load(bar.key()))).isEqualTo(bar);
+    assertThat(ofyTm().transact(() -> ofyTm().maybeLoad(baz.key())).isPresent()).isFalse();
+
+    jpaTm().transact(() -> {
+          jpaTm().delete(bar.key()); jpaTm().saveNew(baz);
+        });
+    task.run();
+
+    assertThat(ofyTm().transact(() -> ofyTm().maybeLoad(bar.key()).isPresent())).isFalse();
+    assertThat(ofyTm().transact(() -> ofyTm().load(baz.key()))).isEqualTo(baz);
+  }
+
+  @Test
+  public void testReplayFromLastTxn() {
+    TestEntity foo = new TestEntity("foo");
+    TestEntity bar = new TestEntity("bar");
+
+    // Write a transaction containing "foo".
+    jpaTm().transact(() -> jpaTm().saveNew(foo));
+    task.run();
+
+    // Verify that it propagated to datastore, then remove "foo" directly from datastore.
+    assertThat(ofyTm().transact(() -> ofyTm().load(foo.key()))).isEqualTo(foo);
+    ofyTm().transact(() -> ofyTm().delete(foo.key()));
+
+    // Write "bar"
+    jpaTm().transact(() -> jpaTm().saveNew(bar));
+    task.run();
+
+    // If we replayed only the most recent transaction, we should have "bar" but not "foo".
+    assertThat(ofyTm().transact(() -> ofyTm().load(bar.key()))).isEqualTo(bar);
+    assertThat(ofyTm().transact(() -> ofyTm().maybeLoad(foo.key()).isPresent())).isFalse();
+  }
+
+
+  @Entity(name = "ReplicationTestEntity")
+  @javax.persistence.Entity(name = "TestEntity")
+  private static class TestEntity extends ImmutableObject {
+    @Id @javax.persistence.Id private String name;
+
+    private TestEntity() {}
+
+    private TestEntity(String name) {
+      this.name = name;
+    }
+
+    public VKey<TestEntity> key() {
+      return VKey.create(TestEntity.class, name, Key.create(this));
+    }
+  }
+}

--- a/core/src/test/resources/google/registry/export/backup_kinds.txt
+++ b/core/src/test/resources/google/registry/export/backup_kinds.txt
@@ -13,6 +13,7 @@ HistoryEntry
 HostResource
 KmsSecret
 KmsSecretRevision
+LastSqlTransaction
 Modification
 OneTime
 PollMessage

--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -916,3 +916,7 @@ class google.registry.persistence.DomainHistoryVKey {
   java.lang.Long historyRevisionId;
   java.lang.String repoId;
 }
+class google.registry.schema.replay.LastSqlTransaction {
+  @Id long id;
+  long transactionId;
+}


### PR DESCRIPTION
Implement the ReplicateToDatastore cron job that will apply all Cloud SQL
transactions to the datastore.  The last transaction id is stored in a
LastSqlTransaction entity in datastore.

Note that this will not be activate in production until a) the cron
configuration is updated and b) the cloudSql.replicateTransactions flag is set
to true in the nomulus config file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/738)
<!-- Reviewable:end -->
