### PR TITLE
Minor python changes

### DIFF
--- a/config/nom_build.py
+++ b/config/nom_build.py
@@ -16,7 +16,7 @@
 """
 
 import argparse
-import attr
+import dataclasses
 import io
 import os
 import shutil
@@ -25,7 +25,7 @@ import sys
 from typing import List, Union
 
 
-@attr.s(auto_attribs=True)
+@dataclasses.dataclass
 class Property:
     name : str = ''
     desc : str = ''
@@ -39,7 +39,7 @@ class Property:
                 raise ValidationError('value of {self.name} must be "true" or '
                                       '"false".')
 
-@attr.s(auto_attribs=True)
+@dataclasses.dataclass
 class GradleFlag:
     flags : Union[str, List[str]]
     desc : str

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,6 +11,7 @@ You will need the following programs installed on your local machine:
 *   [Google App Engine SDK for Java][app-engine-sdk], and configure aliases to
     to the `gcloud` and `appcfg.sh` utilities (you'll use them a lot).
 *   [Git](https://git-scm.com/) version control system.
+*   Python version 3.7 or newer.
 
 **Note:** App Engine does not yet support Java 9. Also, the instructions in this
 document have only been tested on Linux. They might work with some alterations


### PR DESCRIPTION
Use dataclasses instead of attrs. The former is part of the standard lib
while the latter may need to be installed separately. For now we are not
using advanced features in attrs. Ran nom_build_test by hand and it passes.

Also added python3 to the list of prerequisites in docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/832)
<!-- Reviewable:end -->
