### PR TITLE
Add and use temp_history_id_sequence to avoid release error

### DIFF
--- a/core/src/main/java/google/registry/model/contact/ContactHistory.java
+++ b/core/src/main/java/google/registry/model/contact/ContactHistory.java
@@ -53,7 +53,7 @@ public class ContactHistory extends HistoryEntry {
   VKey<ContactResource> contactRepoId;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "HistorySequenceGenerator")
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "TempHistorySequenceGenerator")
   @Column(name = "historyRevisionId")
   @Access(AccessType.PROPERTY)
   @Override

--- a/core/src/main/java/google/registry/model/domain/DomainHistory.java
+++ b/core/src/main/java/google/registry/model/domain/DomainHistory.java
@@ -76,7 +76,7 @@ public class DomainHistory extends HistoryEntry {
   Set<VKey<HostResource>> nsHosts;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "HistorySequenceGenerator")
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "TempHistorySequenceGenerator")
   @Column(name = "historyRevisionId")
   @Access(AccessType.PROPERTY)
   @Override

--- a/core/src/main/java/google/registry/model/host/HostHistory.java
+++ b/core/src/main/java/google/registry/model/host/HostHistory.java
@@ -54,7 +54,7 @@ public class HostHistory extends HistoryEntry {
   VKey<HostResource> hostRepoId;
 
   @Id
-  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "HistorySequenceGenerator")
+  @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "TempHistorySequenceGenerator")
   @Column(name = "historyRevisionId")
   @Access(AccessType.PROPERTY)
   @Override

--- a/core/src/main/resources/META-INF/orm.xml
+++ b/core/src/main/resources/META-INF/orm.xml
@@ -11,7 +11,10 @@
     </attributes>
   </embeddable>
 
-  <sequence-generator name="HistorySequenceGenerator" sequence-name="history_id_sequence" />
+  <sequence-generator name="HistorySequenceGenerator" sequence-name="history_id_sequence"/>
+
+  <!-- TODO(shicong): Drop this sequence and change all history tables to use the above one. -->
+  <sequence-generator name="TempHistorySequenceGenerator" sequence-name="temp_history_id_sequence"/>
 
   <persistence-unit-metadata>
     <persistence-unit-defaults>

--- a/db/src/main/resources/sql/flyway/V53__add_temp_history_id_sequence.sql
+++ b/db/src/main/resources/sql/flyway/V53__add_temp_history_id_sequence.sql
@@ -1,0 +1,20 @@
+-- Copyright 2020 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+create sequence "temp_history_id_sequence"
+    start with 1
+    increment by 50
+    no minvalue
+    no maxvalue
+    cache 1;

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -11,7 +11,7 @@
 -- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
-create sequence history_id_sequence start 1 increment 50;
+create sequence temp_history_id_sequence start 1 increment 50;
 
     create table "AllocationToken" (
        token text not null,

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -931,6 +931,18 @@ CREATE SEQUENCE public.history_id_sequence
 
 
 --
+-- Name: temp_history_id_sequence; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.temp_history_id_sequence
+    START WITH 1
+    INCREMENT BY 50
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
 -- Name: BillingCancellation billing_cancellation_id; Type: DEFAULT; Schema: public; Owner: -
 --
 


### PR DESCRIPTION
We changed `history_id_sequence` to use `INCREMENT BY 50` in #767. However, this change cannot be applied correctly by our release process. Our release process always deploy the code change first then apply the schema change, after the code change is deployed, Hibernate throws the an exception that indicates it expects the sequence to be `INCREMENT BY 50` in the database  as well though at that time the schema change is not applied yet.

So, the work around I made in this PR is to create a temporary sequence for all history tables and also keep the previous change for `history_id_sequence`. After this PR is deployed, we can create another PR to switch back to use `history_id_sequence` for all history tables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/795)
<!-- Reviewable:end -->
