### PR TITLE
Sync the live folder after Nomulus rollback

### DIFF
--- a/release/rollback/plan.py
+++ b/release/rollback/plan.py
@@ -172,6 +172,9 @@ def _generate_steps(
     rollback_steps.append(
         steps.update_deploy_tags(gcs_client.project, env, target_release))
 
+    rollback_steps.append(
+        steps.sync_live_release(gcs_client.project, target_release))
+
     return tuple(rollback_steps)
 
 

--- a/release/rollback/rollback_test.py
+++ b/release/rollback/rollback_test.py
@@ -114,7 +114,7 @@ class RollbackTestCase(unittest.TestCase):
 
         steps = plan.get_rollback_plan(self._gcs_client, self._appengine_admin,
                                        'crash', 'nomulus-20201014-RC00')
-        self.assertEqual(len(steps), 14)
+        self.assertEqual(len(steps), 15)
         self.assertRegex(steps[0].info(),
                          '.*nom_build :integration:sqlIntegrationTest.*')
         self.assertRegex(steps[1].info(), '.*gcloud app versions start.*')
@@ -123,6 +123,7 @@ class RollbackTestCase(unittest.TestCase):
         self.assertRegex(steps[9].info(), '.*gcloud app versions stop.*')
         self.assertRegex(steps[13].info(),
                          '.*echo nomulus-20201014-RC00 | gsutil cat -.*')
+        self.assertRegex(steps[14].info(), '.*gsutil -m rsync -d .*')
 
 
 if __name__ == '__main__':

--- a/release/rollback/steps.py
+++ b/release/rollback/steps.py
@@ -150,3 +150,20 @@ def update_deploy_tags(dev_project: str, env: str,
         f'Update Nomulus tag in {env}',
         (f'echo {nom_tag} | gsutil cp - {destination}', ''), nom_tag,
         destination)
+
+
+def sync_live_release(dev_project: str, nom_tag: str) -> RollbackStep:
+    """Syncs the target release artifacts to the live folder.
+
+    By convention the gs://{dev_project}-deploy/live folder should contain the
+    artifacts from the currently serving release.
+
+    For Domain Registry team members, this step updates the nomulus tool
+    installed on corp desktops.
+    """
+    artifacts_folder = f'gs://{dev_project}-deploy/{nom_tag}'
+    live_folder = f'gs://{dev_project}-deploy/live'
+
+    return RollbackStep(
+        f'Syncing {artifacts_folder} to {live_folder}.',
+        ('gsutil', '-m', 'rsync', '-d', artifacts_folder, live_folder))


### PR DESCRIPTION
To update the nomulus tool on corp desktop, the artifacts from the
rollback target release should be copied to the 'live' folder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/854)
<!-- Reviewable:end -->
