### PR TITLE
Fix empty Domain nameserver loads

### DIFF
--- a/core/src/main/java/google/registry/model/domain/DomainContent.java
+++ b/core/src/main/java/google/registry/model/domain/DomainContent.java
@@ -380,7 +380,7 @@ public class DomainContent extends EppResource
   // Hibernate needs this in order to populate nsHosts but no one else should ever use it
   @SuppressWarnings("UnusedMethod")
   private void setNsHosts(Set<VKey<HostResource>> nsHosts) {
-    this.nsHosts = nsHosts;
+    this.nsHosts = forceEmptyToNull(nsHosts);
   }
 
   // Hibernate needs this in order to populate gracePeriods but no one else should ever use it


### PR DESCRIPTION
Domains with no nameservers were being loaded from SQL as an empty set instead
of null as they should be.

Discovered this will trying to test updates, so added a test for updates in
the course of it.