### PR TITLE
Fix missing-driver in HibernateSchemaExporterTest

### DIFF
--- a/core/src/main/java/google/registry/persistence/HibernateSchemaExporter.java
+++ b/core/src/main/java/google/registry/persistence/HibernateSchemaExporter.java
@@ -59,6 +59,9 @@ public class HibernateSchemaExporter {
     settings.put(Environment.USER, username);
     settings.put(Environment.PASS, password);
     settings.put(Environment.HBM2DDL_AUTO, "none");
+    // Register driver explicitly to work around ServiceLoader change after Java 8.
+    // Driver self-registration only works if driver is declared in a module.
+    settings.put(Environment.DRIVER, "org.postgresql.Driver");
     settings.put(Environment.SHOW_SQL, "true");
     settings.put(
         Environment.PHYSICAL_NAMING_STRATEGY, NomulusNamingStrategy.class.getCanonicalName());


### PR DESCRIPTION
HibernateSchemaExporterTest is failing with "Driver not found" error
after Java 11 upgrade. Reason is that ServiceLoader now only checks
modules for services.

Proper fix is to define modules.

This short term fix is to declare the driver class explicitly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/777)
<!-- Reviewable:end -->
