### PR TITLE
Allow addition of extra entity classes for VKey conversion

### DIFF
--- a/core/src/test/java/google/registry/model/translators/VKeyTranslatorFactoryTest.java
+++ b/core/src/test/java/google/registry/model/translators/VKeyTranslatorFactoryTest.java
@@ -27,15 +27,23 @@ import google.registry.model.ofy.CommitLogCheckpointRoot;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.persistence.VKey;
 import google.registry.testing.AppEngineExtension;
+import google.registry.testing.TestObject;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class VKeyTranslatorFactoryTest {
 
   @RegisterExtension
-  public final AppEngineExtension appEngine = AppEngineExtension.builder().withDatastore().build();
+  public final AppEngineExtension appEngine =
+      AppEngineExtension.builder().withDatastore().withOfyTestEntities(TestObject.class).build();
 
   VKeyTranslatorFactoryTest() {}
+
+  @BeforeAll
+  static void beforeAll() {
+    VKeyTranslatorFactory.addTestEntityClass(TestObject.class);
+  }
 
   @Test
   void testEntityWithFlatKey() {
@@ -87,5 +95,12 @@ public class VKeyTranslatorFactoryTest {
     assertThat(vkey.getKind()).isEqualTo(DomainBase.class);
     assertThat(vkey.getOfyKey()).isEqualTo(key);
     assertThat(vkey.getSqlKey()).isEqualTo("ROID-1");
+  }
+
+  @Test
+  void testExtraEntityClass() {
+    TestObject testObject = TestObject.create("id", "field");
+    Key<TestObject> key = Key.create(testObject);
+    assertThat(VKeyTranslatorFactory.createVKey(key).getSqlKey()).isEqualTo("id");
   }
 }

--- a/core/src/test/java/google/registry/testing/TestObject.java
+++ b/core/src/test/java/google/registry/testing/TestObject.java
@@ -23,6 +23,7 @@ import com.googlecode.objectify.annotation.Parent;
 import google.registry.model.ImmutableObject;
 import google.registry.model.annotations.VirtualEntity;
 import google.registry.model.common.EntityGroupRoot;
+import google.registry.persistence.VKey;
 import google.registry.schema.replay.EntityTest.EntityForTesting;
 
 /** A test model object that can be persisted in any entity group. */
@@ -30,11 +31,9 @@ import google.registry.schema.replay.EntityTest.EntityForTesting;
 @EntityForTesting
 public class TestObject extends ImmutableObject {
 
-  @Parent
-  Key<EntityGroupRoot> parent;
+  @Parent Key<EntityGroupRoot> parent;
 
-  @Id
-  String id;
+  @Id String id;
 
   String field;
 
@@ -44,6 +43,10 @@ public class TestObject extends ImmutableObject {
 
   public String getField() {
     return field;
+  }
+
+  public static VKey<TestObject> createVKey(Key<TestObject> key) {
+    return VKey.create(TestObject.class, key.getName(), key);
   }
 
   public static TestObject create(String id) {
@@ -68,8 +71,7 @@ public class TestObject extends ImmutableObject {
   @EntityForTesting
   public static class TestVirtualObject extends ImmutableObject {
 
-    @Id
-    String id;
+    @Id String id;
 
     /**
      * Expose a factory method for testing saves of virtual entities; in real life this would never


### PR DESCRIPTION
This allows us to create VKeys from Keys for test objects that may not
be part of the original codebase.

This isn't used anywhere directly yet but it will be useful in the
future when testing the replay of SQL transactions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/877)
<!-- Reviewable:end -->
