### PR TITLE
Convert Registry related tests to working with SQL

### DIFF
--- a/core/src/main/java/google/registry/model/registry/label/PremiumList.java
+++ b/core/src/main/java/google/registry/model/registry/label/PremiumList.java
@@ -25,6 +25,7 @@ import static google.registry.model.common.EntityGroupRoot.getCrossTldKey;
 import static google.registry.model.ofy.ObjectifyService.allocateId;
 import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.persistence.transaction.TransactionManagerUtil.ofyOrJpaTm;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
@@ -55,6 +56,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -207,7 +209,9 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
   }
 
   private static PremiumList loadPremiumList(String name) {
-    return ofy().load().type(PremiumList.class).parent(getCrossTldKey()).id(name).now();
+    return ofyOrJpaTm(
+        () -> ofy().load().type(PremiumList.class).parent(getCrossTldKey()).id(name).now(),
+        () -> PremiumListDao.getLatestRevision(name).orElseThrow(NoSuchElementException::new));
   }
 
   /**

--- a/core/src/main/java/google/registry/model/registry/label/ReservedList.java
+++ b/core/src/main/java/google/registry/model/registry/label/ReservedList.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static google.registry.config.RegistryConfig.getDomainLabelListCacheDuration;
 import static google.registry.model.registry.label.ReservationType.FULLY_BLOCKED;
+import static google.registry.persistence.transaction.TransactionManagerUtil.ofyOrJpaTm;
 import static google.registry.util.CollectionUtils.nullToEmpty;
 import static org.joda.time.DateTimeZone.UTC;
 
@@ -246,7 +247,9 @@ public final class ReservedList
               new CacheLoader<String, ReservedList>() {
                 @Override
                 public ReservedList load(String listName) {
-                  return ReservedListDualWriteDao.getLatestRevision(listName).orElse(null);
+                  return ofyOrJpaTm(
+                      () -> ReservedListDualWriteDao.getLatestRevision(listName).orElse(null),
+                      () -> ReservedListSqlDao.getLatestRevision(listName).orElse(null));
                 }
               });
 

--- a/core/src/test/java/google/registry/model/registry/RegistriesTest.java
+++ b/core/src/test/java/google/registry/model/registry/RegistriesTest.java
@@ -24,10 +24,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.google.common.net.InternetDomainName;
 import google.registry.model.registry.Registry.TldType;
 import google.registry.testing.AppEngineExtension;
-import org.junit.jupiter.api.Test;
+import google.registry.testing.DualDatabaseTest;
+import google.registry.testing.TestOfyAndSql;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link Registries}. */
+@DualDatabaseTest
 class RegistriesTest {
 
   @RegisterExtension
@@ -38,13 +40,13 @@ class RegistriesTest {
     createTlds("foo", "a.b.c"); // Test a multipart tld.
   }
 
-  @Test
+  @TestOfyAndSql
   void testGetTlds() {
     initTestTlds();
     assertThat(Registries.getTlds()).containsExactly("foo", "a.b.c");
   }
 
-  @Test
+  @TestOfyAndSql
   void test_getTldEntities() {
     initTestTlds();
     persistResource(newRegistry("testtld", "TESTTLD").asBuilder().setTldType(TldType.TEST).build());
@@ -54,25 +56,25 @@ class RegistriesTest {
         .containsExactly(Registry.get("testtld"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testGetTlds_withNoRegistriesPersisted_returnsEmptySet() {
     assertThat(Registries.getTlds()).isEmpty();
   }
 
-  @Test
+  @TestOfyAndSql
   void testAssertTldExists_doesExist() {
     initTestTlds();
     Registries.assertTldExists("foo");
     Registries.assertTldExists("a.b.c");
   }
 
-  @Test
+  @TestOfyAndSql
   void testAssertTldExists_doesntExist() {
     initTestTlds();
     assertThrows(IllegalArgumentException.class, () -> Registries.assertTldExists("baz"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testFindTldForName() {
     initTestTlds();
     assertThat(Registries.findTldForName(InternetDomainName.from("example.foo")).get().toString())

--- a/core/src/test/java/google/registry/testing/DatastoreHelper.java
+++ b/core/src/test/java/google/registry/testing/DatastoreHelper.java
@@ -322,12 +322,19 @@ public class DatastoreHelper {
 
   public static ReservedList persistReservedList(
     String listName, boolean shouldPublish, String... lines) {
-    return persistResource(
+    ReservedList reservedList =
         new ReservedList.Builder()
             .setName(listName)
             .setReservedListMapFromLines(ImmutableList.copyOf(lines))
             .setShouldPublish(shouldPublish)
-            .build());
+            .setLastUpdateTime(DateTime.now(DateTimeZone.UTC))
+            .build();
+    return ofyOrJpaTm(
+        () -> persistResource(reservedList),
+        () -> {
+          tm().transact(() -> tm().insert(reservedList));
+          return reservedList;
+        });
   }
 
   /**


### PR DESCRIPTION
This PR converted `RegistryTest` and `RegistriesTest` to working with SQL, and it also made the necessary `ofy() -> tm()` changes in the related code.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/862)
<!-- Reviewable:end -->
