### PR TITLE
Improve the uniform_rapid_suspension command

### DIFF
--- a/core/src/main/java/google/registry/tools/CreateOrUpdateDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdateDomainCommand.java
@@ -15,20 +15,11 @@
 package google.registry.tools;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static google.registry.util.CollectionUtils.findDuplicates;
 
-import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.Parameter;
-import com.google.auto.value.AutoValue;
-import com.google.common.base.Ascii;
-import com.google.common.base.CharMatcher;
 import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.BaseEncoding;
-import com.google.template.soy.data.SoyListData;
-import com.google.template.soy.data.SoyMapData;
 import google.registry.tools.params.NameserversParameter;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -80,76 +71,14 @@ abstract class CreateOrUpdateDomainCommand extends MutatingEppToolCommand {
   String password;
 
   @Parameter(
-    names = "--ds_records",
-    description =
-        "Comma-separated list of DS records. Each DS record is given as "
-        + "<keyTag> <alg> <digestType> <digest>, in order, as it appears in the Zonefile.",
-    converter = DsRecordConverter.class
-  )
+      names = "--ds_records",
+      description =
+          "Comma-separated list of DS records. Each DS record is given as "
+              + "<keyTag> <alg> <digestType> <digest>, in order, as it appears in the Zonefile.",
+      converter = DsRecord.Converter.class)
   List<DsRecord> dsRecords = new ArrayList<>();
 
   Set<String> domains;
-
-  @AutoValue
-  abstract static class DsRecord {
-    private static final Splitter SPLITTER =
-        Splitter.on(CharMatcher.whitespace()).omitEmptyStrings();
-
-    public abstract int keyTag();
-    public abstract int alg();
-    public abstract int digestType();
-    public abstract String digest();
-
-    private static DsRecord create(int keyTag, int alg, int digestType, String digest) {
-      digest = Ascii.toUpperCase(digest);
-      checkArgument(
-          BaseEncoding.base16().canDecode(digest),
-          "digest should be even-lengthed hex, but is %s (length %s)",
-          digest,
-          digest.length());
-      return new AutoValue_CreateOrUpdateDomainCommand_DsRecord(keyTag, alg, digestType, digest);
-    }
-
-    /**
-     * Parses a string representation of the DS record.
-     *
-     * <p>The string format accepted is "[keyTag] [alg] [digestType] [digest]" (i.e., the 4
-     * arguments separated by any number of spaces, as it appears in the Zone file)
-     */
-    public static DsRecord parse(String dsRecord) {
-      List<String> elements = SPLITTER.splitToList(dsRecord);
-      checkArgument(
-          elements.size() == 4,
-          "dsRecord %s should have 4 parts, but has %s",
-          dsRecord,
-          elements.size());
-      return DsRecord.create(
-          Integer.parseUnsignedInt(elements.get(0)),
-          Integer.parseUnsignedInt(elements.get(1)),
-          Integer.parseUnsignedInt(elements.get(2)),
-          elements.get(3));
-    }
-
-    public SoyMapData toSoyData() {
-      return new SoyMapData(
-          "keyTag", keyTag(),
-          "alg", alg(),
-          "digestType", digestType(),
-          "digest", digest());
-    }
-
-    public static SoyListData convertToSoy(List<DsRecord> dsRecords) {
-      return new SoyListData(
-          dsRecords.stream().map(DsRecord::toSoyData).collect(toImmutableList()));
-    }
-  }
-
-  public static class DsRecordConverter implements IStringConverter<DsRecord> {
-    @Override
-    public DsRecord convert(String dsRecord) {
-      return DsRecord.parse(dsRecord);
-    }
-  }
 
   @Override
   protected void initEppToolCommand() throws Exception {

--- a/core/src/main/java/google/registry/tools/DsRecord.java
+++ b/core/src/main/java/google/registry/tools/DsRecord.java
@@ -1,0 +1,90 @@
+// Copyright 2017 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.tools;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.beust.jcommander.IStringConverter;
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Ascii;
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
+import com.google.common.io.BaseEncoding;
+import com.google.template.soy.data.SoyListData;
+import com.google.template.soy.data.SoyMapData;
+import java.util.List;
+
+@AutoValue
+abstract class DsRecord {
+  private static final Splitter SPLITTER = Splitter.on(CharMatcher.whitespace()).omitEmptyStrings();
+
+  public abstract int keyTag();
+
+  public abstract int alg();
+
+  public abstract int digestType();
+
+  public abstract String digest();
+
+  private static DsRecord create(int keyTag, int alg, int digestType, String digest) {
+    digest = Ascii.toUpperCase(digest);
+    checkArgument(
+        BaseEncoding.base16().canDecode(digest),
+        "digest should be even-lengthed hex, but is %s (length %s)",
+        digest,
+        digest.length());
+    return new AutoValue_DsRecord(keyTag, alg, digestType, digest);
+  }
+
+  /**
+   * Parses a string representation of the DS record.
+   *
+   * <p>The string format accepted is "[keyTag] [alg] [digestType] [digest]" (i.e., the 4 arguments
+   * separated by any number of spaces, as it appears in the Zone file)
+   */
+  public static DsRecord parse(String dsRecord) {
+    List<String> elements = SPLITTER.splitToList(dsRecord);
+    checkArgument(
+        elements.size() == 4,
+        "dsRecord %s should have 4 parts, but has %s",
+        dsRecord,
+        elements.size());
+    return DsRecord.create(
+        Integer.parseUnsignedInt(elements.get(0)),
+        Integer.parseUnsignedInt(elements.get(1)),
+        Integer.parseUnsignedInt(elements.get(2)),
+        elements.get(3));
+  }
+
+  public SoyMapData toSoyData() {
+    return new SoyMapData(
+        "keyTag", keyTag(),
+        "alg", alg(),
+        "digestType", digestType(),
+        "digest", digest());
+  }
+
+  public static SoyListData convertToSoy(List<DsRecord> dsRecords) {
+    return new SoyListData(dsRecords.stream().map(DsRecord::toSoyData).collect(toImmutableList()));
+  }
+
+  public static class Converter implements IStringConverter<DsRecord> {
+    @Override
+    public DsRecord convert(String dsRecord) {
+      return DsRecord.parse(dsRecord);
+    }
+  }
+}

--- a/core/src/main/java/google/registry/tools/UpdateDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdateDomainCommand.java
@@ -76,10 +76,10 @@ final class UpdateDomainCommand extends CreateOrUpdateDomainCommand {
   private List<String> addStatuses = new ArrayList<>();
 
   @Parameter(
-    names = "--add_ds_records",
-    description = "DS records to add. Cannot be set if --ds_records or --clear_ds_records is set.",
-    converter = DsRecordConverter.class
-  )
+      names = "--add_ds_records",
+      description =
+          "DS records to add. Cannot be set if --ds_records or --clear_ds_records is set.",
+      converter = DsRecord.Converter.class)
   private List<DsRecord> addDsRecords = new ArrayList<>();
 
   @Parameter(
@@ -110,11 +110,10 @@ final class UpdateDomainCommand extends CreateOrUpdateDomainCommand {
   private List<String> removeStatuses = new ArrayList<>();
 
   @Parameter(
-    names = "--remove_ds_records",
-    description =
-        "DS records to remove. Cannot be set if --ds_records or --clear_ds_records is set.",
-    converter = DsRecordConverter.class
-  )
+      names = "--remove_ds_records",
+      description =
+          "DS records to remove. Cannot be set if --ds_records or --clear_ds_records is set.",
+      converter = DsRecord.Converter.class)
   private List<DsRecord> removeDsRecords = new ArrayList<>();
 
   @Parameter(

--- a/core/src/main/resources/google/registry/tools/soy/UniformRapidSuspension.soy
+++ b/core/src/main/resources/google/registry/tools/soy/UniformRapidSuspension.soy
@@ -21,8 +21,8 @@
 {@param domainName: string}
 {@param hostsToAdd: list<string>}
 {@param hostsToRemove: list<string>}
-{@param locksToApply: list<string>}
-{@param locksToRemove: list<string>}
+{@param statusesToApply: list<string>}
+{@param statusesToRemove: list<string>}
 {@param newDsData: list<[keyTag:int, alg:int, digestType:int, digest:string]>}
 {@param reason: string}
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -39,7 +39,7 @@
           {/for}
           </domain:ns>
         {/if}
-        {for $la in $locksToApply}
+        {for $la in $statusesToApply}
           <domain:status s="{$la}" />
         {/for}
         </domain:add>
@@ -51,7 +51,7 @@
           {/for}
           </domain:ns>
         {/if}
-        {for $lr in $locksToRemove}
+        {for $lr in $statusesToRemove}
           <domain:status s="{$lr}" />
         {/for}
         </domain:rem>

--- a/core/src/test/resources/google/registry/tools/server/uniform_rapid_suspension_undo_client_hold.xml
+++ b/core/src/test/resources/google/registry/tools/server/uniform_rapid_suspension_undo_client_hold.xml
@@ -6,18 +6,19 @@
         <domain:name>evil.tld</domain:name>
         <domain:add>
           <domain:ns>
+            <domain:hostObj>ns1.example.com</domain:hostObj>
+            <domain:hostObj>ns2.example.com</domain:hostObj>
+          </domain:ns>
+          <domain:status s="clientHold" />
+        </domain:add>
+        <domain:rem>
+          <domain:ns>
             <domain:hostObj>urs1.example.com</domain:hostObj>
             <domain:hostObj>urs2.example.com</domain:hostObj>
           </domain:ns>
           <domain:status s="serverDeleteProhibited" />
           <domain:status s="serverTransferProhibited" />
           <domain:status s="serverUpdateProhibited" />
-        </domain:add>
-        <domain:rem>
-          <domain:ns>
-            <domain:hostObj>ns2.example.com</domain:hostObj>
-            <domain:hostObj>ns1.example.com</domain:hostObj>
-          </domain:ns>
         </domain:rem>
       </domain:update>
     </update>
@@ -26,17 +27,9 @@
         <secDNS:rem>
           <secDNS:all>true</secDNS:all>
         </secDNS:rem>
-        <secDNS:add>
-          <secDNS:dsData>
-            <secDNS:keyTag>1</secDNS:keyTag>
-            <secDNS:alg>1</secDNS:alg>
-            <secDNS:digestType>1</secDNS:digestType>
-            <secDNS:digest>ABCD</secDNS:digest>
-          </secDNS:dsData>
-        </secDNS:add>
       </secDNS:update>
       <metadata:metadata xmlns:metadata="urn:google:params:xml:ns:metadata-1.0">
-        <metadata:reason>Uniform Rapid Suspension</metadata:reason>
+        <metadata:reason>Undo Uniform Rapid Suspension</metadata:reason>
         <metadata:requestedByRegistrar>false</metadata:requestedByRegistrar>
       </metadata:metadata>
     </extension>

--- a/core/src/test/resources/google/registry/tools/server/uniform_rapid_suspension_with_client_hold.xml
+++ b/core/src/test/resources/google/registry/tools/server/uniform_rapid_suspension_with_client_hold.xml
@@ -9,15 +9,16 @@
             <domain:hostObj>urs1.example.com</domain:hostObj>
             <domain:hostObj>urs2.example.com</domain:hostObj>
           </domain:ns>
-          <domain:status s="serverDeleteProhibited" />
-          <domain:status s="serverTransferProhibited" />
-          <domain:status s="serverUpdateProhibited" />
+          <domain:status s="serverDeleteProhibited"/>
+          <domain:status s="serverTransferProhibited"/>
+          <domain:status s="serverUpdateProhibited"/>
         </domain:add>
         <domain:rem>
           <domain:ns>
             <domain:hostObj>ns2.example.com</domain:hostObj>
             <domain:hostObj>ns1.example.com</domain:hostObj>
           </domain:ns>
+          <domain:status s="clientHold"/>
         </domain:rem>
       </domain:update>
     </update>


### PR DESCRIPTION
- Reuse DS record format processing from the create/update domain commands
  (BIND format, commonly used in URS requests)
- Remove the CLIENT_HOLD status from domains that have it (this blocks us from
  serving the new nameservers and DS record)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/739)
<!-- Reviewable:end -->
