### PR TITLE
Add log4j-core as a runtime dependency

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -245,6 +245,7 @@ dependencies {
   testCompile deps['org.apache.ftpserver:ftpserver-core']
   compile deps['org.apache.httpcomponents:httpclient']
   compile deps['org.apache.httpcomponents:httpcore']
+  runtime deps['org.apache.logging.log4j:log4j-core']
   testCompile deps['org.apache.sshd:sshd-core']
   testCompile deps['org.apache.sshd:sshd-scp']
   testCompile deps['org.apache.sshd:sshd-sftp']

--- a/core/gradle/dependency-locks/default.lockfile
+++ b/core/gradle/dependency-locks/default.lockfile
@@ -201,7 +201,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/core/gradle/dependency-locks/deploy_jar.lockfile
+++ b/core/gradle/dependency-locks/deploy_jar.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/core/gradle/dependency-locks/nonprodRuntime.lockfile
+++ b/core/gradle/dependency-locks/nonprodRuntime.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/core/gradle/dependency-locks/nonprodRuntimeClasspath.lockfile
+++ b/core/gradle/dependency-locks/nonprodRuntimeClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/core/gradle/dependency-locks/runtime.lockfile
+++ b/core/gradle/dependency-locks/runtime.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/core/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/core/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/core/gradle/dependency-locks/testRuntime.lockfile
+++ b/core/gradle/dependency-locks/testRuntime.lockfile
@@ -216,7 +216,8 @@ org.apache.ftpserver:ftplet-api:1.0.6
 org.apache.ftpserver:ftpserver-core:1.0.6
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.apache.mina:mina-core:2.0.4
 org.apache.sshd:sshd-core:2.0.0
 org.apache.sshd:sshd-scp:2.0.0

--- a/core/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/core/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -216,7 +216,8 @@ org.apache.ftpserver:ftplet-api:1.0.6
 org.apache.ftpserver:ftpserver-core:1.0.6
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.apache.mina:mina-core:2.0.4
 org.apache.sshd:sshd-core:2.0.0
 org.apache.sshd:sshd-scp:2.0.0

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -124,6 +124,7 @@ ext {
       'org.apache.ftpserver:ftpserver-core:1.0.6',
       'org.apache.httpcomponents:httpclient:4.5.11',
       'org.apache.httpcomponents:httpcore:4.4.13',
+      'org.apache.logging.log4j:log4j-core:2.13.3',
       'org.apache.sshd:sshd-core:2.0.0',
       'org.apache.sshd:sshd-scp:2.0.0',
       'org.apache.sshd:sshd-sftp:2.0.0',

--- a/docs/gradle/dependency-locks/compile.lockfile
+++ b/docs/gradle/dependency-locks/compile.lockfile
@@ -201,7 +201,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/docs/gradle/dependency-locks/compileClasspath.lockfile
+++ b/docs/gradle/dependency-locks/compileClasspath.lockfile
@@ -199,7 +199,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/docs/gradle/dependency-locks/default.lockfile
+++ b/docs/gradle/dependency-locks/default.lockfile
@@ -201,7 +201,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/docs/gradle/dependency-locks/deploy_jar.lockfile
+++ b/docs/gradle/dependency-locks/deploy_jar.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/docs/gradle/dependency-locks/runtime.lockfile
+++ b/docs/gradle/dependency-locks/runtime.lockfile
@@ -201,7 +201,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/docs/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/docs/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/docs/gradle/dependency-locks/testCompile.lockfile
+++ b/docs/gradle/dependency-locks/testCompile.lockfile
@@ -204,7 +204,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.apiguardian:apiguardian-api:1.1.0
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61

--- a/docs/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/docs/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -203,7 +203,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.apiguardian:apiguardian-api:1.1.0
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61

--- a/docs/gradle/dependency-locks/testRuntime.lockfile
+++ b/docs/gradle/dependency-locks/testRuntime.lockfile
@@ -204,7 +204,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.apiguardian:apiguardian-api:1.1.0
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61

--- a/docs/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/docs/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -204,7 +204,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.apiguardian:apiguardian-api:1.1.0
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61

--- a/services/backend/gradle/dependency-locks/compile.lockfile
+++ b/services/backend/gradle/dependency-locks/compile.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/services/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/backend/gradle/dependency-locks/default.lockfile
+++ b/services/backend/gradle/dependency-locks/default.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/backend/gradle/dependency-locks/runtime.lockfile
+++ b/services/backend/gradle/dependency-locks/runtime.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/services/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/backend/gradle/dependency-locks/testCompile.lockfile
+++ b/services/backend/gradle/dependency-locks/testCompile.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/backend/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/services/backend/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/backend/gradle/dependency-locks/testRuntime.lockfile
+++ b/services/backend/gradle/dependency-locks/testRuntime.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/backend/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/services/backend/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/default/gradle/dependency-locks/compile.lockfile
+++ b/services/default/gradle/dependency-locks/compile.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/default/gradle/dependency-locks/compileClasspath.lockfile
+++ b/services/default/gradle/dependency-locks/compileClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/default/gradle/dependency-locks/default.lockfile
+++ b/services/default/gradle/dependency-locks/default.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/default/gradle/dependency-locks/runtime.lockfile
+++ b/services/default/gradle/dependency-locks/runtime.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/default/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/services/default/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/default/gradle/dependency-locks/testCompile.lockfile
+++ b/services/default/gradle/dependency-locks/testCompile.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/default/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/services/default/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/default/gradle/dependency-locks/testRuntime.lockfile
+++ b/services/default/gradle/dependency-locks/testRuntime.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/default/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/services/default/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/pubapi/gradle/dependency-locks/compile.lockfile
+++ b/services/pubapi/gradle/dependency-locks/compile.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/pubapi/gradle/dependency-locks/compileClasspath.lockfile
+++ b/services/pubapi/gradle/dependency-locks/compileClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/pubapi/gradle/dependency-locks/default.lockfile
+++ b/services/pubapi/gradle/dependency-locks/default.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/pubapi/gradle/dependency-locks/runtime.lockfile
+++ b/services/pubapi/gradle/dependency-locks/runtime.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/pubapi/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/services/pubapi/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/pubapi/gradle/dependency-locks/testCompile.lockfile
+++ b/services/pubapi/gradle/dependency-locks/testCompile.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/pubapi/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/services/pubapi/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/pubapi/gradle/dependency-locks/testRuntime.lockfile
+++ b/services/pubapi/gradle/dependency-locks/testRuntime.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/pubapi/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/services/pubapi/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/tools/gradle/dependency-locks/compile.lockfile
+++ b/services/tools/gradle/dependency-locks/compile.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/tools/gradle/dependency-locks/compileClasspath.lockfile
+++ b/services/tools/gradle/dependency-locks/compileClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/tools/gradle/dependency-locks/default.lockfile
+++ b/services/tools/gradle/dependency-locks/default.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/tools/gradle/dependency-locks/runtime.lockfile
+++ b/services/tools/gradle/dependency-locks/runtime.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/tools/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/services/tools/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/tools/gradle/dependency-locks/testCompile.lockfile
+++ b/services/tools/gradle/dependency-locks/testCompile.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/tools/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/services/tools/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/tools/gradle/dependency-locks/testRuntime.lockfile
+++ b/services/tools/gradle/dependency-locks/testRuntime.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5

--- a/services/tools/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/services/tools/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -200,7 +200,8 @@ org.apache.commons:commons-compress:1.20
 org.apache.commons:commons-lang3:3.5
 org.apache.httpcomponents:httpclient:4.5.11
 org.apache.httpcomponents:httpcore:4.4.13
-org.apache.logging.log4j:log4j-api:2.6.2
+org.apache.logging.log4j:log4j-api:2.13.3
+org.apache.logging.log4j:log4j-core:2.13.3
 org.bouncycastle:bcpg-jdk15on:1.61
 org.bouncycastle:bcprov-jdk15on:1.61
 org.checkerframework:checker-compat-qual:2.5.5


### PR DESCRIPTION
Without it we kept getting the following warning:

ERROR StatusLogger Log4j2 could not find a logging implementation. Please add log4j-core to the classpath. Using SimpleLogger to log to the console...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/817)
<!-- Reviewable:end -->
