### PR TITLE
Improve naming of TransactionManager methods

### DIFF
--- a/core/src/main/java/google/registry/batch/DeleteContactsAndHostsAction.java
+++ b/core/src/main/java/google/registry/batch/DeleteContactsAndHostsAction.java
@@ -464,7 +464,7 @@ public class DeleteContactsAndHostsAction implements Runnable {
         HostResource host = (HostResource) existingResource;
         if (host.isSubordinate()) {
           dnsQueue.addHostRefreshTask(host.getHostName());
-          tm().saveNewOrUpdate(
+          tm().put(
                   tm().load(host.getSuperordinateDomain())
                       .asBuilder()
                       .removeSubordinateHost(host.getHostName())

--- a/core/src/main/java/google/registry/beam/initsql/Transforms.java
+++ b/core/src/main/java/google/registry/beam/initsql/Transforms.java
@@ -437,7 +437,7 @@ public final class Transforms {
                 .map(Optional::get)
                 .map(ofy::toPojo)
                 .collect(ImmutableList.toImmutableList());
-        retry(() -> jpaTm().transact(() -> jpaTm().saveNewOrUpdateAll(ofyEntities)));
+        retry(() -> jpaTm().transact(() -> jpaTm().putAll(ofyEntities)));
       }
     }
 

--- a/core/src/main/java/google/registry/beam/spec11/Spec11Pipeline.java
+++ b/core/src/main/java/google/registry/beam/spec11/Spec11Pipeline.java
@@ -215,7 +215,7 @@ public class Spec11Pipeline implements Serializable {
                           .setRegistrarId(subdomain.registrarId())
                           .build();
                   JpaTransactionManager jpaTransactionManager = jpaSupplierFactory.get();
-                  jpaTransactionManager.transact(() -> jpaTransactionManager.saveNew(threatMatch));
+                  jpaTransactionManager.transact(() -> jpaTransactionManager.insert(threatMatch));
                 }
               }
             }));

--- a/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
@@ -173,7 +173,7 @@ public final class DomainRestoreRequestFlow implements TransactionalFlow  {
             existingDomain, newExpirationTime, autorenewEvent, autorenewPollMessage, now, clientId);
     updateForeignKeyIndexDeletionTime(newDomain);
     entitiesToSave.add(newDomain, historyEntry, autorenewEvent, autorenewPollMessage);
-    tm().saveNewOrUpdateAll(entitiesToSave.build());
+    tm().putAll(entitiesToSave.build());
     tm().delete(existingDomain.getDeletePollMessage());
     dnsQueue.addDomainRefreshTask(existingDomain.getDomainName());
     return responseBuilder

--- a/core/src/main/java/google/registry/flows/host/HostUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostUpdateFlow.java
@@ -285,7 +285,7 @@ public final class HostUpdateFlow implements TransactionalFlow {
         && newHost.isSubordinate()
         && Objects.equals(
             existingHost.getSuperordinateDomain(), newHost.getSuperordinateDomain())) {
-      tm().saveNewOrUpdate(
+      tm().put(
               tm().load(existingHost.getSuperordinateDomain())
                   .asBuilder()
                   .removeSubordinateHost(existingHost.getHostName())
@@ -294,14 +294,14 @@ public final class HostUpdateFlow implements TransactionalFlow {
       return;
     }
     if (existingHost.isSubordinate()) {
-      tm().saveNewOrUpdate(
+      tm().put(
               tm().load(existingHost.getSuperordinateDomain())
                   .asBuilder()
                   .removeSubordinateHost(existingHost.getHostName())
                   .build());
     }
     if (newHost.isSubordinate()) {
-      tm().saveNewOrUpdate(
+      tm().put(
               tm().load(newHost.getSuperordinateDomain())
                   .asBuilder()
                   .addSubordinateHost(newHost.getHostName())

--- a/core/src/main/java/google/registry/flows/poll/PollFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/poll/PollFlowUtils.java
@@ -64,7 +64,7 @@ public final class PollFlowUtils {
       // and re-save it for future autorenew poll messages to be delivered. Otherwise, this
       // autorenew poll message has no more events to deliver and should be deleted.
       if (nextEventTime.isBefore(autorenewPollMessage.getAutorenewEndTime())) {
-        tm().saveNewOrUpdate(autorenewPollMessage.asBuilder().setEventTime(nextEventTime).build());
+        tm().put(autorenewPollMessage.asBuilder().setEventTime(nextEventTime).build());
         includeAckedMessageInCount = isBeforeOrAt(nextEventTime, tm().getTransactionTime());
       } else {
         tm().delete(autorenewPollMessage.createVKey());

--- a/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
+++ b/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
@@ -101,22 +101,22 @@ public class DatastoreTransactionManager implements TransactionManager {
   }
 
   @Override
-  public void saveNew(Object entity) {
+  public void insert(Object entity) {
     saveEntity(entity);
   }
 
   @Override
-  public void saveAllNew(ImmutableCollection<?> entities) {
+  public void insertAll(ImmutableCollection<?> entities) {
     getOfy().save().entities(entities);
   }
 
   @Override
-  public void saveNewOrUpdate(Object entity) {
+  public void put(Object entity) {
     saveEntity(entity);
   }
 
   @Override
-  public void saveNewOrUpdateAll(ImmutableCollection<?> entities) {
+  public void putAll(ImmutableCollection<?> entities) {
     getOfy().save().entities(entities);
   }
 
@@ -131,12 +131,12 @@ public class DatastoreTransactionManager implements TransactionManager {
   }
 
   @Override
-  public boolean checkExists(Object entity) {
+  public boolean exists(Object entity) {
     return getOfy().load().key(Key.create(entity)).now() != null;
   }
 
   @Override
-  public <T> boolean checkExists(VKey<T> key) {
+  public <T> boolean exists(VKey<T> key) {
     return loadNullable(key) != null;
   }
 

--- a/core/src/main/java/google/registry/model/registry/label/ReservedListDualWriteDao.java
+++ b/core/src/main/java/google/registry/model/registry/label/ReservedListDualWriteDao.java
@@ -43,7 +43,7 @@ public class ReservedListDualWriteDao {
 
   /** Persist a new reserved list to Cloud SQL. */
   public static void save(ReservedList reservedList) {
-    ofyTm().transact(() -> ofyTm().saveNewOrUpdate(reservedList));
+    ofyTm().transact(() -> ofyTm().put(reservedList));
     try {
       logger.atInfo().log("Saving reserved list %s to Cloud SQL", reservedList.getName());
       ReservedListSqlDao.save(reservedList);

--- a/core/src/main/java/google/registry/model/registry/label/ReservedListSqlDao.java
+++ b/core/src/main/java/google/registry/model/registry/label/ReservedListSqlDao.java
@@ -31,7 +31,7 @@ public class ReservedListSqlDao {
   /** Persist a new reserved list to Cloud SQL. */
   public static void save(ReservedList reservedList) {
     checkArgumentNotNull(reservedList, "Must specify reservedList");
-    jpaTm().transact(() -> jpaTm().saveNew(reservedList));
+    jpaTm().transact(() -> jpaTm().insert(reservedList));
   }
 
   /**

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -224,7 +224,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   }
 
   @Override
-  public void saveNew(Object entity) {
+  public void insert(Object entity) {
     checkArgumentNotNull(entity, "entity must be specified");
     assertInTransaction();
     getEntityManager().persist(entity);
@@ -232,14 +232,14 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   }
 
   @Override
-  public void saveAllNew(ImmutableCollection<?> entities) {
+  public void insertAll(ImmutableCollection<?> entities) {
     checkArgumentNotNull(entities, "entities must be specified");
     assertInTransaction();
-    entities.forEach(this::saveNew);
+    entities.forEach(this::insert);
   }
 
   @Override
-  public void saveNewOrUpdate(Object entity) {
+  public void put(Object entity) {
     checkArgumentNotNull(entity, "entity must be specified");
     assertInTransaction();
     getEntityManager().merge(entity);
@@ -247,17 +247,17 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   }
 
   @Override
-  public void saveNewOrUpdateAll(ImmutableCollection<?> entities) {
+  public void putAll(ImmutableCollection<?> entities) {
     checkArgumentNotNull(entities, "entities must be specified");
     assertInTransaction();
-    entities.forEach(this::saveNewOrUpdate);
+    entities.forEach(this::put);
   }
 
   @Override
   public void update(Object entity) {
     checkArgumentNotNull(entity, "entity must be specified");
     assertInTransaction();
-    checkArgument(checkExists(entity), "Given entity does not exist");
+    checkArgument(exists(entity), "Given entity does not exist");
     getEntityManager().merge(entity);
     transactionInfo.get().addUpdate(entity);
   }
@@ -270,22 +270,22 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   }
 
   @Override
-  public <T> boolean checkExists(VKey<T> key) {
+  public <T> boolean exists(VKey<T> key) {
     checkArgumentNotNull(key, "key must be specified");
     EntityType<?> entityType = getEntityType(key.getKind());
     ImmutableSet<EntityId> entityIds = getEntityIdsFromSqlKey(entityType, key.getSqlKey());
-    return checkExists(entityType.getName(), entityIds);
+    return exists(entityType.getName(), entityIds);
   }
 
   @Override
-  public boolean checkExists(Object entity) {
+  public boolean exists(Object entity) {
     checkArgumentNotNull(entity, "entity must be specified");
     EntityType<?> entityType = getEntityType(entity.getClass());
     ImmutableSet<EntityId> entityIds = getEntityIdsFromEntity(entityType, entity);
-    return checkExists(entityType.getName(), entityIds);
+    return exists(entityType.getName(), entityIds);
   }
 
-  private boolean checkExists(String entityName, ImmutableSet<EntityId> entityIds) {
+  private boolean exists(String entityName, ImmutableSet<EntityId> entityIds) {
     assertInTransaction();
     TypedQuery<Integer> query =
         getEntityManager()

--- a/core/src/main/java/google/registry/persistence/transaction/Transaction.java
+++ b/core/src/main/java/google/registry/persistence/transaction/Transaction.java
@@ -208,7 +208,7 @@ public class Transaction extends ImmutableObject implements Buildable {
 
     @Override
     public void writeToDatastore() {
-      ofyTm().saveNewOrUpdate(entity);
+      ofyTm().put(entity);
     }
 
     @Override

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
@@ -86,16 +86,16 @@ public interface TransactionManager {
   DateTime getTransactionTime();
 
   /** Persists a new entity in the database, throws exception if the entity already exists. */
-  void saveNew(Object entity);
+  void insert(Object entity);
 
   /** Persists all new entities in the database, throws exception if any entity already exists. */
-  void saveAllNew(ImmutableCollection<?> entities);
+  void insertAll(ImmutableCollection<?> entities);
 
   /** Persists a new entity or update the existing entity in the database. */
-  void saveNewOrUpdate(Object entity);
+  void put(Object entity);
 
   /** Persists all new entities or update the existing entities in the database. */
-  void saveNewOrUpdateAll(ImmutableCollection<?> entities);
+  void putAll(ImmutableCollection<?> entities);
 
   /** Updates an entity in the database, throws exception if the entity does not exist. */
   void update(Object entity);
@@ -104,10 +104,10 @@ public interface TransactionManager {
   void updateAll(ImmutableCollection<?> entities);
 
   /** Returns whether the given entity with same ID exists. */
-  boolean checkExists(Object entity);
+  boolean exists(Object entity);
 
   /** Returns whether the entity of given key exists. */
-  <T> boolean checkExists(VKey<T> key);
+  <T> boolean exists(VKey<T> key);
 
   /** Loads the entity by its id, returns empty if the entity doesn't exist. */
   <T> Optional<T> maybeLoad(VKey<T> key);

--- a/core/src/main/java/google/registry/tools/CreateRegistrarCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateRegistrarCommand.java
@@ -72,7 +72,7 @@ final class CreateRegistrarCommand extends CreateOrUpdateRegistrarCommand
 
   @Override
   void saveToCloudSql(Registrar registrar) {
-    jpaTm().saveNew(registrar);
+    jpaTm().insert(registrar);
   }
 
   @Nullable

--- a/core/src/test/java/google/registry/beam/initsql/WriteToSqlTest.java
+++ b/core/src/test/java/google/registry/beam/initsql/WriteToSqlTest.java
@@ -85,7 +85,7 @@ class WriteToSqlTest implements Serializable {
       // Required for contacts created below.
       Registrar ofyRegistrar = AppEngineExtension.makeRegistrar2();
       store.insertOrUpdate(ofyRegistrar);
-      jpaTm().transact(() -> jpaTm().saveNewOrUpdate(store.loadAsOfyEntity(ofyRegistrar)));
+      jpaTm().transact(() -> jpaTm().put(store.loadAsOfyEntity(ofyRegistrar)));
 
       ImmutableList.Builder<Entity> builder = new ImmutableList.Builder<>();
 

--- a/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
+++ b/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
@@ -285,7 +285,7 @@ class Spec11PipelineTest {
             .build();
 
     verify(mockJpaTm).transact(any(Runnable.class));
-    verify(mockJpaTm).saveNew(expected);
+    verify(mockJpaTm).insert(expected);
     verifyNoMoreInteractions(mockJpaTm);
   }
 

--- a/core/src/test/java/google/registry/model/billing/BillingEventTest.java
+++ b/core/src/test/java/google/registry/model/billing/BillingEventTest.java
@@ -180,7 +180,7 @@ public class BillingEventTest extends EntityTestCase {
 
   private void saveNewBillingEvent(BillingEvent billingEvent) {
     billingEvent.id = null;
-    jpaTm().transact(() -> jpaTm().saveNew(billingEvent));
+    jpaTm().transact(() -> jpaTm().insert(billingEvent));
   }
 
   @Test

--- a/core/src/test/java/google/registry/model/contact/ContactResourceTest.java
+++ b/core/src/test/java/google/registry/model/contact/ContactResourceTest.java
@@ -124,7 +124,7 @@ public class ContactResourceTest extends EntityTestCase {
 
   @Test
   void testCloudSqlPersistence_failWhenViolateForeignKeyConstraint() {
-    assertThrowForeignKeyViolation(() -> jpaTm().transact(() -> jpaTm().saveNew(originalContact)));
+    assertThrowForeignKeyViolation(() -> jpaTm().transact(() -> jpaTm().insert(originalContact)));
   }
 
   @Test
@@ -134,7 +134,7 @@ public class ContactResourceTest extends EntityTestCase {
     saveRegistrar("registrar3");
     saveRegistrar("gaining");
     saveRegistrar("losing");
-    jpaTm().transact(() -> jpaTm().saveNew(originalContact));
+    jpaTm().transact(() -> jpaTm().insert(originalContact));
     ContactResource persisted =
         jpaTm()
             .transact(

--- a/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
@@ -139,9 +139,9 @@ public class DomainBaseSqlTest {
                 .transact(
                     () -> {
                       // Persist the domain without the associated host object.
-                      jpaTm().saveNew(contact);
-                      jpaTm().saveNew(contact2);
-                      jpaTm().saveNew(domain);
+                      jpaTm().insert(contact);
+                      jpaTm().insert(contact2);
+                      jpaTm().insert(domain);
                     }));
   }
 
@@ -153,8 +153,8 @@ public class DomainBaseSqlTest {
                 .transact(
                     () -> {
                       // Persist the domain without the associated contact objects.
-                      jpaTm().saveNew(domain);
-                      jpaTm().saveNew(host);
+                      jpaTm().insert(domain);
+                      jpaTm().insert(host);
                     }));
   }
 
@@ -165,7 +165,7 @@ public class DomainBaseSqlTest {
         .transact(
             () -> {
               DomainBase persisted = jpaTm().load(domain.createVKey());
-              jpaTm().saveNewOrUpdate(persisted.asBuilder().build());
+              jpaTm().put(persisted.asBuilder().build());
             });
     jpaTm()
         .transact(
@@ -185,7 +185,7 @@ public class DomainBaseSqlTest {
               DomainBase persisted = jpaTm().load(domain.createVKey());
               DomainBase modified =
                   persisted.asBuilder().setGracePeriods(ImmutableSet.of()).build();
-              jpaTm().saveNewOrUpdate(modified);
+              jpaTm().put(modified);
             });
 
     jpaTm()
@@ -204,7 +204,7 @@ public class DomainBaseSqlTest {
             () -> {
               DomainBase persisted = jpaTm().load(domain.createVKey());
               DomainBase modified = persisted.asBuilder().setGracePeriods(null).build();
-              jpaTm().saveNewOrUpdate(modified);
+              jpaTm().put(modified);
             });
 
     jpaTm()
@@ -229,7 +229,7 @@ public class DomainBaseSqlTest {
                           GracePeriod.create(
                               GracePeriodStatus.RENEW, "4-COM", END_OF_TIME, "registrar1", null))
                       .build();
-              jpaTm().saveNewOrUpdate(modified);
+              jpaTm().put(modified);
             });
 
     jpaTm()
@@ -281,7 +281,7 @@ public class DomainBaseSqlTest {
                   builder.removeGracePeriod(gracePeriod);
                 }
               }
-              jpaTm().saveNewOrUpdate(builder.build());
+              jpaTm().put(builder.build());
             });
 
     jpaTm()
@@ -301,7 +301,7 @@ public class DomainBaseSqlTest {
               DomainBase persisted = jpaTm().load(domain.createVKey());
               DomainBase modified =
                   persisted.asBuilder().setGracePeriods(ImmutableSet.of()).build();
-              jpaTm().saveNewOrUpdate(modified);
+              jpaTm().put(modified);
             });
 
     jpaTm()
@@ -316,7 +316,7 @@ public class DomainBaseSqlTest {
                           GracePeriod.create(
                               GracePeriodStatus.ADD, "4-COM", END_OF_TIME, "registrar1", null))
                       .build();
-              jpaTm().saveNewOrUpdate(modified);
+              jpaTm().put(modified);
             });
 
     jpaTm()
@@ -339,13 +339,13 @@ public class DomainBaseSqlTest {
     jpaTm()
         .transact(
             () -> {
-              jpaTm().saveNew(contact);
-              jpaTm().saveNew(contact2);
-              jpaTm().saveNew(domain);
-              jpaTm().saveNew(host);
+              jpaTm().insert(contact);
+              jpaTm().insert(contact2);
+              jpaTm().insert(domain);
+              jpaTm().insert(host);
             });
     domain = domain.asBuilder().setNameservers(ImmutableSet.of()).build();
-    jpaTm().transact(() -> jpaTm().saveNewOrUpdate(domain));
+    jpaTm().transact(() -> jpaTm().put(domain));
     jpaTm()
         .transact(
             () -> {
@@ -382,16 +382,16 @@ public class DomainBaseSqlTest {
               // Persist the contacts.  Note that these need to be persisted before the domain
               // otherwise we get a foreign key constraint error.  If we ever decide to defer the
               // relevant foreign key checks to commit time, then the order would not matter.
-              jpaTm().saveNew(contact);
-              jpaTm().saveNew(contact2);
+              jpaTm().insert(contact);
+              jpaTm().insert(contact2);
 
               // Persist the domain.
-              jpaTm().saveNew(domain);
+              jpaTm().insert(domain);
 
               // Persist the host.  This does _not_ need to be persisted before the domain,
               // because only the row in the join table (DomainHost) is subject to foreign key
               // constraints, and Hibernate knows to insert it after domain and host.
-              jpaTm().saveNew(host);
+              jpaTm().insert(host);
             });
   }
 

--- a/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
+++ b/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
@@ -95,8 +95,8 @@ public class AllocationTokenTest extends EntityTestCase {
     jpaTm()
         .transact(
             () -> {
-              jpaTm().saveNew(unlimitedUseToken);
-              jpaTm().saveNew(singleUseToken);
+              jpaTm().insert(unlimitedUseToken);
+              jpaTm().insert(singleUseToken);
             });
     jpaTm()
         .transact(

--- a/core/src/test/java/google/registry/model/history/ContactHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/ContactHistoryTest.java
@@ -44,12 +44,12 @@ public class ContactHistoryTest extends EntityTestCase {
     saveRegistrar("TheRegistrar");
 
     ContactResource contact = newContactResourceWithRoid("contactId", "contact1");
-    jpaTm().transact(() -> jpaTm().saveNew(contact));
+    jpaTm().transact(() -> jpaTm().insert(contact));
     VKey<ContactResource> contactVKey = contact.createVKey();
     ContactResource contactFromDb = jpaTm().transact(() -> jpaTm().load(contactVKey));
     ContactHistory contactHistory = createContactHistory(contactFromDb, contactVKey);
     contactHistory.id = null;
-    jpaTm().transact(() -> jpaTm().saveNew(contactHistory));
+    jpaTm().transact(() -> jpaTm().insert(contactHistory));
     jpaTm()
         .transact(
             () -> {
@@ -65,12 +65,12 @@ public class ContactHistoryTest extends EntityTestCase {
     saveRegistrar("TheRegistrar");
 
     ContactResource contact = newContactResourceWithRoid("contactId", "contact1");
-    tm().transact(() -> tm().saveNew(contact));
+    tm().transact(() -> tm().insert(contact));
     VKey<ContactResource> contactVKey = contact.createVKey();
     ContactResource contactFromDb = tm().transact(() -> tm().load(contactVKey));
     fakeClock.advanceOneMilli();
     ContactHistory contactHistory = createContactHistory(contactFromDb, contactVKey);
-    tm().transact(() -> tm().saveNew(contactHistory));
+    tm().transact(() -> tm().insert(contactHistory));
 
     // retrieving a HistoryEntry or a ContactHistory with the same key should return the same object
     // note: due to the @EntitySubclass annotation. all Keys for ContactHistory objects will have

--- a/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
@@ -59,8 +59,8 @@ public class DomainHistoryTest extends EntityTestCase {
     jpaTm()
         .transact(
             () -> {
-              jpaTm().saveNew(host);
-              jpaTm().saveNew(contact);
+              jpaTm().insert(host);
+              jpaTm().insert(contact);
             });
 
     DomainBase domain =
@@ -68,11 +68,11 @@ public class DomainHistoryTest extends EntityTestCase {
             .asBuilder()
             .setNameservers(host.createVKey())
             .build();
-    jpaTm().transact(() -> jpaTm().saveNew(domain));
+    jpaTm().transact(() -> jpaTm().insert(domain));
 
     DomainHistory domainHistory = createDomainHistory(domain);
     domainHistory.id = null;
-    jpaTm().transact(() -> jpaTm().saveNew(domainHistory));
+    jpaTm().transact(() -> jpaTm().insert(domainHistory));
 
     jpaTm()
         .transact(
@@ -98,8 +98,8 @@ public class DomainHistoryTest extends EntityTestCase {
 
     tm().transact(
             () -> {
-              tm().saveNew(host);
-              tm().saveNew(contact);
+              tm().insert(host);
+              tm().insert(contact);
             });
     fakeClock.advanceOneMilli();
 
@@ -108,11 +108,11 @@ public class DomainHistoryTest extends EntityTestCase {
             .asBuilder()
             .setNameservers(host.createVKey())
             .build();
-    tm().transact(() -> tm().saveNew(domain));
+    tm().transact(() -> tm().insert(domain));
 
     fakeClock.advanceOneMilli();
     DomainHistory domainHistory = createDomainHistory(domain);
-    tm().transact(() -> tm().saveNew(domainHistory));
+    tm().transact(() -> tm().insert(domainHistory));
 
     // retrieving a HistoryEntry or a DomainHistory with the same key should return the same object
     // note: due to the @EntitySubclass annotation. all Keys for ContactHistory objects will have

--- a/core/src/test/java/google/registry/model/history/HostHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/HostHistoryTest.java
@@ -44,12 +44,12 @@ public class HostHistoryTest extends EntityTestCase {
     saveRegistrar("TheRegistrar");
 
     HostResource host = newHostResourceWithRoid("ns1.example.com", "host1");
-    jpaTm().transact(() -> jpaTm().saveNew(host));
+    jpaTm().transact(() -> jpaTm().insert(host));
     VKey<HostResource> hostVKey = VKey.createSql(HostResource.class, "host1");
     HostResource hostFromDb = jpaTm().transact(() -> jpaTm().load(hostVKey));
     HostHistory hostHistory = createHostHistory(hostFromDb, hostVKey);
     hostHistory.id = null;
-    jpaTm().transact(() -> jpaTm().saveNew(hostHistory));
+    jpaTm().transact(() -> jpaTm().insert(hostHistory));
     jpaTm()
         .transact(
             () -> {
@@ -66,12 +66,12 @@ public class HostHistoryTest extends EntityTestCase {
     saveRegistrar("registrar1");
 
     HostResource host = newHostResourceWithRoid("ns1.example.com", "host1");
-    tm().transact(() -> tm().saveNew(host));
+    tm().transact(() -> tm().insert(host));
     VKey<HostResource> hostVKey = VKey.create(HostResource.class, "host1", Key.create(host));
     HostResource hostFromDb = tm().transact(() -> tm().load(hostVKey));
     HostHistory hostHistory = createHostHistory(hostFromDb, hostVKey);
     fakeClock.advanceOneMilli();
-    tm().transact(() -> tm().saveNew(hostHistory));
+    tm().transact(() -> tm().insert(hostHistory));
 
     // retrieving a HistoryEntry or a HostHistory with the same key should return the same object
     // note: due to the @EntitySubclass annotation. all Keys for ContactHistory objects will have

--- a/core/src/test/java/google/registry/model/poll/PollMessageTest.java
+++ b/core/src/test/java/google/registry/model/poll/PollMessageTest.java
@@ -84,7 +84,7 @@ public class PollMessageTest extends EntityTestCase {
   @Test
   void testCloudSqlPersistenceOneTime() {
     saveRegistrar("TheRegistrar");
-    jpaTm().transact(() -> jpaTm().saveNew(oneTime));
+    jpaTm().transact(() -> jpaTm().insert(oneTime));
     PollMessage.OneTime persisted =
         jpaTm().transact(() -> jpaTm().load(VKey.createSql(PollMessage.OneTime.class, oneTime.id)));
     persisted.parent = oneTime.parent;
@@ -94,7 +94,7 @@ public class PollMessageTest extends EntityTestCase {
   @Test
   void testCloudSqlPersistenceAutorenew() {
     saveRegistrar("TheRegistrar");
-    jpaTm().transact(() -> jpaTm().saveNew(autoRenew));
+    jpaTm().transact(() -> jpaTm().insert(autoRenew));
     PollMessage.Autorenew persisted =
         jpaTm()
             .transact(
@@ -107,14 +107,14 @@ public class PollMessageTest extends EntityTestCase {
   void testCloudSqlSupportForPolymorphicVKey() {
     saveRegistrar("TheRegistrar");
 
-    jpaTm().transact(() -> jpaTm().saveNew(oneTime));
+    jpaTm().transact(() -> jpaTm().insert(oneTime));
     PollMessage persistedOneTime =
         jpaTm().transact(() -> jpaTm().load(VKey.createSql(PollMessage.class, oneTime.getId())));
     assertThat(persistedOneTime).isInstanceOf(PollMessage.OneTime.class);
     persistedOneTime.parent = oneTime.parent;
     assertThat(persistedOneTime).isEqualTo(oneTime);
 
-    jpaTm().transact(() -> jpaTm().saveNew(autoRenew));
+    jpaTm().transact(() -> jpaTm().insert(autoRenew));
     PollMessage persistedAutoRenew =
         jpaTm().transact(() -> jpaTm().load(VKey.createSql(PollMessage.class, autoRenew.getId())));
     assertThat(persistedAutoRenew).isInstanceOf(PollMessage.Autorenew.class);

--- a/core/src/test/java/google/registry/model/registry/RegistryTest.java
+++ b/core/src/test/java/google/registry/model/registry/RegistryTest.java
@@ -72,7 +72,7 @@ public class RegistryTest extends EntityTestCase {
     PremiumList pl = persistPremiumList("tld2", "lol,USD 50", "cat,USD 700");
     Registry registry =
         Registry.get("tld").asBuilder().setReservedLists(rl15).setPremiumList(pl).build();
-    jpaTm().transact(() -> jpaTm().saveNew(registry));
+    jpaTm().transact(() -> jpaTm().insert(registry));
     Registry persisted =
         jpaTm().transact(() -> jpaTm().load(VKey.createSql(Registry.class, registry.tldStrId)));
     assertThat(persisted).isEqualTo(registry);

--- a/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchDaoTest.java
+++ b/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchDaoTest.java
@@ -37,8 +37,8 @@ public class Spec11ThreatMatchDaoTest extends EntityTestCase {
     jpaTm()
         .transact(
             () -> {
-              jpaTm().saveAllNew(getThreatMatchesToday());
-              jpaTm().saveAllNew(getThreatMatchesYesterday());
+              jpaTm().insertAll(getThreatMatchesToday());
+              jpaTm().insertAll(getThreatMatchesYesterday());
             });
   }
 

--- a/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchTest.java
+++ b/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchTest.java
@@ -107,10 +107,10 @@ public class Spec11ThreatMatchTest extends EntityTestCase {
     jpaTm()
         .transact(
             () -> {
-              jpaTm().saveNew(registrantContact);
-              jpaTm().saveNew(domain);
-              jpaTm().saveNew(host);
-              jpaTm().saveNew(threat);
+              jpaTm().insert(registrantContact);
+              jpaTm().insert(domain);
+              jpaTm().insert(host);
+              jpaTm().insert(threat);
             });
 
     VKey<Spec11ThreatMatch> threatVKey = VKey.createSql(Spec11ThreatMatch.class, threat.getId());
@@ -130,10 +130,10 @@ public class Spec11ThreatMatchTest extends EntityTestCase {
               .transact(
                   () -> {
                     // Persist the threat without the associated registrar.
-                    jpaTm().saveNew(host);
-                    jpaTm().saveNew(registrantContact);
-                    jpaTm().saveNew(domain);
-                    jpaTm().saveNew(threat);
+                    jpaTm().insert(host);
+                    jpaTm().insert(registrantContact);
+                    jpaTm().insert(domain);
+                    jpaTm().insert(threat);
                   });
         });
 
@@ -145,9 +145,9 @@ public class Spec11ThreatMatchTest extends EntityTestCase {
               .transact(
                   () -> {
                     // Persist the threat without the associated domain.
-                    jpaTm().saveNew(registrantContact);
-                    jpaTm().saveNew(host);
-                    jpaTm().saveNew(threat);
+                    jpaTm().insert(registrantContact);
+                    jpaTm().insert(host);
+                    jpaTm().insert(threat);
                   });
         });
   }

--- a/core/src/test/java/google/registry/persistence/EntityCallbacksListenerTest.java
+++ b/core/src/test/java/google/registry/persistence/EntityCallbacksListenerTest.java
@@ -49,7 +49,7 @@ class EntityCallbacksListenerTest {
   @Test
   void verifyAllCallbacks_executedExpectedTimes() {
     TestEntity testPersist = new TestEntity();
-    jpaTm().transact(() -> jpaTm().saveNew(testPersist));
+    jpaTm().transact(() -> jpaTm().insert(testPersist));
     checkAll(testPersist, 1, 0, 0, 0);
 
     TestEntity testUpdate = new TestEntity();

--- a/core/src/test/java/google/registry/persistence/converter/DurationConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/DurationConverterTest.java
@@ -78,7 +78,7 @@ public class DurationConverterTest {
 
   private void assertPersistedEntityHasSameDuration(Duration duration) {
     DurationTestEntity entity = new DurationTestEntity(duration);
-    jpaTm().transact(() -> jpaTm().saveNew(entity));
+    jpaTm().transact(() -> jpaTm().insert(entity));
     DurationTestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(DurationTestEntity.class, "id"));
     assertThat(persisted.duration.getMillis()).isEqualTo(duration.getMillis());

--- a/core/src/test/java/google/registry/persistence/converter/InetAddressSetConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/InetAddressSetConverterTest.java
@@ -63,7 +63,7 @@ public class InetAddressSetConverterTest {
 
   private void verifySaveAndLoad(@Nullable Set<InetAddress> inetAddresses) {
     InetAddressSetTestEntity testEntity = new InetAddressSetTestEntity(inetAddresses);
-    jpaTm().transact(() -> jpaTm().saveNew(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     InetAddressSetTestEntity persisted =
         jpaTm().transact(() -> jpaTm().load(VKey.createSql(InetAddressSetTestEntity.class, "id")));
     assertThat(persisted.addresses).isEqualTo(inetAddresses);

--- a/core/src/test/java/google/registry/persistence/converter/LocalDateConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/LocalDateConverterTest.java
@@ -54,7 +54,7 @@ public class LocalDateConverterTest {
 
   private LocalDateConverterTestEntity persistAndLoadTestEntity(LocalDate date) {
     LocalDateConverterTestEntity entity = new LocalDateConverterTestEntity(date);
-    jpaTm().transact(() -> jpaTm().saveNew(entity));
+    jpaTm().transact(() -> jpaTm().insert(entity));
     LocalDateConverterTestEntity retrievedEntity =
         jpaTm()
             .transact(() -> jpaTm().load(VKey.createSql(LocalDateConverterTestEntity.class, "id")));

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerImplTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerImplTest.java
@@ -132,10 +132,10 @@ class JpaTransactionManagerImplTest {
   }
 
   @Test
-  void saveNew_succeeds() {
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(theEntity))).isFalse();
-    jpaTm().transact(() -> jpaTm().saveNew(theEntity));
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(theEntity))).isTrue();
+  void insert_succeeds() {
+    assertThat(jpaTm().transact(() -> jpaTm().exists(theEntity))).isFalse();
+    jpaTm().transact(() -> jpaTm().insert(theEntity));
+    assertThat(jpaTm().transact(() -> jpaTm().exists(theEntity))).isTrue();
     assertThat(jpaTm().transact(() -> jpaTm().load(theEntityKey))).isEqualTo(theEntity);
   }
 
@@ -143,7 +143,7 @@ class JpaTransactionManagerImplTest {
   void transact_retriesOptimisticLockExceptions() {
     JpaTransactionManager spyJpaTm = spy(jpaTm());
     doThrow(OptimisticLockException.class).when(spyJpaTm).delete(any(VKey.class));
-    spyJpaTm.transact(() -> spyJpaTm.saveNew(theEntity));
+    spyJpaTm.transact(() -> spyJpaTm.insert(theEntity));
     assertThrows(
         OptimisticLockException.class,
         () -> spyJpaTm.transact(() -> spyJpaTm.delete(theEntityKey)));
@@ -162,7 +162,7 @@ class JpaTransactionManagerImplTest {
   void transactNoRetry_doesNotRetryOptimisticLockException() {
     JpaTransactionManager spyJpaTm = spy(jpaTm());
     doThrow(OptimisticLockException.class).when(spyJpaTm).delete(any(VKey.class));
-    spyJpaTm.transactNoRetry(() -> spyJpaTm.saveNew(theEntity));
+    spyJpaTm.transactNoRetry(() -> spyJpaTm.insert(theEntity));
     assertThrows(
         OptimisticLockException.class,
         () -> spyJpaTm.transactNoRetry(() -> spyJpaTm.delete(theEntityKey)));
@@ -183,7 +183,7 @@ class JpaTransactionManagerImplTest {
     doThrow(new RuntimeException().initCause(new OptimisticLockException()))
         .when(spyJpaTm)
         .delete(any(VKey.class));
-    spyJpaTm.transact(() -> spyJpaTm.saveNew(theEntity));
+    spyJpaTm.transact(() -> spyJpaTm.insert(theEntity));
     assertThrows(
         RuntimeException.class, () -> spyJpaTm.transact(() -> spyJpaTm.delete(theEntityKey)));
     verify(spyJpaTm, times(3)).delete(theEntityKey);
@@ -201,7 +201,7 @@ class JpaTransactionManagerImplTest {
   void transactNewReadOnly_retriesJdbcConnectionExceptions() {
     JpaTransactionManager spyJpaTm = spy(jpaTm());
     doThrow(JDBCConnectionException.class).when(spyJpaTm).load(any(VKey.class));
-    spyJpaTm.transact(() -> spyJpaTm.saveNew(theEntity));
+    spyJpaTm.transact(() -> spyJpaTm.insert(theEntity));
     assertThrows(
         JDBCConnectionException.class,
         () -> spyJpaTm.transactNewReadOnly(() -> spyJpaTm.load(theEntityKey)));
@@ -224,7 +224,7 @@ class JpaTransactionManagerImplTest {
                 .initCause(new JDBCConnectionException("connection exception", new SQLException())))
         .when(spyJpaTm)
         .load(any(VKey.class));
-    spyJpaTm.transact(() -> spyJpaTm.saveNew(theEntity));
+    spyJpaTm.transact(() -> spyJpaTm.insert(theEntity));
     assertThrows(
         RuntimeException.class,
         () -> spyJpaTm.transactNewReadOnly(() -> spyJpaTm.load(theEntityKey)));
@@ -243,7 +243,7 @@ class JpaTransactionManagerImplTest {
   void doTransactionless_retriesJdbcConnectionExceptions() {
     JpaTransactionManager spyJpaTm = spy(jpaTm());
     doThrow(JDBCConnectionException.class).when(spyJpaTm).load(any(VKey.class));
-    spyJpaTm.transact(() -> spyJpaTm.saveNew(theEntity));
+    spyJpaTm.transact(() -> spyJpaTm.insert(theEntity));
     assertThrows(
         RuntimeException.class,
         () -> spyJpaTm.doTransactionless(() -> spyJpaTm.load(theEntityKey)));
@@ -251,19 +251,19 @@ class JpaTransactionManagerImplTest {
   }
 
   @Test
-  void saveNew_throwsExceptionIfEntityExists() {
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(theEntity))).isFalse();
-    jpaTm().transact(() -> jpaTm().saveNew(theEntity));
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(theEntity))).isTrue();
+  void insert_throwsExceptionIfEntityExists() {
+    assertThat(jpaTm().transact(() -> jpaTm().exists(theEntity))).isFalse();
+    jpaTm().transact(() -> jpaTm().insert(theEntity));
+    assertThat(jpaTm().transact(() -> jpaTm().exists(theEntity))).isTrue();
     assertThat(jpaTm().transact(() -> jpaTm().load(theEntityKey))).isEqualTo(theEntity);
-    assertThrows(RollbackException.class, () -> jpaTm().transact(() -> jpaTm().saveNew(theEntity)));
+    assertThrows(RollbackException.class, () -> jpaTm().transact(() -> jpaTm().insert(theEntity)));
   }
 
   @Test
   void createCompoundIdEntity_succeeds() {
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(compoundIdEntity))).isFalse();
-    jpaTm().transact(() -> jpaTm().saveNew(compoundIdEntity));
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(compoundIdEntity))).isTrue();
+    assertThat(jpaTm().transact(() -> jpaTm().exists(compoundIdEntity))).isFalse();
+    jpaTm().transact(() -> jpaTm().insert(compoundIdEntity));
+    assertThat(jpaTm().transact(() -> jpaTm().exists(compoundIdEntity))).isTrue();
     assertThat(jpaTm().transact(() -> jpaTm().load(compoundIdEntityKey)))
         .isEqualTo(compoundIdEntity);
   }
@@ -271,10 +271,10 @@ class JpaTransactionManagerImplTest {
   @Test
   void saveAllNew_succeeds() {
     moreEntities.forEach(
-        entity -> assertThat(jpaTm().transact(() -> jpaTm().checkExists(entity))).isFalse());
-    jpaTm().transact(() -> jpaTm().saveAllNew(moreEntities));
+        entity -> assertThat(jpaTm().transact(() -> jpaTm().exists(entity))).isFalse());
+    jpaTm().transact(() -> jpaTm().insertAll(moreEntities));
     moreEntities.forEach(
-        entity -> assertThat(jpaTm().transact(() -> jpaTm().checkExists(entity))).isTrue());
+        entity -> assertThat(jpaTm().transact(() -> jpaTm().exists(entity))).isTrue());
     assertThat(jpaTm().transact(() -> jpaTm().loadAll(TestEntity.class)))
         .containsExactlyElementsIn(moreEntities);
   }
@@ -282,48 +282,48 @@ class JpaTransactionManagerImplTest {
   @Test
   void saveAllNew_rollsBackWhenFailure() {
     moreEntities.forEach(
-        entity -> assertThat(jpaTm().transact(() -> jpaTm().checkExists(entity))).isFalse());
-    jpaTm().transact(() -> jpaTm().saveNew(moreEntities.get(0)));
+        entity -> assertThat(jpaTm().transact(() -> jpaTm().exists(entity))).isFalse());
+    jpaTm().transact(() -> jpaTm().insert(moreEntities.get(0)));
     assertThrows(
-        RollbackException.class, () -> jpaTm().transact(() -> jpaTm().saveAllNew(moreEntities)));
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(moreEntities.get(0)))).isTrue();
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(moreEntities.get(1)))).isFalse();
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(moreEntities.get(2)))).isFalse();
+        RollbackException.class, () -> jpaTm().transact(() -> jpaTm().insertAll(moreEntities)));
+    assertThat(jpaTm().transact(() -> jpaTm().exists(moreEntities.get(0)))).isTrue();
+    assertThat(jpaTm().transact(() -> jpaTm().exists(moreEntities.get(1)))).isFalse();
+    assertThat(jpaTm().transact(() -> jpaTm().exists(moreEntities.get(2)))).isFalse();
   }
 
   @Test
-  void saveNewOrUpdate_persistsNewEntity() {
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(theEntity))).isFalse();
-    jpaTm().transact(() -> jpaTm().saveNewOrUpdate(theEntity));
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(theEntity))).isTrue();
+  void put_persistsNewEntity() {
+    assertThat(jpaTm().transact(() -> jpaTm().exists(theEntity))).isFalse();
+    jpaTm().transact(() -> jpaTm().put(theEntity));
+    assertThat(jpaTm().transact(() -> jpaTm().exists(theEntity))).isTrue();
     assertThat(jpaTm().transact(() -> jpaTm().load(theEntityKey))).isEqualTo(theEntity);
   }
 
   @Test
-  void saveNewOrUpdate_updatesExistingEntity() {
-    jpaTm().transact(() -> jpaTm().saveNew(theEntity));
+  void put_updatesExistingEntity() {
+    jpaTm().transact(() -> jpaTm().insert(theEntity));
     TestEntity persisted = jpaTm().transact(() -> jpaTm().load(theEntityKey));
     assertThat(persisted.data).isEqualTo("foo");
     theEntity.data = "bar";
-    jpaTm().transact(() -> jpaTm().saveNewOrUpdate(theEntity));
+    jpaTm().transact(() -> jpaTm().put(theEntity));
     persisted = jpaTm().transact(() -> jpaTm().load(theEntityKey));
     assertThat(persisted.data).isEqualTo("bar");
   }
 
   @Test
-  void saveNewOrUpdateAll_succeeds() {
+  void putAll_succeeds() {
     moreEntities.forEach(
-        entity -> assertThat(jpaTm().transact(() -> jpaTm().checkExists(entity))).isFalse());
-    jpaTm().transact(() -> jpaTm().saveNewOrUpdateAll(moreEntities));
+        entity -> assertThat(jpaTm().transact(() -> jpaTm().exists(entity))).isFalse());
+    jpaTm().transact(() -> jpaTm().putAll(moreEntities));
     moreEntities.forEach(
-        entity -> assertThat(jpaTm().transact(() -> jpaTm().checkExists(entity))).isTrue());
+        entity -> assertThat(jpaTm().transact(() -> jpaTm().exists(entity))).isTrue());
     assertThat(jpaTm().transact(() -> jpaTm().loadAll(TestEntity.class)))
         .containsExactlyElementsIn(moreEntities);
   }
 
   @Test
   void update_succeeds() {
-    jpaTm().transact(() -> jpaTm().saveNew(theEntity));
+    jpaTm().transact(() -> jpaTm().insert(theEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().load(VKey.createSql(TestEntity.class, "theEntity")));
     assertThat(persisted.data).isEqualTo("foo");
@@ -335,7 +335,7 @@ class JpaTransactionManagerImplTest {
 
   @Test
   void updateCompoundIdEntity_succeeds() {
-    jpaTm().transact(() -> jpaTm().saveNew(compoundIdEntity));
+    jpaTm().transact(() -> jpaTm().insert(compoundIdEntity));
     TestCompoundIdEntity persisted = jpaTm().transact(() -> jpaTm().load(compoundIdEntityKey));
     assertThat(persisted.data).isEqualTo("foo");
     compoundIdEntity.data = "bar";
@@ -346,15 +346,15 @@ class JpaTransactionManagerImplTest {
 
   @Test
   void update_throwsExceptionWhenEntityDoesNotExist() {
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(theEntity))).isFalse();
+    assertThat(jpaTm().transact(() -> jpaTm().exists(theEntity))).isFalse();
     assertThrows(
         IllegalArgumentException.class, () -> jpaTm().transact(() -> jpaTm().update(theEntity)));
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(theEntity))).isFalse();
+    assertThat(jpaTm().transact(() -> jpaTm().exists(theEntity))).isFalse();
   }
 
   @Test
   void updateAll_succeeds() {
-    jpaTm().transact(() -> jpaTm().saveAllNew(moreEntities));
+    jpaTm().transact(() -> jpaTm().insertAll(moreEntities));
     ImmutableList<TestEntity> updated =
         ImmutableList.of(
             new TestEntity("entity1", "foo_updated"),
@@ -367,7 +367,7 @@ class JpaTransactionManagerImplTest {
 
   @Test
   void updateAll_rollsBackWhenFailure() {
-    jpaTm().transact(() -> jpaTm().saveAllNew(moreEntities));
+    jpaTm().transact(() -> jpaTm().insertAll(moreEntities));
     ImmutableList<TestEntity> updated =
         ImmutableList.of(
             new TestEntity("entity1", "foo_updated"),
@@ -382,8 +382,8 @@ class JpaTransactionManagerImplTest {
 
   @Test
   void load_succeeds() {
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(theEntity))).isFalse();
-    jpaTm().transact(() -> jpaTm().saveNew(theEntity));
+    assertThat(jpaTm().transact(() -> jpaTm().exists(theEntity))).isFalse();
+    jpaTm().transact(() -> jpaTm().insert(theEntity));
     TestEntity persisted = jpaTm().transact(() -> jpaTm().load(theEntityKey));
     assertThat(persisted.name).isEqualTo("theEntity");
     assertThat(persisted.data).isEqualTo("foo");
@@ -391,15 +391,15 @@ class JpaTransactionManagerImplTest {
 
   @Test
   void load_throwsOnMissingElement() {
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(theEntity))).isFalse();
+    assertThat(jpaTm().transact(() -> jpaTm().exists(theEntity))).isFalse();
     assertThrows(
         NoSuchElementException.class, () -> jpaTm().transact(() -> jpaTm().load(theEntityKey)));
   }
 
   @Test
   void maybeLoad_succeeds() {
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(theEntity))).isFalse();
-    jpaTm().transact(() -> jpaTm().saveNew(theEntity));
+    assertThat(jpaTm().transact(() -> jpaTm().exists(theEntity))).isFalse();
+    jpaTm().transact(() -> jpaTm().insert(theEntity));
     TestEntity persisted = jpaTm().transact(() -> jpaTm().maybeLoad(theEntityKey).get());
     assertThat(persisted.name).isEqualTo("theEntity");
     assertThat(persisted.data).isEqualTo("foo");
@@ -407,14 +407,14 @@ class JpaTransactionManagerImplTest {
 
   @Test
   void maybeLoad_nonExistentObject() {
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(theEntity))).isFalse();
+    assertThat(jpaTm().transact(() -> jpaTm().exists(theEntity))).isFalse();
     assertThat(jpaTm().transact(() -> jpaTm().maybeLoad(theEntityKey)).isPresent()).isFalse();
   }
 
   @Test
   void loadCompoundIdEntity_succeeds() {
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(compoundIdEntity))).isFalse();
-    jpaTm().transact(() -> jpaTm().saveNew(compoundIdEntity));
+    assertThat(jpaTm().transact(() -> jpaTm().exists(compoundIdEntity))).isFalse();
+    jpaTm().transact(() -> jpaTm().insert(compoundIdEntity));
     TestCompoundIdEntity persisted = jpaTm().transact(() -> jpaTm().load(compoundIdEntityKey));
     assertThat(persisted.name).isEqualTo("compoundIdEntity");
     assertThat(persisted.age).isEqualTo(10);
@@ -423,37 +423,37 @@ class JpaTransactionManagerImplTest {
 
   @Test
   void loadAll_succeeds() {
-    jpaTm().transact(() -> jpaTm().saveAllNew(moreEntities));
+    jpaTm().transact(() -> jpaTm().insertAll(moreEntities));
     ImmutableList<TestEntity> persisted = jpaTm().transact(() -> jpaTm().loadAll(TestEntity.class));
     assertThat(persisted).containsExactlyElementsIn(moreEntities);
   }
 
   @Test
   void delete_succeeds() {
-    jpaTm().transact(() -> jpaTm().saveNew(theEntity));
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(theEntity))).isTrue();
+    jpaTm().transact(() -> jpaTm().insert(theEntity));
+    assertThat(jpaTm().transact(() -> jpaTm().exists(theEntity))).isTrue();
     jpaTm().transact(() -> jpaTm().delete(theEntityKey));
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(theEntity))).isFalse();
+    assertThat(jpaTm().transact(() -> jpaTm().exists(theEntity))).isFalse();
   }
 
   @Test
   void delete_returnsZeroWhenNoEntity() {
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(theEntity))).isFalse();
+    assertThat(jpaTm().transact(() -> jpaTm().exists(theEntity))).isFalse();
     jpaTm().transact(() -> jpaTm().delete(theEntityKey));
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(theEntity))).isFalse();
+    assertThat(jpaTm().transact(() -> jpaTm().exists(theEntity))).isFalse();
   }
 
   @Test
   void deleteCompoundIdEntity_succeeds() {
-    jpaTm().transact(() -> jpaTm().saveNew(compoundIdEntity));
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(compoundIdEntity))).isTrue();
+    jpaTm().transact(() -> jpaTm().insert(compoundIdEntity));
+    assertThat(jpaTm().transact(() -> jpaTm().exists(compoundIdEntity))).isTrue();
     jpaTm().transact(() -> jpaTm().delete(compoundIdEntityKey));
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(compoundIdEntity))).isFalse();
+    assertThat(jpaTm().transact(() -> jpaTm().exists(compoundIdEntity))).isFalse();
   }
 
   @Test
   void assertDelete_throwsExceptionWhenEntityNotDeleted() {
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(theEntity))).isFalse();
+    assertThat(jpaTm().transact(() -> jpaTm().exists(theEntity))).isFalse();
     assertThrows(
         IllegalArgumentException.class,
         () -> jpaTm().transact(() -> jpaTm().assertDelete(theEntityKey)));

--- a/core/src/test/java/google/registry/persistence/transaction/TransactionTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/TransactionTest.java
@@ -66,7 +66,7 @@ class TransactionTest {
 
     txn = new Transaction.Builder().addDelete(barEntity.key()).build();
     txn.writeToDatastore();
-    assertThat(ofyTm().checkExists(barEntity.key())).isEqualTo(false);
+    assertThat(ofyTm().exists(barEntity.key())).isEqualTo(false);
   }
 
   @Test
@@ -83,7 +83,7 @@ class TransactionTest {
         .transact(
             () -> {
               assertThat(ofyTm().load(fooEntity.key())).isEqualTo(fooEntity);
-              assertThat(ofyTm().checkExists(barEntity.key())).isEqualTo(false);
+              assertThat(ofyTm().exists(barEntity.key())).isEqualTo(false);
             });
   }
 
@@ -107,8 +107,8 @@ class TransactionTest {
       jpaTm()
           .transact(
               () -> {
-                jpaTm().saveNew(fooEntity);
-                jpaTm().saveNew(barEntity);
+                jpaTm().insert(fooEntity);
+                jpaTm().insert(barEntity);
               });
       TransactionEntity txnEnt =
           jpaTm().transact(() -> jpaTm().load(VKey.createSql(TransactionEntity.class, 1L)));
@@ -123,8 +123,7 @@ class TransactionTest {
 
       // Verify that no transaction was persisted for the load transaction.
       assertThat(
-              jpaTm()
-                  .transact(() -> jpaTm().checkExists(VKey.createSql(TransactionEntity.class, 2L))))
+              jpaTm().transact(() -> jpaTm().exists(VKey.createSql(TransactionEntity.class, 2L))))
           .isFalse();
     } finally {
       RegistryConfig.overrideCloudSqlReplicateTransactions(false);
@@ -136,12 +135,10 @@ class TransactionTest {
     jpaTm()
         .transact(
             () -> {
-              jpaTm().saveNew(fooEntity);
-              jpaTm().saveNew(barEntity);
+              jpaTm().insert(fooEntity);
+              jpaTm().insert(barEntity);
             });
-    assertThat(
-            jpaTm()
-                .transact(() -> jpaTm().checkExists(VKey.createSql(TransactionEntity.class, 1L))))
+    assertThat(jpaTm().transact(() -> jpaTm().exists(VKey.createSql(TransactionEntity.class, 1L))))
         .isFalse();
   }
 

--- a/core/src/test/java/google/registry/rde/RdeStagingMapperTest.java
+++ b/core/src/test/java/google/registry/rde/RdeStagingMapperTest.java
@@ -73,7 +73,7 @@ class RdeStagingMapperTest {
     // Set Registrar states which are required for reporting.
     tm().transact(
             () ->
-                tm().saveNewOrUpdateAll(
+                tm().putAll(
                         ImmutableList.of(
                             externalMonitoringRegistrar.asBuilder().setState(State.ACTIVE).build(),
                             testRegistrar.asBuilder().setState(State.ACTIVE).build(),

--- a/core/src/test/java/google/registry/schema/registrar/RegistrarContactTest.java
+++ b/core/src/test/java/google/registry/schema/registrar/RegistrarContactTest.java
@@ -65,7 +65,7 @@ class RegistrarContactTest {
 
   @Test
   void testPersistence_succeeds() {
-    jpaTm().transact(() -> jpaTm().saveNew(testRegistrarPoc));
+    jpaTm().transact(() -> jpaTm().insert(testRegistrarPoc));
     RegistrarContact persisted =
         jpaTm().transact(() -> jpaTm().load(testRegistrarPoc.createVKey()));
     assertThat(persisted).isEqualTo(testRegistrarPoc);

--- a/core/src/test/java/google/registry/schema/registrar/RegistrarDaoTest.java
+++ b/core/src/test/java/google/registry/schema/registrar/RegistrarDaoTest.java
@@ -70,14 +70,14 @@ public class RegistrarDaoTest {
 
   @Test
   void saveNew_worksSuccessfully() {
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(testRegistrar))).isFalse();
-    jpaTm().transact(() -> jpaTm().saveNew(testRegistrar));
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(testRegistrar))).isTrue();
+    assertThat(jpaTm().transact(() -> jpaTm().exists(testRegistrar))).isFalse();
+    jpaTm().transact(() -> jpaTm().insert(testRegistrar));
+    assertThat(jpaTm().transact(() -> jpaTm().exists(testRegistrar))).isTrue();
   }
 
   @Test
   void update_worksSuccessfully() {
-    jpaTm().transact(() -> jpaTm().saveNew(testRegistrar));
+    jpaTm().transact(() -> jpaTm().insert(testRegistrar));
     Registrar persisted = jpaTm().transact(() -> jpaTm().load(registrarKey));
     assertThat(persisted.getRegistrarName()).isEqualTo("registrarName");
     jpaTm()
@@ -92,7 +92,7 @@ public class RegistrarDaoTest {
 
   @Test
   void update_throwsExceptionWhenEntityDoesNotExist() {
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(testRegistrar))).isFalse();
+    assertThat(jpaTm().transact(() -> jpaTm().exists(testRegistrar))).isFalse();
     assertThrows(
         IllegalArgumentException.class,
         () -> jpaTm().transact(() -> jpaTm().update(testRegistrar)));
@@ -100,8 +100,8 @@ public class RegistrarDaoTest {
 
   @Test
   void load_worksSuccessfully() {
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(testRegistrar))).isFalse();
-    jpaTm().transact(() -> jpaTm().saveNew(testRegistrar));
+    assertThat(jpaTm().transact(() -> jpaTm().exists(testRegistrar))).isFalse();
+    jpaTm().transact(() -> jpaTm().insert(testRegistrar));
     Registrar persisted = jpaTm().transact(() -> jpaTm().load(registrarKey));
 
     assertThat(persisted.getClientId()).isEqualTo("registrarId");

--- a/core/src/test/java/google/registry/testing/SqlHelper.java
+++ b/core/src/test/java/google/registry/testing/SqlHelper.java
@@ -62,7 +62,7 @@ public class SqlHelper {
 
   public static Registrar saveRegistrar(String clientId) {
     Registrar registrar = makeRegistrar1().asBuilder().setClientId(clientId).build();
-    jpaTm().transact(() -> jpaTm().saveNew(registrar));
+    jpaTm().transact(() -> jpaTm().insert(registrar));
     return jpaTm().transact(() -> jpaTm().load(registrar.createVKey()));
   }
 

--- a/core/src/test/java/google/registry/tools/CreateRegistrarCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateRegistrarCommandTest.java
@@ -120,7 +120,7 @@ class CreateRegistrarCommandTest extends CommandTestCase<CreateRegistrarCommand>
     Optional<Registrar> registrar = Registrar.loadByClientId("clientz");
     assertThat(registrar).isPresent();
     assertThat(registrar.get().verifyPassword("some_password")).isTrue();
-    assertThat(jpaTm().transact(() -> jpaTm().checkExists(registrar.get()))).isTrue();
+    assertThat(jpaTm().transact(() -> jpaTm().exists(registrar.get()))).isTrue();
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/UpdateRegistrarCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateRegistrarCommandTest.java
@@ -47,7 +47,7 @@ class UpdateRegistrarCommandTest extends CommandTestCase<UpdateRegistrarCommand>
   @Test
   void testSuccess_alsoUpdateInCloudSql() throws Exception {
     assertThat(loadRegistrar("NewRegistrar").verifyPassword("some_password")).isFalse();
-    jpaTm().transact(() -> jpaTm().saveNew(loadRegistrar("NewRegistrar")));
+    jpaTm().transact(() -> jpaTm().insert(loadRegistrar("NewRegistrar")));
     runCommand("--password=some_password", "--force", "NewRegistrar");
     assertThat(loadRegistrar("NewRegistrar").verifyPassword("some_password")).isTrue();
     assertThat(


### PR DESCRIPTION
Per internal discussion, convert names of methods as follows:

    saveNew -> insert
    saveNewOrUpdate -> put
    checkExists -> exists

Likewise, convert derived names to their corresponding forms, e.g.
saveNewOrUpdateAll -> putAll.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/802)
<!-- Reviewable:end -->
