### PR TITLE
Wait for contact add page to load before doing screenshot diff

### DIFF
--- a/core/src/test/java/google/registry/webdriver/RegistrarConsoleScreenshotTest.java
+++ b/core/src/test/java/google/registry/webdriver/RegistrarConsoleScreenshotTest.java
@@ -238,6 +238,9 @@ class RegistrarConsoleScreenshotTest extends WebDriverTestCase {
     Thread.sleep(1000);
     driver.waitForElement(By.tagName("h1"));
     driver.waitForElement(By.id("reg-app-btn-add")).click();
+    // Attempt to fix flaky tests. The going theory is that the click button CSS animation needs to
+    // finish before the screenshot is captured.
+    Thread.sleep(250);
     driver.diffPage("page");
   }
 


### PR DESCRIPTION
This test is flaky and the going theory is that we take a screenshot
immediately after we click the "Add" button and the CSS hover effect is
somehow still playing on the button.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/756)
<!-- Reviewable:end -->
