### PR TITLE
Use nodesource to install node

### DIFF
--- a/release/builder/build.sh
+++ b/release/builder/build.sh
@@ -21,15 +21,11 @@ apt-get install apt-utils gnupg -y
 apt-get upgrade -y
 # Install Java
 apt-get install openjdk-11-jdk-headless -y
-# Install nvm
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
-# Install node
-nvm install node
-# Install npm
-nvm install-latest-npm
+# Install Python
+apt-get install python -y
+# Install Node
+curl -sL https://deb.nodesource.com/setup_current.x | bash -
+apt-get install -y nodejs
 # Install gcloud
 # Cribbed from https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu
 apt-get install lsb-release -y


### PR DESCRIPTION
The node installed by nvm gives errors when running "npm install".

Also installs Python as it is need. Presumbly the system provided npm
version has python as a dependency so it was installed when npm was
installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/742)
<!-- Reviewable:end -->
