### PR TITLE
Fix entity annotations for a few classes

### DIFF
--- a/core/src/main/java/google/registry/model/billing/BillingEvent.java
+++ b/core/src/main/java/google/registry/model/billing/BillingEvent.java
@@ -24,6 +24,7 @@ import static google.registry.util.CollectionUtils.nullToEmptyImmutableCopy;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -49,6 +50,8 @@ import google.registry.model.transfer.TransferData.TransferServerApproveEntity;
 import google.registry.persistence.VKey;
 import google.registry.persistence.WithLongVKey;
 import google.registry.schema.replay.DatastoreAndSqlEntity;
+import google.registry.schema.replay.DatastoreEntity;
+import google.registry.schema.replay.SqlEntity;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -685,7 +688,7 @@ public abstract class BillingEvent extends ImmutableObject
   @ReportedOn
   @Entity
   @WithLongVKey
-  public static class Modification extends BillingEvent implements DatastoreAndSqlEntity {
+  public static class Modification extends BillingEvent implements DatastoreEntity {
 
     /** The change in cost that should be applied to the original billing event. */
     Money cost;
@@ -745,6 +748,11 @@ public abstract class BillingEvent extends ImmutableObject
           .setCost(billingEvent.getCost().negated())
           .setParent(historyEntry)
           .build();
+    }
+
+    @Override
+    public ImmutableList<SqlEntity> toSqlEntities() {
+      return ImmutableList.of(); // not persisted in SQL
     }
 
     /** A builder for {@link Modification} since it is immutable. */

--- a/core/src/main/java/google/registry/model/domain/secdns/DomainDsDataBase.java
+++ b/core/src/main/java/google/registry/model/domain/secdns/DomainDsDataBase.java
@@ -17,7 +17,6 @@ package google.registry.model.domain.secdns;
 import com.googlecode.objectify.annotation.Embed;
 import com.googlecode.objectify.annotation.Ignore;
 import google.registry.model.ImmutableObject;
-import google.registry.schema.replay.DatastoreAndSqlEntity;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
 import javax.persistence.MappedSuperclass;
@@ -32,7 +31,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 @Embed
 @MappedSuperclass
 @Access(AccessType.FIELD)
-public abstract class DomainDsDataBase extends ImmutableObject implements DatastoreAndSqlEntity {
+public abstract class DomainDsDataBase extends ImmutableObject {
 
   @Ignore @XmlTransient @Transient String domainRepoId;
 

--- a/core/src/main/java/google/registry/model/domain/secdns/DomainDsDataHistory.java
+++ b/core/src/main/java/google/registry/model/domain/secdns/DomainDsDataHistory.java
@@ -14,8 +14,11 @@
 
 package google.registry.model.domain.secdns;
 
+import com.google.common.collect.ImmutableList;
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.ofy.ObjectifyService;
+import google.registry.schema.replay.DatastoreEntity;
+import google.registry.schema.replay.SqlEntity;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
 import javax.persistence.Column;
@@ -24,7 +27,7 @@ import javax.persistence.Id;
 
 /** Entity class to represent a historic {@link DelegationSignerData}. */
 @Entity
-public class DomainDsDataHistory extends DomainDsDataBase {
+public class DomainDsDataHistory extends DomainDsDataBase implements SqlEntity {
 
   @Id Long dsDataHistoryRevisionId;
 
@@ -80,5 +83,10 @@ public class DomainDsDataHistory extends DomainDsDataBase {
   @Column(nullable = false)
   public byte[] getDigest() {
     return super.getDigest();
+  }
+
+  @Override
+  public ImmutableList<DatastoreEntity> toDatastoreEntities() {
+    return ImmutableList.of(); // not persisted in Datastore
   }
 }


### PR DESCRIPTION
- Abstract classes shouldn't implement DatastoreEntity/SqlEntity
- We aren't persisting Modification in SQL
- Because DelegationSignerData is embedded, we don't need to worry about
converting and persisting it
- DomainDsDataHistory isn't persisted in Datastore

After this, there are only three classes left to fix before we can enable EntityTest

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/856)
<!-- Reviewable:end -->
