### PR TITLE
Update ICANN activity reporting logging

### DIFF
--- a/core/src/main/java/google/registry/reporting/icann/IcannHttpReporter.java
+++ b/core/src/main/java/google/registry/reporting/icann/IcannHttpReporter.java
@@ -116,14 +116,10 @@ public class IcannHttpReporter {
       // 1000 (i. e. success), there is no need to parse it.
       if (response.getStatusCode() == HttpStatusCodes.STATUS_CODE_BAD_REQUEST) {
         success = false;
-        // To debug if there is a problem with our parsing, we wrap the response and print the stack
-        // trace of it. As far as we can tell, the stack trace for such an exception contains the
-        // response content that is decoded correctly using the expected charset.
-        new HttpResponseException(response).printStackTrace();
         XjcIirdeaResult result = parseResult(content);
         logger.atWarning().log(
             "PUT rejected, status code %s:\n%s\n%s",
-            result.getCode(), result.getMsg(), result.getDescription());
+            result.getCode().getValue(), result.getMsg(), result.getDescription());
       }
     } finally {
       if (response != null) {


### PR DESCRIPTION
1. It appears that when we have a 200 response, the response content is
   garbled, but we don't care since we know the request is successful.
   When we have a 400 response, the response is indeed UTF-8 encoded.
   Print the stack trace of the HTTP exception doesn't help anymore.

2. The result code is a complex type which includes the xml element with
   all its attributes, which don't care. We only want to print the
   value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/808)
<!-- Reviewable:end -->
