### PR TITLE
Add an action to resave all Domain entities

### DIFF
--- a/core/src/main/java/google/registry/batch/ResaveAllDomainsAction.java
+++ b/core/src/main/java/google/registry/batch/ResaveAllDomainsAction.java
@@ -1,0 +1,89 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.batch;
+
+import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+
+import com.google.appengine.tools.mapreduce.Mapper;
+import com.google.common.collect.ImmutableList;
+import com.googlecode.objectify.Key;
+import google.registry.mapreduce.MapreduceRunner;
+import google.registry.mapreduce.inputs.EppResourceInputs;
+import google.registry.model.domain.DomainBase;
+import google.registry.model.domain.GracePeriod;
+import google.registry.request.Action;
+import google.registry.request.Response;
+import google.registry.request.auth.Auth;
+import javax.inject.Inject;
+
+/**
+ * A mapreduce that re-saves all Domain entities so all {@link GracePeriod#gracePeriodId}.
+ *
+ * <p>We added the {@link GracePeriod#gracePeriodId} to help migrate Domain entity to Cloud SQL. As
+ * it is a newly added field, all existing {@link DomainBase#gracePeriods} won't have it until its
+ * domain gets loaded. Ths mapreduce job loads all Domain entities and resave them so the {@link
+ * GracePeriod#gracePeriodId} can get assigned correctly.
+ */
+@Action(
+    service = Action.Service.BACKEND,
+    path = "/_dr/task/resaveAllDomains",
+    auth = Auth.AUTH_INTERNAL_OR_ADMIN)
+public class ResaveAllDomainsAction implements Runnable {
+
+  @Inject MapreduceRunner mrRunner;
+  @Inject Response response;
+
+  @Inject
+  ResaveAllDomainsAction() {}
+
+  @Override
+  public void run() {
+    mrRunner
+        .setJobName("Re-save all Domain entities")
+        .setModuleName("backend")
+        .runMapOnly(
+            new ResaveAllDomainsActionMapper(),
+            ImmutableList.of(EppResourceInputs.createKeyInput(DomainBase.class)))
+        .sendLinkToMapreduceConsole(response);
+  }
+
+  /** Mapper to re-save all Domain entities. */
+  public static class ResaveAllDomainsActionMapper extends Mapper<Key<DomainBase>, Void, Void> {
+
+    private static final long serialVersionUID = 1L;
+
+    public ResaveAllDomainsActionMapper() {}
+
+    @Override
+    public final void map(final Key<DomainBase> domainKey) {
+      tm().transact(
+              () -> {
+                DomainBase domain = ofy().load().key(domainKey).now();
+                domain
+                    .getGracePeriods()
+                    .forEach(
+                        gracePeriod -> {
+                          if (gracePeriod.getGracePeriodId() == 0L) {
+                            throw new IllegalStateException(
+                                String.format("gracePeriodId is not set for %s", gracePeriod));
+                          }
+                        });
+                ofy().save().entity(domain).now();
+              });
+      getContext().incrementCounter("Domain is re-saved");
+    }
+  }
+}

--- a/core/src/main/java/google/registry/model/domain/GracePeriod.java
+++ b/core/src/main/java/google/registry/model/domain/GracePeriod.java
@@ -195,15 +195,14 @@ public class GracePeriod extends GracePeriodBase implements DatastoreAndSqlEntit
   }
 
   /**
-   * Returns a clone of this {@link GracePeriod} with prepopulated {@link #gracePeriodId} generated
-   * by {@link ObjectifyService#allocateId()}.
+   * Returns a clone of this {@link GracePeriod} with {@link #gracePeriodId} set to null.
    *
-   * <p>TODO(shicong): Figure out how to generate the id only when the entity is used for Cloud SQL.
+   * <p>TODO(b/169873747): Remove this method after all domain entities are re-saved.
    */
   @VisibleForTesting
-  public GracePeriod cloneWithPrepopulatedId() {
+  public GracePeriod cloneWithNullId() {
     GracePeriod clone = clone(this);
-    clone.gracePeriodId = ObjectifyService.allocateId();
+    clone.gracePeriodId = null;
     return clone;
   }
 

--- a/core/src/main/java/google/registry/module/backend/BackendRequestComponent.java
+++ b/core/src/main/java/google/registry/module/backend/BackendRequestComponent.java
@@ -27,6 +27,7 @@ import google.registry.batch.DeleteProberDataAction;
 import google.registry.batch.ExpandRecurringBillingEventsAction;
 import google.registry.batch.RefreshDnsOnHostRenameAction;
 import google.registry.batch.RelockDomainAction;
+import google.registry.batch.ResaveAllDomainsAction;
 import google.registry.batch.ResaveAllEppResourcesAction;
 import google.registry.batch.ResaveEntityAction;
 import google.registry.cron.CommitLogFanoutAction;
@@ -174,6 +175,8 @@ interface BackendRequestComponent {
   RefreshDnsOnHostRenameAction refreshDnsOnHostRenameAction();
 
   RelockDomainAction relockDomainAction();
+
+  ResaveAllDomainsAction resaveAllDomainsAction();
 
   ResaveAllEppResourcesAction resaveAllEppResourcesAction();
 

--- a/core/src/test/java/google/registry/batch/ResaveAllDomainsActionTest.java
+++ b/core/src/test/java/google/registry/batch/ResaveAllDomainsActionTest.java
@@ -1,0 +1,132 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.batch;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.model.ImmutableObjectSubject.immutableObjectCorrespondence;
+import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.testing.DatabaseHelper.createTld;
+import static google.registry.testing.DatabaseHelper.newDomainBase;
+import static google.registry.testing.DatabaseHelper.persistResource;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.truth.Correspondence;
+import google.registry.model.ImmutableObject;
+import google.registry.model.domain.DomainBase;
+import google.registry.model.domain.GracePeriod;
+import google.registry.model.domain.rgp.GracePeriodStatus;
+import google.registry.testing.FakeClock;
+import google.registry.testing.FakeResponse;
+import google.registry.testing.mapreduce.MapreduceTestCase;
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit test for {@link ResaveAllDomainsAction}. */
+public class ResaveAllDomainsActionTest extends MapreduceTestCase<ResaveAllDomainsAction> {
+  private FakeClock fakeClock = new FakeClock();
+
+  @BeforeEach
+  void beforeEach() {
+    action = new ResaveAllDomainsAction();
+    action.mrRunner = makeDefaultRunner();
+    action.response = new FakeResponse();
+  }
+
+  private void runMapreduce() throws Exception {
+    action.run();
+    executeTasksUntilEmpty("mapreduce");
+  }
+
+  @Test
+  void test_mapreduceSuccessfullyResavesEntity() throws Exception {
+    createTld("tld");
+    DomainBase testDomain = newDomainBase("with-grace-period-id.tld");
+    DomainBase domainWithGracePeriodId =
+        persistResource(
+            testDomain
+                .asBuilder()
+                .addGracePeriod(
+                    GracePeriod.create(
+                        GracePeriodStatus.ADD,
+                        testDomain.getRepoId(),
+                        fakeClock.nowUtc().plusDays(1),
+                        "registrar",
+                        null))
+                .build());
+
+    DomainBase anotherDomain = newDomainBase("with-grace-period-id.tld");
+    DomainBase domainWithoutGracePeriodId =
+        persistResource(
+            anotherDomain
+                .asBuilder()
+                .addGracePeriod(
+                    GracePeriod.create(
+                            GracePeriodStatus.ADD,
+                            anotherDomain.getRepoId(),
+                            fakeClock.nowUtc().plusDays(1),
+                            "registrar",
+                            null)
+                        .cloneWithNullId())
+                .build());
+
+    ofy().clearSessionCache();
+    runMapreduce();
+
+    assertThat(ImmutableList.of(loadDomain(domainWithGracePeriodId)))
+        .comparingElementsUsing(getDomainCorrespondence())
+        .containsExactly(domainWithGracePeriodId);
+
+    DomainBase persisted = loadDomain(domainWithoutGracePeriodId);
+    assertThat(ImmutableList.of(persisted))
+        .comparingElementsUsing(getDomainCorrespondence("gracePeriods"))
+        .containsExactly(domainWithoutGracePeriodId);
+    assertThat(persisted.getGracePeriods())
+        .comparingElementsUsing(immutableObjectCorrespondence("gracePeriodId"))
+        .containsExactly(
+            GracePeriod.create(
+                    GracePeriodStatus.ADD,
+                    anotherDomain.getRepoId(),
+                    fakeClock.nowUtc().plusDays(1),
+                    "registrar",
+                    null)
+                .cloneWithNullId());
+    assertThat(persisted.getGracePeriods().iterator().next().getGracePeriodId()).isNotEqualTo(0L);
+
+    // Execute the MapReduce job again to verify it dose not change existing gracePeriodId
+    ofy().clearSessionCache();
+    beforeEach();
+    runMapreduce();
+
+    assertThat(ImmutableList.of(loadDomain(domainWithGracePeriodId)))
+        .comparingElementsUsing(getDomainCorrespondence())
+        .containsExactly(domainWithGracePeriodId);
+    assertThat(ImmutableList.of(loadDomain(domainWithoutGracePeriodId)))
+        .comparingElementsUsing(getDomainCorrespondence())
+        .containsExactly(persisted);
+  }
+
+  private static DomainBase loadDomain(DomainBase domain) {
+    return ofy().load().key(domain.createVKey().getOfyKey()).now();
+  }
+
+  private static Correspondence<ImmutableObject, ImmutableObject> getDomainCorrespondence(
+      String... ignoredFields) {
+    return immutableObjectCorrespondence(
+        Stream.concat(Stream.of("revisions", "updateTimestamp"), Arrays.stream(ignoredFields))
+            .toArray(String[]::new));
+  }
+}

--- a/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
@@ -225,8 +225,7 @@ public class DomainHistoryTest extends EntityTestCase {
         .setGracePeriods(
             ImmutableSet.of(
                 GracePeriod.create(
-                        GracePeriodStatus.ADD, "domainRepoId", END_OF_TIME, "clientId", null)
-                    .cloneWithPrepopulatedId()))
+                    GracePeriodStatus.ADD, "domainRepoId", END_OF_TIME, "clientId", null)))
         .build();
   }
 


### PR DESCRIPTION
We added a new field `gracePeriodId` to `GracePeriod` class but it cannot get assigned until the Domain entity is loaded. So, using this action can load all existing Domain entities and resave them to set `gracePeriodId`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/889)
<!-- Reviewable:end -->
