### PR TITLE
Display concrete test method name for @DualDatabaseTest

### DIFF
--- a/core/src/test/java/google/registry/testing/DualDatabaseTestInvocationContextProvider.java
+++ b/core/src/test/java/google/registry/testing/DualDatabaseTestInvocationContextProvider.java
@@ -54,9 +54,11 @@ class DualDatabaseTestInvocationContextProvider implements TestTemplateInvocatio
   public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
       ExtensionContext context) {
     TestTemplateInvocationContext ofyContext =
-        createInvocationContext("Test Datastore", TransactionManagerFactory::ofyTm);
+        createInvocationContext(
+            context.getDisplayName() + " with Datastore", TransactionManagerFactory::ofyTm);
     TestTemplateInvocationContext sqlContext =
-        createInvocationContext("Test PostgreSQL", TransactionManagerFactory::jpaTm);
+        createInvocationContext(
+            context.getDisplayName() + " with PostgreSQL", TransactionManagerFactory::jpaTm);
     Method testMethod = context.getTestMethod().orElseThrow(IllegalStateException::new);
     if (testMethod.isAnnotationPresent(TestOfyAndSql.class)) {
       return Stream.of(ofyContext, sqlContext);


### PR DESCRIPTION
Display the concrete test method name in the build result and test report for `@DualDatabaseTest` to provide better context.

After this change, the build result for failed test will look like:

![image](https://user-images.githubusercontent.com/13003249/99575487-b2711f00-29a6-11eb-8be6-82dbcfea235a.png)

And the test report will look like:

![image](https://user-images.githubusercontent.com/13003249/99575408-98cfd780-29a6-11eb-9595-b7f99859888c.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/876)
<!-- Reviewable:end -->
