### PR TITLE
Add VKey.restoreOfy() method for fixing ofy keys

### DIFF
--- a/core/src/test/java/google/registry/persistence/VKeyTest.java
+++ b/core/src/test/java/google/registry/persistence/VKeyTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.googlecode.objectify.Key;
+import com.googlecode.objectify.annotation.Entity;
 import google.registry.model.billing.BillingEvent.OneTime;
 import google.registry.model.registrar.RegistrarContact;
 import google.registry.testing.AppEngineExtension;
@@ -59,4 +60,60 @@ class VKeyTest {
             () -> VKey.create(RegistrarContact.class, "fake@example.com"));
     assertThat(thrown).hasMessageThat().contains("BackupGroupRoot");
   }
+
+  @Test
+  void testRestoreOfy() {
+    assertThat(VKey.restoreOfyFrom(null, TestObject.class, 100)).isNull();
+
+    VKey<TestObject> key = VKey.createSql(TestObject.class, "foo");
+    VKey<TestObject> restored = key.restoreOfy(TestObject.class, "bar");
+    assertThat(restored.getOfyKey())
+        .isEqualTo(Key.create(Key.create(TestObject.class, "bar"), TestObject.class, "foo"));
+    assertThat(restored.getSqlKey()).isEqualTo("foo");
+
+    assertThat(VKey.restoreOfyFrom(key).getOfyKey()).isEqualTo(Key.create(TestObject.class, "foo"));
+
+    restored = key.restoreOfy(OtherObject.class, "baz", TestObject.class, "bar");
+    assertThat(restored.getOfyKey())
+        .isEqualTo(
+            Key.create(
+                Key.create(Key.create(OtherObject.class, "baz"), TestObject.class, "bar"),
+                TestObject.class,
+                "foo"));
+
+    // Verify that we can use a key as the first argument.
+    restored = key.restoreOfy(Key.create(TestObject.class, "bar"));
+    assertThat(restored.getOfyKey())
+        .isEqualTo(Key.create(Key.create(TestObject.class, "bar"), TestObject.class, "foo"));
+
+    // Verify that we get an exception when a key is not the first argument.
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> key.restoreOfy(TestObject.class, "foo", Key.create(TestObject.class, "bar")));
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains("Objectify keys may only be used for the first argument");
+
+    // Verify other exception cases.
+    thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> key.restoreOfy(TestObject.class, TestObject.class));
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains("class google.registry.testing.TestObject used as a key value.");
+
+    thrown =
+        assertThrows(IllegalArgumentException.class, () -> key.restoreOfy(TestObject.class, 1.5));
+    assertThat(thrown).hasMessageThat().contains("Key value 1.5 must be a string or long.");
+
+    thrown = assertThrows(IllegalArgumentException.class, () -> key.restoreOfy(TestObject.class));
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains("Missing value for last key of type class google.registry.testing.TestObject");
+  }
+
+  @Entity
+  static class OtherObject {}
 }


### PR DESCRIPTION
Add a restoreOfy() instance method and a restoreOfyFrom() static method to
assist in restoring the objectify key for classes that have composite keys
that do not restore automatically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/820)
<!-- Reviewable:end -->
