### PR TITLE
Fix DomainHistory merge issues

### DIFF
--- a/core/src/main/java/google/registry/model/domain/DomainHistory.java
+++ b/core/src/main/java/google/registry/model/domain/DomainHistory.java
@@ -101,6 +101,7 @@ public class DomainHistory extends HistoryEntry implements SqlEntity {
   @Column(name = "host_repo_id")
   Set<VKey<HostResource>> nsHosts;
 
+  @Ignore
   @OneToMany(
       cascade = {CascadeType.ALL},
       fetch = FetchType.EAGER,
@@ -117,8 +118,9 @@ public class DomainHistory extends HistoryEntry implements SqlEntity {
         insertable = false,
         updatable = false)
   })
-  Set<DomainDsDataHistory> dsDataHistories;
+  Set<DomainDsDataHistory> dsDataHistories = ImmutableSet.of();
 
+  @Ignore
   @OneToMany(
       cascade = {CascadeType.ALL},
       fetch = FetchType.EAGER,
@@ -135,7 +137,7 @@ public class DomainHistory extends HistoryEntry implements SqlEntity {
         insertable = false,
         updatable = false)
   })
-  Set<GracePeriodHistory> gracePeriodHistories;
+  Set<GracePeriodHistory> gracePeriodHistories = ImmutableSet.of();
 
   @Override
   @Nullable

--- a/core/src/main/java/google/registry/model/registry/Registries.java
+++ b/core/src/main/java/google/registry/model/registry/Registries.java
@@ -14,10 +14,10 @@
 
 package google.registry.model.registry;
 
-//import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.equalTo;
-//import static com.google.common.base.Predicates.in;
-//import static com.google.common.base.Predicates.not;
+import static com.google.common.base.Predicates.in;
+import static com.google.common.base.Predicates.not;
 import static com.google.common.base.Strings.emptyToNull;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Maps.filterValues;
@@ -28,12 +28,12 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.util.CollectionUtils.entriesToImmutableMap;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
-//import com.google.common.base.Joiner;
+import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-//import com.google.common.collect.Streams;
+import com.google.common.collect.Streams;
 import com.google.common.net.InternetDomainName;
 import com.googlecode.objectify.Key;
 import google.registry.model.registry.Registry.TldType;
@@ -99,10 +99,10 @@ public final class Registries {
 
   /** Pass-through check that the specified TLD exists, otherwise throw an IAE. */
   public static String assertTldExists(String tld) {
-//    checkArgument(
-//        getTlds().contains(checkArgumentNotNull(emptyToNull(tld), "Null or empty TLD specified")),
-//        "TLD %s does not exist",
-//        tld);
+    checkArgument(
+        getTlds().contains(checkArgumentNotNull(emptyToNull(tld), "Null or empty TLD specified")),
+        "TLD %s does not exist",
+        tld);
     return tld;
   }
 
@@ -111,9 +111,9 @@ public final class Registries {
     for (String tld : tlds) {
       checkArgumentNotNull(emptyToNull(tld), "Null or empty TLD specified");
     }
-//    ImmutableSet<String> badTlds =
-//        Streams.stream(tlds).filter(not(in(getTlds()))).collect(toImmutableSet());
-//    checkArgument(badTlds.isEmpty(), "TLDs do not exist: %s", Joiner.on(", ").join(badTlds));
+    ImmutableSet<String> badTlds =
+        Streams.stream(tlds).filter(not(in(getTlds()))).collect(toImmutableSet());
+    checkArgument(badTlds.isEmpty(), "TLDs do not exist: %s", Joiner.on(", ").join(badTlds));
     return tlds;
   }
 

--- a/core/src/main/java/google/registry/model/registry/Registries.java
+++ b/core/src/main/java/google/registry/model/registry/Registries.java
@@ -14,10 +14,10 @@
 
 package google.registry.model.registry;
 
-import static com.google.common.base.Preconditions.checkArgument;
+//import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Predicates.equalTo;
-import static com.google.common.base.Predicates.in;
-import static com.google.common.base.Predicates.not;
+//import static com.google.common.base.Predicates.in;
+//import static com.google.common.base.Predicates.not;
 import static com.google.common.base.Strings.emptyToNull;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Maps.filterValues;
@@ -28,12 +28,12 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.util.CollectionUtils.entriesToImmutableMap;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
-import com.google.common.base.Joiner;
+//import com.google.common.base.Joiner;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Streams;
+//import com.google.common.collect.Streams;
 import com.google.common.net.InternetDomainName;
 import com.googlecode.objectify.Key;
 import google.registry.model.registry.Registry.TldType;
@@ -99,10 +99,10 @@ public final class Registries {
 
   /** Pass-through check that the specified TLD exists, otherwise throw an IAE. */
   public static String assertTldExists(String tld) {
-    checkArgument(
-        getTlds().contains(checkArgumentNotNull(emptyToNull(tld), "Null or empty TLD specified")),
-        "TLD %s does not exist",
-        tld);
+//    checkArgument(
+//        getTlds().contains(checkArgumentNotNull(emptyToNull(tld), "Null or empty TLD specified")),
+//        "TLD %s does not exist",
+//        tld);
     return tld;
   }
 
@@ -111,9 +111,9 @@ public final class Registries {
     for (String tld : tlds) {
       checkArgumentNotNull(emptyToNull(tld), "Null or empty TLD specified");
     }
-    ImmutableSet<String> badTlds =
-        Streams.stream(tlds).filter(not(in(getTlds()))).collect(toImmutableSet());
-    checkArgument(badTlds.isEmpty(), "TLDs do not exist: %s", Joiner.on(", ").join(badTlds));
+//    ImmutableSet<String> badTlds =
+//        Streams.stream(tlds).filter(not(in(getTlds()))).collect(toImmutableSet());
+//    checkArgument(badTlds.isEmpty(), "TLDs do not exist: %s", Joiner.on(", ").join(badTlds));
     return tlds;
   }
 

--- a/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
@@ -14,7 +14,7 @@
 
 package google.registry.model.history;
 
-//import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
 import static google.registry.model.ImmutableObjectSubject.immutableObjectCorrespondence;
@@ -25,7 +25,7 @@ import static google.registry.testing.DatastoreHelper.createTld;
 import static google.registry.testing.DatastoreHelper.newContactResourceWithRoid;
 import static google.registry.testing.DatastoreHelper.newDomainBase;
 import static google.registry.testing.DatastoreHelper.newHostResourceWithRoid;
-//import static google.registry.util.DateTimeUtils.END_OF_TIME;
+import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -37,13 +37,14 @@ import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.domain.DomainContent;
 import google.registry.model.domain.DomainHistory;
-//import google.registry.model.domain.GracePeriod;
+import google.registry.model.domain.GracePeriod;
 import google.registry.model.domain.Period;
-//import google.registry.model.domain.rgp.GracePeriodStatus;
+import google.registry.model.domain.rgp.GracePeriodStatus;
 import google.registry.model.domain.secdns.DelegationSignerData;
 import google.registry.model.eppcommon.Trid;
 import google.registry.model.host.HostResource;
 import google.registry.model.registrar.Registrar;
+import google.registry.model.registry.Registries;
 import google.registry.model.registry.Registry;
 import google.registry.model.reporting.DomainTransactionRecord;
 import google.registry.model.reporting.DomainTransactionRecord.TransactionReportField;
@@ -52,7 +53,7 @@ import google.registry.persistence.VKey;
 import google.registry.testing.DatastoreHelper;
 import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.TestOfyOnly;
-//import google.registry.testing.TestSqlOnly;
+import google.registry.testing.TestSqlOnly;
 
 /** Tests for {@link DomainHistory}. */
 @DualDatabaseTest
@@ -62,90 +63,44 @@ public class DomainHistoryTest extends EntityTestCase {
     super(JpaEntityCoverageCheck.ENABLED);
   }
 
-//  @TestSqlOnly
-//  void testPersistence() {
-//    DomainBase domain = addGracePeriodForSql(createDomainWithContactsAndHosts());
-//    DomainHistory domainHistory = createDomainHistory(domain);
-//    jpaTm().transact(() -> jpaTm().insert(domainHistory));
-//
-//    jpaTm()
-//        .transact(
-//            () -> {
-//              DomainHistory fromDatabase = jpaTm().load(domainHistory.createVKey());
-//              assertDomainHistoriesEqual(fromDatabase, domainHistory);
-//              assertThat(fromDatabase.getParentVKey()).isEqualTo(domainHistory.getParentVKey());
-//            });
-//  }
-//
-//  @TestSqlOnly
-//  void testLegacyPersistence_nullResource() {
-//    DomainBase domain = addGracePeriodForSql(createDomainWithContactsAndHosts());
-//    DomainHistory domainHistory =
-//        createDomainHistory(domain).asBuilder().setDomainContent(null).build();
-//    jpaTm().transact(() -> jpaTm().insert(domainHistory));
-//
-//    jpaTm()
-//        .transact(
-//            () -> {
-//              DomainHistory fromDatabase = jpaTm().load(domainHistory.createVKey());
-//              assertDomainHistoriesEqual(fromDatabase, domainHistory);
-//              assertThat(fromDatabase.getParentVKey()).isEqualTo(domainHistory.getParentVKey());
-//              assertThat(fromDatabase.getNsHosts())
-//                  .containsExactlyElementsIn(
-//                      domainHistory.getNsHosts().stream()
-//                          .map(key -> VKey.createSql(HostResource.class, key.getSqlKey()))
-//                          .collect(toImmutableSet()));
-//            });
-//  }
-//
-//  @TestOfyOnly
-//  void testOfyPersistence() {
-//    HostResource host = newHostResourceWithRoid("ns1.example.com", "host1");
-//    ContactResource contact = newContactResourceWithRoid("contactId", "contact1");
-//
-//    tm().transact(
-//            () -> {
-//              tm().insert(host);
-//              tm().insert(contact);
-//            });
-//    fakeClock.advanceOneMilli();
-//
-//    DomainBase domain =
-//        newDomainBase("example.tld", "domainRepoId", contact)
-//            .asBuilder()
-//            .setNameservers(host.createVKey())
-//            .build();
-//    tm().transact(() -> tm().insert(domain));
-//
-//    fakeClock.advanceOneMilli();
-//    DomainHistory domainHistory = createDomainHistory(domain);
-//    tm().transact(() -> tm().insert(domainHistory));
-//
-//    // retrieving a HistoryEntry or a DomainHistory with the same key should return the same
-//    // object
-//    // note: due to the @EntitySubclass annotation. all Keys for DomainHistory objects will have
-//    // type HistoryEntry
-//    VKey<DomainHistory> domainHistoryVKey = domainHistory.createVKey();
-//    VKey<HistoryEntry> historyEntryVKey =
-//        VKey.createOfy(HistoryEntry.class, Key.create(domainHistory.asHistoryEntry()));
-//    DomainHistory domainHistoryFromDb = tm().transact(() -> tm().load(domainHistoryVKey));
-//    HistoryEntry historyEntryFromDb = tm().transact(() -> tm().load(historyEntryVKey));
-//
-//    assertThat(domainHistoryFromDb).isEqualTo(historyEntryFromDb);
-//  }
+  @TestSqlOnly
+  void testPersistence() {
+    DomainBase domain = addGracePeriodForSql(createDomainWithContactsAndHosts());
+    DomainHistory domainHistory = createDomainHistory(domain);
+    jpaTm().transact(() -> jpaTm().insert(domainHistory));
+
+    jpaTm()
+        .transact(
+            () -> {
+              DomainHistory fromDatabase = jpaTm().load(domainHistory.createVKey());
+              assertDomainHistoriesEqual(fromDatabase, domainHistory);
+              assertThat(fromDatabase.getParentVKey()).isEqualTo(domainHistory.getParentVKey());
+            });
+  }
+
+  @TestSqlOnly
+  void testLegacyPersistence_nullResource() {
+    DomainBase domain = addGracePeriodForSql(createDomainWithContactsAndHosts());
+    DomainHistory domainHistory =
+        createDomainHistory(domain).asBuilder().setDomainContent(null).build();
+    jpaTm().transact(() -> jpaTm().insert(domainHistory));
+
+    jpaTm()
+        .transact(
+            () -> {
+              DomainHistory fromDatabase = jpaTm().load(domainHistory.createVKey());
+              assertDomainHistoriesEqual(fromDatabase, domainHistory);
+              assertThat(fromDatabase.getParentVKey()).isEqualTo(domainHistory.getParentVKey());
+              assertThat(fromDatabase.getNsHosts())
+                  .containsExactlyElementsIn(
+                      domainHistory.getNsHosts().stream()
+                          .map(key -> VKey.createSql(HostResource.class, key.getSqlKey()))
+                          .collect(toImmutableSet()));
+            });
+  }
 
   @TestOfyOnly
-  void testDoubleWriteOfOfyResource() {
-    jpaTm().transact(() -> {
-          Registry registry =
-              DatastoreHelper.newRegistry(
-                  "tld", "TLD", ImmutableSortedMap.of(START_OF_TIME, GENERAL_AVAILABILITY));
-          jpaTm().insert(registry);
-          Registrar registrar = appEngine.makeRegistrar2().asBuilder()
-              .setAllowedTlds(ImmutableSet.of("tld")).build();
-          jpaTm().insert(registrar);
-        });
-
+  void testOfyPersistence() {
     HostResource host = newHostResourceWithRoid("ns1.example.com", "host1");
     ContactResource contact = newContactResourceWithRoid("contactId", "contact1");
 
@@ -153,11 +108,6 @@ public class DomainHistoryTest extends EntityTestCase {
             () -> {
               tm().insert(host);
               tm().insert(contact);
-            });
-    jpaTm().transact(
-            () -> {
-              jpaTm().insert(host);
-              jpaTm().insert(contact);
             });
     fakeClock.advanceOneMilli();
 
@@ -167,13 +117,13 @@ public class DomainHistoryTest extends EntityTestCase {
             .setNameservers(host.createVKey())
             .build();
     tm().transact(() -> tm().insert(domain));
-    jpaTm().transact(() -> jpaTm().insert(domain));
 
     fakeClock.advanceOneMilli();
     DomainHistory domainHistory = createDomainHistory(domain);
     tm().transact(() -> tm().insert(domainHistory));
 
-    // retrieving a HistoryEntry or a DomainHistory with the same key should return the same object
+    // retrieving a HistoryEntry or a DomainHistory with the same key should return the same
+    // object
     // note: due to the @EntitySubclass annotation. all Keys for DomainHistory objects will have
     // type HistoryEntry
     VKey<DomainHistory> domainHistoryVKey = domainHistory.createVKey();
@@ -183,7 +133,61 @@ public class DomainHistoryTest extends EntityTestCase {
     HistoryEntry historyEntryFromDb = tm().transact(() -> tm().load(historyEntryVKey));
 
     assertThat(domainHistoryFromDb).isEqualTo(historyEntryFromDb);
+  }
 
+  @TestOfyOnly
+  void testDoubleWriteOfOfyResource() {
+    // We have to add the registry to ofy, since we're currently loading the cache from ofy.  We
+    // also have to add it to SQL to satisfy the foreign key constraints of the registrar.
+    Registry registry =
+        DatastoreHelper.newRegistry(
+            "tld", "TLD", ImmutableSortedMap.of(START_OF_TIME, GENERAL_AVAILABILITY));
+    tm().transact(() -> tm().insert(registry));
+    Registries.resetCache();
+    jpaTm()
+        .transact(
+            () -> {
+              jpaTm().insert(registry);
+              Registrar registrar =
+                  appEngine
+                      .makeRegistrar2()
+                      .asBuilder()
+                      .setAllowedTlds(ImmutableSet.of("tld"))
+                      .build();
+              jpaTm().insert(registrar);
+            });
+
+    HostResource host = newHostResourceWithRoid("ns1.example.com", "host1");
+    ContactResource contact = newContactResourceWithRoid("contactId", "contact1");
+
+    // Set up the host and domain objects in both databases.
+    tm().transact(
+            () -> {
+              tm().insert(host);
+              tm().insert(contact);
+            });
+    jpaTm()
+        .transact(
+            () -> {
+              jpaTm().insert(host);
+              jpaTm().insert(contact);
+            });
+    fakeClock.advanceOneMilli();
+    DomainBase domain =
+        newDomainBase("example.tld", "domainRepoId", contact)
+            .asBuilder()
+            .setNameservers(host.createVKey())
+            .build();
+    tm().transact(() -> tm().insert(domain));
+    jpaTm().transact(() -> jpaTm().insert(domain));
+    fakeClock.advanceOneMilli();
+
+    DomainHistory domainHistory = createDomainHistory(domain);
+    tm().transact(() -> tm().insert(domainHistory));
+
+    // Load the DomainHistory object from the datastore.
+    VKey<DomainHistory> domainHistoryVKey = domainHistory.createVKey();
+    DomainHistory domainHistoryFromDb = tm().transact(() -> tm().load(domainHistoryVKey));
 
     // attempt to write to SQL.
     jpaTm().transact(() -> jpaTm().insert(domainHistoryFromDb));
@@ -215,16 +219,16 @@ public class DomainHistoryTest extends EntityTestCase {
     return domain;
   }
 
-//  private static DomainBase addGracePeriodForSql(DomainBase domainBase) {
-//    return domainBase
-//        .asBuilder()
-//        .setGracePeriods(
-//            ImmutableSet.of(
-//                GracePeriod.create(
-//                        GracePeriodStatus.ADD, "domainRepoId", END_OF_TIME, "clientId", null)
-//                    .cloneWithPrepopulatedId()))
-//        .build();
-//  }
+  private static DomainBase addGracePeriodForSql(DomainBase domainBase) {
+    return domainBase
+        .asBuilder()
+        .setGracePeriods(
+            ImmutableSet.of(
+                GracePeriod.create(
+                        GracePeriodStatus.ADD, "domainRepoId", END_OF_TIME, "clientId", null)
+                    .cloneWithPrepopulatedId()))
+        .build();
+  }
 
   static void assertDomainHistoriesEqual(DomainHistory one, DomainHistory two) {
     assertAboutImmutableObjects()

--- a/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
@@ -21,10 +21,10 @@ import static google.registry.model.ImmutableObjectSubject.immutableObjectCorres
 import static google.registry.model.registry.Registry.TldState.GENERAL_AVAILABILITY;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatastoreHelper.createTld;
-import static google.registry.testing.DatastoreHelper.newContactResourceWithRoid;
-import static google.registry.testing.DatastoreHelper.newDomainBase;
-import static google.registry.testing.DatastoreHelper.newHostResourceWithRoid;
+import static google.registry.testing.DatabaseHelper.createTld;
+import static google.registry.testing.DatabaseHelper.newContactResourceWithRoid;
+import static google.registry.testing.DatabaseHelper.newDomainBase;
+import static google.registry.testing.DatabaseHelper.newHostResourceWithRoid;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -50,7 +50,7 @@ import google.registry.model.reporting.DomainTransactionRecord;
 import google.registry.model.reporting.DomainTransactionRecord.TransactionReportField;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.persistence.VKey;
-import google.registry.testing.DatastoreHelper;
+import google.registry.testing.DatabaseHelper;
 import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.TestOfyOnly;
 import google.registry.testing.TestSqlOnly;
@@ -140,7 +140,7 @@ public class DomainHistoryTest extends EntityTestCase {
     // We have to add the registry to ofy, since we're currently loading the cache from ofy.  We
     // also have to add it to SQL to satisfy the foreign key constraints of the registrar.
     Registry registry =
-        DatastoreHelper.newRegistry(
+        DatabaseHelper.newRegistry(
             "tld", "TLD", ImmutableSortedMap.of(START_OF_TIME, GENERAL_AVAILABILITY));
     tm().transact(() -> tm().insert(registry));
     Registries.resetCache();

--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -273,8 +273,6 @@ class google.registry.model.domain.DomainHistory {
   java.lang.String clientId;
   java.lang.String otherClientId;
   java.lang.String reason;
-  java.util.Set<google.registry.model.domain.GracePeriod$GracePeriodHistory> gracePeriodHistories;
-  java.util.Set<google.registry.model.domain.secdns.DomainDsDataHistory> dsDataHistories;
   java.util.Set<google.registry.model.reporting.DomainTransactionRecord> domainTransactionRecords;
   org.joda.time.DateTime modificationTime;
 }
@@ -282,16 +280,6 @@ class google.registry.model.domain.GracePeriod {
   google.registry.model.domain.rgp.GracePeriodStatus type;
   google.registry.persistence.VKey<google.registry.model.billing.BillingEvent$OneTime> billingEventOneTime;
   google.registry.persistence.VKey<google.registry.model.billing.BillingEvent$Recurring> billingEventRecurring;
-  java.lang.Long gracePeriodId;
-  java.lang.String clientId;
-  org.joda.time.DateTime expirationTime;
-}
-class google.registry.model.domain.GracePeriod$GracePeriodHistory {
-  google.registry.model.domain.rgp.GracePeriodStatus type;
-  google.registry.persistence.VKey<google.registry.model.billing.BillingEvent$OneTime> billingEventOneTime;
-  google.registry.persistence.VKey<google.registry.model.billing.BillingEvent$Recurring> billingEventRecurring;
-  java.lang.Long domainHistoryRevisionId;
-  java.lang.Long gracePeriodHistoryRevisionId;
   java.lang.Long gracePeriodId;
   java.lang.String clientId;
   org.joda.time.DateTime expirationTime;
@@ -327,14 +315,6 @@ class google.registry.model.domain.secdns.DelegationSignerData {
   int algorithm;
   int digestType;
   int keyTag;
-}
-class google.registry.model.domain.secdns.DomainDsDataHistory {
-  byte[] digest;
-  int algorithm;
-  int digestType;
-  int keyTag;
-  java.lang.Long domainHistoryRevisionId;
-  java.lang.Long dsDataHistoryRevisionId;
 }
 class google.registry.model.domain.token.AllocationToken {
   @Id java.lang.String token;


### PR DESCRIPTION
Make dsDataHistories and gracePeriodHistories in DomainHistory default to empty immutable sets (instead of null) and annotate them as "Ignore" since they should not be persisted in datastore.  This fixes problems we see trying to merge a detached instance of this entity type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/884)
<!-- Reviewable:end -->
