### PR TITLE
Consolidate conversion from Duration to Period in DurationConverter

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -63,8 +63,6 @@ def dockerIncompatibleTestPatterns = [
     // methods, so we exclude the whole test class.
     "google/registry/tools/params/PathParameterTest.*",
     "google/registry/persistence/PersistenceModuleTest.*",
-    // This test is failing in docker when using Java 11. The cause is unclear.
-    "google/registry/tools/DomainLockUtilsTest.*",
 ]
 
 // Tests that conflict with members of both the main test suite and the

--- a/core/src/main/java/google/registry/persistence/converter/DurationConverter.java
+++ b/core/src/main/java/google/registry/persistence/converter/DurationConverter.java
@@ -40,14 +40,17 @@ public class DurationConverter implements AttributeConverter<Duration, PGInterva
     if (duration == null) {
       return new PGInterval();
     }
-    PGInterval interval = new PGInterval();
+    // When the period is created from duration by calling duration.toPeriod(), only precise fields
+    // in the period type will be used. Thus, only the hour, minute, second and millisecond fields
+    // on the period will be used. The year, month, week and day fields will not be populated:
+    //   1. If the duration is small, less than one day, then this method will just set
+    //      hours/minutes/seconds correctly.
+    //   2. If the duration is larger than one day then all the remaining duration will
+    //      be stored in the largest available field, hours in this case.
+    // So, when we convert the period to a PGInterval instance, we set the days field by extracting
+    // it from period's hours field.
     Period period = duration.toPeriod();
-    // When the period is created from duration by calling duration.toPeriod(), it shows the
-    // following behaviors:
-    // 1. If the duration is small, less than one day, then this method will perform
-    //    as you might expect and split the fields evenly.
-    // 2. If the duration is larger than one day then all the remaining duration will
-    //    be stored in the largest available field, hours in this case.
+    PGInterval interval = new PGInterval();
     interval.setDays(period.getHours() / 24);
     interval.setHours(period.getHours() % 24);
     interval.setMinutes(period.getMinutes());

--- a/core/src/main/java/google/registry/persistence/converter/DurationConverter.java
+++ b/core/src/main/java/google/registry/persistence/converter/DurationConverter.java
@@ -41,10 +41,13 @@ public class DurationConverter implements AttributeConverter<Duration, PGInterva
       return new PGInterval();
     }
     PGInterval interval = new PGInterval();
-    Period period = new Period(duration);
-    // For some reason when the period is created from the duration, it does not set days, but
-    // instead just a total number of hours. Years and months are not created because those can
-    // differ in length of milliseconds.
+    Period period = duration.toPeriod();
+    // When the period is created from duration by calling duration.toPeriod(), it shows the
+    // following behaviors:
+    // 1. If the duration is small, less than one day, then this method will perform
+    //    as you might expect and split the fields evenly.
+    // 2. If the duration is larger than one day then all the remaining duration will
+    //    be stored in the largest available field, hours in this case.
     interval.setDays(period.getHours() / 24);
     interval.setHours(period.getHours() % 24);
     interval.setMinutes(period.getMinutes());

--- a/core/src/test/java/google/registry/persistence/converter/DurationConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/DurationConverterTest.java
@@ -51,22 +51,37 @@ public class DurationConverterTest {
             .plus(Duration.standardMinutes(30))
             .plus(Duration.standardSeconds(15))
             .plus(Duration.millis(7));
-    DurationTestEntity entity = new DurationTestEntity(testDuration);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(entity));
-    DurationTestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(DurationTestEntity.class, "id"));
-    assertThat(persisted.duration.getMillis()).isEqualTo(testDuration.getMillis());
+    assertPersistedEntityHasSameDuration(testDuration);
   }
 
   @Test
   void testRoundTripLargeNumberOfDays() {
     Duration testDuration =
         Duration.standardDays(10001).plus(Duration.standardHours(100)).plus(Duration.millis(790));
-    DurationTestEntity entity = new DurationTestEntity(testDuration);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(entity));
+    assertPersistedEntityHasSameDuration(testDuration);
+  }
+
+  @Test
+  void testRoundTripLessThanOneDay() {
+    Duration testDuration =
+        Duration.standardHours(15)
+            .plus(Duration.standardMinutes(40))
+            .plus(Duration.standardSeconds(50));
+    assertPersistedEntityHasSameDuration(testDuration);
+  }
+
+  @Test
+  void testRoundTripExactOneDay() {
+    Duration testDuration = Duration.standardDays(1);
+    assertPersistedEntityHasSameDuration(testDuration);
+  }
+
+  private void assertPersistedEntityHasSameDuration(Duration duration) {
+    DurationTestEntity entity = new DurationTestEntity(duration);
+    jpaTm().transact(() -> jpaTm().saveNew(entity));
     DurationTestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(DurationTestEntity.class, "id"));
-    assertThat(persisted.duration.getMillis()).isEqualTo(testDuration.getMillis());
+    assertThat(persisted.duration.getMillis()).isEqualTo(duration.getMillis());
   }
 
   @Entity(name = "TestEntity") // Override entity name to avoid the nested class reference.


### PR DESCRIPTION
Apparently, the behavior of converting from `Duration` to `Period` by using `new Period(duration)` is not deterministic.
We expect that it behaves the same as `duration.toPeriod()` which stores the remaining duration to `hours` when the duration
is more than a day. However, sometimes, it just drops the remaining duration and only keeps the part that less than a day, e.g.,
if the duration is 1 day and 1 hour, the converted period is only 1 hour, and if the duration is exact 1 day, the persisted period
would become `null` because the whole duration is dropped during conversion(This is the reason why there was failing test in `DomainLockUtilsTest `). The exact reason is not clear but I guess `new Period(duration)` depends on some OS setup or timezone of the host running the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/786)
<!-- Reviewable:end -->
