### PR TITLE
Remove spec11 domain foreign key

### DIFF
--- a/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchTest.java
+++ b/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchTest.java
@@ -33,6 +33,7 @@ import google.registry.persistence.VKey;
 import org.joda.time.LocalDate;
 import org.joda.time.format.ISODateTimeFormat;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link Spec11ThreatMatch}. */
@@ -121,6 +122,7 @@ public class Spec11ThreatMatchTest extends EntityTestCase {
   }
 
   @Test
+  @Disabled("We can't rely on foreign keys until we've migrated to SQL")
   void testThreatForeignKeyConstraints() {
     assertThrowForeignKeyViolation(
         () -> {

--- a/db/src/main/resources/sql/flyway/V47__remove_spec11_domain_foreign_key.sql
+++ b/db/src/main/resources/sql/flyway/V47__remove_spec11_domain_foreign_key.sql
@@ -1,0 +1,16 @@
+-- Copyright 2020 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- We want this in general, but not until we've migrated
+ALTER TABLE IF EXISTS "Spec11ThreatMatch" DROP CONSTRAINT "fk_safebrowsing_threat_domain_repo_id";

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -1872,14 +1872,6 @@ ALTER TABLE ONLY public."PollMessage"
 
 
 --
--- Name: Spec11ThreatMatch fk_safebrowsing_threat_domain_repo_id; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."Spec11ThreatMatch"
-    ADD CONSTRAINT fk_safebrowsing_threat_domain_repo_id FOREIGN KEY (domain_repo_id) REFERENCES public."Domain"(repo_id);
-
-
---
 -- Name: DomainHost fkfmi7bdink53swivs390m2btxg; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 


### PR DESCRIPTION
We'll want this eventually but until the Domain SQL table is populated,
we can't rely on domains' existence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/757)
<!-- Reviewable:end -->
