### PR TITLE
Fix DatastoreHelper -> DatabaseHelper in comments

### DIFF
--- a/core/src/test/java/google/registry/backup/DeleteOldCommitLogsActionTest.java
+++ b/core/src/test/java/google/registry/backup/DeleteOldCommitLogsActionTest.java
@@ -95,7 +95,7 @@ public class DeleteOldCommitLogsActionTest
     // Before deleting the unneeded manifests - we have 11 of them (one for the first
     // creation, and 10 more for the mutateContacts)
     assertThat(ofy().load().type(CommitLogManifest.class).count()).isEqualTo(11);
-    // And each DatastoreHelper.persistResourceWithCommitLog creates 3 mutations
+    // And each DatabaseHelper.persistResourceWithCommitLog creates 3 mutations
     assertThat(ofy().load().type(CommitLogMutation.class).count()).isEqualTo(33);
   }
 
@@ -111,7 +111,7 @@ public class DeleteOldCommitLogsActionTest
     assertThat(ImmutableList.copyOf(ofy().load().type(CommitLogManifest.class).keys().iterable()))
         .containsExactlyElementsIn(contact.getRevisions().values());
 
-    // And each DatastoreHelper.persistResourceWithCommitLog creates 3 mutations
+    // And each DatabaseHelper.persistResourceWithCommitLog creates 3 mutations
     assertThat(ofyLoadType(CommitLogMutation.class)).hasSize(contact.getRevisions().size() * 3);
   }
 

--- a/core/src/test/java/google/registry/model/index/EppResourceIndexTest.java
+++ b/core/src/test/java/google/registry/model/index/EppResourceIndexTest.java
@@ -37,7 +37,7 @@ class EppResourceIndexTest extends EntityTestCase {
   @BeforeEach
   void setUp() {
     createTld("tld");
-    // The DatastoreHelper here creates the EppResourceIndex for us.
+    // The DatabaseHelper here creates the EppResourceIndex for us.
     contact = persistActiveContact("abcd1357");
   }
 


### PR DESCRIPTION
Fix a few comments that still make reference to DatastoreHelper.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/885)
<!-- Reviewable:end -->
