### PR TITLE
Request 101m CPU in sandbox proxy

### DIFF
--- a/proxy/kubernetes/proxy-deployment-sandbox-canary.yaml
+++ b/proxy/kubernetes/proxy-deployment-sandbox-canary.yaml
@@ -18,6 +18,9 @@ spec:
       containers:
       - name: proxy-canary
         image: gcr.io/GCP_PROJECT/proxy
+        resources:
+          requests:
+            cpu: "101m"
         ports:
         - containerPort: 30000
           name: health-check

--- a/proxy/kubernetes/proxy-deployment-sandbox.yaml
+++ b/proxy/kubernetes/proxy-deployment-sandbox.yaml
@@ -18,6 +18,9 @@ spec:
       containers:
       - name: proxy
         image: gcr.io/GCP_PROJECT/proxy
+        resources:
+          requests:
+            cpu: "101m"
         ports:
         - containerPort: 30000
           name: health-check


### PR DESCRIPTION
This is suggested as a mitigation to allow us to deploy to sandbox. The default
value is 100m.

See: https://b.corp.google.com/issues/167295064#comment36.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/813)
<!-- Reviewable:end -->
