### PR TITLE
Double the timeout length for WebDriver screenshot tests

### DIFF
--- a/core/src/test/java/google/registry/webdriver/WebDriverTestCase.java
+++ b/core/src/test/java/google/registry/webdriver/WebDriverTestCase.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Base class for tests that needs a {@link WebDriverPlusScreenDifferExtension}. */
-@Timeout(60)
+@Timeout(120)
 class WebDriverTestCase {
 
   @RegisterExtension


### PR DESCRIPTION
My theory is that this timeout is being applied to all retries of a failing test
rather than each one, and thus flaky screenshot tests aren't being given
sufficient time to complete any attempt past the first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/758)
<!-- Reviewable:end -->
