### PR TITLE
Convert CertificateViolation into an enum

### DIFF
--- a/util/src/main/java/google/registry/util/CertificateChecker.java
+++ b/util/src/main/java/google/registry/util/CertificateChecker.java
@@ -14,8 +14,11 @@
 
 package google.registry.util;
 
-import com.google.auto.value.AutoValue;
+import static com.google.common.base.Preconditions.checkArgument;
+import static google.registry.util.DateTimeUtils.START_OF_TIME;
+
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
@@ -26,95 +29,96 @@ import org.joda.time.Days;
 /** An utility to check that a given certificate meets our requirements */
 public class CertificateChecker {
 
-  private final int maxValidityDays;
+  private final ImmutableSortedMap<DateTime, Integer> maxValidityLengthSchedule;
   private final int daysToExpiration;
   private final int minimumRsaKeyLength;
-  public final CertificateViolation certificateExpiredViolation;
-  public final CertificateViolation certificateNotYetValidViolation;
-  public final CertificateViolation certificateValidityLengthViolation;
-  public final CertificateViolation certificateOldValidityLengthValidViolation;
-  public final CertificateViolation certificateRsaKeyLengthViolation;
-  public final CertificateViolation certificateAlgorithmViolation;
+  private final Clock clock;
 
-  public CertificateChecker(int maxValidityDays, int daysToExpiration, int minimumRsaKeyLength) {
-    this.maxValidityDays = maxValidityDays;
+  /**
+   * Constructs a CertificateChecker instance with the specified configuration parameters.
+   *
+   * <p>The max validity length schedule is a sorted map of {@link DateTime} to {@link Integer}
+   * entries representing a maximum validity period for certificates issued on or after that date.
+   * The first entry must have a key of {@link DateTimeUtils#START_OF_TIME}, such that every
+   * possible date has an applicable max validity period. Since security requirements tighten over
+   * time, the max validity periods will be decreasing as the date increases.
+   *
+   * <p>The validity length schedule used by all major Web browsers as of 2020Q4 would be
+   * represented as:
+   *
+   * <pre>
+   *   ImmutableSortedMap.of(
+   *     START_OF_TIME, 825,
+   *     DateTime.parse("2020-09-01T00:00:00Z"), 398
+   *   );
+   * </pre>
+   */
+  // TODO(sarahbot): Inject this.
+  public CertificateChecker(
+      ImmutableSortedMap<DateTime, Integer> maxValidityLengthSchedule,
+      int daysToExpiration,
+      int minimumRsaKeyLength,
+      Clock clock) {
+    checkArgument(
+        maxValidityLengthSchedule.containsKey(START_OF_TIME),
+        "Max validity length schedule must contain an entry for START_OF_TIME");
+    this.maxValidityLengthSchedule = maxValidityLengthSchedule;
     this.daysToExpiration = daysToExpiration;
     this.minimumRsaKeyLength = minimumRsaKeyLength;
-    this.certificateExpiredViolation =
-        CertificateViolation.create("Expired Certificate", "This certificate is expired.");
-    this.certificateNotYetValidViolation =
-        CertificateViolation.create(
-            "Not Yet Valid", "This certificate's start date has not yet passed.");
-    this.certificateOldValidityLengthValidViolation =
-        CertificateViolation.create(
-            "Validity Period Too Long",
-            String.format(
-                "The certificate's validity length must be less than or equal to %d days, or %d"
-                    + " days if issued prior to 2020-09-01.",
-                maxValidityDays, 825));
-    this.certificateValidityLengthViolation =
-        CertificateViolation.create(
-            "Validity Period Too Long",
-            String.format(
-                "The certificate must have a validity length of less than %d days.",
-                maxValidityDays));
-    this.certificateRsaKeyLengthViolation =
-        CertificateViolation.create(
-            "RSA Key Length Too Long",
-            String.format("The minimum RSA key length is %d.", minimumRsaKeyLength));
-    this.certificateAlgorithmViolation =
-        CertificateViolation.create(
-            "Certificate Algorithm Not Allowed", "Only RSA and ECDSA keys are accepted.");
+    this.clock = clock;
   }
 
   /**
    * Checks a certificate for violations and returns a list of all the violations the certificate
    * has.
    */
-  public ImmutableSet<CertificateViolation> checkCertificate(
-      X509Certificate certificate, Date now) {
+  public ImmutableSet<CertificateViolation> checkCertificate(X509Certificate certificate) {
     ImmutableSet.Builder<CertificateViolation> violations = new ImmutableSet.Builder<>();
 
-    // Check Expiration
+    // Check if currently in validity period
+    Date now = clock.nowUtc().toDate();
     if (certificate.getNotAfter().before(now)) {
-      violations.add(certificateExpiredViolation);
+      violations.add(CertificateViolation.EXPIRED);
     } else if (certificate.getNotBefore().after(now)) {
-      violations.add(certificateNotYetValidViolation);
-    }
-    int validityLength = getValidityLengthInDays(certificate);
-    if (validityLength > maxValidityDays) {
-      if (new DateTime(certificate.getNotBefore())
-          .isBefore(DateTime.parse("2020-09-01T00:00:00Z"))) {
-        if (validityLength > 825) {
-          violations.add(certificateOldValidityLengthValidViolation);
-        }
-      } else {
-        violations.add(certificateValidityLengthViolation);
-      }
+      violations.add(CertificateViolation.NOT_YET_VALID);
     }
 
-    // Check Key Strengths
+    // Check validity period length
+    int maxValidityDays =
+        maxValidityLengthSchedule.floorEntry(new DateTime(certificate.getNotBefore())).getValue();
+    if (getValidityLengthInDays(certificate) > maxValidityDays) {
+      violations.add(CertificateViolation.VALIDITY_LENGTH_TOO_LONG);
+    }
+
+    // Check key strengths
     PublicKey key = certificate.getPublicKey();
     if (key.getAlgorithm().equals("RSA")) {
       RSAPublicKey rsaPublicKey = (RSAPublicKey) key;
       if (rsaPublicKey.getModulus().bitLength() < minimumRsaKeyLength) {
-        violations.add(certificateRsaKeyLengthViolation);
+        violations.add(CertificateViolation.RSA_KEY_LENGTH_TOO_SHORT);
       }
     } else if (key.getAlgorithm().equals("EC")) {
       // TODO(sarahbot): Add verification of ECDSA curves
     } else {
-      violations.add(certificateAlgorithmViolation);
+      violations.add(CertificateViolation.ALGORITHM_CONSTRAINED);
     }
     return violations.build();
   }
 
-  /** Returns true if the certificate is nearing expiration. */
-  public boolean isNearingExpiration(X509Certificate certificate, Date now) {
+  /**
+   * Returns whether the certificate is nearing expiration.
+   *
+   * <p>Note that this is <i>all</i> that it checks. The certificate itself may well be expired or
+   * not yet valid and this message will still return false. So you definitely want to pair a call
+   * to this method with a call to {@link #checkCertificate} to determine other issues with the
+   * certificate that may be occurring.
+   */
+  public boolean isNearingExpiration(X509Certificate certificate) {
     Date nearingExpirationDate =
         DateTime.parse(certificate.getNotAfter().toInstant().toString())
             .minusDays(daysToExpiration)
             .toDate();
-    return now.after(nearingExpirationDate);
+    return clock.nowUtc().toDate().after(nearingExpirationDate);
   }
 
   private static int getValidityLengthInDays(X509Certificate certificate) {
@@ -122,20 +126,52 @@ public class CertificateChecker {
     DateTime end = DateTime.parse(certificate.getNotAfter().toInstant().toString());
     return Days.daysBetween(start.withTimeAtStartOfDay(), end.withTimeAtStartOfDay()).getDays();
   }
-}
 
-/**
- * The type of violation a certificate has based on the certificate requirements
- * (go/registry-proxy-security).
- */
-@AutoValue
-abstract class CertificateViolation {
+  private String getViolationDisplayMessage(CertificateViolation certificateViolation) {
+    // Yes, we'd rather do this as an instance method on the CertificateViolation enum itself, but
+    // we can't because we need access to configuration (injected as instance variables) which you
+    // can't get in a static enum context.
+    switch (certificateViolation) {
+      case EXPIRED:
+        return "Certificate is expired.";
+      case NOT_YET_VALID:
+        return "Certificate start date is in the future.";
+      case ALGORITHM_CONSTRAINED:
+        return "Certificate key algorithm must be RSA or ECDSA.";
+      case RSA_KEY_LENGTH_TOO_SHORT:
+        return String.format(
+            "RSA key length is too short; the minimum allowed length is %d bits.",
+            this.minimumRsaKeyLength);
+      case VALIDITY_LENGTH_TOO_LONG:
+        return String.format(
+            "Certificate validity period is too long; it must be less than or equal to %d days.",
+            this.maxValidityLengthSchedule.lastEntry().getValue());
+      default:
+        throw new IllegalArgumentException(
+            String.format(
+                "Unknown CertificateViolation enum value: %s", certificateViolation.name()));
+    }
+  }
 
-  public abstract String name();
+  /**
+   * The type of violation a certificate has based on the certificate requirements
+   * (go/registry-proxy-security).
+   */
+  public enum CertificateViolation {
+    EXPIRED,
+    NOT_YET_VALID,
+    VALIDITY_LENGTH_TOO_LONG,
+    RSA_KEY_LENGTH_TOO_SHORT,
+    ALGORITHM_CONSTRAINED;
 
-  public abstract String displayMessage();
-
-  public static CertificateViolation create(String name, String displayMessage) {
-    return new AutoValue_CertificateViolation(name, displayMessage);
+    /**
+     * Gets a suitable end-user-facing display message for this particular certificate violation.
+     *
+     * <p>Note that the {@link CertificateChecker} instance must be passed in because it contains
+     * configuration values (e.g. minimum RSA key length) that go into the error message text.
+     */
+    public String getDisplayMessage(CertificateChecker certificateChecker) {
+      return certificateChecker.getViolationDisplayMessage(this);
+    }
   }
 }

--- a/util/src/main/java/google/registry/util/SelfSignedCaCertificate.java
+++ b/util/src/main/java/google/registry/util/SelfSignedCaCertificate.java
@@ -37,6 +37,7 @@ import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.joda.time.DateTime;
 
 /** A self-signed certificate authority (CA) cert for use in tests. */
 // TODO(weiminyu): make this class test-only. Requires refactor in proxy and prober.
@@ -83,9 +84,20 @@ public class SelfSignedCaCertificate {
     return create(keyGen.generateKeyPair(), fqdn, from, to);
   }
 
+  public static SelfSignedCaCertificate create(String fqdn, DateTime from, DateTime to)
+      throws Exception {
+    return create(keyGen.generateKeyPair(), fqdn, from.toDate(), to.toDate());
+  }
+
   public static SelfSignedCaCertificate create(KeyPair keyPair, String fqdn, Date from, Date to)
       throws Exception {
     return new SelfSignedCaCertificate(keyPair.getPrivate(), createCaCert(keyPair, fqdn, from, to));
+  }
+
+  public static SelfSignedCaCertificate create(
+      KeyPair keyPair, String fqdn, DateTime from, DateTime to) throws Exception {
+    return new SelfSignedCaCertificate(
+        keyPair.getPrivate(), createCaCert(keyPair, fqdn, from.toDate(), to.toDate()));
   }
 
   static KeyPairGenerator createKeyPairGenerator() {


### PR DESCRIPTION
This ends up being nicer to deal with from callsites than class instances, while
still permitting full configurability of all parameters. There are various other
changes/fixes as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/829)
<!-- Reviewable:end -->
