### PR TITLE
Allow allocation token discounts on premiums and for multiple years

### DIFF
--- a/core/src/main/java/google/registry/model/BackupGroupRoot.java
+++ b/core/src/main/java/google/registry/model/BackupGroupRoot.java
@@ -30,6 +30,7 @@ import javax.xml.bind.annotation.XmlTransient;
  */
 @MappedSuperclass
 public abstract class BackupGroupRoot extends ImmutableObject {
+
   /**
    * An automatically managed timestamp of when this object was last written to Datastore.
    *
@@ -40,11 +41,21 @@ public abstract class BackupGroupRoot extends ImmutableObject {
   // Prevents subclasses from unexpectedly accessing as property (e.g., HostResource), which would
   // require an unnecessary non-private setter method.
   @Access(AccessType.FIELD)
-  @VisibleForTesting
   UpdateAutoTimestamp updateTimestamp = UpdateAutoTimestamp.create(null);
 
   /** Get the {@link UpdateAutoTimestamp} for this entity. */
   public UpdateAutoTimestamp getUpdateTimestamp() {
     return updateTimestamp;
+  }
+
+  /**
+   * Reset the given entity's update timestamp FOR TEST USE ONLY.
+   *
+   * <p>Don't you care call this in production code as it violates the {@link ImmutableObject}
+   * contract.
+   */
+  @VisibleForTesting
+  public static void resetUpdateTimestampForTest(BackupGroupRoot entity) {
+    entity.updateTimestamp = UpdateAutoTimestamp.create(null);
   }
 }

--- a/core/src/main/java/google/registry/model/BackupGroupRoot.java
+++ b/core/src/main/java/google/registry/model/BackupGroupRoot.java
@@ -14,7 +14,6 @@
 
 package google.registry.model;
 
-import com.google.common.annotations.VisibleForTesting;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
 import javax.persistence.MappedSuperclass;
@@ -46,16 +45,5 @@ public abstract class BackupGroupRoot extends ImmutableObject {
   /** Get the {@link UpdateAutoTimestamp} for this entity. */
   public UpdateAutoTimestamp getUpdateTimestamp() {
     return updateTimestamp;
-  }
-
-  /**
-   * Reset the given entity's update timestamp FOR TEST USE ONLY.
-   *
-   * <p>Don't you care call this in production code as it violates the {@link ImmutableObject}
-   * contract.
-   */
-  @VisibleForTesting
-  public static void resetUpdateTimestampForTest(BackupGroupRoot entity) {
-    entity.updateTimestamp = UpdateAutoTimestamp.create(null);
   }
 }

--- a/core/src/main/java/google/registry/model/domain/DomainContent.java
+++ b/core/src/main/java/google/registry/model/domain/DomainContent.java
@@ -534,8 +534,10 @@ public class DomainContent extends EppResource
 
   /** Loads and returns the fully qualified host names of all linked nameservers. */
   public ImmutableSortedSet<String> loadNameserverHostNames() {
-    return ofy().load()
-        .keys(getNameservers().stream().map(VKey::getOfyKey).collect(toImmutableSet())).values()
+    return ofy()
+        .load()
+        .keys(getNameservers().stream().map(VKey::getOfyKey).collect(toImmutableSet()))
+        .values()
         .stream()
         .map(HostResource::getHostName)
         .collect(toImmutableSortedSet(Ordering.natural()));

--- a/core/src/main/java/google/registry/model/domain/DomainHistory.java
+++ b/core/src/main/java/google/registry/model/domain/DomainHistory.java
@@ -38,10 +38,10 @@ import javax.persistence.JoinTable;
 @Entity
 @javax.persistence.Table(
     indexes = {
-        @javax.persistence.Index(columnList = "creationTime"),
-        @javax.persistence.Index(columnList = "historyRegistrarId"),
-        @javax.persistence.Index(columnList = "historyType"),
-        @javax.persistence.Index(columnList = "historyModificationTime")
+      @javax.persistence.Index(columnList = "creationTime"),
+      @javax.persistence.Index(columnList = "historyRegistrarId"),
+      @javax.persistence.Index(columnList = "historyType"),
+      @javax.persistence.Index(columnList = "historyModificationTime")
     })
 public class DomainHistory extends HistoryEntry {
   // Store DomainContent instead of DomainBase so we don't pick up its @Id

--- a/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
+++ b/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
@@ -29,12 +29,14 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.Range;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.annotation.Embed;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
 import com.googlecode.objectify.annotation.Mapify;
+import com.googlecode.objectify.annotation.OnLoad;
 import google.registry.flows.EppException;
 import google.registry.flows.domain.DomainFlowUtils;
 import google.registry.model.BackupGroupRoot;
@@ -108,9 +110,22 @@ public class AllocationToken extends BackupGroupRoot implements Buildable {
    */
   double discountFraction;
 
+  /** Whether the discount fraction (if any) also applies to premium names. Defaults to false. */
+  boolean discountPremiums;
+
+  /** Up to how many years of initial creation receive the discount (if any). Defaults to 1. */
+  int discountYears = 1;
+
   /** The type of the token, either single-use or unlimited-use. */
-  // TODO(b/130301183): this should not be nullable, we can remove this once we're sure it isn't
-  @Nullable TokenType tokenType;
+  TokenType tokenType;
+
+  // TODO: Remove onLoad once all allocation tokens are migrated to have a discountYears of 1.
+  @OnLoad
+  void onLoad() {
+    if (discountYears == 0) {
+      discountYears = 1;
+    }
+  }
 
   /**
    * Promotional token validity periods.
@@ -146,8 +161,8 @@ public class AllocationToken extends BackupGroupRoot implements Buildable {
     return token;
   }
 
-  public Key<HistoryEntry> getRedemptionHistoryEntry() {
-    return redemptionHistoryEntry;
+  public Optional<Key<HistoryEntry>> getRedemptionHistoryEntry() {
+    return Optional.ofNullable(redemptionHistoryEntry);
   }
 
   public boolean isRedeemed() {
@@ -174,6 +189,16 @@ public class AllocationToken extends BackupGroupRoot implements Buildable {
     return discountFraction;
   }
 
+  public boolean shouldDiscountPremiums() {
+    return discountPremiums;
+  }
+
+  public int getDiscountYears() {
+    // Allocation tokens created prior to the addition of the discountYears field will have a value
+    // of 0 for it, but it should be the default value of 1 to retain the previous behavior.
+    return Math.max(1, discountYears);
+  }
+
   public TokenType getTokenType() {
     return tokenType;
   }
@@ -193,6 +218,7 @@ public class AllocationToken extends BackupGroupRoot implements Buildable {
 
   /** A builder for constructing {@link AllocationToken} objects, since they are immutable. */
   public static class Builder extends Buildable.Builder<AllocationToken> {
+
     public Builder() {}
 
     private Builder(AllocationToken instance) {
@@ -210,6 +236,12 @@ public class AllocationToken extends BackupGroupRoot implements Buildable {
           getInstance().redemptionHistoryEntry == null
               || TokenType.SINGLE_USE.equals(getInstance().tokenType),
           "Redemption history entry can only be specified for SINGLE_USE tokens");
+      checkArgument(
+          getInstance().discountFraction > 0 || !getInstance().discountPremiums,
+          "Discount premiums can only be specified along with a discount fraction");
+      checkArgument(
+          getInstance().discountFraction > 0 || getInstance().discountYears == 1,
+          "Discount years can only be specified along with a discount fraction");
       if (getInstance().domainName != null) {
         try {
           DomainFlowUtils.validateDomainName(getInstance().domainName);
@@ -247,6 +279,13 @@ public class AllocationToken extends BackupGroupRoot implements Buildable {
       return this;
     }
 
+    @VisibleForTesting
+    public Builder clearTimestampsForTest() {
+      getInstance().creationTime = CreateAutoTimestamp.create(null);
+      resetUpdateTimestampForTest(getInstance());
+      return this;
+    }
+
     public Builder setAllowedClientIds(Set<String> allowedClientIds) {
       getInstance().allowedClientIds = forceEmptyToNull(allowedClientIds);
       return this;
@@ -258,7 +297,23 @@ public class AllocationToken extends BackupGroupRoot implements Buildable {
     }
 
     public Builder setDiscountFraction(double discountFraction) {
+      checkArgument(
+          Range.closed(0.0d, 1.0d).contains(discountFraction),
+          "Discount fraction must be between 0 and 1 inclusive");
       getInstance().discountFraction = discountFraction;
+      return this;
+    }
+
+    public Builder setDiscountPremiums(boolean discountPremiums) {
+      getInstance().discountPremiums = discountPremiums;
+      return this;
+    }
+
+    public Builder setDiscountYears(int discountYears) {
+      checkArgument(
+          Range.closed(1, 10).contains(discountYears),
+          "Discount years must be between 1 and 10 inclusive");
+      getInstance().discountYears = discountYears;
       return this;
     }
 

--- a/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
+++ b/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
@@ -279,13 +279,6 @@ public class AllocationToken extends BackupGroupRoot implements Buildable {
       return this;
     }
 
-    @VisibleForTesting
-    public Builder clearTimestampsForTest() {
-      getInstance().creationTime = CreateAutoTimestamp.create(null);
-      resetUpdateTimestampForTest(getInstance());
-      return this;
-    }
-
     public Builder setAllowedClientIds(Set<String> allowedClientIds) {
       getInstance().allowedClientIds = forceEmptyToNull(allowedClientIds);
       return this;

--- a/core/src/main/java/google/registry/tools/GenerateAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateAllocationTokensCommand.java
@@ -115,7 +115,20 @@ class GenerateAllocationTokensCommand implements CommandWithRemoteApi {
       description =
           "A discount off the base price for the first year between 0.0 and 1.0. Default is 0.0,"
               + " i.e. no discount.")
-  private double discountFraction;
+  private Double discountFraction;
+
+  @Parameter(
+      names = {"--discount_premiums"},
+      description =
+          "Whether the discount is valid for premium names in addition to standard ones. Default"
+              + " is false.",
+      arity = 1)
+  private Boolean discountPremiums;
+
+  @Parameter(
+      names = {"--discount_years"},
+      description = "The number of years the discount applies for. Default is 1, max value is 10.")
+  private Integer discountYears;
 
   @Parameter(
       names = "--token_status_transitions",
@@ -170,8 +183,10 @@ class GenerateAllocationTokensCommand implements CommandWithRemoteApi {
                             .setToken(t)
                             .setTokenType(tokenType == null ? SINGLE_USE : tokenType)
                             .setAllowedClientIds(ImmutableSet.copyOf(nullToEmpty(allowedClientIds)))
-                            .setAllowedTlds(ImmutableSet.copyOf(nullToEmpty(allowedTlds)))
-                            .setDiscountFraction(discountFraction);
+                            .setAllowedTlds(ImmutableSet.copyOf(nullToEmpty(allowedTlds)));
+                    Optional.ofNullable(discountFraction).ifPresent(token::setDiscountFraction);
+                    Optional.ofNullable(discountPremiums).ifPresent(token::setDiscountPremiums);
+                    Optional.ofNullable(discountYears).ifPresent(token::setDiscountYears);
                     Optional.ofNullable(tokenStatusTransitions)
                         .ifPresent(token::setTokenStatusTransitions);
                     Optional.ofNullable(domainNames)

--- a/core/src/main/java/google/registry/tools/UpdateAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdateAllocationTokensCommand.java
@@ -67,6 +67,19 @@ final class UpdateAllocationTokensCommand extends UpdateOrDeleteAllocationTokens
   private Double discountFraction;
 
   @Parameter(
+      names = {"--discount_premiums"},
+      description =
+          "Whether the discount is valid for premium names in addition to standard ones. Default"
+              + " is false.",
+      arity = 1)
+  private Boolean discountPremiums;
+
+  @Parameter(
+      names = {"--discount_years"},
+      description = "The number of years the discount applies for. Default is 1, max value is 10.")
+  private Integer discountYears;
+
+  @Parameter(
       names = "--token_status_transitions",
       converter = TokenStatusTransitions.class,
       validateWith = TokenStatusTransitions.class,
@@ -122,6 +135,8 @@ final class UpdateAllocationTokensCommand extends UpdateOrDeleteAllocationTokens
     Optional.ofNullable(allowedTlds)
         .ifPresent(tlds -> builder.setAllowedTlds(ImmutableSet.copyOf(tlds)));
     Optional.ofNullable(discountFraction).ifPresent(builder::setDiscountFraction);
+    Optional.ofNullable(discountPremiums).ifPresent(builder::setDiscountPremiums);
+    Optional.ofNullable(discountYears).ifPresent(builder::setDiscountYears);
     Optional.ofNullable(tokenStatusTransitions).ifPresent(builder::setTokenStatusTransitions);
     return builder.build();
   }

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -150,7 +150,6 @@ import google.registry.model.domain.rgp.GracePeriodStatus;
 import google.registry.model.domain.secdns.DelegationSignerData;
 import google.registry.model.domain.token.AllocationToken;
 import google.registry.model.domain.token.AllocationToken.TokenStatus;
-import google.registry.model.domain.token.AllocationToken.TokenType;
 import google.registry.model.poll.PendingActionNotificationResponse.DomainPendingActionNotificationResponse;
 import google.registry.model.poll.PollMessage;
 import google.registry.model.registrar.Registrar;
@@ -435,7 +434,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Test
   void testFailure_invalidAllocationToken() {
-    setEppInput("domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "example.tld"));
+    setEppInput(
+        "domain_create_allocationtoken.xml",
+        ImmutableMap.of("DOMAIN", "example.tld", "YEARS", "2"));
     persistContactsAndHosts();
     EppException thrown = assertThrows(InvalidAllocationTokenException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
@@ -445,7 +446,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   void testFailure_reservedDomainCreate_allocationTokenIsForADifferentDomain() {
     // Try to register a reserved domain name with an allocation token valid for a different domain
     // name.
-    setEppInput("domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "resdom.tld"));
+    setEppInput(
+        "domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "resdom.tld", "YEARS", "2"));
     persistContactsAndHosts();
     persistResource(
         new AllocationToken.Builder()
@@ -464,7 +466,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   void testFailure_nonreservedDomainCreate_allocationTokenIsForADifferentDomain() {
     // Try to register a non-reserved domain name with an allocation token valid for a different
     // domain name.
-    setEppInput("domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "example.tld"));
+    setEppInput(
+        "domain_create_allocationtoken.xml",
+        ImmutableMap.of("DOMAIN", "example.tld", "YEARS", "2"));
     persistContactsAndHosts();
     persistResource(
         new AllocationToken.Builder()
@@ -481,7 +485,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Test
   void testFailure_alreadyRedemeedAllocationToken() {
-    setEppInput("domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "example.tld"));
+    setEppInput(
+        "domain_create_allocationtoken.xml",
+        ImmutableMap.of("DOMAIN", "example.tld", "YEARS", "2"));
     persistContactsAndHosts();
     persistResource(
         new AllocationToken.Builder()
@@ -497,7 +503,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Test
   void testSuccess_validAllocationToken_isRedeemed() throws Exception {
-    setEppInput("domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "example.tld"));
+    setEppInput(
+        "domain_create_allocationtoken.xml",
+        ImmutableMap.of("DOMAIN", "example.tld", "YEARS", "2"));
     persistContactsAndHosts();
     AllocationToken token =
         persistResource(
@@ -508,12 +516,14 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     HistoryEntry historyEntry =
         ofy().load().type(HistoryEntry.class).ancestor(reloadResourceByForeignKey()).first().now();
     assertThat(ofy().load().entity(token).now().getRedemptionHistoryEntry())
-        .isEqualTo(Key.create(historyEntry));
+        .hasValue(Key.create(historyEntry));
   }
 
   @Test
   void testSuccess_validAllocationToken_multiUse() throws Exception {
-    setEppInput("domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "example.tld"));
+    setEppInput(
+        "domain_create_allocationtoken.xml",
+        ImmutableMap.of("DOMAIN", "example.tld", "YEARS", "2"));
     persistContactsAndHosts();
     allocationToken =
         persistResource(
@@ -531,7 +541,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     runFlow();
     assertSuccessfulCreate("tld", ImmutableSet.of(), allocationToken);
     clock.advanceOneMilli();
-    setEppInput("domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "otherexample.tld"));
+    setEppInput(
+        "domain_create_allocationtoken.xml",
+        ImmutableMap.of("DOMAIN", "otherexample.tld", "YEARS", "2"));
     runFlowAssertResponse(
         loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "otherexample.tld")));
   }
@@ -543,8 +555,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistContactsAndHosts("foo.tld");
     assertTransactionalFlow(true);
     String expectedResponseXml =
-        loadFile(
-            "domain_create_response.xml", ImmutableMap.of("DOMAIN", "example.foo.tld"));
+        loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "example.foo.tld"));
     runFlowAssertResponse(CommitMode.LIVE, UserPrivileges.NORMAL, expectedResponseXml);
     assertSuccessfulCreate("foo.tld", ImmutableSet.of());
     assertNoLordn();
@@ -576,8 +587,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         "domain_create_registration_encoded_signed_mark.xml",
         ImmutableMap.of("DOMAIN", "test-validate.tld", "PHASE", "open"));
     persistContactsAndHosts();
-    EppException thrown =
-        assertThrows(SignedMarksOnlyDuringSunriseException.class, this::runFlow);
+    EppException thrown = assertThrows(SignedMarksOnlyDuringSunriseException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
@@ -1185,11 +1195,15 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .asBuilder()
             .setTldStateTransitions(
                 ImmutableSortedMap.of(
-                    START_OF_TIME, PREDELEGATION,
-                    DateTime.parse("1999-01-01T00:00:00Z"), QUIET_PERIOD,
+                    START_OF_TIME,
+                    PREDELEGATION,
+                    DateTime.parse("1999-01-01T00:00:00Z"),
+                    QUIET_PERIOD,
                     // The anchor tenant is created here, on 1999-04-03
-                    DateTime.parse("1999-07-01T00:00:00Z"), START_DATE_SUNRISE,
-                    DateTime.parse("2000-01-01T00:00:00Z"), GENERAL_AVAILABILITY))
+                    DateTime.parse("1999-07-01T00:00:00Z"),
+                    START_DATE_SUNRISE,
+                    DateTime.parse("2000-01-01T00:00:00Z"),
+                    GENERAL_AVAILABILITY))
             .build());
     setEppInput("domain_create_anchor_allocationtoken.xml");
     persistContactsAndHosts();
@@ -1210,7 +1224,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 .build());
     // Despite the domain being FULLY_BLOCKED, the non-superuser create succeeds the domain is also
     // RESERVED_FOR_SPECIFIC_USE and the correct allocation token is passed.
-    setEppInput("domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "resdom.tld"));
+    setEppInput(
+        "domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "resdom.tld", "YEARS", "2"));
     persistContactsAndHosts();
     runFlowAssertResponse(
         loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "resdom.tld")));
@@ -1233,7 +1248,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 .setTokenType(SINGLE_USE)
                 .setDomainName("resdom.tld")
                 .build());
-    setEppInput("domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "resdom.tld"));
+    setEppInput(
+        "domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "resdom.tld", "YEARS", "2"));
     persistContactsAndHosts();
     runFlowAssertResponse(
         loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "resdom.tld")));
@@ -1247,7 +1263,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         ofy().load().key(Key.create(AllocationToken.class, token)).now();
     assertThat(reloadedToken.isRedeemed()).isTrue();
     assertThat(reloadedToken.getRedemptionHistoryEntry())
-        .isEqualTo(Key.create(getHistoryEntries(reloadResourceByForeignKey()).get(0)));
+        .hasValue(Key.create(getHistoryEntries(reloadResourceByForeignKey()).get(0)));
   }
 
   private void assertAllocationTokenWasNotRedeemed(String token) {
@@ -1264,7 +1280,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         new AllocationToken.Builder()
             .setToken("abc123")
-            .setTokenType(TokenType.UNLIMITED_USE)
+            .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
                 ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
@@ -1274,13 +1290,134 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                     .build())
             .build());
     clock.advanceOneMilli();
-    setEppInput("domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "example.tld"));
+    setEppInput(
+        "domain_create_allocationtoken.xml",
+        ImmutableMap.of("DOMAIN", "example.tld", "YEARS", "2"));
     runFlowAssertResponse(
         loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "example.tld")));
     BillingEvent.OneTime billingEvent =
         Iterables.getOnlyElement(ofy().load().type(BillingEvent.OneTime.class));
     assertThat(billingEvent.getTargetId()).isEqualTo("example.tld");
     assertThat(billingEvent.getCost()).isEqualTo(Money.of(USD, BigDecimal.valueOf(19.5)));
+  }
+
+  @Test
+  void testSuccess_allocationToken_multiYearDiscount_maxesAtTokenDiscountYears() throws Exception {
+    // 2yrs @ $13 + 3yrs @ $13 * (1 - 0.73) = $36.53
+    runTest_allocationToken_multiYearDiscount(false, 0.73, 3, Money.of(USD, 36.53));
+  }
+
+  @Test
+  void testSuccess_allocationToken_multiYearDiscount_maxesAtNumRegistrationYears()
+      throws Exception {
+    // 5yrs @ $13 * (1 - 0.276) = $47.06
+    runTest_allocationToken_multiYearDiscount(false, 0.276, 10, Money.of(USD, 47.06));
+  }
+
+  void runTest_allocationToken_multiYearDiscount(
+      boolean discountPremiums, double discountFraction, int discountYears, Money expectedPrice)
+      throws Exception {
+    persistContactsAndHosts();
+    persistResource(
+        new AllocationToken.Builder()
+            .setToken("abc123")
+            .setTokenType(SINGLE_USE)
+            .setDomainName("example.tld")
+            .setDiscountFraction(discountFraction)
+            .setDiscountYears(discountYears)
+            .setDiscountPremiums(discountPremiums)
+            .setTokenStatusTransitions(
+                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
+                    .put(clock.nowUtc().plusMillis(1), TokenStatus.VALID)
+                    .put(clock.nowUtc().plusSeconds(1), TokenStatus.ENDED)
+                    .build())
+            .build());
+    clock.advanceOneMilli();
+    setEppInput(
+        "domain_create_allocationtoken.xml",
+        ImmutableMap.of("DOMAIN", "example.tld", "YEARS", "5"));
+    runFlowAssertResponse(
+        loadFile(
+            "domain_create_response_wildcard.xml",
+            ImmutableMap.of(
+                "DOMAIN",
+                "example.tld",
+                "CRDATE",
+                "1999-04-03T22:00:00.0Z",
+                "EXDATE",
+                "2004-04-03T22:00:00.0Z")));
+    BillingEvent.OneTime billingEvent =
+        Iterables.getOnlyElement(ofy().load().type(BillingEvent.OneTime.class));
+    assertThat(billingEvent.getTargetId()).isEqualTo("example.tld");
+    assertThat(billingEvent.getCost()).isEqualTo(expectedPrice);
+  }
+
+  @Test
+  void testSuccess_allocationToken_multiYearDiscount_worksForPremiums() throws Exception {
+    createTld("example");
+    persistContactsAndHosts();
+    persistResource(
+        new AllocationToken.Builder()
+            .setToken("abc123")
+            .setTokenType(SINGLE_USE)
+            .setDomainName("rich.example")
+            .setDiscountFraction(0.98)
+            .setDiscountYears(2)
+            .setDiscountPremiums(true)
+            .setTokenStatusTransitions(
+                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
+                    .put(clock.nowUtc().plusMillis(1), TokenStatus.VALID)
+                    .put(clock.nowUtc().plusSeconds(1), TokenStatus.ENDED)
+                    .build())
+            .build());
+    clock.advanceOneMilli();
+    setEppInput(
+        "domain_create_premium_allocationtoken.xml",
+        ImmutableMap.of("YEARS", "3", "FEE", "104.00"));
+    runFlowAssertResponse(
+        loadFile(
+            "domain_create_response_premium.xml",
+            ImmutableMap.of("EXDATE", "2002-04-03T22:00:00.0Z", "FEE", "104.00")));
+    BillingEvent.OneTime billingEvent =
+        Iterables.getOnlyElement(ofy().load().type(BillingEvent.OneTime.class));
+    assertThat(billingEvent.getTargetId()).isEqualTo("rich.example");
+    // 1yr @ $100 + 2yrs @ $100 * (1 - 0.98) = $104
+    assertThat(billingEvent.getCost()).isEqualTo(Money.of(USD, 104.00));
+  }
+
+  @Test
+  void testSuccess_allocationToken_singleYearDiscount_worksForPremiums() throws Exception {
+    createTld("example");
+    persistContactsAndHosts();
+    persistResource(
+        new AllocationToken.Builder()
+            .setToken("abc123")
+            .setTokenType(SINGLE_USE)
+            .setDomainName("rich.example")
+            .setDiscountFraction(0.95555)
+            .setDiscountPremiums(true)
+            .setTokenStatusTransitions(
+                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
+                    .put(clock.nowUtc().plusMillis(1), TokenStatus.VALID)
+                    .put(clock.nowUtc().plusSeconds(1), TokenStatus.ENDED)
+                    .build())
+            .build());
+    clock.advanceOneMilli();
+    setEppInput(
+        "domain_create_premium_allocationtoken.xml",
+        ImmutableMap.of("YEARS", "3", "FEE", "204.44"));
+    runFlowAssertResponse(
+        loadFile(
+            "domain_create_response_premium.xml",
+            ImmutableMap.of("EXDATE", "2002-04-03T22:00:00.0Z", "FEE", "204.44")));
+    BillingEvent.OneTime billingEvent =
+        Iterables.getOnlyElement(ofy().load().type(BillingEvent.OneTime.class));
+    assertThat(billingEvent.getTargetId()).isEqualTo("rich.example");
+    // 2yrs @ $100 + 1yr @ $100 * (1 - 0.95555) = $204.44
+    assertThat(billingEvent.getCost()).isEqualTo(Money.of(USD, 204.44));
   }
 
   @Test
@@ -1291,7 +1428,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         new AllocationToken.Builder()
             .setToken("abc123")
-            .setTokenType(TokenType.UNLIMITED_USE)
+            .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
                 ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
@@ -1301,7 +1438,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                     .build())
             .build());
     clock.advanceOneMilli();
-    setEppInput("domain_create_premium_allocationtoken.xml");
+    setEppInput(
+        "domain_create_premium_allocationtoken.xml",
+        ImmutableMap.of("YEARS", "2", "FEE", "193.50"));
     assertAboutEppExceptions()
         .that(assertThrows(AllocationTokenInvalidForPremiumNameException.class, this::runFlow))
         .marshalsToXml();
@@ -1313,7 +1452,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         new AllocationToken.Builder()
             .setToken("abc123")
-            .setTokenType(TokenType.UNLIMITED_USE)
+            .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
                 ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
@@ -1322,7 +1461,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                     .put(clock.nowUtc().plusDays(60), TokenStatus.ENDED)
                     .build())
             .build());
-    setEppInput("domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "example.tld"));
+    setEppInput(
+        "domain_create_allocationtoken.xml",
+        ImmutableMap.of("DOMAIN", "example.tld", "YEARS", "2"));
     assertAboutEppExceptions()
         .that(assertThrows(AllocationTokenNotInPromotionException.class, this::runFlow))
         .marshalsToXml();
@@ -1334,7 +1475,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         new AllocationToken.Builder()
             .setToken("abc123")
-            .setTokenType(TokenType.UNLIMITED_USE)
+            .setTokenType(UNLIMITED_USE)
             .setAllowedTlds(ImmutableSet.of("example"))
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
@@ -1344,7 +1485,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                     .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
-    setEppInput("domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "example.tld"));
+    setEppInput(
+        "domain_create_allocationtoken.xml",
+        ImmutableMap.of("DOMAIN", "example.tld", "YEARS", "2"));
     assertAboutEppExceptions()
         .that(assertThrows(AllocationTokenNotValidForTldException.class, this::runFlow))
         .marshalsToXml();
@@ -1356,7 +1499,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         new AllocationToken.Builder()
             .setToken("abc123")
-            .setTokenType(TokenType.UNLIMITED_USE)
+            .setTokenType(UNLIMITED_USE)
             .setAllowedClientIds(ImmutableSet.of("someClientId"))
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
@@ -1366,7 +1509,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                     .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
-    setEppInput("domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "example.tld"));
+    setEppInput(
+        "domain_create_allocationtoken.xml",
+        ImmutableMap.of("DOMAIN", "example.tld", "YEARS", "2"));
     assertAboutEppExceptions()
         .that(assertThrows(AllocationTokenNotValidForRegistrarException.class, this::runFlow))
         .marshalsToXml();
@@ -1562,7 +1707,11 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     // Modify the Registrar to block premium names.
     persistResource(loadRegistrar("TheRegistrar").asBuilder().setBlockPremiumNames(true).build());
     runFlowAssertResponse(
-        CommitMode.LIVE, SUPERUSER, loadFile("domain_create_response_premium.xml"));
+        CommitMode.LIVE,
+        SUPERUSER,
+        loadFile(
+            "domain_create_response_premium.xml",
+            ImmutableMap.of("EXDATE", "2001-04-03T22:00:00.0Z", "FEE", "200.00")));
     assertSuccessfulCreate("example", ImmutableSet.of());
   }
 

--- a/core/src/test/java/google/registry/model/history/ContactHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/ContactHistoryTest.java
@@ -69,9 +69,11 @@ public class ContactHistoryTest extends EntityTestCase {
   }
 
   static void assertContactHistoriesEqual(ContactHistory one, ContactHistory two) {
-    assertAboutImmutableObjects().that(one)
+    assertAboutImmutableObjects()
+        .that(one)
         .isEqualExceptFields(two, "contactBase", "contactRepoId", "parent");
-    assertAboutImmutableObjects().that(one.getContactBase())
+    assertAboutImmutableObjects()
+        .that(one.getContactBase())
         .isEqualExceptFields(two.getContactBase(), "repoId");
   }
 }

--- a/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
@@ -83,7 +83,8 @@ public class DomainHistoryTest extends EntityTestCase {
   }
 
   static void assertDomainHistoriesEqual(DomainHistory one, DomainHistory two) {
-    assertAboutImmutableObjects().that(one)
+    assertAboutImmutableObjects()
+        .that(one)
         .isEqualExceptFields(two, "domainContent", "domainRepoId", "parent");
   }
 }

--- a/core/src/test/java/google/registry/testing/DatastoreHelper.java
+++ b/core/src/test/java/google/registry/testing/DatastoreHelper.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Suppliers.memoize;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.toArray;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.truth.Truth.assertThat;
@@ -71,6 +72,7 @@ import google.registry.model.domain.DomainAuthInfo;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.domain.GracePeriod;
 import google.registry.model.domain.rgp.GracePeriodStatus;
+import google.registry.model.domain.token.AllocationToken;
 import google.registry.model.eppcommon.AuthInfo.PasswordAuth;
 import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.eppcommon.Trid;
@@ -830,6 +832,22 @@ public class DatastoreHelper {
         .filter(subType::isInstance)
         .map(subType::cast)
         .collect(onlyElement());
+  }
+
+  public static void assertAllocationTokens(AllocationToken... expectedTokens) {
+    ImmutableSet<AllocationToken> actualTokens =
+        ofy().load().type(AllocationToken.class).list().stream()
+            .map(DatastoreHelper::stripAllocationToken)
+            .collect(toImmutableSet());
+    assertThat(actualTokens)
+        .containsExactlyElementsIn(
+            Arrays.stream(expectedTokens)
+                .map(DatastoreHelper::stripAllocationToken)
+                .collect(toImmutableSet()));
+  }
+
+  private static AllocationToken stripAllocationToken(AllocationToken token) {
+    return token.asBuilder().clearTimestampsForTest().build();
   }
 
   /** Returns a newly allocated, globally unique domain repoId of the format HEX-TLD. */

--- a/core/src/test/java/google/registry/tools/UpdateAllocationTokensCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateAllocationTokensCommandTest.java
@@ -78,6 +78,24 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
   }
 
   @Test
+  void testUpdateDiscountPremiums() throws Exception {
+    AllocationToken token =
+        persistResource(
+            builderWithPromo().setDiscountFraction(0.5).setDiscountPremiums(false).build());
+    runCommandForced("--prefix", "token", "--discount_premiums", "true");
+    assertThat(reloadResource(token).shouldDiscountPremiums()).isTrue();
+    runCommandForced("--prefix", "token", "--discount_premiums", "false");
+    assertThat(reloadResource(token).shouldDiscountPremiums()).isFalse();
+  }
+
+  @Test
+  void testUpdateDiscountYears() throws Exception {
+    AllocationToken token = persistResource(builderWithPromo().setDiscountFraction(0.5).build());
+    runCommandForced("--prefix", "token", "--discount_years", "4");
+    assertThat(reloadResource(token).getDiscountYears()).isEqualTo(4);
+  }
+
+  @Test
   void testUpdateStatusTransitions() throws Exception {
     DateTime now = DateTime.now(UTC);
     AllocationToken token = persistResource(builderWithPromo().build());

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_promotion.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_promotion.xml
@@ -1,0 +1,39 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <command>
+    <check>
+      <domain:check
+          xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>%DOMAIN%</domain:name>
+      </domain:check>
+    </check>
+    <extension>
+      <allocationToken:allocationToken
+          xmlns:allocationToken=
+              "urn:ietf:params:xml:ns:allocationToken-1.0">
+        abc123
+      </allocationToken:allocationToken>
+      <fee:check
+          xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
+        <fee:domain>
+          <fee:name>%DOMAIN%</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">1</fee:period>
+        </fee:domain>
+        <fee:domain>
+          <fee:name>%DOMAIN%</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">2</fee:period>
+        </fee:domain>
+        <fee:domain>
+          <fee:name>%DOMAIN%</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">5</fee:period>
+        </fee:domain>
+      </fee:check>
+    </extension>
+    <clTRID>ABC-12345</clTRID>
+  </command>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_promotion_response.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_promotion_response.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<epp xmlns:launch="urn:ietf:params:xml:ns:launch-1.0" xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1" xmlns:host="urn:ietf:params:xml:ns:host-1.0" xmlns:fee11="urn:ietf:params:xml:ns:fee-0.11" xmlns:fee12="urn:ietf:params:xml:ns:fee-0.12" xmlns:fee="urn:ietf:params:xml:ns:fee-0.6" xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0" xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xmlns:contact="urn:ietf:params:xml:ns:contact-1.0">
+  <response>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
+    </result>
+    <resData>
+      <domain:chkData>
+        <domain:cd>
+          <domain:name avail="true">%DOMAIN%</domain:name>
+        </domain:cd>
+      </domain:chkData>
+    </resData>
+    <extension>
+      <fee:chkData>
+        <fee:cd>
+          <fee:name>%DOMAIN%</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:fee description="create">%COST_1YR%</fee:fee>
+          %FEE_CLASS%
+        </fee:cd>
+        <fee:cd>
+          <fee:name>%DOMAIN%</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">2</fee:period>
+          <fee:fee description="create">%COST_2YR%</fee:fee>
+          %FEE_CLASS%
+        </fee:cd>
+        <fee:cd>
+          <fee:name>%DOMAIN%</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">5</fee:period>
+          <fee:fee description="create">%COST_5YR%</fee:fee>
+          %FEE_CLASS%
+        </fee:cd>
+      </fee:chkData>
+    </extension>
+    <trID>
+      <clTRID>ABC-12345</clTRID>
+      <svTRID>server-trid</svTRID>
+    </trID>
+  </response>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_allocationtoken.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_allocationtoken.xml
@@ -4,7 +4,7 @@
       <domain:create
        xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
         <domain:name>%DOMAIN%</domain:name>
-        <domain:period unit="y">2</domain:period>
+        <domain:period unit="y">%YEARS%</domain:period>
         <domain:ns>
           <domain:hostObj>ns1.example.net</domain:hostObj>
           <domain:hostObj>ns2.example.net</domain:hostObj>

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_premium_allocationtoken.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_premium_allocationtoken.xml
@@ -4,7 +4,7 @@
       <domain:create
           xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
         <domain:name>rich.example</domain:name>
-        <domain:period unit="y">2</domain:period>
+        <domain:period unit="y">%YEARS%</domain:period>
         <domain:ns>
           <domain:hostObj>ns1.example.net</domain:hostObj>
           <domain:hostObj>ns2.example.net</domain:hostObj>
@@ -25,7 +25,7 @@
       </allocationToken:allocationToken>
       <fee:create xmlns:fee="urn:ietf:params:xml:ns:fee-0.12">
         <fee:currency>USD</fee:currency>
-        <fee:fee>193.5</fee:fee>
+        <fee:fee>%FEE%</fee:fee>
       </fee:create>
     </extension>
     <clTRID>ABC-12345</clTRID>

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_response_wildcard.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_response_wildcard.xml
@@ -6,17 +6,11 @@
     <resData>
       <domain:creData
        xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
-        <domain:name>rich.example</domain:name>
-        <domain:crDate>1999-04-03T22:00:00.0Z</domain:crDate>
+        <domain:name>%DOMAIN%</domain:name>
+        <domain:crDate>%CRDATE%</domain:crDate>
         <domain:exDate>%EXDATE%</domain:exDate>
       </domain:creData>
     </resData>
-    <extension>
-      <fee:creData xmlns:fee="urn:ietf:params:xml:ns:fee-0.12">
-        <fee:currency>USD</fee:currency>
-        <fee:fee description="create">%FEE%</fee:fee>
-      </fee:creData>
-    </extension>
     <trID>
       <clTRID>ABC-12345</clTRID>
       <svTRID>server-trid</svTRID>

--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -231,12 +231,14 @@ class google.registry.model.domain.secdns.DelegationSignerData {
 }
 class google.registry.model.domain.token.AllocationToken {
   @Id java.lang.String token;
+  boolean discountPremiums;
   com.googlecode.objectify.Key<google.registry.model.reporting.HistoryEntry> redemptionHistoryEntry;
   double discountFraction;
   google.registry.model.CreateAutoTimestamp creationTime;
   google.registry.model.UpdateAutoTimestamp updateTimestamp;
   google.registry.model.common.TimedTransitionProperty<google.registry.model.domain.token.AllocationToken$TokenStatus, google.registry.model.domain.token.AllocationToken$TokenStatusTransition> tokenStatusTransitions;
   google.registry.model.domain.token.AllocationToken$TokenType tokenType;
+  int discountYears;
   java.lang.String domainName;
   java.util.Set<java.lang.String> allowedClientIds;
   java.util.Set<java.lang.String> allowedTlds;

--- a/java-format/google-java-format-git-diff.sh
+++ b/java-format/google-java-format-git-diff.sh
@@ -69,7 +69,7 @@ function callGoogleJavaFormatDiff() {
     "format")
       showNoncompliantFiles "$forkPoint" "\033[1mReformatting: "
       callResult=$(git diff -U0 ${forkPoint} | \
-          ${SCRIPT_DIR}/google-java-format-diff.py \ 
+          ${SCRIPT_DIR}/google-java-format-diff.py \
           --google-java-format-jar "${SCRIPT_DIR}/${JAR_NAME}" \
           -p1 -i)
       ;;

--- a/util/src/main/java/google/registry/util/CollectionUtils.java
+++ b/util/src/main/java/google/registry/util/CollectionUtils.java
@@ -75,38 +75,39 @@ public class CollectionUtils {
   }
 
   /** Defensive copy helper for {@link Set}. */
-  public static <V> ImmutableSet<V> nullSafeImmutableCopy(Set<V> data) {
+  public static <V> ImmutableSet<V> nullSafeImmutableCopy(@Nullable Set<V> data) {
     return data == null ? null : ImmutableSet.copyOf(data);
   }
 
   /** Defensive copy helper for {@link List}. */
-  public static <V> ImmutableList<V> nullSafeImmutableCopy(List<V> data) {
+  public static <V> ImmutableList<V> nullSafeImmutableCopy(@Nullable List<V> data) {
     return data == null ? null : ImmutableList.copyOf(data);
   }
 
   /** Defensive copy helper for {@link Set}. */
-  public static <V> ImmutableSet<V> nullToEmptyImmutableCopy(Set<V> data) {
+  public static <V> ImmutableSet<V> nullToEmptyImmutableCopy(@Nullable Set<V> data) {
     return data == null ? ImmutableSet.of() : ImmutableSet.copyOf(data);
   }
 
   /** Defensive copy helper for {@link Set}. */
-  public static <V extends Comparable<V>>
-      ImmutableSortedSet<V> nullToEmptyImmutableSortedCopy(Set<V> data) {
+  public static <V extends Comparable<V>> ImmutableSortedSet<V> nullToEmptyImmutableSortedCopy(
+      @Nullable Set<V> data) {
     return data == null ? ImmutableSortedSet.of() : ImmutableSortedSet.copyOf(data);
   }
 
   /** Defensive copy helper for {@link SortedMap}. */
-  public static <K, V> ImmutableSortedMap<K, V> nullToEmptyImmutableCopy(SortedMap<K, V> data) {
+  public static <K, V> ImmutableSortedMap<K, V> nullToEmptyImmutableCopy(
+      @Nullable SortedMap<K, V> data) {
     return data == null ? ImmutableSortedMap.of() : ImmutableSortedMap.copyOfSorted(data);
   }
 
   /** Defensive copy helper for {@link List}. */
-  public static <V> ImmutableList<V> nullToEmptyImmutableCopy(List<V> data) {
+  public static <V> ImmutableList<V> nullToEmptyImmutableCopy(@Nullable List<V> data) {
     return data == null ? ImmutableList.of() : ImmutableList.copyOf(data);
   }
 
   /** Defensive copy helper for {@link Map}. */
-  public static <K, V> ImmutableMap<K, V> nullToEmptyImmutableCopy(Map<K, V> data) {
+  public static <K, V> ImmutableMap<K, V> nullToEmptyImmutableCopy(@Nullable Map<K, V> data) {
     return data == null ? ImmutableMap.of() : ImmutableMap.copyOf(data);
   }
 

--- a/util/src/main/java/google/registry/util/PreconditionsUtils.java
+++ b/util/src/main/java/google/registry/util/PreconditionsUtils.java
@@ -29,33 +29,36 @@ public class PreconditionsUtils {
    * preferable to throw an IAE instead of an NPE, such as where we want an IAE to indicate that
    * it's just a bad argument/parameter and reserve NPEs for bugs and unexpected null values.
    */
-  public static <T> T checkArgumentNotNull(T reference) {
+  public static <T> T checkArgumentNotNull(@Nullable T reference) {
     checkArgument(reference != null);
     return reference;
   }
 
   /** Checks whether the provided reference is null, throws IAE if it is, and returns it if not. */
-  public static <T> T checkArgumentNotNull(T reference, @Nullable Object errorMessage) {
+  public static <T> T checkArgumentNotNull(@Nullable T reference, @Nullable Object errorMessage) {
     checkArgument(reference != null, errorMessage);
     return reference;
   }
 
   /** Checks whether the provided reference is null, throws IAE if it is, and returns it if not. */
   public static <T> T checkArgumentNotNull(
-      T reference, @Nullable String errorMessageTemplate, @Nullable Object... errorMessageArgs) {
+      @Nullable T reference,
+      @Nullable String errorMessageTemplate,
+      @Nullable Object... errorMessageArgs) {
     checkArgument(reference != null, errorMessageTemplate, errorMessageArgs);
     return reference;
   }
 
   /** Checks if the provided Optional is present, returns its value if so, and throws IAE if not. */
-  public static <T> T checkArgumentPresent(Optional<T> reference) {
+  public static <T> T checkArgumentPresent(@Nullable Optional<T> reference) {
     checkArgumentNotNull(reference);
     checkArgument(reference.isPresent());
     return reference.get();
   }
 
   /** Checks if the provided Optional is present, returns its value if so, and throws IAE if not. */
-  public static <T> T checkArgumentPresent(Optional<T> reference, @Nullable Object errorMessage) {
+  public static <T> T checkArgumentPresent(
+      @Nullable Optional<T> reference, @Nullable Object errorMessage) {
     checkArgumentNotNull(reference, errorMessage);
     checkArgument(reference.isPresent(), errorMessage);
     return reference.get();
@@ -63,7 +66,7 @@ public class PreconditionsUtils {
 
   /** Checks if the provided Optional is present, returns its value if so, and throws IAE if not. */
   public static <T> T checkArgumentPresent(
-      Optional<T> reference,
+      @Nullable Optional<T> reference,
       @Nullable String errorMessageTemplate,
       @Nullable Object... errorMessageArgs) {
     checkArgumentNotNull(reference, errorMessageTemplate, errorMessageArgs);


### PR DESCRIPTION
These are optional and default to off, but as of this PR we will have the ability to, when we want it, create an allocation token with a discount valid for premium names as well as standard names, and that will discount as many years of the initial registration as we want (rather than just the first).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/744)
<!-- Reviewable:end -->
