### PR TITLE
Upgrade error-prone to 3.3.4

### DIFF
--- a/buildSrc/gradle/dependency-locks/annotationProcessor.lockfile
+++ b/buildSrc/gradle/dependency-locks/annotationProcessor.lockfile
@@ -1,25 +1,28 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto.value:auto-value:1.6.3
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/buildSrc/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/buildSrc/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/common/gradle/dependency-locks/annotationProcessor.lockfile
+++ b/common/gradle/dependency-locks/annotationProcessor.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/common/gradle/dependency-locks/errorprone.lockfile
+++ b/common/gradle/dependency-locks/errorprone.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/common/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/common/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/common/gradle/dependency-locks/testingAnnotationProcessor.lockfile
+++ b/common/gradle/dependency-locks/testingAnnotationProcessor.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/common/src/main/java/google/registry/util/SystemSleeper.java
+++ b/common/src/main/java/google/registry/util/SystemSleeper.java
@@ -18,7 +18,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.util.concurrent.Uninterruptibles;
 import java.io.Serializable;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 import org.joda.time.ReadableDuration;
@@ -41,6 +40,6 @@ public final class SystemSleeper implements Sleeper, Serializable {
   @Override
   public void sleepUninterruptibly(ReadableDuration duration) {
     checkArgument(duration.getMillis() >= 0);
-    Uninterruptibles.sleepUninterruptibly(duration.getMillis(), TimeUnit.MILLISECONDS);
+    Uninterruptibles.sleepUninterruptibly(java.time.Duration.ofMillis(duration.getMillis()));
   }
 }

--- a/core/gradle/dependency-locks/annotationProcessor.lockfile
+++ b/core/gradle/dependency-locks/annotationProcessor.lockfile
@@ -1,8 +1,8 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto.value:auto-value:1.6.3
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
@@ -11,11 +11,11 @@ com.google.dagger:dagger-compiler:2.28
 com.google.dagger:dagger-producers:2.28
 com.google.dagger:dagger-spi:2.28
 com.google.dagger:dagger:2.28
-com.google.errorprone:error_prone_annotation:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
 com.google.errorprone:error_prone_annotations:2.3.4
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.errorprone:javac-shaded:9-dev-r4023-3
 com.google.googlejavaformat:google-java-format:1.5
 com.google.guava:failureaccess:1.0.1
@@ -30,11 +30,14 @@ javax.inject:javax.inject:1
 javax.persistence:javax.persistence-api:2.2
 net.ltgt.gradle.incap:incap:0.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:2.11.1
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.61
 org.jetbrains.kotlin:kotlin-stdlib:1.3.61
 org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0
 org.jetbrains:annotations:13.0
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/core/gradle/dependency-locks/errorprone.lockfile
+++ b/core/gradle/dependency-locks/errorprone.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/core/gradle/dependency-locks/nonprodAnnotationProcessor.lockfile
+++ b/core/gradle/dependency-locks/nonprodAnnotationProcessor.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/core/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/core/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,8 +1,8 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto.value:auto-value:1.6.3
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
@@ -11,11 +11,11 @@ com.google.dagger:dagger-compiler:2.28
 com.google.dagger:dagger-producers:2.28
 com.google.dagger:dagger-spi:2.28
 com.google.dagger:dagger:2.28
-com.google.errorprone:error_prone_annotation:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
 com.google.errorprone:error_prone_annotations:2.3.4
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.errorprone:javac-shaded:9-dev-r4023-3
 com.google.googlejavaformat:google-java-format:1.5
 com.google.guava:failureaccess:1.0.1
@@ -30,11 +30,14 @@ javax.inject:javax.inject:1
 javax.persistence:javax.persistence-api:2.2
 net.ltgt.gradle.incap:incap:0.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:2.11.1
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.61
 org.jetbrains.kotlin:kotlin-stdlib:1.3.61
 org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0
 org.jetbrains:annotations:13.0
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/core/src/main/java/google/registry/model/EppResource.java
+++ b/core/src/main/java/google/registry/model/EppResource.java
@@ -24,7 +24,6 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.util.CollectionUtils.nullToEmpty;
 import static google.registry.util.CollectionUtils.nullToEmptyImmutableCopy;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
@@ -387,7 +386,7 @@ public abstract class EppResource extends BackupGroupRoot implements Buildable {
   private static LoadingCache<VKey<? extends EppResource>, EppResource> createEppResourcesCache(
       Duration expiry) {
     return CacheBuilder.newBuilder()
-        .expireAfterWrite(expiry.getMillis(), MILLISECONDS)
+        .expireAfterWrite(java.time.Duration.ofMillis(expiry.getMillis()))
         .maximumSize(getEppResourceMaxCachedEntries())
         .build(CACHE_LOADER);
   }

--- a/core/src/main/java/google/registry/model/index/ForeignKeyIndex.java
+++ b/core/src/main/java/google/registry/model/index/ForeignKeyIndex.java
@@ -20,7 +20,6 @@ import static google.registry.config.RegistryConfig.getEppResourceMaxCachedEntri
 import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.TypeUtils.instantiate;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
@@ -244,7 +243,7 @@ public abstract class ForeignKeyIndex<E extends EppResource> extends BackupGroup
   private static LoadingCache<Key<ForeignKeyIndex<?>>, Optional<ForeignKeyIndex<?>>>
       createForeignKeyIndexesCache(Duration expiry) {
     return CacheBuilder.newBuilder()
-        .expireAfterWrite(expiry.getMillis(), MILLISECONDS)
+        .expireAfterWrite(java.time.Duration.ofMillis(expiry.getMillis()))
         .maximumSize(getEppResourceMaxCachedEntries())
         .build(CACHE_LOADER);
   }

--- a/core/src/main/java/google/registry/model/registry/Registry.java
+++ b/core/src/main/java/google/registry/model/registry/Registry.java
@@ -28,7 +28,6 @@ import static google.registry.util.CollectionUtils.nullToEmptyImmutableCopy;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.joda.money.CurrencyUnit.USD;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -260,7 +259,8 @@ public class Registry extends ImmutableObject implements Buildable, DatastoreAnd
   /** A cache that loads the {@link Registry} for a given tld. */
   private static final LoadingCache<String, Optional<Registry>> CACHE =
       CacheBuilder.newBuilder()
-          .expireAfterWrite(getSingletonCacheRefreshDuration().getMillis(), MILLISECONDS)
+          .expireAfterWrite(
+              java.time.Duration.ofMillis(getSingletonCacheRefreshDuration().getMillis()))
           .build(
               new CacheLoader<String, Optional<Registry>>() {
                 @Override

--- a/core/src/main/java/google/registry/model/registry/label/PremiumList.java
+++ b/core/src/main/java/google/registry/model/registry/label/PremiumList.java
@@ -25,7 +25,6 @@ import static google.registry.model.common.EntityGroupRoot.getCrossTldKey;
 import static google.registry.model.ofy.ObjectifyService.allocateId;
 import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
@@ -197,7 +196,7 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
   @VisibleForTesting
   static LoadingCache<String, PremiumList> createCachePremiumLists(Duration cachePersistDuration) {
     return CacheBuilder.newBuilder()
-        .expireAfterWrite(cachePersistDuration.getMillis(), MILLISECONDS)
+        .expireAfterWrite(java.time.Duration.ofMillis(cachePersistDuration.getMillis()))
         .build(
             new CacheLoader<String, PremiumList>() {
               @Override
@@ -221,7 +220,8 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
   static final LoadingCache<Key<PremiumListRevision>, PremiumListRevision>
       cachePremiumListRevisions =
           CacheBuilder.newBuilder()
-              .expireAfterWrite(getSingletonCachePersistDuration().getMillis(), MILLISECONDS)
+              .expireAfterWrite(
+                  java.time.Duration.ofMillis(getSingletonCachePersistDuration().getMillis()))
               .build(
                   new CacheLoader<Key<PremiumListRevision>, PremiumListRevision>() {
                     @Override
@@ -260,14 +260,14 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
   static LoadingCache<Key<PremiumListEntry>, Optional<PremiumListEntry>>
       createCachePremiumListEntries(Duration cachePersistDuration) {
     return CacheBuilder.newBuilder()
-        .expireAfterWrite(cachePersistDuration.getMillis(), MILLISECONDS)
+        .expireAfterWrite(java.time.Duration.ofMillis(cachePersistDuration.getMillis()))
         .maximumSize(getStaticPremiumListMaxCachedEntries())
         .build(
             new CacheLoader<Key<PremiumListEntry>, Optional<PremiumListEntry>>() {
               @Override
               public Optional<PremiumListEntry> load(final Key<PremiumListEntry> entryKey) {
-                return tm()
-                    .doTransactionless(() -> Optional.ofNullable(ofy().load().key(entryKey).now()));
+                return tm().doTransactionless(
+                        () -> Optional.ofNullable(ofy().load().key(entryKey).now()));
               }
             });
   }

--- a/core/src/main/java/google/registry/model/registry/label/ReservedList.java
+++ b/core/src/main/java/google/registry/model/registry/label/ReservedList.java
@@ -20,7 +20,6 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static google.registry.config.RegistryConfig.getDomainLabelListCacheDuration;
 import static google.registry.model.registry.label.ReservationType.FULLY_BLOCKED;
 import static google.registry.util.CollectionUtils.nullToEmpty;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.joda.time.DateTimeZone.UTC;
 
 import com.google.common.base.Splitter;
@@ -241,7 +240,8 @@ public final class ReservedList
 
   private static LoadingCache<String, ReservedList> cache =
       CacheBuilder.newBuilder()
-          .expireAfterWrite(getDomainLabelListCacheDuration().getMillis(), MILLISECONDS)
+          .expireAfterWrite(
+              java.time.Duration.ofMillis(getDomainLabelListCacheDuration().getMillis()))
           .build(
               new CacheLoader<String, ReservedList>() {
                 @Override

--- a/core/src/main/java/google/registry/model/tmch/ClaimsListShard.java
+++ b/core/src/main/java/google/registry/model/tmch/ClaimsListShard.java
@@ -57,7 +57,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
@@ -146,8 +145,7 @@ public class ClaimsListShard extends ImmutableObject implements DatastoreAndSqlE
 
   private static final Retrier LOADER_RETRIER = new Retrier(new SystemSleeper(), 2);
 
-  private static final Callable<ClaimsListShard> LOADER_CALLABLE =
-      () -> {
+  private static ClaimsListShard loadClaimsListShard() {
         // Find the most recent revision.
         Key<ClaimsListRevision> revisionKey = getCurrentRevision();
 
@@ -246,7 +244,9 @@ public class ClaimsListShard extends ImmutableObject implements DatastoreAndSqlE
    */
   private static final Supplier<ClaimsListShard> CACHE =
       memoizeWithShortExpiration(
-          () -> LOADER_RETRIER.callWithRetry(LOADER_CALLABLE, IllegalStateException.class));
+          () ->
+              LOADER_RETRIER.callWithRetry(
+                  ClaimsListShard::loadClaimsListShard, IllegalStateException.class));
 
   /** Returns the revision id of this claims list, or throws exception if it is null. */
   public Long getRevisionId() {

--- a/core/src/main/java/google/registry/model/transfer/DomainTransferData.java
+++ b/core/src/main/java/google/registry/model/transfer/DomainTransferData.java
@@ -144,16 +144,19 @@ public class DomainTransferData extends TransferData<DomainTransferData.Builder>
             rootKey, serverApproveAutorenewPollMessage, serverApproveAutorenewPollMessageHistoryId);
   }
 
+  @SuppressWarnings("unused") // For Hibernate.
   private void loadServerApproveBillingEventHistoryId(
       @AlsoLoad("serverApproveBillingEvent") VKey<BillingEvent.OneTime> val) {
     serverApproveBillingEventHistoryId = DomainBase.getHistoryId(val);
   }
 
+  @SuppressWarnings("unused") // For Hibernate.
   private void loadServerApproveAutorenewEventHistoryId(
       @AlsoLoad("serverApproveAutorenewEvent") VKey<BillingEvent.Recurring> val) {
     serverApproveAutorenewEventHistoryId = DomainBase.getHistoryId(val);
   }
 
+  @SuppressWarnings("unused") // For Hibernate.
   private void loadServerApproveAutorenewPollMessageHistoryId(
       @AlsoLoad("serverApproveAutorenewPollMessage") VKey<PollMessage.Autorenew> val) {
     serverApproveAutorenewPollMessageHistoryId = DomainBase.getHistoryId(val);

--- a/core/src/main/java/google/registry/module/ServletBase.java
+++ b/core/src/main/java/google/registry/module/ServletBase.java
@@ -22,7 +22,6 @@ import google.registry.request.RequestHandler;
 import google.registry.util.SystemClock;
 import java.io.IOException;
 import java.security.Security;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -51,13 +50,16 @@ public class ServletBase extends HttpServlet {
     // etc), we log the error but keep the main thread running. Also the shutdown hook will only be
     // registered if metric reporter starts up correctly.
     try {
-      metricReporter.get().startAsync().awaitRunning(10, TimeUnit.SECONDS);
+      metricReporter.get().startAsync().awaitRunning(java.time.Duration.ofSeconds(10));
       logger.atInfo().log("Started up MetricReporter");
       LifecycleManager.getInstance()
           .setShutdownHook(
               () -> {
                 try {
-                  metricReporter.get().stopAsync().awaitTerminated(10, TimeUnit.SECONDS);
+                  metricReporter
+                      .get()
+                      .stopAsync()
+                      .awaitTerminated(java.time.Duration.ofSeconds(10));
                   logger.atInfo().log("Shut down MetricReporter");
                 } catch (TimeoutException e) {
                   logger.atSevere().withCause(e).log("Failed to stop MetricReporter.");

--- a/core/src/main/java/google/registry/schema/tld/PremiumListCache.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumListCache.java
@@ -18,7 +18,6 @@ import static google.registry.config.RegistryConfig.getDomainLabelListCacheDurat
 import static google.registry.config.RegistryConfig.getSingletonCachePersistDuration;
 import static google.registry.config.RegistryConfig.getStaticPremiumListMaxCachedEntries;
 import static google.registry.schema.tld.PremiumListDao.getPriceForLabel;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
@@ -48,7 +47,7 @@ class PremiumListCache {
   static LoadingCache<String, Optional<PremiumList>> createCachePremiumLists(
       Duration cachePersistDuration) {
     return CacheBuilder.newBuilder()
-        .expireAfterWrite(cachePersistDuration.getMillis(), MILLISECONDS)
+        .expireAfterWrite(java.time.Duration.ofMillis(cachePersistDuration.getMillis()))
         .build(
             new CacheLoader<String, Optional<PremiumList>>() {
               @Override
@@ -81,7 +80,7 @@ class PremiumListCache {
   static LoadingCache<RevisionIdAndLabel, Optional<BigDecimal>> createCachePremiumEntries(
       Duration cachePersistDuration) {
     return CacheBuilder.newBuilder()
-        .expireAfterWrite(cachePersistDuration.getMillis(), MILLISECONDS)
+        .expireAfterWrite(java.time.Duration.ofMillis(cachePersistDuration.getMillis()))
         .maximumSize(getStaticPremiumListMaxCachedEntries())
         .build(
             new CacheLoader<RevisionIdAndLabel, Optional<BigDecimal>>() {

--- a/core/src/main/java/google/registry/tmch/TmchCertificateAuthority.java
+++ b/core/src/main/java/google/registry/tmch/TmchCertificateAuthority.java
@@ -18,7 +18,6 @@ import static google.registry.config.RegistryConfig.ConfigModule.TmchCaMode.PILO
 import static google.registry.config.RegistryConfig.ConfigModule.TmchCaMode.PRODUCTION;
 import static google.registry.config.RegistryConfig.getSingletonCacheRefreshDuration;
 import static google.registry.util.ResourceUtils.readResourceUtf8;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -77,7 +76,8 @@ public final class TmchCertificateAuthority {
    */
   private static final LoadingCache<TmchCaMode, X509CRL> CRL_CACHE =
       CacheBuilder.newBuilder()
-          .expireAfterWrite(getSingletonCacheRefreshDuration().getMillis(), MILLISECONDS)
+          .expireAfterWrite(
+              java.time.Duration.ofMillis(getSingletonCacheRefreshDuration().getMillis()))
           .build(
               new CacheLoader<TmchCaMode, X509CRL>() {
                 @Override

--- a/core/src/main/java/google/registry/tools/CompareDbBackups.java
+++ b/core/src/main/java/google/registry/tools/CompareDbBackups.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
 import java.io.File;
-import java.util.function.Predicate;
 
 /**
  * Compares two Datastore backups in V3 format on local file system. This is for use in tests and
@@ -30,8 +29,10 @@ import java.util.function.Predicate;
  */
 class CompareDbBackups {
   private static final String DS_V3_BACKUP_FILE_PREFIX = "output-";
-  private static final Predicate<File> DATA_FILE_MATCHER =
-      file -> file.isFile() && file.getName().startsWith(DS_V3_BACKUP_FILE_PREFIX);
+
+  private static boolean isDatastoreV3File(File file) {
+    return file.isFile() && file.getName().startsWith(DS_V3_BACKUP_FILE_PREFIX);
+  }
 
   public static void main(String[] args) {
     if (args.length != 2) {
@@ -40,9 +41,11 @@ class CompareDbBackups {
     }
 
     ImmutableSet<EntityWrapper> entities1 =
-        RecordAccumulator.readDirectory(new File(args[0]), DATA_FILE_MATCHER).getEntityWrapperSet();
+        RecordAccumulator.readDirectory(new File(args[0]), CompareDbBackups::isDatastoreV3File)
+            .getEntityWrapperSet();
     ImmutableSet<EntityWrapper> entities2 =
-        RecordAccumulator.readDirectory(new File(args[1]), DATA_FILE_MATCHER).getEntityWrapperSet();
+        RecordAccumulator.readDirectory(new File(args[1]), CompareDbBackups::isDatastoreV3File)
+            .getEntityWrapperSet();
 
     // Calculate the entities added and removed.
     SetView<EntityWrapper> added = Sets.difference(entities2, entities1);

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
@@ -64,7 +64,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 import javax.inject.Inject;
 import org.joda.time.DateTime;
 
@@ -96,8 +95,9 @@ public class RegistrarSettingsAction implements Runnable, JsonActionRunner.JsonA
 
   @Inject RegistrarSettingsAction() {}
 
-  private static final Predicate<RegistrarContact> HAS_PHONE =
-      contact -> contact.getPhoneNumber() != null;
+  private static boolean hasPhone(RegistrarContact contact) {
+    return contact.getPhoneNumber() != null;
+  }
 
   @Override
   public void run() {
@@ -512,8 +512,8 @@ public class RegistrarSettingsAction implements Runnable, JsonActionRunner.JsonA
       Multimap<Type, RegistrarContact> newContactsByType,
       Type... types) {
     for (Type type : types) {
-      if (oldContactsByType.get(type).stream().anyMatch(HAS_PHONE)
-          && newContactsByType.get(type).stream().noneMatch(HAS_PHONE)) {
+      if (oldContactsByType.get(type).stream().anyMatch(RegistrarSettingsAction::hasPhone)
+          && newContactsByType.get(type).stream().noneMatch(RegistrarSettingsAction::hasPhone)) {
         throw new ContactRequirementException(
             String.format(
                 "Please provide a phone number for at least one %s contact",

--- a/core/src/test/java/google/registry/beam/TestPipelineExtension.java
+++ b/core/src/test/java/google/registry/beam/TestPipelineExtension.java
@@ -143,6 +143,7 @@ public class TestPipelineExtension extends Pipeline
     // Null until the pipeline has been run
     @Nullable private List<TransformHierarchy.Node> runVisitedNodes;
 
+    @SuppressWarnings("UnnecessaryLambda") // Stay true to the original class.
     private final Predicate<Node> isPAssertNode =
         node ->
             node.getTransform() instanceof PAssert.GroupThenAssert

--- a/core/src/test/java/google/registry/model/ofy/OfyTest.java
+++ b/core/src/test/java/google/registry/model/ofy/OfyTest.java
@@ -27,7 +27,6 @@ import static google.registry.testing.DatastoreHelper.persistActiveContact;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -225,7 +224,7 @@ public class OfyTest {
                 if (firstAttemptTime == null) {
                   // Sleep a bit to ensure that the next attempt is at a new millisecond.
                   firstAttemptTime = tm().getTransactionTime();
-                  sleepUninterruptibly(10, MILLISECONDS);
+                  sleepUninterruptibly(java.time.Duration.ofMillis(10));
                   throw new ConcurrentModificationException();
                 }
                 assertThat(tm().getTransactionTime()).isGreaterThan(firstAttemptTime);

--- a/core/src/test/java/google/registry/testing/sftp/TestSftpServer.java
+++ b/core/src/test/java/google/registry/testing/sftp/TestSftpServer.java
@@ -93,7 +93,7 @@ public class TestSftpServer implements FtpServer {
     try (PEMParser pemParser = new PEMParser(new StringReader(key))) {
       PEMKeyPair pemPair = (PEMKeyPair) pemParser.readObject();
       KeyPair result = new JcaPEMKeyConverter().setProvider("BC").getKeyPair(pemPair);
-      logger.atInfo().log("Read key pair %s", result);
+      logger.atInfo().log("Read key pair successfully.");
       return result;
     } catch (IOException e) {
       logger.atSevere().withCause(e).log("Couldn't read key pair from string.");

--- a/db/gradle/dependency-locks/annotationProcessor.lockfile
+++ b/db/gradle/dependency-locks/annotationProcessor.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/db/gradle/dependency-locks/errorprone.lockfile
+++ b/db/gradle/dependency-locks/errorprone.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/db/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/db/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -53,7 +53,7 @@ ext {
       'com.google.code.gson:gson:2.8.5',
       'com.google.dagger:dagger-compiler:2.28',
       'com.google.dagger:dagger:2.28',
-      'com.google.errorprone:error_prone_annotations:2.3.3',
+      'com.google.errorprone:error_prone_annotations:2.3.4',
       'com.google.flogger:flogger-system-backend:0.1',
       'com.google.flogger:flogger:0.1',
       'com.google.guava:guava-testlib:29.0-jre',

--- a/docs/gradle/dependency-locks/annotationProcessor.lockfile
+++ b/docs/gradle/dependency-locks/annotationProcessor.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/docs/gradle/dependency-locks/errorprone.lockfile
+++ b/docs/gradle/dependency-locks/errorprone.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/docs/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/docs/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -67,7 +67,7 @@ configurations {
 
 dependencies {
     // compatibility with Java 8
-    errorprone("com.google.errorprone:error_prone_core:2.3.3")
+    errorprone("com.google.errorprone:error_prone_core:2.3.4")
 }
 
 test {

--- a/networking/gradle/dependency-locks/annotationProcessor.lockfile
+++ b/networking/gradle/dependency-locks/annotationProcessor.lockfile
@@ -1,8 +1,8 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
@@ -10,11 +10,11 @@ com.google.dagger:dagger-compiler:2.28
 com.google.dagger:dagger-producers:2.28
 com.google.dagger:dagger-spi:2.28
 com.google.dagger:dagger:2.28
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.errorprone:javac-shaded:9-dev-r4023-3
 com.google.googlejavaformat:google-java-format:1.5
 com.google.guava:failureaccess:1.0.1
@@ -28,12 +28,15 @@ javax.annotation:jsr250-api:1.0
 javax.inject:javax.inject:1
 net.ltgt.gradle.incap:incap:0.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.61
 org.jetbrains.kotlin:kotlin-stdlib:1.3.61
 org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0
 org.jetbrains:annotations:13.0
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/networking/gradle/dependency-locks/errorprone.lockfile
+++ b/networking/gradle/dependency-locks/errorprone.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/networking/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/networking/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,8 +1,8 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
@@ -10,11 +10,11 @@ com.google.dagger:dagger-compiler:2.28
 com.google.dagger:dagger-producers:2.28
 com.google.dagger:dagger-spi:2.28
 com.google.dagger:dagger:2.28
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.errorprone:javac-shaded:9-dev-r4023-3
 com.google.googlejavaformat:google-java-format:1.5
 com.google.guava:failureaccess:1.0.1
@@ -28,12 +28,15 @@ javax.annotation:jsr250-api:1.0
 javax.inject:javax.inject:1
 net.ltgt.gradle.incap:incap:0.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.61
 org.jetbrains.kotlin:kotlin-stdlib:1.3.61
 org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0
 org.jetbrains:annotations:13.0
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/networking/src/test/java/google/registry/networking/handler/SslClientInitializerTest.java
+++ b/networking/src/test/java/google/registry/networking/handler/SslClientInitializerTest.java
@@ -46,7 +46,6 @@ import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
-import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
@@ -74,9 +73,13 @@ class SslClientInitializerTest {
   /** Fake port to test if the SSL engine gets the correct peer port. */
   private static final int SSL_PORT = 12345;
 
-  private static final Function<Channel, String> hostProvider = channel -> SSL_HOST;
+  private static String hostProvider(Channel channel) {
+    return SSL_HOST;
+  }
 
-  private static final Function<Channel, Integer> portProvider = channel -> SSL_PORT;
+  private static int portProvider(Channel channel) {
+    return SSL_PORT;
+  }
 
   @RegisterExtension NettyExtension nettyExtension = new NettyExtension();
 
@@ -114,7 +117,12 @@ class SslClientInitializerTest {
   void testSuccess_swappedInitializerWithSslHandler(SslProvider sslProvider) {
     SslClientInitializer<EmbeddedChannel> sslClientInitializer =
         new SslClientInitializer<>(
-            sslProvider, hostProvider, portProvider, ImmutableList.of(), null, null);
+            sslProvider,
+            SslClientInitializerTest::hostProvider,
+            SslClientInitializerTest::portProvider,
+            ImmutableList.of(),
+            null,
+            null);
     EmbeddedChannel channel = new EmbeddedChannel();
     ChannelPipeline pipeline = channel.pipeline();
     pipeline.addLast(sslClientInitializer);
@@ -131,7 +139,12 @@ class SslClientInitializerTest {
   void testSuccess_nullHost(SslProvider sslProvider) {
     SslClientInitializer<EmbeddedChannel> sslClientInitializer =
         new SslClientInitializer<>(
-            sslProvider, channel -> null, portProvider, ImmutableList.of(), null, null);
+            sslProvider,
+            channel -> null,
+            SslClientInitializerTest::portProvider,
+            ImmutableList.of(),
+            null,
+            null);
     EmbeddedChannel channel = new EmbeddedChannel();
     ChannelPipeline pipeline = channel.pipeline();
     pipeline.addLast(sslClientInitializer);
@@ -144,7 +157,12 @@ class SslClientInitializerTest {
   void testSuccess_nullPort(SslProvider sslProvider) {
     SslClientInitializer<EmbeddedChannel> sslClientInitializer =
         new SslClientInitializer<>(
-            sslProvider, hostProvider, channel -> null, ImmutableList.of(), null, null);
+            sslProvider,
+            SslClientInitializerTest::hostProvider,
+            channel -> null,
+            ImmutableList.of(),
+            null,
+            null);
     EmbeddedChannel channel = new EmbeddedChannel();
     ChannelPipeline pipeline = channel.pipeline();
     pipeline.addLast(sslClientInitializer);
@@ -162,7 +180,12 @@ class SslClientInitializerTest {
     nettyExtension.setUpServer(localAddress, getServerHandler(false, ssc.key(), ssc.cert()));
     SslClientInitializer<LocalChannel> sslClientInitializer =
         new SslClientInitializer<>(
-            sslProvider, hostProvider, portProvider, ImmutableList.of(), null, null);
+            sslProvider,
+            SslClientInitializerTest::hostProvider,
+            SslClientInitializerTest::portProvider,
+            ImmutableList.of(),
+            null,
+            null);
     nettyExtension.setUpClient(localAddress, sslClientInitializer);
     // The connection is now terminated, both the client side and the server side should get
     // exceptions.
@@ -192,7 +215,12 @@ class SslClientInitializerTest {
     // Set up the client to trust the self signed cert used to sign the cert that server provides.
     SslClientInitializer<LocalChannel> sslClientInitializer =
         new SslClientInitializer<>(
-            sslProvider, hostProvider, portProvider, ImmutableList.of(ssc.cert()), null, null);
+            sslProvider,
+            SslClientInitializerTest::hostProvider,
+            SslClientInitializerTest::portProvider,
+            ImmutableList.of(ssc.cert()),
+            null,
+            null);
     nettyExtension.setUpClient(localAddress, sslClientInitializer);
 
     setUpSslChannel(nettyExtension.getClientChannel(), cert);
@@ -228,7 +256,12 @@ class SslClientInitializerTest {
     // Set up the client to trust the self signed cert used to sign the cert that server provides.
     SslClientInitializer<LocalChannel> sslClientInitializer =
         new SslClientInitializer<>(
-            sslProvider, hostProvider, portProvider, ImmutableList.of(ssc.cert()), null, null);
+            sslProvider,
+            SslClientInitializerTest::hostProvider,
+            SslClientInitializerTest::portProvider,
+            ImmutableList.of(ssc.cert()),
+            null,
+            null);
     nettyExtension.setUpClient(localAddress, sslClientInitializer);
 
     verifySslException(
@@ -264,7 +297,12 @@ class SslClientInitializerTest {
     // Set up the client to trust the self signed cert used to sign the cert that server provides.
     SslClientInitializer<LocalChannel> sslClientInitializer =
         new SslClientInitializer<>(
-            sslProvider, hostProvider, portProvider, ImmutableList.of(ssc.cert()), null, null);
+            sslProvider,
+            SslClientInitializerTest::hostProvider,
+            SslClientInitializerTest::portProvider,
+            ImmutableList.of(ssc.cert()),
+            null,
+            null);
     nettyExtension.setUpClient(localAddress, sslClientInitializer);
 
     verifySslException(
@@ -292,8 +330,8 @@ class SslClientInitializerTest {
     SslClientInitializer<LocalChannel> sslClientInitializer =
         new SslClientInitializer<>(
             sslProvider,
-            hostProvider,
-            portProvider,
+            SslClientInitializerTest::hostProvider,
+            SslClientInitializerTest::portProvider,
             ImmutableList.of(serverSsc.cert()),
             () -> clientSsc.key(),
             () -> ImmutableList.of(clientSsc.cert()));
@@ -333,7 +371,12 @@ class SslClientInitializerTest {
     // Set up the client to trust the self signed cert used to sign the cert that server provides.
     SslClientInitializer<LocalChannel> sslClientInitializer =
         new SslClientInitializer<>(
-            sslProvider, hostProvider, portProvider, ImmutableList.of(ssc.cert()), null, null);
+            sslProvider,
+            SslClientInitializerTest::hostProvider,
+            SslClientInitializerTest::portProvider,
+            ImmutableList.of(ssc.cert()),
+            null,
+            null);
     nettyExtension.setUpClient(localAddress, sslClientInitializer);
 
     // When the client rejects the server cert due to wrong hostname, both the client and server

--- a/prober/gradle/dependency-locks/annotationProcessor.lockfile
+++ b/prober/gradle/dependency-locks/annotationProcessor.lockfile
@@ -1,8 +1,8 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto.value:auto-value:1.6.3
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
@@ -11,11 +11,11 @@ com.google.dagger:dagger-compiler:2.28
 com.google.dagger:dagger-producers:2.28
 com.google.dagger:dagger-spi:2.28
 com.google.dagger:dagger:2.28
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.errorprone:javac-shaded:9-dev-r4023-3
 com.google.googlejavaformat:google-java-format:1.5
 com.google.guava:failureaccess:1.0.1
@@ -29,12 +29,15 @@ javax.annotation:jsr250-api:1.0
 javax.inject:javax.inject:1
 net.ltgt.gradle.incap:incap:0.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.61
 org.jetbrains.kotlin:kotlin-stdlib:1.3.61
 org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0
 org.jetbrains:annotations:13.0
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/prober/gradle/dependency-locks/errorprone.lockfile
+++ b/prober/gradle/dependency-locks/errorprone.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/prober/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/prober/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,8 +1,8 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto.value:auto-value:1.6.3
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
@@ -11,11 +11,11 @@ com.google.dagger:dagger-compiler:2.28
 com.google.dagger:dagger-producers:2.28
 com.google.dagger:dagger-spi:2.28
 com.google.dagger:dagger:2.28
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.errorprone:javac-shaded:9-dev-r4023-3
 com.google.googlejavaformat:google-java-format:1.5
 com.google.guava:failureaccess:1.0.1
@@ -29,12 +29,15 @@ javax.annotation:jsr250-api:1.0
 javax.inject:javax.inject:1
 net.ltgt.gradle.incap:incap:0.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.61
 org.jetbrains.kotlin:kotlin-stdlib:1.3.61
 org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0
 org.jetbrains:annotations:13.0
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/processor/gradle/dependency-locks/annotationProcessor.lockfile
+++ b/processor/gradle/dependency-locks/annotationProcessor.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/processor/gradle/dependency-locks/errorprone.lockfile
+++ b/processor/gradle/dependency-locks/errorprone.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/processor/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/processor/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/proxy/gradle/dependency-locks/annotationProcessor.lockfile
+++ b/proxy/gradle/dependency-locks/annotationProcessor.lockfile
@@ -1,8 +1,8 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto.value:auto-value:1.6.3
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
@@ -11,11 +11,11 @@ com.google.dagger:dagger-compiler:2.28
 com.google.dagger:dagger-producers:2.28
 com.google.dagger:dagger-spi:2.28
 com.google.dagger:dagger:2.28
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.errorprone:javac-shaded:9-dev-r4023-3
 com.google.googlejavaformat:google-java-format:1.5
 com.google.guava:failureaccess:1.0.1
@@ -29,12 +29,15 @@ javax.annotation:jsr250-api:1.0
 javax.inject:javax.inject:1
 net.ltgt.gradle.incap:incap:0.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.61
 org.jetbrains.kotlin:kotlin-stdlib:1.3.61
 org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0
 org.jetbrains:annotations:13.0
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/proxy/gradle/dependency-locks/errorprone.lockfile
+++ b/proxy/gradle/dependency-locks/errorprone.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/proxy/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/proxy/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,8 +1,8 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto.value:auto-value:1.6.3
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
@@ -11,11 +11,11 @@ com.google.dagger:dagger-compiler:2.28
 com.google.dagger:dagger-producers:2.28
 com.google.dagger:dagger-spi:2.28
 com.google.dagger:dagger:2.28
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.errorprone:javac-shaded:9-dev-r4023-3
 com.google.googlejavaformat:google-java-format:1.5
 com.google.guava:failureaccess:1.0.1
@@ -29,12 +29,15 @@ javax.annotation:jsr250-api:1.0
 javax.inject:javax.inject:1
 net.ltgt.gradle.incap:incap:0.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.61
 org.jetbrains.kotlin:kotlin-stdlib:1.3.61
 org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0
 org.jetbrains:annotations:13.0
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/proxy/src/main/java/google/registry/proxy/ProxyServer.java
+++ b/proxy/src/main/java/google/registry/proxy/ProxyServer.java
@@ -46,7 +46,6 @@ import io.netty.util.internal.logging.JdkLoggerFactory;
 import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.Queue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.inject.Provider;
 
@@ -317,7 +316,7 @@ public class ProxyServer implements Runnable {
     if (proxyModule.provideEnvironment() != Environment.LOCAL) {
       MetricReporter metricReporter = proxyComponent.metricReporter();
       try {
-        metricReporter.startAsync().awaitRunning(10, TimeUnit.SECONDS);
+        metricReporter.startAsync().awaitRunning(java.time.Duration.ofSeconds(10));
         logger.atInfo().log("Started up MetricReporter");
       } catch (TimeoutException timeoutException) {
         logger.atSevere().withCause(timeoutException).log(
@@ -328,7 +327,7 @@ public class ProxyServer implements Runnable {
               new Thread(
                   () -> {
                     try {
-                      metricReporter.stopAsync().awaitTerminated(10, TimeUnit.SECONDS);
+                      metricReporter.stopAsync().awaitTerminated(java.time.Duration.ofSeconds(10));
                       logger.atInfo().log("Shut down MetricReporter");
                     } catch (TimeoutException timeoutException) {
                       logger.atWarning().withCause(timeoutException).log(

--- a/util/gradle/dependency-locks/annotationProcessor.lockfile
+++ b/util/gradle/dependency-locks/annotationProcessor.lockfile
@@ -1,8 +1,8 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto.value:auto-value:1.6.3
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
@@ -11,11 +11,11 @@ com.google.dagger:dagger-compiler:2.28
 com.google.dagger:dagger-producers:2.28
 com.google.dagger:dagger-spi:2.28
 com.google.dagger:dagger:2.28
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.errorprone:javac-shaded:9-dev-r4023-3
 com.google.googlejavaformat:google-java-format:1.5
 com.google.guava:failureaccess:1.0.1
@@ -29,12 +29,15 @@ javax.annotation:jsr250-api:1.0
 javax.inject:javax.inject:1
 net.ltgt.gradle.incap:incap:0.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.61
 org.jetbrains.kotlin:kotlin-stdlib:1.3.61
 org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0
 org.jetbrains:annotations:13.0
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/util/gradle/dependency-locks/errorprone.lockfile
+++ b/util/gradle/dependency-locks/errorprone.lockfile
@@ -1,24 +1,27 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:27.0.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.1
 com.google.protobuf:protobuf-java:3.4.0
 com.googlecode.java-diff-utils:diffutils:1.3.0
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/util/gradle/dependency-locks/testAnnotationProcessor.lockfile
+++ b/util/gradle/dependency-locks/testAnnotationProcessor.lockfile
@@ -1,8 +1,8 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.github.ben-manes.caffeine:caffeine:2.7.0
 com.github.kevinstern:software-and-algorithms:1.0
-com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.auto.value:auto-value:1.6.3
 com.google.auto:auto-common:0.10
 com.google.code.findbugs:jFormatString:3.0.0
@@ -11,11 +11,11 @@ com.google.dagger:dagger-compiler:2.28
 com.google.dagger:dagger-producers:2.28
 com.google.dagger:dagger-spi:2.28
 com.google.dagger:dagger:2.28
-com.google.errorprone:error_prone_annotation:2.3.3
-com.google.errorprone:error_prone_annotations:2.3.3
-com.google.errorprone:error_prone_check_api:2.3.3
-com.google.errorprone:error_prone_core:2.3.3
-com.google.errorprone:error_prone_type_annotations:2.3.3
+com.google.errorprone:error_prone_annotation:2.3.4
+com.google.errorprone:error_prone_annotations:2.3.4
+com.google.errorprone:error_prone_check_api:2.3.4
+com.google.errorprone:error_prone_core:2.3.4
+com.google.errorprone:error_prone_type_annotations:2.3.4
 com.google.errorprone:javac-shaded:9-dev-r4023-3
 com.google.googlejavaformat:google-java-format:1.5
 com.google.guava:failureaccess:1.0.1
@@ -29,12 +29,15 @@ javax.annotation:jsr250-api:1.0
 javax.inject:javax.inject:1
 net.ltgt.gradle.incap:incap:0.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:2.5.3
-org.checkerframework:dataflow:2.5.3
-org.checkerframework:javacutil:2.5.3
+org.checkerframework:checker-qual:3.0.0
+org.checkerframework:dataflow:3.0.0
+org.checkerframework:javacutil:3.0.0
 org.codehaus.mojo:animal-sniffer-annotations:1.17
 org.jetbrains.kotlin:kotlin-stdlib-common:1.3.61
 org.jetbrains.kotlin:kotlin-stdlib:1.3.61
 org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0
 org.jetbrains:annotations:13.0
 org.pcollections:pcollections:2.1.2
+org.plumelib:plume-util:1.0.6
+org.plumelib:reflection-util:0.0.2
+org.plumelib:require-javadoc:0.1.0

--- a/util/src/main/java/google/registry/util/Retrier.java
+++ b/util/src/main/java/google/registry/util/Retrier.java
@@ -71,7 +71,7 @@ public class Retrier implements Serializable {
    * @return the value returned by the {@link Callable}.
    */
   public <V> V callWithRetry(Callable<V> callable, Predicate<Throwable> isRetryable) {
-    return callWithRetry(callable, LOGGING_FAILURE_REPORTER, isRetryable);
+    return callWithRetry(callable, Retrier::reportFailure, isRetryable);
   }
 
   /**
@@ -92,7 +92,7 @@ public class Retrier implements Serializable {
       Callable<V> callable,
       Class<? extends Throwable> retryableError,
       Class<? extends Throwable>... moreRetryableErrors) {
-    return callWithRetry(callable, LOGGING_FAILURE_REPORTER, retryableError, moreRetryableErrors);
+    return callWithRetry(callable, Retrier::reportFailure, retryableError, moreRetryableErrors);
   }
 
   /**
@@ -171,8 +171,8 @@ public class Retrier implements Serializable {
     }
   }
 
-  private static final FailureReporter LOGGING_FAILURE_REPORTER =
-      (thrown, failures, maxAttempts) ->
-          logger.atInfo().withCause(thrown).log(
-              "Retrying transient error, attempt %d/%d", failures, maxAttempts);
+  private static void reportFailure(Throwable thrown, int failures, int maxAttempts) {
+    logger.atInfo().withCause(thrown).log(
+        "Retrying transient error, attempt %d/%d", failures, maxAttempts);
+  }
 }


### PR DESCRIPTION
This would fix the error the failure with openjdk 11.0.9 in
3.3.3.

Fixed new antipatterns raised by the new version:
- Replaced unnecessary lambdas with methods.
- Switched wait/sleep calls to equivalent methods using java.time types
- Types inheriting Object.toString() should not be assigned to string
parameter in logging statements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/848)
<!-- Reviewable:end -->
