### PR TITLE
Small SQL persistence fixes to model classes

### DIFF
--- a/core/src/main/java/google/registry/model/registry/Registry.java
+++ b/core/src/main/java/google/registry/model/registry/Registry.java
@@ -285,6 +285,10 @@ public class Registry extends ImmutableObject implements Buildable, DatastoreAnd
     return VKey.create(Registry.class, tld, Key.create(getCrossTldKey(), Registry.class, tld));
   }
 
+  public static VKey<Registry> createVKey(Key<Registry> key) {
+    return createVKey(key.getName());
+  }
+
   /**
    * The name of the pricing engine that this TLD uses.
    *

--- a/core/src/main/java/google/registry/model/registry/label/PremiumList.java
+++ b/core/src/main/java/google/registry/model/registry/label/PremiumList.java
@@ -444,11 +444,6 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
     }
   }
 
-  @Override
-  public ImmutableList<SqlEntity> toSqlEntities() {
-    return ImmutableList.of();
-  }
-
   @PrePersist
   void prePersist() {
     lastUpdateTime = creationTime;

--- a/core/src/main/java/google/registry/model/registry/label/PremiumList.java
+++ b/core/src/main/java/google/registry/model/registry/label/PremiumList.java
@@ -352,7 +352,7 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
 
     @Override
     public ImmutableList<SqlEntity> toSqlEntities() {
-      return null;
+      return ImmutableList.of();
     }
 
     /** A builder for constructing {@link PremiumListEntry} objects, since they are immutable. */
@@ -442,6 +442,11 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
       }
       return super.build();
     }
+  }
+
+  @Override
+  public ImmutableList<SqlEntity> toSqlEntities() {
+    return ImmutableList.of();
   }
 
   @PrePersist

--- a/core/src/main/java/google/registry/model/registry/label/ReservedList.java
+++ b/core/src/main/java/google/registry/model/registry/label/ReservedList.java
@@ -27,6 +27,7 @@ import com.google.common.base.Splitter;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.UncheckedExecutionException;
@@ -38,7 +39,12 @@ import com.googlecode.objectify.mapper.Mapper;
 import google.registry.model.Buildable;
 import google.registry.model.registry.Registry;
 import google.registry.model.registry.label.DomainLabelMetrics.MetricsReservedListMatch;
+<<<<<<< HEAD
 import google.registry.schema.replay.NonReplicatedEntity;
+=======
+import google.registry.schema.replay.DatastoreAndSqlEntity;
+import google.registry.schema.replay.SqlEntity;
+>>>>>>> 1aa54ebd1 (Small SQL persistence fixes to model classes)
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -316,5 +322,10 @@ public final class ReservedList
     public Builder setReservedListMapFromLines(Iterable<String> lines) {
       return setReservedListMap(getInstance().parse(lines));
     }
+  }
+
+  @Override
+  public ImmutableList<SqlEntity> toSqlEntities() {
+    return ImmutableList.of();
   }
 }

--- a/core/src/main/java/google/registry/model/registry/label/ReservedList.java
+++ b/core/src/main/java/google/registry/model/registry/label/ReservedList.java
@@ -27,7 +27,6 @@ import com.google.common.base.Splitter;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.UncheckedExecutionException;
@@ -39,12 +38,7 @@ import com.googlecode.objectify.mapper.Mapper;
 import google.registry.model.Buildable;
 import google.registry.model.registry.Registry;
 import google.registry.model.registry.label.DomainLabelMetrics.MetricsReservedListMatch;
-<<<<<<< HEAD
 import google.registry.schema.replay.NonReplicatedEntity;
-=======
-import google.registry.schema.replay.DatastoreAndSqlEntity;
-import google.registry.schema.replay.SqlEntity;
->>>>>>> 1aa54ebd1 (Small SQL persistence fixes to model classes)
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -322,10 +316,5 @@ public final class ReservedList
     public Builder setReservedListMapFromLines(Iterable<String> lines) {
       return setReservedListMap(getInstance().parse(lines));
     }
-  }
-
-  @Override
-  public ImmutableList<SqlEntity> toSqlEntities() {
-    return ImmutableList.of();
   }
 }


### PR DESCRIPTION
- Add a createVKey() method to Registry (Registry vkeys are composite)
- Add/fix toSqlEntities() methods in premium and reserved list classes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/863)
<!-- Reviewable:end -->
