### PR TITLE
Convert AllocationToken-related classes to tm()

### DIFF
--- a/core/src/main/java/google/registry/reporting/spec11/Spec11RegistrarThreatMatchesParser.java
+++ b/core/src/main/java/google/registry/reporting/spec11/Spec11RegistrarThreatMatchesParser.java
@@ -67,7 +67,6 @@ public class Spec11RegistrarThreatMatchesParser {
     if (!gcsUtils.existsAndNotEmpty(spec11ReportFilename)) {
       return ImmutableSet.of();
     }
-    ImmutableSet.Builder<RegistrarThreatMatches> builder = ImmutableSet.builder();
     try (InputStream in = gcsUtils.openInputStream(spec11ReportFilename);
         InputStreamReader isr = new InputStreamReader(in, UTF_8)) {
       // Skip the header at line 0

--- a/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
+++ b/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
@@ -16,15 +16,14 @@ package google.registry.model.domain.token;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
-import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.CANCELLED;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.ENDED;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.NOT_STARTED;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.VALID;
 import static google.registry.model.domain.token.AllocationToken.TokenType.SINGLE_USE;
 import static google.registry.model.domain.token.AllocationToken.TokenType.UNLIMITED_USE;
-import static google.registry.model.ofy.ObjectifyService.ofy;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.persistence.transaction.TransactionManagerUtil.transactIfJpaTm;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistResource;
@@ -40,12 +39,14 @@ import google.registry.model.domain.DomainBase;
 import google.registry.model.domain.token.AllocationToken.TokenStatus;
 import google.registry.model.domain.token.AllocationToken.TokenType;
 import google.registry.model.reporting.HistoryEntry;
-import google.registry.persistence.VKey;
+import google.registry.testing.DualDatabaseTest;
+import google.registry.testing.TestOfyAndSql;
+import google.registry.testing.TestOfyOnly;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link AllocationToken}. */
+@DualDatabaseTest
 public class AllocationTokenTest extends EntityTestCase {
 
   public AllocationTokenTest() {
@@ -57,7 +58,7 @@ public class AllocationTokenTest extends EntityTestCase {
     createTld("foo");
   }
 
-  @Test
+  @TestOfyAndSql
   void testPersistence() {
     AllocationToken unlimitedUseToken =
         persistResource(
@@ -77,7 +78,7 @@ public class AllocationTokenTest extends EntityTestCase {
                         .put(DateTime.now(UTC).plusWeeks(8), TokenStatus.ENDED)
                         .build())
                 .build());
-    assertThat(ofy().load().entity(unlimitedUseToken).now()).isEqualTo(unlimitedUseToken);
+    assertThat(transactIfJpaTm(() -> tm().load(unlimitedUseToken))).isEqualTo(unlimitedUseToken);
 
     DomainBase domain = persistActiveDomain("example.foo");
     Key<HistoryEntry> historyEntryKey = Key.create(Key.create(domain), HistoryEntry.class, 1);
@@ -90,32 +91,10 @@ public class AllocationTokenTest extends EntityTestCase {
                 .setCreationTimeForTest(DateTime.parse("2010-11-12T05:00:00Z"))
                 .setTokenType(SINGLE_USE)
                 .build());
-    assertThat(ofy().load().entity(singleUseToken).now()).isEqualTo(singleUseToken);
-
-    jpaTm()
-        .transact(
-            () -> {
-              jpaTm().insert(unlimitedUseToken);
-              jpaTm().insert(singleUseToken);
-            });
-    jpaTm()
-        .transact(
-            () -> {
-              assertAboutImmutableObjects()
-                  .that(jpaTm().load(VKey.createSql(AllocationToken.class, "abc123Unlimited")))
-                  .isEqualExceptFields(
-                      unlimitedUseToken,
-                      "creationTime",
-                      "updateTimestamp",
-                      "redemptionHistoryEntry");
-              assertAboutImmutableObjects()
-                  .that(jpaTm().load(VKey.createSql(AllocationToken.class, "abc123Single")))
-                  .isEqualExceptFields(
-                      singleUseToken, "creationTime", "updateTimestamp", "redemptionHistoryEntry");
-            });
+    assertThat(transactIfJpaTm(() -> tm().load(singleUseToken))).isEqualTo(singleUseToken);
   }
 
-  @Test
+  @TestOfyOnly
   void testIndexing() throws Exception {
     DomainBase domain = persistActiveDomain("blahdomain.foo");
     Key<HistoryEntry> historyEntryKey = Key.create(Key.create(domain), HistoryEntry.class, 1);
@@ -133,7 +112,7 @@ public class AllocationTokenTest extends EntityTestCase {
         "domainName");
   }
 
-  @Test
+  @TestOfyAndSql
   void testCreationTime_autoPopulates() {
     AllocationToken tokenBeforePersisting =
         new AllocationToken.Builder().setToken("abc123").setTokenType(SINGLE_USE).build();
@@ -142,7 +121,7 @@ public class AllocationTokenTest extends EntityTestCase {
     assertThat(tokenAfterPersisting.getCreationTime()).hasValue(fakeClock.nowUtc());
   }
 
-  @Test
+  @TestOfyAndSql
   void testSetCreationTime_cantCallMoreThanOnce() {
     AllocationToken.Builder builder =
         new AllocationToken.Builder()
@@ -156,7 +135,7 @@ public class AllocationTokenTest extends EntityTestCase {
     assertThat(thrown).hasMessageThat().isEqualTo("Creation time can only be set once");
   }
 
-  @Test
+  @TestOfyAndSql
   void testSetToken_cantCallMoreThanOnce() {
     AllocationToken.Builder builder = new AllocationToken.Builder().setToken("foobar");
     IllegalStateException thrown =
@@ -164,7 +143,7 @@ public class AllocationTokenTest extends EntityTestCase {
     assertThat(thrown).hasMessageThat().isEqualTo("Token can only be set once");
   }
 
-  @Test
+  @TestOfyAndSql
   void testSetTokenType_cantCallMoreThanOnce() {
     AllocationToken.Builder builder =
         new AllocationToken.Builder().setTokenType(TokenType.UNLIMITED_USE);
@@ -173,7 +152,7 @@ public class AllocationTokenTest extends EntityTestCase {
     assertThat(thrown).hasMessageThat().isEqualTo("Token type can only be set once");
   }
 
-  @Test
+  @TestOfyAndSql
   void testBuild_DomainNameWithLessThanTwoParts() {
     IllegalArgumentException thrown =
         assertThrows(
@@ -191,7 +170,7 @@ public class AllocationTokenTest extends EntityTestCase {
     assertThat(thrown).hasMessageThat().isEqualTo("Invalid domain name: example");
   }
 
-  @Test
+  @TestOfyAndSql
   void testBuild_invalidTld() {
     IllegalArgumentException thrown =
         assertThrows(
@@ -209,7 +188,7 @@ public class AllocationTokenTest extends EntityTestCase {
     assertThat(thrown).hasMessageThat().isEqualTo("Invalid domain name: example.nosuchtld");
   }
 
-  @Test
+  @TestOfyAndSql
   void testBuild_domainNameOnlyOnSingleUse() {
     AllocationToken.Builder builder =
         new AllocationToken.Builder()
@@ -222,7 +201,7 @@ public class AllocationTokenTest extends EntityTestCase {
         .isEqualTo("Domain name can only be specified for SINGLE_USE tokens");
   }
 
-  @Test
+  @TestOfyAndSql
   void testBuild_redemptionHistoryEntryOnlyInSingleUse() {
     DomainBase domain = persistActiveDomain("blahdomain.foo");
     Key<HistoryEntry> historyEntryKey = Key.create(Key.create(domain), HistoryEntry.class, 1);
@@ -237,7 +216,7 @@ public class AllocationTokenTest extends EntityTestCase {
         .isEqualTo("Redemption history entry can only be specified for SINGLE_USE tokens");
   }
 
-  @Test
+  @TestOfyAndSql
   void testSetTransitions_notStartOfTime() {
     IllegalArgumentException thrown =
         assertThrows(
@@ -255,7 +234,7 @@ public class AllocationTokenTest extends EntityTestCase {
         .isEqualTo("tokenStatusTransitions map must start at START_OF_TIME.");
   }
 
-  @Test
+  @TestOfyAndSql
   void testSetTransitions_badInitialValue() {
     IllegalArgumentException thrown =
         assertThrows(
@@ -272,14 +251,14 @@ public class AllocationTokenTest extends EntityTestCase {
         .isEqualTo("tokenStatusTransitions must start with NOT_STARTED");
   }
 
-  @Test
+  @TestOfyAndSql
   void testSetTransitions_invalidInitialTransitions() {
     // NOT_STARTED can only go to VALID or CANCELLED
     assertBadInitialTransition(NOT_STARTED);
     assertBadInitialTransition(ENDED);
   }
 
-  @Test
+  @TestOfyAndSql
   void testSetTransitions_badTransitionsFromValid() {
     // VALID can only go to ENDED or CANCELLED
     assertBadTransition(
@@ -300,14 +279,14 @@ public class AllocationTokenTest extends EntityTestCase {
         NOT_STARTED);
   }
 
-  @Test
+  @TestOfyAndSql
   void testSetTransitions_terminalTransitions() {
     // both ENDED and CANCELLED are terminal
     assertTerminal(ENDED);
     assertTerminal(CANCELLED);
   }
 
-  @Test
+  @TestOfyAndSql
   void testSetDiscountFractionTooHigh() {
     IllegalArgumentException thrown =
         assertThrows(
@@ -318,7 +297,7 @@ public class AllocationTokenTest extends EntityTestCase {
         .isEqualTo("Discount fraction must be between 0 and 1 inclusive");
   }
 
-  @Test
+  @TestOfyAndSql
   void testSetDiscountFractionTooLow() {
     IllegalArgumentException thrown =
         assertThrows(
@@ -329,7 +308,7 @@ public class AllocationTokenTest extends EntityTestCase {
         .isEqualTo("Discount fraction must be between 0 and 1 inclusive");
   }
 
-  @Test
+  @TestOfyAndSql
   void testSetDiscountYearsTooHigh() {
     IllegalArgumentException thrown =
         assertThrows(
@@ -340,7 +319,7 @@ public class AllocationTokenTest extends EntityTestCase {
         .isEqualTo("Discount years must be between 1 and 10 inclusive");
   }
 
-  @Test
+  @TestOfyAndSql
   void testSetDiscountYearsTooLow() {
     IllegalArgumentException thrown =
         assertThrows(
@@ -351,7 +330,7 @@ public class AllocationTokenTest extends EntityTestCase {
         .isEqualTo("Discount years must be between 1 and 10 inclusive");
   }
 
-  @Test
+  @TestOfyAndSql
   void testBuild_noTokenType() {
     IllegalArgumentException thrown =
         assertThrows(
@@ -360,7 +339,7 @@ public class AllocationTokenTest extends EntityTestCase {
     assertThat(thrown).hasMessageThat().isEqualTo("Token type must be specified");
   }
 
-  @Test
+  @TestOfyAndSql
   void testBuild_noToken() {
     IllegalArgumentException thrown =
         assertThrows(
@@ -369,7 +348,7 @@ public class AllocationTokenTest extends EntityTestCase {
     assertThat(thrown).hasMessageThat().isEqualTo("Token must not be null or empty");
   }
 
-  @Test
+  @TestOfyAndSql
   void testBuild_emptyToken() {
     IllegalArgumentException thrown =
         assertThrows(
@@ -378,7 +357,7 @@ public class AllocationTokenTest extends EntityTestCase {
     assertThat(thrown).hasMessageThat().isEqualTo("Token must not be blank");
   }
 
-  @Test
+  @TestOfyAndSql
   void testBuild_discountPremiumsRequiresDiscountFraction() {
     IllegalArgumentException thrown =
         assertThrows(
@@ -394,7 +373,7 @@ public class AllocationTokenTest extends EntityTestCase {
         .isEqualTo("Discount premiums can only be specified along with a discount fraction");
   }
 
-  @Test
+  @TestOfyAndSql
   void testBuild_discountYearsRequiresDiscountFraction() {
     IllegalArgumentException thrown =
         assertThrows(

--- a/core/src/test/java/google/registry/tools/CommandTestCase.java
+++ b/core/src/test/java/google/registry/tools/CommandTestCase.java
@@ -18,6 +18,8 @@ import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.toArray;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.persistence.transaction.TransactionManagerUtil.transactIfJpaTm;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.joda.time.DateTimeZone.UTC;
 
@@ -185,7 +187,7 @@ public abstract class CommandTestCase<C extends Command> {
 
   /** Reloads the given resource from Datastore. */
   <T> T reloadResource(T resource) {
-    return ofy().load().entity(resource).now();
+    return transactIfJpaTm(() -> tm().load(resource));
   }
 
   /** Returns count of all poll messages in Datastore. */

--- a/core/src/test/java/google/registry/tools/UpdateAllocationTokensCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateAllocationTokensCommandTest.java
@@ -30,12 +30,14 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import google.registry.model.domain.token.AllocationToken;
 import google.registry.model.domain.token.AllocationToken.TokenStatus;
+import google.registry.testing.DualDatabaseTest;
+import google.registry.testing.TestOfyAndSql;
 import org.joda.time.DateTime;
-import org.junit.jupiter.api.Test;
 
+@DualDatabaseTest
 class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocationTokensCommand> {
 
-  @Test
+  @TestOfyAndSql
   void testUpdateTlds_setTlds() throws Exception {
     AllocationToken token =
         persistResource(builderWithPromo().setAllowedTlds(ImmutableSet.of("toRemove")).build());
@@ -43,7 +45,7 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
     assertThat(reloadResource(token).getAllowedTlds()).containsExactly("tld", "example");
   }
 
-  @Test
+  @TestOfyAndSql
   void testUpdateTlds_clearTlds() throws Exception {
     AllocationToken token =
         persistResource(builderWithPromo().setAllowedTlds(ImmutableSet.of("toRemove")).build());
@@ -51,7 +53,7 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
     assertThat(reloadResource(token).getAllowedTlds()).isEmpty();
   }
 
-  @Test
+  @TestOfyAndSql
   void testUpdateClientIds_setClientIds() throws Exception {
     AllocationToken token =
         persistResource(
@@ -61,7 +63,7 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
         .containsExactly("clientone", "clienttwo");
   }
 
-  @Test
+  @TestOfyAndSql
   void testUpdateClientIds_clearClientIds() throws Exception {
     AllocationToken token =
         persistResource(
@@ -70,14 +72,14 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
     assertThat(reloadResource(token).getAllowedRegistrarIds()).isEmpty();
   }
 
-  @Test
+  @TestOfyAndSql
   void testUpdateDiscountFraction() throws Exception {
     AllocationToken token = persistResource(builderWithPromo().setDiscountFraction(0.5).build());
     runCommandForced("--prefix", "token", "--discount_fraction", "0.15");
     assertThat(reloadResource(token).getDiscountFraction()).isEqualTo(0.15);
   }
 
-  @Test
+  @TestOfyAndSql
   void testUpdateDiscountPremiums() throws Exception {
     AllocationToken token =
         persistResource(
@@ -88,14 +90,14 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
     assertThat(reloadResource(token).shouldDiscountPremiums()).isFalse();
   }
 
-  @Test
+  @TestOfyAndSql
   void testUpdateDiscountYears() throws Exception {
     AllocationToken token = persistResource(builderWithPromo().setDiscountFraction(0.5).build());
     runCommandForced("--prefix", "token", "--discount_years", "4");
     assertThat(reloadResource(token).getDiscountYears()).isEqualTo(4);
   }
 
-  @Test
+  @TestOfyAndSql
   void testUpdateStatusTransitions() throws Exception {
     DateTime now = DateTime.now(UTC);
     AllocationToken token = persistResource(builderWithPromo().build());
@@ -110,7 +112,7 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
         .containsExactly(START_OF_TIME, NOT_STARTED, now.minusDays(1), VALID, now, CANCELLED);
   }
 
-  @Test
+  @TestOfyAndSql
   void testUpdateStatusTransitions_badTransitions() {
     DateTime now = DateTime.now(UTC);
     persistResource(builderWithPromo().build());
@@ -130,7 +132,7 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
         .isEqualTo("tokenStatusTransitions map cannot transition from NOT_STARTED to ENDED.");
   }
 
-  @Test
+  @TestOfyAndSql
   void testUpdate_onlyWithPrefix() throws Exception {
     AllocationToken token =
         persistResource(builderWithPromo().setAllowedTlds(ImmutableSet.of("tld")).build());
@@ -146,7 +148,7 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
     assertThat(reloadResource(otherToken).getAllowedTlds()).isEmpty();
   }
 
-  @Test
+  @TestOfyAndSql
   void testUpdate_onlyTokensProvided() throws Exception {
     AllocationToken firstToken =
         persistResource(builderWithPromo().setAllowedTlds(ImmutableSet.of("tld")).build());
@@ -170,7 +172,7 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
     assertThat(reloadResource(thirdToken).getAllowedTlds()).isEmpty();
   }
 
-  @Test
+  @TestOfyAndSql
   void testDoNothing() throws Exception {
     AllocationToken token =
         persistResource(
@@ -186,7 +188,7 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
     assertThat(reloaded.getDiscountFraction()).isEqualTo(token.getDiscountFraction());
   }
 
-  @Test
+  @TestOfyAndSql
   void testFailure_bothTokensAndPrefix() {
     assertThat(
             assertThrows(
@@ -196,7 +198,7 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
         .isEqualTo("Must provide one of --tokens or --prefix, not both / neither");
   }
 
-  @Test
+  @TestOfyAndSql
   void testFailure_neitherTokensNorPrefix() {
     assertThat(
             assertThrows(
@@ -205,7 +207,7 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
         .isEqualTo("Must provide one of --tokens or --prefix, not both / neither");
   }
 
-  @Test
+  @TestOfyAndSql
   void testFailure_emptyPrefix() {
     IllegalArgumentException thrown =
         assertThrows(IllegalArgumentException.class, () -> runCommandForced("--prefix", ""));


### PR DESCRIPTION
For the most part this is a fairly simple converstion -- changing Key
references to VKey references, using JPA transactions when necessary,
and using the TransactionManager interface. There's a bit of cleanup too
in related code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/909)
<!-- Reviewable:end -->
