### PR TITLE
Make sure post load work happens in GracePeriod

### DIFF
--- a/core/src/main/java/google/registry/model/domain/DomainContent.java
+++ b/core/src/main/java/google/registry/model/domain/DomainContent.java
@@ -311,6 +311,9 @@ public class DomainContent extends EppResource
         nullToEmptyImmutableCopy(gracePeriods).stream()
             .map(gracePeriod -> gracePeriod.cloneAfterOfyLoad(getRepoId()))
             .collect(toImmutableSet());
+    // TODO(b/169873747): Remove this method after explicitly re-saving all domain entities.
+    // See also: GradePeriod.onLoad.
+    gracePeriods.forEach(GracePeriod::onLoad);
 
     // Restore history record ids.
     autorenewPollMessageHistoryId = getHistoryId(autorenewPollMessage);

--- a/core/src/main/java/google/registry/model/domain/GracePeriod.java
+++ b/core/src/main/java/google/registry/model/domain/GracePeriod.java
@@ -55,6 +55,8 @@ public class GracePeriod extends GracePeriodBase implements DatastoreAndSqlEntit
   // TODO(b/169873747): Remove this method after explicitly re-saving all domain entities.
   // This method is invoked from DomainContent.load(): Objectify's @OnLoad annotation
   // apparently does not work on embedded objects inside an entity.
+  // Changing signature to void onLoad(@AlsoLoad("gracePeriodId") Long gracePeriodId)
+  // would not work. Method is not called if gracePeriodId is null.
   void onLoad() {
     if (gracePeriodId == null) {
       gracePeriodId = ObjectifyService.allocateId();

--- a/core/src/main/java/google/registry/model/domain/GracePeriod.java
+++ b/core/src/main/java/google/registry/model/domain/GracePeriod.java
@@ -19,7 +19,6 @@ import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.googlecode.objectify.annotation.Embed;
-import com.googlecode.objectify.annotation.OnLoad;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Recurring;
 import google.registry.model.domain.rgp.GracePeriodStatus;
@@ -54,7 +53,8 @@ public class GracePeriod extends GracePeriodBase implements DatastoreAndSqlEntit
   }
 
   // TODO(b/169873747): Remove this method after explicitly re-saving all domain entities.
-  @OnLoad
+  // This method is invoked from DomainContent.load(): Objectify's @OnLoad annotation
+  // apparently does not work on embedded objects inside an entity.
   void onLoad() {
     if (gracePeriodId == null) {
       gracePeriodId = ObjectifyService.allocateId();

--- a/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
@@ -20,7 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static google.registry.model.EppResourceUtils.loadByForeignKey;
 import static google.registry.model.ofy.ObjectifyService.ofy;
-import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.ofyTm;
 import static google.registry.testing.DatabaseHelper.cloneAndSetAutoTimestamps;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.newDomainBase;
@@ -169,9 +169,9 @@ public class DomainBaseTest extends EntityTestCase {
 
   @Test
   void testGracePeriod_nullIdFromOfy() {
-    Entity entity = tm().transact(() -> ofy().save().toEntity(domain));
+    Entity entity = ofyTm().transact(() -> ofy().save().toEntity(domain));
     entity.setUnindexedProperty("gracePeriods.gracePeriodId", null);
-    DomainBase domainFromEntity = tm().transact(() -> ofy().load().fromEntity(entity));
+    DomainBase domainFromEntity = ofyTm().transact(() -> ofy().load().fromEntity(entity));
     GracePeriod gracePeriod = domainFromEntity.getGracePeriods().iterator().next();
     assertThat(gracePeriod.gracePeriodId).isNotNull();
   }

--- a/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
@@ -19,6 +19,8 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static google.registry.model.EppResourceUtils.loadByForeignKey;
+import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.cloneAndSetAutoTimestamps;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.newDomainBase;
@@ -30,6 +32,7 @@ import static org.joda.money.CurrencyUnit.USD;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.appengine.api.datastore.Entity;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
@@ -162,6 +165,15 @@ public class DomainBaseTest extends EntityTestCase {
                             null))
                     .setAutorenewEndTime(Optional.of(fakeClock.nowUtc().plusYears(2)))
                     .build()));
+  }
+
+  @Test
+  void testGracePeriod_nullIdFromOfy() {
+    Entity entity = tm().transact(() -> ofy().save().toEntity(domain));
+    entity.setUnindexedProperty("gracePeriods.gracePeriodId", null);
+    DomainBase domainFromEntity = tm().transact(() -> ofy().load().fromEntity(entity));
+    GracePeriod gracePeriod = domainFromEntity.getGracePeriods().iterator().next();
+    assertThat(gracePeriod.gracePeriodId).isNotNull();
   }
 
   @Test


### PR DESCRIPTION
The GracePeriod method with ofy @OnLoad annotation is not called.

Apparently Ofy only checks for @OnLoad on first-class entities,
not embedded ones.

Added a call to this method from DomainContent's OnLoad method.

Reproduced issue with a test and verified that the fix works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/878)
<!-- Reviewable:end -->
