### PR TITLE
Add an extension to verify transaction replay

### DIFF
--- a/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
+++ b/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
@@ -57,6 +57,7 @@ import javax.persistence.Column;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 import org.joda.time.DateTime;
 
 /** An entity representing an allocation token. */
@@ -105,7 +106,8 @@ public class AllocationToken extends BackupGroupRoot implements Buildable, Datas
   @javax.persistence.Id @Id String token;
 
   /** The key of the history entry for which the token was used. Null if not yet used. */
-  @Nullable @Index VKey<HistoryEntry> redemptionHistoryEntry;
+  // TODO(b/172848495): Remove the "Transient" when we can finally persist and restore this.
+  @Transient @Nullable @Index VKey<HistoryEntry> redemptionHistoryEntry;
 
   /** The fully-qualified domain name that this token is limited to, if any. */
   @Nullable @Index String domainName;

--- a/core/src/main/java/google/registry/model/ofy/CommitLoggedWork.java
+++ b/core/src/main/java/google/registry/model/ofy/CommitLoggedWork.java
@@ -161,6 +161,7 @@ class CommitLoggedWork<R> implements Runnable {
           .addAll(untouchedRootsWithTouchedChildren)
           .build())
       .now();
+    ReplayQueue.addInTests(info);
   }
 
   /** Check that the timestamp of each BackupGroupRoot is in the past. */

--- a/core/src/main/java/google/registry/model/ofy/ReplayQueue.java
+++ b/core/src/main/java/google/registry/model/ofy/ReplayQueue.java
@@ -1,0 +1,46 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.model.ofy;
+
+import google.registry.config.RegistryEnvironment;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Implements simplified datastore to SQL transaction replay.
+ *
+ * <p>This code is to be removed when the actual replay cron job is implemented.
+ */
+public class ReplayQueue {
+
+  static ConcurrentLinkedQueue<TransactionInfo> queue =
+      new ConcurrentLinkedQueue<TransactionInfo>();
+
+  static void addInTests(TransactionInfo info) {
+    if (RegistryEnvironment.get() == RegistryEnvironment.UNITTEST) {
+      queue.add(info);
+    }
+  }
+
+  public static void replay() {
+    TransactionInfo info;
+    while ((info = queue.poll()) != null) {
+      info.saveToJpa();
+    }
+  }
+
+  public static void clear() {
+    queue.clear();
+  }
+}

--- a/core/src/main/java/google/registry/model/ofy/TransactionInfo.java
+++ b/core/src/main/java/google/registry/model/ofy/TransactionInfo.java
@@ -21,10 +21,14 @@ import static com.google.common.collect.Maps.filterValues;
 import static com.google.common.collect.Maps.toMap;
 import static google.registry.model.ofy.CommitLogBucket.getArbitraryBucketId;
 import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.googlecode.objectify.Key;
+import google.registry.persistence.VKey;
+import google.registry.schema.replay.DatastoreEntity;
+import google.registry.schema.replay.SqlEntity;
 import java.util.Map;
 import org.joda.time.DateTime;
 
@@ -91,5 +95,50 @@ class TransactionInfo {
         .stream()
         .filter(not(Delete.SENTINEL::equals))
         .collect(toImmutableSet());
+  }
+
+  // Mapping from class name to "weight" (which in this case is the order in which the class must
+  // be "put" in a transaction with respect to instances of other classes).  Lower weight classes
+  // are put first, by default all classes have a weight of zero.
+  static final ImmutableMap<String, Integer> CLASS_WEIGHTS =
+      ImmutableMap.of(
+          "HistoryEntry", -1,
+          "DomainBase", 1);
+
+  // The beginning of the range of weights reserved for delete.  This must be greater than any of
+  // the values in CLASS_WEIGHTS.
+  static final int DELETE_RANGE = 100;
+
+  /** Returns the weight of the entity type in the map entry. */
+  private static int getWeight(ImmutableMap.Entry<Key<?>, Object> entry) {
+    Integer weightObject = CLASS_WEIGHTS.get(entry.getKey().getKind());
+    int weight = weightObject == null ? 0 : weightObject;
+    return entry.getValue().equals(Delete.SENTINEL) ? DELETE_RANGE + -weight : weight;
+  }
+
+  private static int compareByWeight(
+      ImmutableMap.Entry<Key<?>, Object> a, ImmutableMap.Entry<Key<?>, Object> b) {
+    return getWeight(a) - getWeight(b);
+  }
+
+  void saveToJpa() {
+    // Sort the changes into an order that will work for insertion into the database.
+    jpaTm()
+        .transact(
+            () -> {
+              changesBuilder.build().entrySet().stream()
+                  .sorted(TransactionInfo::compareByWeight)
+                  .forEach(
+                      entry -> {
+                        if (entry.getValue().equals(Delete.SENTINEL)) {
+                          jpaTm().delete(VKey.from(entry.getKey()));
+                        } else {
+                          for (SqlEntity entity :
+                              ((DatastoreEntity) entry.getValue()).toSqlEntities()) {
+                            jpaTm().put(entity);
+                          }
+                        }
+                      });
+            });
   }
 }

--- a/core/src/main/java/google/registry/model/ofy/TransactionInfo.java
+++ b/core/src/main/java/google/registry/model/ofy/TransactionInfo.java
@@ -107,7 +107,8 @@ class TransactionInfo {
 
   // The beginning of the range of weights reserved for delete.  This must be greater than any of
   // the values in CLASS_WEIGHTS.
-  static final int DELETE_RANGE = 100;
+  static final int DELETE_RANGE =
+      CLASS_WEIGHTS.values().stream().mapToInt(Integer::intValue).max().getAsInt() + 1;
 
   /** Returns the weight of the entity type in the map entry. */
   private static int getWeight(ImmutableMap.Entry<Key<?>, Object> entry) {

--- a/core/src/main/java/google/registry/model/ofy/TransactionInfo.java
+++ b/core/src/main/java/google/registry/model/ofy/TransactionInfo.java
@@ -111,8 +111,7 @@ class TransactionInfo {
 
   /** Returns the weight of the entity type in the map entry. */
   private static int getWeight(ImmutableMap.Entry<Key<?>, Object> entry) {
-    Integer weightObject = CLASS_WEIGHTS.get(entry.getKey().getKind());
-    int weight = weightObject == null ? 0 : weightObject;
+    int weight = CLASS_WEIGHTS.getOrDefault(entry.getKey().getKind(), 0);
     return entry.getValue().equals(Delete.SENTINEL) ? DELETE_RANGE + -weight : weight;
   }
 

--- a/core/src/main/java/google/registry/model/ofy/TransactionInfo.java
+++ b/core/src/main/java/google/registry/model/ofy/TransactionInfo.java
@@ -26,15 +26,11 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Streams;
 import com.googlecode.objectify.Key;
 import google.registry.persistence.VKey;
 import google.registry.schema.replay.DatastoreEntity;
 import google.registry.schema.replay.SqlEntity;
-import java.util.IntSummaryStatistics;
 import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.joda.time.DateTime;
 
 /** Metadata for an {@link Ofy} transaction that saves commit logs. */
@@ -108,7 +104,6 @@ class TransactionInfo {
   // Mapping from class name to "weight" (which in this case is the order in which the class must
   // be "put" in a transaction with respect to instances of other classes).  Lower weight classes
   // are put first, by default all classes have a weight of zero.
-  @VisibleForTesting
   static final ImmutableMap<String, Integer> CLASS_WEIGHTS =
       ImmutableMap.of(
           "HistoryEntry", -1,
@@ -116,15 +111,7 @@ class TransactionInfo {
 
   // The beginning of the range of weights reserved for delete.  This must be greater than any of
   // the values in CLASS_WEIGHTS by enough overhead to accomodate any negative values in it.
-  static final int DELETE_RANGE = calculateDeleteRangeStart(CLASS_WEIGHTS);
-
-  @VisibleForTesting
-  static int calculateDeleteRangeStart(ImmutableMap<String, Integer> map) {
-    IntSummaryStatistics stats =
-        Streams.concat(map.values().stream(), Stream.of(0))
-            .collect(Collectors.summarizingInt(Integer::intValue));
-    return stats.getMax() * 2 + 1;
-  }
+  @VisibleForTesting static final int DELETE_RANGE = Integer.MAX_VALUE / 2;
 
   /** Returns the weight of the entity type in the map entry. */
   @VisibleForTesting

--- a/core/src/main/java/google/registry/model/ofy/TransactionInfo.java
+++ b/core/src/main/java/google/registry/model/ofy/TransactionInfo.java
@@ -123,7 +123,7 @@ class TransactionInfo {
     IntSummaryStatistics stats =
         Streams.concat(map.values().stream(), Stream.of(0))
             .collect(Collectors.summarizingInt(Integer::intValue));
-    return stats.getMax() - stats.getMin() + 1;
+    return stats.getMax() * 2 + 1;
   }
 
   /** Returns the weight of the entity type in the map entry. */

--- a/core/src/main/java/google/registry/model/registry/label/BaseDomainLabelList.java
+++ b/core/src/main/java/google/registry/model/registry/label/BaseDomainLabelList.java
@@ -79,7 +79,7 @@ public abstract class BaseDomainLabelList<T extends Comparable<?>, R extends Dom
   // set to the timestamp when the list is created. In Datastore, we have two fields and the
   // lastUpdateTime is set to the current timestamp when creating and updating a list. So, we use
   // lastUpdateTime as the creation_timestamp column during the dual-write phase for compatibility.
-  @Column(name = "creation_timestamp", nullable = false)
+  @Column(name = "creation_timestamp")
   DateTime lastUpdateTime;
 
   /** Returns the ID of this revision, or throws if null. */

--- a/core/src/test/java/google/registry/flows/FlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/FlowTestCase.java
@@ -101,7 +101,6 @@ public abstract class FlowTestCase<F extends Flow> {
   @RegisterExtension
   final AppEngineExtension appEngine =
       AppEngineExtension.builder()
-          //          .withClock(clock)
           .withDatastoreAndCloudSql()
           .withTaskQueue()
           .build();

--- a/core/src/test/java/google/registry/flows/FlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/FlowTestCase.java
@@ -59,6 +59,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
@@ -80,12 +81,6 @@ public abstract class FlowTestCase<F extends Flow> {
     SUPERUSER
   }
 
-  @RegisterExtension
-  final AppEngineExtension appEngine =
-      AppEngineExtension.builder().withDatastoreAndCloudSql().withTaskQueue().build();
-
-  @RegisterExtension final InjectExtension inject = new InjectExtension();
-
   protected EppLoader eppLoader;
   protected SessionMetadata sessionMetadata;
   protected FakeClock clock = new FakeClock(DateTime.now(UTC));
@@ -95,14 +90,28 @@ public abstract class FlowTestCase<F extends Flow> {
 
   private EppMetric.Builder eppMetricBuilder;
 
+  // Set the clock for transactional flows.  We have to order this before the AppEngineExtension
+  // which populates data (and may do so with clock-dependent commit logs if mixed with
+  // ReplayExtension).
+  @Order(value = Order.DEFAULT - 1)
+  @RegisterExtension
+  final InjectExtension inject =
+      new InjectExtension().withStaticFieldOverride(Ofy.class, "clock", clock);
+
+  @RegisterExtension
+  final AppEngineExtension appEngine =
+      AppEngineExtension.builder()
+          //          .withClock(clock)
+          .withDatastoreAndCloudSql()
+          .withTaskQueue()
+          .build();
+
   @BeforeEach
   public void beforeEachFlowTestCase() {
     sessionMetadata = new HttpSessionMetadata(new FakeHttpSession());
     sessionMetadata.setClientId("TheRegistrar");
     sessionMetadata.setServiceExtensionUris(ProtocolDefinition.getVisibleServiceExtensionUris());
     ofy().saveWithoutBackup().entity(new ClaimsListSingleton()).now();
-    // For transactional flows
-    inject.setStaticField(Ofy.class, "clock", clock);
  }
 
   protected void removeServiceExtensionUri(String uri) {

--- a/core/src/test/java/google/registry/flows/FlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/FlowTestCase.java
@@ -100,10 +100,7 @@ public abstract class FlowTestCase<F extends Flow> {
 
   @RegisterExtension
   final AppEngineExtension appEngine =
-      AppEngineExtension.builder()
-          .withDatastoreAndCloudSql()
-          .withTaskQueue()
-          .build();
+      AppEngineExtension.builder().withDatastoreAndCloudSql().withTaskQueue().build();
 
   @BeforeEach
   public void beforeEachFlowTestCase() {

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -163,6 +163,7 @@ import google.registry.model.reporting.DomainTransactionRecord.TransactionReport
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.monitoring.whitebox.EppMetric;
 import google.registry.persistence.VKey;
+import google.registry.testing.ReplayExtension;
 import google.registry.testing.TaskQueueHelper.TaskMatcher;
 import java.math.BigDecimal;
 import java.util.Map;
@@ -172,6 +173,7 @@ import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link DomainCreateFlow}. */
 class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, DomainBase> {
@@ -179,6 +181,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   private static final String CLAIMS_KEY = "2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001";
 
   private AllocationToken allocationToken;
+
+  @RegisterExtension final ReplayExtension replayExtension = new ReplayExtension();
 
   DomainCreateFlowTest() {
     setEppInput("domain_create.xml", ImmutableMap.of("DOMAIN", "example.tld"));

--- a/core/src/test/java/google/registry/model/ofy/TransactionInfoTest.java
+++ b/core/src/test/java/google/registry/model/ofy/TransactionInfoTest.java
@@ -45,9 +45,10 @@ class TransactionInfoTest {
     // just verify that the lowest is what we expect for both save and delete and verify that the
     // Registrar class is zero.
     ImmutableMap<Key<?>, Object> actions =
-        ImmutableMap.of(Key.create(HistoryEntry.class, 100), TransactionInfo.Delete.SENTINEL,
-                        Key.create(HistoryEntry.class, 200), "fake history entry",
-                        Key.create(Registrar.class, 300), "fake registrar");
+        ImmutableMap.of(
+            Key.create(HistoryEntry.class, 100), TransactionInfo.Delete.SENTINEL,
+            Key.create(HistoryEntry.class, 200), "fake history entry",
+            Key.create(Registrar.class, 300), "fake registrar");
     ImmutableMap<Long, Integer> expectedValues = ImmutableMap.of(100L, 4, 200L, -1, 300L, 0);
 
     for (ImmutableMap.Entry<Key<?>, Object> entry : actions.entrySet()) {

--- a/core/src/test/java/google/registry/model/ofy/TransactionInfoTest.java
+++ b/core/src/test/java/google/registry/model/ofy/TransactionInfoTest.java
@@ -1,0 +1,58 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.model.ofy;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.googlecode.objectify.Key;
+import google.registry.model.registrar.Registrar;
+import google.registry.model.reporting.HistoryEntry;
+import google.registry.testing.AppEngineExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class TransactionInfoTest {
+
+  @RegisterExtension
+  AppEngineExtension appEngine = new AppEngineExtension.Builder().withDatastore().build();
+
+  @Test
+  void testDeleteCalculation() {
+    // Test the default class weights, which range from -1 to 1.
+    assertThat(TransactionInfo.calculateDeleteRangeStart(TransactionInfo.CLASS_WEIGHTS))
+        .isEqualTo(3);
+
+    // Verify that this works with an implicit weight of zero.
+    assertThat(TransactionInfo.calculateDeleteRangeStart(ImmutableMap.of("foo", 10, "bar", 20)))
+        .isEqualTo(21);
+  }
+
+  @Test
+  void testGetWeight() {
+    // just verify that the lowest is what we expect for both save and delete and verify that the
+    // Registrar class is zero.
+    ImmutableMap<Key<?>, Object> actions =
+        ImmutableMap.of(Key.create(HistoryEntry.class, 100), TransactionInfo.Delete.SENTINEL,
+                        Key.create(HistoryEntry.class, 200), "fake history entry",
+                        Key.create(Registrar.class, 300), "fake registrar");
+    ImmutableMap<Long, Integer> expectedValues = ImmutableMap.of(100L, 4, 200L, -1, 300L, 0);
+
+    for (ImmutableMap.Entry<Key<?>, Object> entry : actions.entrySet()) {
+      assertThat(TransactionInfo.getWeight(entry))
+          .isEqualTo(expectedValues.get(entry.getKey().getId()));
+    }
+  }
+}

--- a/core/src/test/java/google/registry/model/ofy/TransactionInfoTest.java
+++ b/core/src/test/java/google/registry/model/ofy/TransactionInfoTest.java
@@ -37,7 +37,7 @@ class TransactionInfoTest {
 
     // Verify that this works with an implicit weight of zero.
     assertThat(TransactionInfo.calculateDeleteRangeStart(ImmutableMap.of("foo", 10, "bar", 20)))
-        .isEqualTo(21);
+        .isEqualTo(41);
   }
 
   @Test

--- a/core/src/test/java/google/registry/model/ofy/TransactionInfoTest.java
+++ b/core/src/test/java/google/registry/model/ofy/TransactionInfoTest.java
@@ -30,17 +30,6 @@ class TransactionInfoTest {
   AppEngineExtension appEngine = new AppEngineExtension.Builder().withDatastore().build();
 
   @Test
-  void testDeleteCalculation() {
-    // Test the default class weights, which range from -1 to 1.
-    assertThat(TransactionInfo.calculateDeleteRangeStart(TransactionInfo.CLASS_WEIGHTS))
-        .isEqualTo(3);
-
-    // Verify that this works with an implicit weight of zero.
-    assertThat(TransactionInfo.calculateDeleteRangeStart(ImmutableMap.of("foo", 10, "bar", 20)))
-        .isEqualTo(41);
-  }
-
-  @Test
   void testGetWeight() {
     // just verify that the lowest is what we expect for both save and delete and verify that the
     // Registrar class is zero.
@@ -49,7 +38,8 @@ class TransactionInfoTest {
             Key.create(HistoryEntry.class, 100), TransactionInfo.Delete.SENTINEL,
             Key.create(HistoryEntry.class, 200), "fake history entry",
             Key.create(Registrar.class, 300), "fake registrar");
-    ImmutableMap<Long, Integer> expectedValues = ImmutableMap.of(100L, 4, 200L, -1, 300L, 0);
+    ImmutableMap<Long, Integer> expectedValues =
+        ImmutableMap.of(100L, TransactionInfo.DELETE_RANGE + 1, 200L, -1, 300L, 0);
 
     for (ImmutableMap.Entry<Key<?>, Object> entry : actions.entrySet()) {
       assertThat(TransactionInfo.getWeight(entry))

--- a/core/src/test/java/google/registry/testing/AppEngineExtension.java
+++ b/core/src/test/java/google/registry/testing/AppEngineExtension.java
@@ -477,6 +477,14 @@ public final class AppEngineExtension implements BeforeEachCallback, AfterEachCa
   public void afterEach(ExtensionContext context) throws Exception {
     checkArgumentNotNull(context, "The ExtensionContext must not be null");
     try {
+      // If there is a replay extension, we'll want to call its replayToSql() method.
+      ReplayExtension replayer =
+          (ReplayExtension)
+              context.getStore(ExtensionContext.Namespace.GLOBAL).get(ReplayExtension.class);
+      if (replayer != null) {
+        replayer.replayToSql();
+      }
+
       if (withCloudSql) {
         if (enableJpaEntityCoverageCheck) {
           jpaIntegrationWithCoverageExtension.afterEach(context);

--- a/core/src/test/java/google/registry/testing/AppEngineExtension.java
+++ b/core/src/test/java/google/registry/testing/AppEngineExtension.java
@@ -478,6 +478,16 @@ public final class AppEngineExtension implements BeforeEachCallback, AfterEachCa
     checkArgumentNotNull(context, "The ExtensionContext must not be null");
     try {
       // If there is a replay extension, we'll want to call its replayToSql() method.
+      //
+      // We have to provide this hook here for ReplayExtension instead of relying on
+      // ReplayExtension's afterEach() method because of ordering and the conflation of environment
+      // initialization and basic entity initialization.
+      //
+      // ReplayExtension's beforeEach() has to be called before this so that the entities that we
+      // initialize (e.g. "TheRegistrar") also get replayed.  But that means that ReplayExtension's
+      // afterEach() won't be called until after ours.  Since we tear down the datastore and SQL
+      // database in our own afterEach(), ReplayExtension's afterEach() would fail if we let the
+      // replay happen there.
       ReplayExtension replayer =
           (ReplayExtension)
               context.getStore(ExtensionContext.Namespace.GLOBAL).get(ReplayExtension.class);

--- a/core/src/test/java/google/registry/testing/DatastoreHelper.java
+++ b/core/src/test/java/google/registry/testing/DatastoreHelper.java
@@ -122,6 +122,8 @@ import org.joda.time.DateTimeZone;
 /** Static utils for setting up test resources. */
 public class DatastoreHelper {
 
+  // The following two fields are injected by ReplayExtension.
+
   // If this is true, all of the methods that save to the datastore do so with backup.
   private static boolean alwaysSaveWithBackup;
 

--- a/core/src/test/java/google/registry/testing/DatastoreHelper.java
+++ b/core/src/test/java/google/registry/testing/DatastoreHelper.java
@@ -122,6 +122,12 @@ import org.joda.time.DateTimeZone;
 /** Static utils for setting up test resources. */
 public class DatastoreHelper {
 
+  // If this is true, all of the methods that save to the datastore do so with backup.
+  private static boolean alwaysSaveWithBackup;
+
+  // If the clock is defined, it will always be advanced by one millsecond after a transaction.
+  private static FakeClock clock;
+
   private static final Supplier<String[]> DEFAULT_PREMIUM_LIST_CONTENTS =
       memoize(
           () ->
@@ -131,6 +137,20 @@ public class DatastoreHelper {
                           readResourceUtf8(
                               DatastoreHelper.class, "default_premium_list_testdata.csv")),
                   String.class));
+
+  public static void setAlwaysSaveWithBackup(boolean enable) {
+    alwaysSaveWithBackup = enable;
+  }
+
+  public static void setClock(FakeClock fakeClock) {
+    clock = fakeClock;
+  }
+
+  private static void maybeAdvanceClock() {
+    if (clock != null) {
+      clock.advanceOneMilli();
+    }
+  }
 
   public static HostResource newHostResource(String hostName) {
     return newHostResourceWithRoid(hostName, generateNewContactHostRoid());
@@ -312,6 +332,7 @@ public class DatastoreHelper {
     // the
     // transaction time is set correctly.
     tm().transactNew(() -> LordnTaskUtils.enqueueDomainBaseTask(persistedDomain));
+    maybeAdvanceClock();
     return persistedDomain;
   }
 
@@ -365,14 +386,25 @@ public class DatastoreHelper {
     PremiumListRevision revision = PremiumListRevision.create(premiumList, entries.keySet());
 
     if (tm().isOfy()) {
-      tm().putAllWithoutBackup(
-              ImmutableList.of(
-                  premiumList.asBuilder().setRevision(Key.create(revision)).build(), revision));
-      tm().putAllWithoutBackup(
-              parentPremiumListEntriesOnRevision(entries.values(), Key.create(revision)));
+      ImmutableList<Object> premiumLists =
+          ImmutableList.of(
+              premiumList.asBuilder().setRevision(Key.create(revision)).build(), revision);
+      ImmutableSet<PremiumListEntry> entriesOnRevision =
+          parentPremiumListEntriesOnRevision(entries.values(), Key.create(revision));
+      if (alwaysSaveWithBackup) {
+        tm().transact(
+                () -> {
+                  tm().putAll(premiumLists);
+                  tm().putAll(entriesOnRevision);
+                });
+      } else {
+        tm().putAllWithoutBackup(premiumLists);
+        tm().putAllWithoutBackup(entriesOnRevision);
+      }
     } else {
       tm().transact(() -> tm().insert(premiumList));
     }
+    maybeAdvanceClock();
     // The above premiumList is in the session cache and it is different from the corresponding
     // entity stored in Datastore because it has some @Ignore fields set dedicated for SQL. This
     // breaks the assumption we have in our application code, see
@@ -934,7 +966,7 @@ public class DatastoreHelper {
 
   private static <R> void saveResource(R resource, boolean wantBackup) {
     if (tm().isOfy()) {
-      Saver saver = wantBackup ? ofy().save() : ofy().saveWithoutBackup();
+      Saver saver = wantBackup || alwaysSaveWithBackup ? ofy().save() : ofy().saveWithoutBackup();
       saver.entity(resource);
       if (resource instanceof EppResource) {
         EppResource eppResource = (EppResource) resource;
@@ -962,6 +994,7 @@ public class DatastoreHelper {
         .that(resource)
         .isNotInstanceOf(Buildable.Builder.class);
     tm().transact(() -> saveResource(resource, wantBackup));
+    maybeAdvanceClock();
     // Force the session cache to be cleared so that when we read the resource back, we read from
     // Datastore and not from the session cache. This is needed to trigger Objectify's load process
     // (unmarshalling entity protos to POJOs, nulling out empty collections, calling @OnLoad
@@ -984,6 +1017,7 @@ public class DatastoreHelper {
                 tm().put(resource);
               }
             });
+    maybeAdvanceClock();
     tm().clearSessionCache();
     return transactIfJpaTm(() -> tm().load(resource));
   }
@@ -1001,6 +1035,7 @@ public class DatastoreHelper {
     // Persist domains ten at a time, to avoid exceeding the entity group limit.
     for (final List<R> chunk : Iterables.partition(resources, 10)) {
       tm().transact(() -> chunk.forEach(resource -> saveResource(resource, wantBackup)));
+      maybeAdvanceClock();
     }
     // Force the session to be cleared so that when we read it back, we read from Datastore
     // and not from the transaction's session cache.
@@ -1035,6 +1070,7 @@ public class DatastoreHelper {
               ofyTmOrDoNothing(
                   () -> tm().put(ForeignKeyIndex.create(resource, resource.getDeletionTime())));
             });
+    maybeAdvanceClock();
     tm().clearSessionCache();
     return transactIfJpaTm(() -> tm().load(resource));
   }
@@ -1128,7 +1164,15 @@ public class DatastoreHelper {
    * ForeignKeyedEppResources.
    */
   public static <R> ImmutableList<R> persistSimpleResources(final Iterable<R> resources) {
-    tm().transact(() -> tm().putAllWithoutBackup(ImmutableList.copyOf(resources)));
+    tm().transact(
+            () -> {
+              if (alwaysSaveWithBackup) {
+                tm().putAll(ImmutableList.copyOf(resources));
+              } else {
+                tm().putAllWithoutBackup(ImmutableList.copyOf(resources));
+              }
+            });
+    maybeAdvanceClock();
     // Force the session to be cleared so that when we read it back, we read from Datastore
     // and not from the transaction's session cache.
     tm().clearSessionCache();
@@ -1136,7 +1180,11 @@ public class DatastoreHelper {
   }
 
   public static void deleteResource(final Object resource) {
-    transactIfJpaTm(() -> tm().deleteWithoutBackup(resource));
+    if (alwaysSaveWithBackup) {
+      tm().transact(() -> tm().delete(resource));
+    } else {
+      transactIfJpaTm(() -> tm().deleteWithoutBackup(resource));
+    }
     // Force the session to be cleared so that when we read it back, we read from Datastore and
     // not from the transaction's session cache.
     tm().clearSessionCache();
@@ -1144,15 +1192,16 @@ public class DatastoreHelper {
 
   /** Force the create and update timestamps to get written into the resource. **/
   public static <R> R cloneAndSetAutoTimestamps(final R resource) {
-    if (tm().isOfy()) {
-      return tm().transact(() -> ofy().load().fromEntity(ofy().save().toEntity(resource)));
-    } else {
-      // We have to separate the read and write operation into different transactions
-      // otherwise JPA would just return the input entity instead of actually creating a
-      // clone.
-      tm().transact(() -> tm().put(resource));
-      return tm().transact(() -> tm().load(resource));
-    }
+    R result =
+        tm().transact(
+                tm().isOfy()
+                    ? () -> ofy().load().fromEntity(ofy().save().toEntity(resource))
+                    : () -> {
+                      tm().put(resource);
+                      return tm().load(resource);
+                    });
+    maybeAdvanceClock();
+    return result;
   }
 
   /** Returns the entire map of {@link PremiumListEntry}s for the given {@link PremiumList}. */

--- a/core/src/test/java/google/registry/testing/DatastoreHelper.java
+++ b/core/src/test/java/google/registry/testing/DatastoreHelper.java
@@ -1198,6 +1198,9 @@ public class DatastoreHelper {
     if (tm().isOfy()) {
       result = tm().transact(() -> ofy().load().fromEntity(ofy().save().toEntity(resource)));
     } else {
+      // We have to separate the read and write operation into different transactions
+      // otherwise JPA would just return the input entity instead of actually creating a
+      // clone.
       tm().transact(() -> tm().put(resource));
       result = tm().transact(() -> tm().load(resource));
     }

--- a/core/src/test/java/google/registry/testing/DatastoreHelper.java
+++ b/core/src/test/java/google/registry/testing/DatastoreHelper.java
@@ -1194,14 +1194,13 @@ public class DatastoreHelper {
 
   /** Force the create and update timestamps to get written into the resource. **/
   public static <R> R cloneAndSetAutoTimestamps(final R resource) {
-    R result =
-        tm().transact(
-                tm().isOfy()
-                    ? () -> ofy().load().fromEntity(ofy().save().toEntity(resource))
-                    : () -> {
-                      tm().put(resource);
-                      return tm().load(resource);
-                    });
+    R result;
+    if (tm().isOfy()) {
+      result = tm().transact(() -> ofy().load().fromEntity(ofy().save().toEntity(resource)));
+    } else {
+      tm().transact(() -> tm().put(resource));
+      result = tm().transact(() -> tm().load(resource));
+    }
     maybeAdvanceClock();
     return result;
   }

--- a/core/src/test/java/google/registry/testing/ReplayExtension.java
+++ b/core/src/test/java/google/registry/testing/ReplayExtension.java
@@ -1,0 +1,35 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.testing;
+
+import google.registry.model.ofy.ReplayQueue;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * A JUnit extension that replays datastore transactions against postgresql.
+ */
+public class ReplayExtension implements BeforeEachCallback, AfterEachCallback {
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    ReplayQueue.clear();
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) {
+    ReplayQueue.replay();
+  }
+}

--- a/core/src/test/java/google/registry/testing/ReplayExtension.java
+++ b/core/src/test/java/google/registry/testing/ReplayExtension.java
@@ -22,9 +22,10 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 /**
  * A JUnit extension that replays datastore transactions against postgresql.
  *
- * <p>This extension must be ordered before AppEngineExtension. If AppEngineExtension is not used,
- * JpaTransactionManagerException must be, and this extension should be ordered _after_
- * JpaTransactionManagerException.
+ * <p>This extension must be ordered before AppEngineExtension so that the test entities saved in
+ * that extension are also replayed. If AppEngineExtension is not used,
+ * JpaTransactionManagerExtension must be, and this extension should be ordered _after_
+ * JpaTransactionManagerExtension so that writes to SQL work.
  */
 public class ReplayExtension implements BeforeEachCallback, AfterEachCallback {
 

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_response_eap_fee.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_response_eap_fee.xml
@@ -15,7 +15,7 @@
       <fee:creData xmlns:fee="urn:ietf:params:xml:ns:fee-%FEE_VERSION%">
         <fee:currency>USD</fee:currency>
         <fee:fee description="create">26.00</fee:fee>
-        <fee:fee description="Early Access Period, fee expires: 1999-04-04T22:00:00.000Z">100.00</fee:fee>
+        <fee:fee description="Early Access Period, fee expires: 1999-04-04T22:00:00.024Z">100.00</fee:fee>
       </fee:creData>
     </extension>
     <trID>

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_response_premium_eap.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_response_premium_eap.xml
@@ -15,7 +15,7 @@
       <fee:creData xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
         <fee:currency>USD</fee:currency>
         <fee:fee description="create">200.00</fee:fee>
-        <fee:fee description="Early Access Period, fee expires: 1999-04-04T22:00:00.000Z">100.00
+        <fee:fee description="Early Access Period, fee expires: 1999-04-04T22:00:00.028Z">100.00
         </fee:fee>
       </fee:creData>
     </extension>

--- a/db/src/main/resources/sql/er_diagram/brief_er_diagram.html
+++ b/db/src/main/resources/sql/er_diagram/brief_er_diagram.html
@@ -261,11 +261,11 @@ td.section {
     </tr> 
     <tr> 
      <td class="property_name">generated on</td> 
-     <td class="property_value">2020-11-13 19:34:54.398919</td> 
+     <td class="property_value">2020-11-16 16:45:08.581361</td> 
     </tr> 
     <tr>
      <td class="property_name">last flyway file</td>
-     <td id="lastFlywayFile" class="property_value">V76__change_history_nullability.sql</td>
+     <td id="lastFlywayFile" class="property_value">V77__fixes_for_replay.sql</td>
     </tr>
    </tbody>
   </table> 
@@ -284,7 +284,7 @@ td.section {
      generated on
     </text> 
     <text text-anchor="start" x="5830.94" y="-10.8" font-family="Helvetica,sans-Serif" font-size="14.00">
-     2020-11-13 19:34:54.398919
+     2020-11-16 16:45:08.581361
     </text> 
     <polygon fill="none" stroke="#888888" points="5743.44,-4 5743.44,-44 6008.44,-44 6008.44,-4 5743.44,-4" /> <!-- allocationtoken_a08ccbef --> 
     <g id="node1" class="node"> 

--- a/db/src/main/resources/sql/er_diagram/full_er_diagram.html
+++ b/db/src/main/resources/sql/er_diagram/full_er_diagram.html
@@ -261,11 +261,11 @@ td.section {
     </tr> 
     <tr> 
      <td class="property_name">generated on</td> 
-     <td class="property_value">2020-11-13 19:34:52.404634</td> 
+     <td class="property_value">2020-11-16 16:45:06.707088</td> 
     </tr> 
     <tr>
      <td class="property_name">last flyway file</td>
-     <td id="lastFlywayFile" class="property_value">V76__change_history_nullability.sql</td>
+     <td id="lastFlywayFile" class="property_value">V77__fixes_for_replay.sql</td>
     </tr>
    </tbody>
   </table> 
@@ -284,7 +284,7 @@ td.section {
      generated on
     </text> 
     <text text-anchor="start" x="6501.68" y="-10.8" font-family="Helvetica,sans-Serif" font-size="14.00">
-     2020-11-13 19:34:52.404634
+     2020-11-16 16:45:06.707088
     </text> 
     <polygon fill="none" stroke="#888888" points="6414.18,-4 6414.18,-44 6679.18,-44 6679.18,-4 6414.18,-4" /> <!-- allocationtoken_a08ccbef --> 
     <g id="node1" class="node"> 
@@ -5690,70 +5690,70 @@ td.section {
     </g> <!-- premiumlist_7c3ea68b --> 
     <g id="node26" class="node"> 
      <title>premiumlist_7c3ea68b</title> 
-     <polygon fill="#ebcef2" stroke="transparent" points="5717.5,-3349.5 5717.5,-3368.5 5849.5,-3368.5 5849.5,-3349.5 5717.5,-3349.5" /> 
-     <text text-anchor="start" x="5719.5" y="-3356.3" font-family="Helvetica,sans-Serif" font-weight="bold" font-style="italic" font-size="14.00">
+     <polygon fill="#ebcef2" stroke="transparent" points="5725.5,-3349.5 5725.5,-3368.5 5857.5,-3368.5 5857.5,-3349.5 5725.5,-3349.5" /> 
+     <text text-anchor="start" x="5727.5" y="-3356.3" font-family="Helvetica,sans-Serif" font-weight="bold" font-style="italic" font-size="14.00">
       public.PremiumList
      </text> 
-     <polygon fill="#ebcef2" stroke="transparent" points="5849.5,-3349.5 5849.5,-3368.5 5975.5,-3368.5 5975.5,-3349.5 5849.5,-3349.5" /> 
-     <text text-anchor="start" x="5936.5" y="-3355.3" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <polygon fill="#ebcef2" stroke="transparent" points="5857.5,-3349.5 5857.5,-3368.5 5967.5,-3368.5 5967.5,-3349.5 5857.5,-3349.5" /> 
+     <text text-anchor="start" x="5928.5" y="-3355.3" font-family="Helvetica,sans-Serif" font-size="14.00">
       [table]
      </text> 
-     <text text-anchor="start" x="5719.5" y="-3337.3" font-family="Helvetica,sans-Serif" font-weight="bold" font-style="italic" font-size="14.00">
+     <text text-anchor="start" x="5727.5" y="-3337.3" font-family="Helvetica,sans-Serif" font-weight="bold" font-style="italic" font-size="14.00">
       revision_id
      </text> 
-     <text text-anchor="start" x="5843.5" y="-3336.3" font-family="Helvetica,sans-Serif" font-size="14.00"> 
+     <text text-anchor="start" x="5851.5" y="-3336.3" font-family="Helvetica,sans-Serif" font-size="14.00"> 
      </text> 
-     <text text-anchor="start" x="5851.5" y="-3336.3" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <text text-anchor="start" x="5859.5" y="-3336.3" font-family="Helvetica,sans-Serif" font-size="14.00">
       bigserial not null
      </text> 
-     <text text-anchor="start" x="5843.5" y="-3317.3" font-family="Helvetica,sans-Serif" font-size="14.00"> 
+     <text text-anchor="start" x="5851.5" y="-3317.3" font-family="Helvetica,sans-Serif" font-size="14.00"> 
      </text> 
-     <text text-anchor="start" x="5851.5" y="-3317.3" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <text text-anchor="start" x="5859.5" y="-3317.3" font-family="Helvetica,sans-Serif" font-size="14.00">
       auto-incremented
      </text> 
-     <text text-anchor="start" x="5719.5" y="-3298.3" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <text text-anchor="start" x="5727.5" y="-3298.3" font-family="Helvetica,sans-Serif" font-size="14.00">
       creation_timestamp
      </text> 
-     <text text-anchor="start" x="5843.5" y="-3298.3" font-family="Helvetica,sans-Serif" font-size="14.00"> 
+     <text text-anchor="start" x="5851.5" y="-3298.3" font-family="Helvetica,sans-Serif" font-size="14.00"> 
      </text> 
-     <text text-anchor="start" x="5851.5" y="-3298.3" font-family="Helvetica,sans-Serif" font-size="14.00">
-      timestamptz not null
+     <text text-anchor="start" x="5859.5" y="-3298.3" font-family="Helvetica,sans-Serif" font-size="14.00">
+      timestamptz
      </text> 
-     <text text-anchor="start" x="5719.5" y="-3279.3" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <text text-anchor="start" x="5727.5" y="-3279.3" font-family="Helvetica,sans-Serif" font-size="14.00">
       name
      </text> 
-     <text text-anchor="start" x="5843.5" y="-3279.3" font-family="Helvetica,sans-Serif" font-size="14.00"> 
+     <text text-anchor="start" x="5851.5" y="-3279.3" font-family="Helvetica,sans-Serif" font-size="14.00"> 
      </text> 
-     <text text-anchor="start" x="5851.5" y="-3279.3" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <text text-anchor="start" x="5859.5" y="-3279.3" font-family="Helvetica,sans-Serif" font-size="14.00">
       text not null
      </text> 
-     <text text-anchor="start" x="5719.5" y="-3260.3" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <text text-anchor="start" x="5727.5" y="-3260.3" font-family="Helvetica,sans-Serif" font-size="14.00">
       bloom_filter
      </text> 
-     <text text-anchor="start" x="5843.5" y="-3260.3" font-family="Helvetica,sans-Serif" font-size="14.00"> 
+     <text text-anchor="start" x="5851.5" y="-3260.3" font-family="Helvetica,sans-Serif" font-size="14.00"> 
      </text> 
-     <text text-anchor="start" x="5851.5" y="-3260.3" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <text text-anchor="start" x="5859.5" y="-3260.3" font-family="Helvetica,sans-Serif" font-size="14.00">
       bytea not null
      </text> 
-     <text text-anchor="start" x="5719.5" y="-3241.3" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <text text-anchor="start" x="5727.5" y="-3241.3" font-family="Helvetica,sans-Serif" font-size="14.00">
       currency
      </text> 
-     <text text-anchor="start" x="5843.5" y="-3241.3" font-family="Helvetica,sans-Serif" font-size="14.00"> 
+     <text text-anchor="start" x="5851.5" y="-3241.3" font-family="Helvetica,sans-Serif" font-size="14.00"> 
      </text> 
-     <text text-anchor="start" x="5851.5" y="-3241.3" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <text text-anchor="start" x="5859.5" y="-3241.3" font-family="Helvetica,sans-Serif" font-size="14.00">
       text not null
      </text> 
-     <polygon fill="none" stroke="#888888" points="5716.5,-3235 5716.5,-3370 5976.5,-3370 5976.5,-3235 5716.5,-3235" /> 
+     <polygon fill="none" stroke="#888888" points="5724.5,-3235 5724.5,-3370 5968.5,-3370 5968.5,-3235 5724.5,-3235" /> 
     </g> <!-- premiumentry_b0060b91&#45;&gt;premiumlist_7c3ea68b --> 
     <g id="edge52" class="edge"> 
      <title>premiumentry_b0060b91:w-&gt;premiumlist_7c3ea68b:e</title> 
-     <path fill="none" stroke="black" d="M6320.18,-3340.5C6177.56,-3340.5 6133.1,-3340.5 5986.75,-3340.5" /> 
+     <path fill="none" stroke="black" d="M6320.23,-3340.5C6173.96,-3340.5 6128.62,-3340.5 5978.54,-3340.5" /> 
      <polygon fill="black" stroke="black" points="6328.5,-3340.5 6338.5,-3345 6333.5,-3340.5 6338.5,-3340.5 6338.5,-3340.5 6338.5,-3340.5 6333.5,-3340.5 6338.5,-3336 6328.5,-3340.5 6328.5,-3340.5" /> 
      <ellipse fill="none" stroke="black" cx="6324.5" cy="-3340.5" rx="4" ry="4" /> 
-     <polygon fill="black" stroke="black" points="5977.5,-3345.5 5977.5,-3335.5 5979.5,-3335.5 5979.5,-3345.5 5977.5,-3345.5" /> 
-     <polyline fill="none" stroke="black" points="5976.5,-3340.5 5981.5,-3340.5 " /> 
-     <polygon fill="black" stroke="black" points="5982.5,-3345.5 5982.5,-3335.5 5984.5,-3335.5 5984.5,-3345.5 5982.5,-3345.5" /> 
-     <polyline fill="none" stroke="black" points="5981.5,-3340.5 5986.5,-3340.5 " /> 
+     <polygon fill="black" stroke="black" points="5969.5,-3345.5 5969.5,-3335.5 5971.5,-3335.5 5971.5,-3345.5 5969.5,-3345.5" /> 
+     <polyline fill="none" stroke="black" points="5968.5,-3340.5 5973.5,-3340.5 " /> 
+     <polygon fill="black" stroke="black" points="5974.5,-3345.5 5974.5,-3335.5 5976.5,-3335.5 5976.5,-3345.5 5974.5,-3345.5" /> 
+     <polyline fill="none" stroke="black" points="5973.5,-3340.5 5978.5,-3340.5 " /> 
      <text text-anchor="start" x="6081.5" y="-3344.3" font-family="Helvetica,sans-Serif" font-size="14.00">
       fko0gw90lpo1tuee56l0nb6y6g5
      </text> 
@@ -11600,7 +11600,7 @@ td.section {
     <tr> 
      <td class="spacer"></td> 
      <td class="minwidth">creation_timestamp</td> 
-     <td class="minwidth">timestamptz not null</td> 
+     <td class="minwidth">timestamptz</td> 
     </tr> 
     <tr> 
      <td class="spacer"></td> 

--- a/db/src/main/resources/sql/flyway.txt
+++ b/db/src/main/resources/sql/flyway.txt
@@ -74,3 +74,4 @@ V73__singleton_entities.sql
 V74__sql_replay_checkpoint.sql
 V75__add_grace_period_history.sql
 V76__change_history_nullability.sql
+V77__fixes_for_replay.sql

--- a/db/src/main/resources/sql/flyway/V77__fixes_for_replay.sql
+++ b/db/src/main/resources/sql/flyway/V77__fixes_for_replay.sql
@@ -1,0 +1,15 @@
+-- Copyright 2020 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+ALTER TABLE "PremiumList" ALTER COLUMN creation_timestamp DROP NOT NULL;

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -22,7 +22,6 @@
         discount_premiums boolean not null,
         discount_years int4 not null,
         domain_name text,
-        redemption_history_entry text,
         token_status_transitions hstore,
         token_type text,
         primary key (token)
@@ -524,7 +523,7 @@
 
     create table "PremiumList" (
        revision_id  bigserial not null,
-        creation_timestamp timestamptz not null,
+        creation_timestamp timestamptz,
         name text not null,
         bloom_filter bytea not null,
         currency text not null,
@@ -635,7 +634,7 @@
 
     create table "ReservedList" (
        revision_id  bigserial not null,
-        creation_timestamp timestamptz not null,
+        creation_timestamp timestamptz,
         name text not null,
         should_publish boolean not null,
         primary key (revision_id)

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -686,7 +686,7 @@ CREATE TABLE public."PremiumEntry" (
 
 CREATE TABLE public."PremiumList" (
     revision_id bigint NOT NULL,
-    creation_timestamp timestamp with time zone NOT NULL,
+    creation_timestamp timestamp with time zone,
     name text NOT NULL,
     bloom_filter bytea NOT NULL,
     currency text NOT NULL


### PR DESCRIPTION
Add ReplayExtension, which can be applied to test suites to verify that
transactions committed to datastore can be replayed to SQL.

This introduces a ReplayQueue class, which serves as a stand-in for the
current lack of replay-from-commit-logs.  It also includes replay logic in
TransactionInfo which introduces the concept of "entity class weights."
Entity weighting allows us store and delete objects in an order that is
consistent with the direction of foreign key and deferred foreign key
relationships.  As a general rule, lower weight classes must have no direct or
indirect non-deferred foreign key relationships on higher weight classes.

It is expected that much of this code will change when the final replay
mechanism is implemented.

NOTE: this code currently breaks the one test that it is applied to
(DomainCreateFlowTest) due to a few outstanding persistence bugs.
Merge after these are resolved.  Also, we'll want to revisit this if the
final replay mechanism is implemented soon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/857)
<!-- Reviewable:end -->
