### PR TITLE
Fix vkey construction in PollMessage and BillingEvent

### DIFF
--- a/core/src/main/java/google/registry/model/billing/BillingEvent.java
+++ b/core/src/main/java/google/registry/model/billing/BillingEvent.java
@@ -351,7 +351,7 @@ public abstract class BillingEvent extends ImmutableObject
     }
 
     public static VKey<OneTime> createVKey(Key<OneTime> key) {
-      return key == null ? null : VKey.create(OneTime.class, key.getId(), key);
+      return VKey.create(OneTime.class, key.getId(), key);
     }
 
     @Override
@@ -493,7 +493,7 @@ public abstract class BillingEvent extends ImmutableObject
     }
 
     public static VKey<Recurring> createVKey(Key<Recurring> key) {
-      return key == null ? null : VKey.create(Recurring.class, key.getId(), key);
+      return VKey.create(Recurring.class, key.getId(), key);
     }
 
     @Override
@@ -617,7 +617,7 @@ public abstract class BillingEvent extends ImmutableObject
     }
 
     public static VKey<Cancellation> createVKey(Key<Cancellation> key) {
-      return key == null ? null : VKey.create(Cancellation.class, key.getId(), key);
+      return VKey.create(Cancellation.class, key.getId(), key);
     }
 
     @Override
@@ -701,7 +701,7 @@ public abstract class BillingEvent extends ImmutableObject
     }
 
     public static VKey<Modification> createVKey(Key<Modification> key) {
-      return key == null ? null : VKey.create(Modification.class, key.getId(), key);
+      return VKey.create(Modification.class, key.getId(), key);
     }
 
     /**

--- a/core/src/main/java/google/registry/model/billing/BillingEvent.java
+++ b/core/src/main/java/google/registry/model/billing/BillingEvent.java
@@ -347,27 +347,11 @@ public abstract class BillingEvent extends ImmutableObject
 
     @Override
     public VKey<OneTime> createVKey() {
-      return VKey.create(
-          getClass(),
-          parent.getParent().getName() + "/" + parent.getId() + "/" + getId(),
-          Key.create(this));
+      return VKey.create(getClass(), getId(), Key.create(this));
     }
 
     public static VKey<OneTime> createVKey(Key<OneTime> key) {
-      // TODO(b/159207551): As it stands, the SQL key generated here doesn't mesh with the primary
-      // key type for the table, which is a single long integer.
-      if (key == null) {
-        return null;
-      }
-      Key parent = key.getParent();
-      Key grandparent = (parent != null) ? parent.getParent() : null;
-      String path =
-          (grandparent != null ? grandparent.getName() : "")
-              + "/"
-              + (parent != null ? parent.getId() : "")
-              + "/"
-              + key.getId();
-      return VKey.create(OneTime.class, path, key);
+      return key == null ? null : VKey.create(OneTime.class, key.getId(), key);
     }
 
     @Override
@@ -505,21 +489,11 @@ public abstract class BillingEvent extends ImmutableObject
 
     @Override
     public VKey<Recurring> createVKey() {
-      return VKey.create(
-          getClass(),
-          parent.getParent().getName() + "/" + parent.getId() + "/" + getId(),
-          Key.create(this));
+      return VKey.create(getClass(), getId(), Key.create(this));
     }
 
     public static VKey<Recurring> createVKey(Key<Recurring> key) {
-      // TODO(b/159207551): As it stands, the SQL key generated here doesn't mesh with the primary
-      // key type for the table, which is a single long integer.
-      if (key == null) {
-        return null;
-      }
-      String path =
-          key.getParent().getParent().getName() + "/" + key.getParent().getId() + "/" + key.getId();
-      return VKey.create(Recurring.class, path, key);
+      return key == null ? null : VKey.create(Recurring.class, key.getId(), key);
     }
 
     @Override
@@ -639,21 +613,11 @@ public abstract class BillingEvent extends ImmutableObject
 
     @Override
     public VKey<Cancellation> createVKey() {
-      return VKey.create(
-          getClass(),
-          parent.getParent().getName() + "/" + parent.getId() + "/" + getId(),
-          Key.create(this));
+      return VKey.create(getClass(), getId(), Key.create(this));
     }
 
     public static VKey<Cancellation> createVKey(Key<Cancellation> key) {
-      // TODO(b/159207551): As it stands, the SQL key generated here doesn't mesh with the primary
-      // key type for the table, which is a single long integer.
-      if (key == null) {
-        return null;
-      }
-      String path =
-          key.getParent().getParent().getName() + "/" + key.getParent().getId() + "/" + key.getId();
-      return VKey.create(Cancellation.class, path, key);
+      return key == null ? null : VKey.create(Cancellation.class, key.getId(), key);
     }
 
     @Override
@@ -733,21 +697,11 @@ public abstract class BillingEvent extends ImmutableObject
 
     @Override
     public VKey<Modification> createVKey() {
-      return VKey.create(
-          getClass(),
-          parent.getParent().getName() + "/" + parent.getId() + "/" + getId(),
-          Key.create(this));
+      return VKey.create(getClass(), getId(), Key.create(this));
     }
 
     public static VKey<Modification> createVKey(Key<Modification> key) {
-      // TODO(b/159207551): As it stands, the SQL key generated here doesn't mesh with the primary
-      // key type for the table, which is a single long integer.
-      if (key == null) {
-        return null;
-      }
-      String path =
-          key.getParent().getParent().getName() + "/" + key.getParent().getId() + "/" + key.getId();
-      return VKey.create(Modification.class, path, key);
+      return key == null ? null : VKey.create(Modification.class, key.getId(), key);
     }
 
     /**

--- a/core/src/main/java/google/registry/model/poll/PollMessage.java
+++ b/core/src/main/java/google/registry/model/poll/PollMessage.java
@@ -155,7 +155,7 @@ public abstract class PollMessage extends ImmutableObject
   public abstract VKey<? extends PollMessage> createVKey();
 
   public static VKey<PollMessage> createVKey(Key<PollMessage> key) {
-    return key == null ? null : VKey.create(PollMessage.class, key.getId(), key);
+    return VKey.create(PollMessage.class, key.getId(), key);
   }
 
   /** Override Buildable.asBuilder() to give this method stronger typing. */

--- a/core/src/main/java/google/registry/model/poll/PollMessage.java
+++ b/core/src/main/java/google/registry/model/poll/PollMessage.java
@@ -155,15 +155,7 @@ public abstract class PollMessage extends ImmutableObject
   public abstract VKey<? extends PollMessage> createVKey();
 
   public static VKey<PollMessage> createVKey(Key<PollMessage> key) {
-    // TODO(b/159207551): As it stands, the SQL key generated here doesn't mesh with the primary key
-    // type for the table, which is a single long integer.  Also note that the class id is not
-    // correct here and as such the resulting key will not be loadable from SQL.
-    if (key == null) {
-      return null;
-    }
-    String path =
-        key.getParent().getParent().getName() + "/" + key.getParent().getId() + key.getId();
-    return VKey.create(PollMessage.class, path, key);
+    return key == null ? null : VKey.create(PollMessage.class, key.getId(), key);
   }
 
   /** Override Buildable.asBuilder() to give this method stronger typing. */


### PR DESCRIPTION
This PR removed the code to construct a fake SQL key for VKey in PollMessage and BillingEvent
because it doesn't work with some entities having old key structure.

The reason why we construct the fake SQL key is because we discovered that there were some PollMessage
and BillingEvent entities having duplicate ids. So, we wanted the fake SQL key to be served as an alert to
remind us to fix the data problem before migrating to Cloud SQL. The problem has been fixed for 
PollMessage entities and we are actively working on the fix for BillingEvent entities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/747)
<!-- Reviewable:end -->
