### PR TITLE
Add a full ASCII StringGenerator alphabet

### DIFF
--- a/util/src/main/java/google/registry/util/StringGenerator.java
+++ b/util/src/main/java/google/registry/util/StringGenerator.java
@@ -39,6 +39,10 @@ public abstract class StringGenerator implements Serializable {
 
     /** Digit-only alphabet. */
     public static final String DIGITS_ONLY = "0123456789";
+
+    /** Full ASCII alphabet with a wide selection of punctuation characters. */
+    public static final String FULL_ASCII =
+        "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ`~!@#$%^&*()_-+={}[]\\/<>,.;?':| ";
   }
 
   protected String alphabet;


### PR DESCRIPTION
This is intended for the purpose of generating maximally secure passwords for
PostgreSQL and others. We may need to remove a few of these punctuation
characters if they prove to be more trouble than they're worth (e.g. backtick).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/882)
<!-- Reviewable:end -->
