### PR TITLE
Maintain a release-to-Version map in deployment

### DIFF
--- a/release/cloudbuild-deploy.yaml
+++ b/release/cloudbuild-deploy.yaml
@@ -63,17 +63,6 @@ steps:
   - --credential
   - tool-credential.json
   - deploy_invoicing_pipeline
-# Save the deployed tag for the current environment on GCS. Because of b/137891685
-# which causes the for-loop in the next step to fail, this may not be the last step.
-# TODO(weiminyu): do this in last step.
-- name: 'gcr.io/$PROJECT_ID/builder:latest'
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    set -e
-    echo ${TAG_NAME} | \
-      gsutil cp - gs://$PROJECT_ID-deployed-tags/nomulus.${_ENV}.tag
 # Deploy the GAE config files.
 # First authorize the gcloud tool to use the credential json file, then
 # download and unzip the tarball that contains the relevant config files
@@ -97,6 +86,39 @@ steps:
       gcloud -q --project $project_id app deploy \
         default/WEB-INF/appengine-generated/$filename.yaml
     done
+# Save the deployed tag for the current environment on GCS, and update the
+# mappings from Nomulus releases to Appengine versions.
+- name: 'gcr.io/$PROJECT_ID/builder:latest'
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    echo ${TAG_NAME} | \
+      gsutil cp - gs://$PROJECT_ID-deployed-tags/nomulus.${_ENV}.tag
+    # Update the release to AppEngine version mapping.
+    if [ ${_ENV} == production ]; then
+      project_id="domain-registry"
+    else
+      project_id="domain-registry-${_ENV}"
+    fi
+    local_map="nomulus.${_ENV}.tmp"
+    gcloud app versions list \
+      --project $project_id --hide-no-traffic \
+      --format="csv[no-heading](SERVICE,VERSION.ID)" | \
+      grep -e "^backend\|^default\|^pubapi\|^tools" |\
+      while read line; do echo "${TAG_NAME},$line"; done | tee "$local_map"
+    num_versions=$(cat "$local_map" | wc -l)
+    if [ "$num_versions" -ne 4 ]; then
+      echo "Expecting exactly four active services. Found $num_versions"
+      exit 1
+    fi
+    gsutil cp "$local_map" gs://$PROJECT_ID-deployed-tags/nomulus.${_ENV}.tmp
+    # Atomically append uploaded tmp file to nomulus.${_ENV}.versions
+    gsutil compose \
+      gs://$PROJECT_ID-deployed-tags/nomulus.${_ENV}.versions \
+      gs://$PROJECT_ID-deployed-tags/nomulus.${_ENV}.tmp \
+      gs://$PROJECT_ID-deployed-tags/nomulus.${_ENV}.versions
 
 timeout: 3600s
 options:


### PR DESCRIPTION
Keep track of the mapping between Nomulus release tags and AppEngine
version ids with a mapping file. This is necessary because AppEngine
does not support custom versioning. With this mapping, rollbacks could
be automated. Automation of rollbacks is important since there are
test-supporting metadata to be updated, but are easily forgotten.

During the last stage of deployment, current per-service version ids
are fetched using gcloud and are appended to a file on GCS. Each line
is of the format "{RELEASE_TAG},{APPENGINE_SERVICE},{APPENGINE_VERSION}.

This change has been tested in crash. The rollback script is still a
work in progress.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/831)
<!-- Reviewable:end -->
