### PR TITLE
Add unique constraints on domain_hosts

### DIFF
--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -75,7 +75,9 @@ public class DomainBase extends DomainContent
   }
 
   @ElementCollection
-  @JoinTable(name = "DomainHost")
+  @JoinTable(
+      name = "DomainHost",
+      indexes = {@Index(columnList = "domain_repo_id,host_repo_id", unique = true)})
   @Access(AccessType.PROPERTY)
   @Column(name = "host_repo_id")
   public Set<VKey<HostResource>> getNsHosts() {

--- a/core/src/main/java/google/registry/model/domain/DomainHistory.java
+++ b/core/src/main/java/google/registry/model/domain/DomainHistory.java
@@ -96,7 +96,14 @@ public class DomainHistory extends HistoryEntry implements SqlEntity {
   // TODO(b/166776754): Investigate if we can reuse domainContent.nsHosts for storing host keys.
   @Ignore
   @ElementCollection
-  @JoinTable(name = "DomainHistoryHost")
+  @JoinTable(
+      name = "DomainHistoryHost",
+      indexes = {
+        @Index(
+            columnList =
+                "domain_history_history_revision_id,domain_history_domain_repo_id,host_repo_id",
+            unique = true),
+      })
   @Column(name = "host_repo_id")
   Set<VKey<HostResource>> nsHosts;
 

--- a/db/src/main/resources/sql/er_diagram/brief_er_diagram.html
+++ b/db/src/main/resources/sql/er_diagram/brief_er_diagram.html
@@ -261,11 +261,11 @@ td.section {
     </tr> 
     <tr> 
      <td class="property_name">generated on</td> 
-     <td class="property_value">2020-12-16 16:26:55.279224</td> 
+     <td class="property_value">2020-12-21 17:41:59.495189</td> 
     </tr> 
     <tr>
      <td class="property_name">last flyway file</td>
-     <td id="lastFlywayFile" class="property_value">V82__add_columns_to_restore_symmetric_billing_vkey.sql</td>
+     <td id="lastFlywayFile" class="property_value">V83__add_indexes_on_domainhost.sql</td>
     </tr>
    </tbody>
   </table> 
@@ -284,7 +284,7 @@ td.section {
      generated on
     </text> 
     <text text-anchor="start" x="4027.94" y="-10.8" font-family="Helvetica,sans-Serif" font-size="14.00">
-     2020-12-16 16:26:55.279224
+     2020-12-21 17:41:59.495189
     </text> 
     <polygon fill="none" stroke="#888888" points="3940.44,-4 3940.44,-44 4205.44,-44 4205.44,-4 3940.44,-4" /> <!-- allocationtoken_a08ccbef --> 
     <g id="node1" class="node"> 
@@ -568,14 +568,14 @@ td.section {
     </g> <!-- billingevent_a57d1815&#45;&gt;domainhistory_a54cc226 --> 
     <g id="edge29" class="edge"> 
      <title>billingevent_a57d1815:w-&gt;domainhistory_a54cc226:e</title> 
-     <path fill="none" stroke="black" d="M3219.23,-1185.48C3119.47,-1183.67 2900.01,-1171.05 2844,-1231.68 2807.56,-1271.12 2864.68,-1677.42 2826,-1714.68 2771.83,-1766.87 2203.88,-1761.13 2149,-1709.68 2124.77,-1686.96 2153.47,-1433.39 2130.83,-1389.98" /> 
+     <path fill="none" stroke="black" d="M3219.23,-1185.48C3119.47,-1183.66 2899.97,-1171.01 2844,-1231.68 2806.23,-1272.62 2866.09,-1694 2826,-1732.68 2771.86,-1784.9 2203.77,-1779.24 2149,-1727.68 2123.44,-1703.61 2155.05,-1434.99 2131.08,-1390.04" /> 
      <polygon fill="black" stroke="black" points="3227.5,-1185.57 3237.45,-1190.18 3232.5,-1185.62 3237.5,-1185.68 3237.5,-1185.68 3237.5,-1185.68 3232.5,-1185.62 3237.55,-1181.18 3227.5,-1185.57 3227.5,-1185.57" /> 
      <ellipse fill="none" stroke="black" cx="3223.5" cy="-1185.53" rx="4" ry="4" /> 
-     <polygon fill="black" stroke="black" points="2120.64,-1388.2 2126.91,-1380.41 2128.47,-1381.66 2122.2,-1389.45 2120.64,-1388.2" /> 
-     <polyline fill="none" stroke="black" points="2123,-1383.68 2126.89,-1386.81 " /> 
-     <polygon fill="black" stroke="black" points="2124.54,-1391.33 2130.81,-1383.54 2132.37,-1384.8 2126.1,-1392.59 2124.54,-1391.33" /> 
-     <polyline fill="none" stroke="black" points="2126.89,-1386.81 2130.79,-1389.95 " /> 
-     <text text-anchor="start" x="2555" y="-1755.48" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <polygon fill="black" stroke="black" points="2120.69,-1388.22 2126.88,-1380.37 2128.45,-1381.6 2122.26,-1389.46 2120.69,-1388.22" /> 
+     <polyline fill="none" stroke="black" points="2123,-1383.68 2126.93,-1386.77 " /> 
+     <polygon fill="black" stroke="black" points="2124.62,-1391.32 2130.81,-1383.46 2132.38,-1384.7 2126.19,-1392.55 2124.62,-1391.32" /> 
+     <polyline fill="none" stroke="black" points="2126.93,-1386.77 2130.86,-1389.86 " /> 
+     <text text-anchor="start" x="2555" y="-1773.48" font-family="Helvetica,sans-Serif" font-size="14.00">
       fk_billing_event_domain_history
      </text> 
     </g> <!-- registrar_6e1503e3 --> 
@@ -617,14 +617,14 @@ td.section {
     </g> <!-- billingevent_a57d1815&#45;&gt;registrar_6e1503e3 --> 
     <g id="edge49" class="edge"> 
      <title>billingevent_a57d1815:w-&gt;registrar_6e1503e3:e</title> 
-     <path fill="none" stroke="black" d="M3222.22,-1215.14C3145.17,-1290.97 2857.5,-1753.9 2826,-1770.68 2621.48,-1879.58 2536.71,-1789.68 2305,-1789.68 2305,-1789.68 2305,-1789.68 640.5,-1789.68 391.14,-1789.68 324.15,-1646.84 217,-1421.68 199.61,-1385.13 230.41,-733.26 198.48,-654.45" /> 
-     <polygon fill="black" stroke="black" points="3229.25,-1210.33 3240.04,-1208.39 3233.37,-1207.5 3237.5,-1204.68 3237.5,-1204.68 3237.5,-1204.68 3233.37,-1207.5 3234.96,-1200.96 3229.25,-1210.33 3229.25,-1210.33" /> 
-     <ellipse fill="none" stroke="black" cx="3225.95" cy="-1212.59" rx="4" ry="4" /> 
-     <polygon fill="black" stroke="black" points="188.45,-650.76 195.89,-644.08 197.22,-645.57 189.78,-652.25 188.45,-650.76" /> 
-     <polyline fill="none" stroke="black" points="191.5,-646.68 194.84,-650.4 " /> 
-     <polygon fill="black" stroke="black" points="191.79,-654.48 199.23,-647.8 200.57,-649.29 193.12,-655.97 191.79,-654.48" /> 
-     <polyline fill="none" stroke="black" points="194.84,-650.4 198.18,-654.12 " /> 
-     <text text-anchor="start" x="1546" y="-1793.48" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <path fill="none" stroke="black" d="M3222.55,-1214.98C3145.79,-1291.68 2858.1,-1771.28 2826,-1788.68 2622.29,-1899.09 2536.71,-1807.68 2305,-1807.68 2305,-1807.68 2305,-1807.68 640.5,-1807.68 385.83,-1807.68 323.7,-1652.92 217,-1421.68 200.04,-1384.93 230.46,-733.23 198.49,-654.45" /> 
+     <polygon fill="black" stroke="black" points="3229.27,-1210.35 3240.05,-1208.38 3233.38,-1207.51 3237.5,-1204.68 3237.5,-1204.68 3237.5,-1204.68 3233.38,-1207.51 3234.95,-1200.97 3229.27,-1210.35 3229.27,-1210.35" /> 
+     <ellipse fill="none" stroke="black" cx="3225.97" cy="-1212.62" rx="4" ry="4" /> 
+     <polygon fill="black" stroke="black" points="188.45,-650.76 195.89,-644.08 197.22,-645.56 189.79,-652.25 188.45,-650.76" /> 
+     <polyline fill="none" stroke="black" points="191.5,-646.68 194.84,-650.39 " /> 
+     <polygon fill="black" stroke="black" points="191.79,-654.48 199.23,-647.8 200.57,-649.28 193.13,-655.97 191.79,-654.48" /> 
+     <polyline fill="none" stroke="black" points="194.84,-650.39 198.18,-654.11 " /> 
+     <text text-anchor="start" x="1546" y="-1811.48" font-family="Helvetica,sans-Serif" font-size="14.00">
       fk_billing_event_registrar_id
      </text> 
     </g> <!-- billingcancellation_6eedf614 --> 
@@ -1754,14 +1754,14 @@ td.section {
     </g> <!-- pollmessage_614a523e&#45;&gt;domainhistory_a54cc226 --> 
     <g id="edge41" class="edge"> 
      <title>pollmessage_614a523e:w-&gt;domainhistory_a54cc226:e</title> 
-     <path fill="none" stroke="black" d="M3236.68,-451.33C3193.59,-492.92 3251.04,-717.2 3211,-769.68 3103.7,-910.31 2943.71,-777.57 2844,-923.68 2820.69,-957.83 2855.47,-1638.68 2826,-1667.68 2799.19,-1694.06 2176.77,-1696.04 2149,-1670.68 2104.49,-1630.02 2177.5,-1411.56 2132.78,-1386.1" /> 
+     <path fill="none" stroke="black" d="M3236.68,-451.33C3193.59,-492.92 3251.04,-717.2 3211,-769.68 3103.7,-910.31 2943.67,-777.54 2844,-923.68 2820.11,-958.71 2856.25,-1656.97 2826,-1686.68 2799.16,-1713.03 2176.7,-1714.12 2149,-1688.68 2126.25,-1667.78 2151.43,-1433.27 2130.77,-1390.39" /> 
      <polygon fill="black" stroke="black" points="3244.2,-448.35 3255.15,-448.86 3248.85,-446.51 3253.5,-444.68 3253.5,-444.68 3253.5,-444.68 3248.85,-446.51 3251.85,-440.49 3244.2,-448.35 3244.2,-448.35" /> 
      <ellipse fill="none" stroke="black" cx="3240.48" cy="-449.82" rx="4" ry="4" /> 
-     <polygon fill="black" stroke="black" points="2122.77,-1388.77 2125.17,-1379.06 2127.11,-1379.54 2124.71,-1389.25 2122.77,-1388.77" /> 
-     <polyline fill="none" stroke="black" points="2123,-1383.68 2127.85,-1384.88 " /> 
-     <polygon fill="black" stroke="black" points="2127.62,-1389.97 2130.03,-1380.27 2131.97,-1380.75 2129.56,-1390.45 2127.62,-1389.97" /> 
-     <polyline fill="none" stroke="black" points="2127.85,-1384.88 2132.71,-1386.08 " /> 
-     <text text-anchor="start" x="2550.5" y="-1692.48" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <polygon fill="black" stroke="black" points="2120.49,-1388.11 2127.03,-1380.55 2128.54,-1381.85 2122,-1389.42 2120.49,-1388.11" /> 
+     <polyline fill="none" stroke="black" points="2123,-1383.68 2126.78,-1386.94 " /> 
+     <polygon fill="black" stroke="black" points="2124.27,-1391.38 2130.81,-1383.81 2132.32,-1385.12 2125.79,-1392.69 2124.27,-1391.38" /> 
+     <polyline fill="none" stroke="black" points="2126.78,-1386.94 2130.57,-1390.21 " /> 
+     <text text-anchor="start" x="2550.5" y="-1711.48" font-family="Helvetica,sans-Serif" font-size="14.00">
       fk_poll_message_domain_history
      </text> 
     </g> <!-- host_f21b78de --> 
@@ -2252,21 +2252,29 @@ td.section {
     </g> <!-- domainhistoryhost_9f3f23ee --> 
     <g id="node18" class="node"> 
      <title>domainhistoryhost_9f3f23ee</title> 
-     <polygon fill="#ebcef2" stroke="transparent" points="2502.5,-1634.68 2502.5,-1653.68 2726.5,-1653.68 2726.5,-1634.68 2502.5,-1634.68" /> 
-     <text text-anchor="start" x="2504.5" y="-1641.48" font-family="Helvetica,sans-Serif" font-weight="bold" font-style="italic" font-size="14.00">
+     <polygon fill="#ebcef2" stroke="transparent" points="2502.5,-1653.68 2502.5,-1672.68 2726.5,-1672.68 2726.5,-1653.68 2502.5,-1653.68" /> 
+     <text text-anchor="start" x="2504.5" y="-1660.48" font-family="Helvetica,sans-Serif" font-weight="bold" font-style="italic" font-size="14.00">
       public.DomainHistoryHost
      </text> 
-     <polygon fill="#ebcef2" stroke="transparent" points="2726.5,-1634.68 2726.5,-1653.68 2800.5,-1653.68 2800.5,-1634.68 2726.5,-1634.68" /> 
-     <text text-anchor="start" x="2761.5" y="-1640.48" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <polygon fill="#ebcef2" stroke="transparent" points="2726.5,-1653.68 2726.5,-1672.68 2800.5,-1672.68 2800.5,-1653.68 2726.5,-1653.68" /> 
+     <text text-anchor="start" x="2761.5" y="-1659.48" font-family="Helvetica,sans-Serif" font-size="14.00">
       [table]
      </text> 
-     <text text-anchor="start" x="2504.5" y="-1621.48" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <text text-anchor="start" x="2504.5" y="-1640.48" font-family="Helvetica,sans-Serif" font-size="14.00">
       domain_history_history_revision_id
+     </text> 
+     <text text-anchor="start" x="2720.5" y="-1640.48" font-family="Helvetica,sans-Serif" font-size="14.00"> 
+     </text> 
+     <text text-anchor="start" x="2728.5" y="-1640.48" font-family="Helvetica,sans-Serif" font-size="14.00">
+      int8 not null
+     </text> 
+     <text text-anchor="start" x="2504.5" y="-1621.48" font-family="Helvetica,sans-Serif" font-size="14.00">
+      host_repo_id
      </text> 
      <text text-anchor="start" x="2720.5" y="-1621.48" font-family="Helvetica,sans-Serif" font-size="14.00"> 
      </text> 
      <text text-anchor="start" x="2728.5" y="-1621.48" font-family="Helvetica,sans-Serif" font-size="14.00">
-      int8 not null
+      text
      </text> 
      <text text-anchor="start" x="2504.5" y="-1602.48" font-family="Helvetica,sans-Serif" font-size="14.00">
       domain_history_domain_repo_id
@@ -2276,31 +2284,31 @@ td.section {
      <text text-anchor="start" x="2728.5" y="-1602.48" font-family="Helvetica,sans-Serif" font-size="14.00">
       text not null
      </text> 
-     <polygon fill="none" stroke="#888888" points="2501.5,-1596.18 2501.5,-1655.18 2801.5,-1655.18 2801.5,-1596.18 2501.5,-1596.18" /> 
+     <polygon fill="none" stroke="#888888" points="2501.5,-1595.68 2501.5,-1673.68 2801.5,-1673.68 2801.5,-1595.68 2501.5,-1595.68" /> 
     </g> <!-- domainhistoryhost_9f3f23ee&#45;&gt;domainhistory_a54cc226 --> 
     <g id="edge34" class="edge"> 
      <title>domainhistoryhost_9f3f23ee:w-&gt;domainhistory_a54cc226:e</title> 
-     <path fill="none" stroke="black" d="M2484.5,-1599.62C2477.03,-1593.04 2472.75,-1582.78 2459,-1577.68 2393.88,-1553.5 2197.51,-1587.39 2149,-1537.68 2112.74,-1500.51 2169.71,-1316.37 2133.01,-1290.66" /> 
-     <polygon fill="black" stroke="black" points="2492.08,-1602.32 2499.99,-1609.91 2496.79,-1604 2501.5,-1605.68 2501.5,-1605.68 2501.5,-1605.68 2496.79,-1604 2503.01,-1601.44 2492.08,-1602.32 2492.08,-1602.32" /> 
-     <ellipse fill="none" stroke="black" cx="2488.31" cy="-1600.98" rx="4" ry="4" /> 
-     <polygon fill="black" stroke="black" points="2122.53,-1292.75 2125.39,-1283.17 2127.3,-1283.74 2124.45,-1293.32 2122.53,-1292.75" /> 
-     <polyline fill="none" stroke="black" points="2123,-1287.68 2127.79,-1289.1 " /> 
-     <polygon fill="black" stroke="black" points="2127.32,-1294.18 2130.18,-1284.6 2132.09,-1285.17 2129.24,-1294.75 2127.32,-1294.18" /> 
-     <polyline fill="none" stroke="black" points="2127.79,-1289.1 2132.58,-1290.53 " /> 
-     <text text-anchor="start" x="2209.5" y="-1581.48" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <path fill="none" stroke="black" d="M2483.6,-1602.41C2476.45,-1599.52 2470.57,-1595.37 2459,-1592.68 2391.03,-1576.88 2196.88,-1593.43 2149,-1542.68 2112.51,-1503.99 2171.14,-1315.28 2132.74,-1290.39" /> 
+     <polygon fill="black" stroke="black" points="2491.66,-1603.88 2500.69,-1610.1 2496.58,-1604.78 2501.5,-1605.68 2501.5,-1605.68 2501.5,-1605.68 2496.58,-1604.78 2502.31,-1601.25 2491.66,-1603.88 2491.66,-1603.88" /> 
+     <ellipse fill="none" stroke="black" cx="2487.73" cy="-1603.16" rx="4" ry="4" /> 
+     <polygon fill="black" stroke="black" points="2122.62,-1292.76 2125.31,-1283.13 2127.23,-1283.66 2124.55,-1293.3 2122.62,-1292.76" /> 
+     <polyline fill="none" stroke="black" points="2123,-1287.68 2127.82,-1289.02 " /> 
+     <polygon fill="black" stroke="black" points="2127.44,-1294.1 2130.12,-1284.47 2132.05,-1285.01 2129.36,-1294.64 2127.44,-1294.1" /> 
+     <polyline fill="none" stroke="black" points="2127.82,-1289.02 2132.63,-1290.36 " /> 
+     <text text-anchor="start" x="2209.5" y="-1596.48" font-family="Helvetica,sans-Serif" font-size="14.00">
       fka9woh3hu8gx5x0vly6bai327n
      </text> 
     </g> <!-- domainhistoryhost_9f3f23ee&#45;&gt;domainhistory_a54cc226 --> 
     <g id="edge35" class="edge"> 
      <title>domainhistoryhost_9f3f23ee:w-&gt;domainhistory_a54cc226:e</title> 
-     <path fill="none" stroke="black" d="M2483.4,-1625.01C2337.73,-1630.44 2257.65,-1697.78 2149,-1592.68 2118.12,-1562.81 2161.46,-1411.66 2132.58,-1387.06" /> 
-     <polygon fill="black" stroke="black" points="2491.5,-1624.86 2501.58,-1629.18 2496.5,-1624.77 2501.5,-1624.68 2501.5,-1624.68 2501.5,-1624.68 2496.5,-1624.77 2501.42,-1620.18 2491.5,-1624.86 2491.5,-1624.86" /> 
-     <ellipse fill="none" stroke="black" cx="2487.5" cy="-1624.94" rx="4" ry="4" /> 
-     <polygon fill="black" stroke="black" points="2122.28,-1388.72 2125.61,-1379.3 2127.49,-1379.96 2124.16,-1389.39 2122.28,-1388.72" /> 
-     <polyline fill="none" stroke="black" points="2123,-1383.68 2127.71,-1385.34 " /> 
-     <polygon fill="black" stroke="black" points="2126.99,-1390.39 2130.32,-1380.96 2132.21,-1381.63 2128.88,-1391.06 2126.99,-1390.39" /> 
-     <polyline fill="none" stroke="black" points="2127.71,-1385.34 2132.43,-1387.01 " /> 
-     <text text-anchor="start" x="2209.5" y="-1655.48" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <path fill="none" stroke="black" d="M2483.37,-1645C2337.45,-1650.16 2256.62,-1714.12 2149,-1607.68 2116.16,-1575.19 2164.36,-1412.23 2132.83,-1386.97" /> 
+     <polygon fill="black" stroke="black" points="2491.5,-1644.85 2501.58,-1649.18 2496.5,-1644.76 2501.5,-1644.68 2501.5,-1644.68 2501.5,-1644.68 2496.5,-1644.76 2501.42,-1640.18 2491.5,-1644.85 2491.5,-1644.85" /> 
+     <ellipse fill="none" stroke="black" cx="2487.5" cy="-1644.93" rx="4" ry="4" /> 
+     <polygon fill="black" stroke="black" points="2122.36,-1388.73 2125.54,-1379.25 2127.43,-1379.89 2124.26,-1389.37 2122.36,-1388.73" /> 
+     <polyline fill="none" stroke="black" points="2123,-1383.68 2127.74,-1385.26 " /> 
+     <polygon fill="black" stroke="black" points="2127.1,-1390.32 2130.28,-1380.84 2132.17,-1381.48 2129,-1390.96 2127.1,-1390.32" /> 
+     <polyline fill="none" stroke="black" points="2127.74,-1385.26 2132.48,-1386.85 " /> 
+     <text text-anchor="start" x="2209.5" y="-1673.48" font-family="Helvetica,sans-Serif" font-size="14.00">
       fka9woh3hu8gx5x0vly6bai327n
      </text> 
     </g> <!-- domaintransactionrecord_6e77ff61 --> 
@@ -2430,14 +2438,14 @@ td.section {
     </g> <!-- graceperiodhistory_40ccc1f1&#45;&gt;domainhistory_a54cc226 --> 
     <g id="edge38" class="edge"> 
      <title>graceperiodhistory_40ccc1f1:w-&gt;domainhistory_a54cc226:e</title> 
-     <path fill="none" stroke="black" d="M2481.03,-1520.46C2406.48,-1519.12 2174.32,-1511.17 2149,-1486.68 2119.7,-1458.33 2159.5,-1315.54 2132.5,-1291.2" /> 
-     <polygon fill="black" stroke="black" points="2489.5,-1520.56 2499.45,-1525.18 2494.5,-1520.62 2499.5,-1520.68 2499.5,-1520.68 2499.5,-1520.68 2494.5,-1520.62 2499.55,-1516.18 2489.5,-1520.56 2489.5,-1520.56" /> 
-     <ellipse fill="none" stroke="black" cx="2485.5" cy="-1520.51" rx="4" ry="4" /> 
+     <path fill="none" stroke="black" d="M2481.33,-1520.94C2392.06,-1523.15 2201.35,-1537.31 2149,-1486.68 2119.7,-1458.33 2159.5,-1315.54 2132.5,-1291.2" /> 
+     <polygon fill="black" stroke="black" points="2489.5,-1520.82 2499.57,-1525.18 2494.5,-1520.75 2499.5,-1520.68 2499.5,-1520.68 2499.5,-1520.68 2494.5,-1520.75 2499.43,-1516.18 2489.5,-1520.82 2489.5,-1520.82" /> 
+     <ellipse fill="none" stroke="black" cx="2485.5" cy="-1520.88" rx="4" ry="4" /> 
      <polygon fill="black" stroke="black" points="2122.2,-1292.71 2125.68,-1283.34 2127.55,-1284.03 2124.07,-1293.41 2122.2,-1292.71" /> 
      <polyline fill="none" stroke="black" points="2123,-1287.68 2127.69,-1289.42 " /> 
      <polygon fill="black" stroke="black" points="2126.88,-1294.45 2130.37,-1285.08 2132.24,-1285.77 2128.76,-1295.15 2126.88,-1294.45" /> 
      <polyline fill="none" stroke="black" points="2127.69,-1289.42 2132.37,-1291.16 " /> 
-     <text text-anchor="start" x="2210" y="-1524.48" font-family="Helvetica,sans-Serif" font-size="14.00">
+     <text text-anchor="start" x="2210" y="-1528.48" font-family="Helvetica,sans-Serif" font-size="14.00">
       fk7w3cx8d55q8bln80e716tr7b8
      </text> 
     </g> <!-- graceperiodhistory_40ccc1f1&#45;&gt;domainhistory_a54cc226 --> 
@@ -4789,6 +4797,11 @@ td.section {
      <td class="spacer"></td> 
      <td class="minwidth">domain_history_history_revision_id</td> 
      <td class="minwidth">int8 not null</td> 
+    </tr> 
+    <tr> 
+     <td class="spacer"></td> 
+     <td class="minwidth">host_repo_id</td> 
+     <td class="minwidth">text</td> 
     </tr> 
     <tr> 
      <td class="spacer"></td> 

--- a/db/src/main/resources/sql/er_diagram/full_er_diagram.html
+++ b/db/src/main/resources/sql/er_diagram/full_er_diagram.html
@@ -261,11 +261,11 @@ td.section {
     </tr> 
     <tr> 
      <td class="property_name">generated on</td> 
-     <td class="property_value">2020-12-16 16:26:53.180789</td> 
+     <td class="property_value">2020-12-21 17:41:57.553769</td> 
     </tr> 
     <tr>
      <td class="property_name">last flyway file</td>
-     <td id="lastFlywayFile" class="property_value">V82__add_columns_to_restore_symmetric_billing_vkey.sql</td>
+     <td id="lastFlywayFile" class="property_value">V83__add_indexes_on_domainhost.sql</td>
     </tr>
    </tbody>
   </table> 
@@ -284,7 +284,7 @@ td.section {
      generated on
     </text> 
     <text text-anchor="start" x="4631.68" y="-10.8" font-family="Helvetica,sans-Serif" font-size="14.00">
-     2020-12-16 16:26:53.180789
+     2020-12-21 17:41:57.553769
     </text> 
     <polygon fill="none" stroke="#888888" points="4544.18,-4 4544.18,-44 4809.18,-44 4809.18,-4 4544.18,-4" /> <!-- allocationtoken_a08ccbef --> 
     <g id="node1" class="node"> 
@@ -9921,6 +9921,34 @@ td.section {
      <td class="minwidth">domain_history_history_revision_id (0..many)→ <a href="#domainhistory_a54cc226">public.DomainHistory.history_revision_id</a></td> 
      <td class="minwidth"></td> 
     </tr> 
+    <tr> 
+     <td colspan="3"></td> 
+    </tr> 
+    <tr> 
+     <td colspan="3" class="section">Indexes</td> 
+    </tr> 
+    <tr> 
+     <td colspan="3"></td> 
+    </tr> 
+    <tr> 
+     <td colspan="2" class="name">ukt2e7ae3t8gcsxd13wjx2ka7ij</td> 
+     <td class="description right">[unique index]</td> 
+    </tr> 
+    <tr> 
+     <td class="spacer"></td> 
+     <td class="minwidth">domain_history_history_revision_id</td> 
+     <td class="minwidth">ascending</td> 
+    </tr> 
+    <tr> 
+     <td class="spacer"></td> 
+     <td class="minwidth">domain_history_domain_repo_id</td> 
+     <td class="minwidth">ascending</td> 
+    </tr> 
+    <tr> 
+     <td class="spacer"></td> 
+     <td class="minwidth">host_repo_id</td> 
+     <td class="minwidth">ascending</td> 
+    </tr> 
    </tbody>
   </table> 
   <p>&nbsp;</p> 
@@ -9967,6 +9995,29 @@ td.section {
      <td class="spacer"></td> 
      <td class="minwidth">host_repo_id (0..many)→ <a href="#host_f21b78de">public.Host.repo_id</a></td> 
      <td class="minwidth"></td> 
+    </tr> 
+    <tr> 
+     <td colspan="3"></td> 
+    </tr> 
+    <tr> 
+     <td colspan="3" class="section">Indexes</td> 
+    </tr> 
+    <tr> 
+     <td colspan="3"></td> 
+    </tr> 
+    <tr> 
+     <td colspan="2" class="name">ukat9erbh52e4lg3jw6ai9wkjj9</td> 
+     <td class="description right">[unique index]</td> 
+    </tr> 
+    <tr> 
+     <td class="spacer"></td> 
+     <td class="minwidth">domain_repo_id</td> 
+     <td class="minwidth">ascending</td> 
+    </tr> 
+    <tr> 
+     <td class="spacer"></td> 
+     <td class="minwidth">host_repo_id</td> 
+     <td class="minwidth">ascending</td> 
     </tr> 
    </tbody>
   </table> 

--- a/db/src/main/resources/sql/flyway.txt
+++ b/db/src/main/resources/sql/flyway.txt
@@ -80,3 +80,4 @@ V79__drop_foreign_keys_on_pollmessage.sql
 V80__defer_bill_event_key.sql
 V81__drop_spec11_fkeys.sql
 V82__add_columns_to_restore_symmetric_billing_vkey.sql
+V83__add_indexes_on_domainhost.sql

--- a/db/src/main/resources/sql/flyway/V83__add_indexes_on_domainhost.sql
+++ b/db/src/main/resources/sql/flyway/V83__add_indexes_on_domainhost.sql
@@ -1,0 +1,23 @@
+-- Copyright 2020 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+alter table if exists "DomainHistoryHost"
+   add constraint UKt2e7ae3t8gcsxd13wjx2ka7ij unique (
+       domain_history_history_revision_id,
+       domain_history_domain_repo_id,
+       host_repo_id);
+
+alter table if exists "DomainHost"
+   add constraint UKat9erbh52e4lg3jw6ai9wkjj9 unique (
+       domain_repo_id, host_repo_id);

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -768,6 +768,12 @@ create index IDXrh4xmrot9bd63o382ow9ltfig on "DomainHistory" (creation_time);
 create index IDXaro1omfuaxjwmotk3vo00trwm on "DomainHistory" (history_registrar_id);
 create index IDXsu1nam10cjes9keobapn5jvxj on "DomainHistory" (history_type);
 create index IDX6w3qbtgce93cal2orjg1tw7b7 on "DomainHistory" (history_modification_time);
+
+    alter table if exists "DomainHistoryHost" 
+       add constraint UKt2e7ae3t8gcsxd13wjx2ka7ij unique (domain_history_history_revision_id, domain_history_domain_repo_id, host_repo_id);
+
+    alter table if exists "DomainHost" 
+       add constraint UKat9erbh52e4lg3jw6ai9wkjj9 unique (domain_repo_id, host_repo_id);
 create index IDXj1mtx98ndgbtb1bkekahms18w on "GracePeriod" (domain_repo_id);
 create index IDXd01j17vrpjxaerxdmn8bwxs7s on "GracePeriodHistory" (domain_repo_id);
 create index IDXfg2nnjlujxo6cb9fha971bq2n on "HostHistory" (creation_time);

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -1429,6 +1429,22 @@ ALTER TABLE ONLY public."RegistryLock"
 
 
 --
+-- Name: DomainHost ukat9erbh52e4lg3jw6ai9wkjj9; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."DomainHost"
+    ADD CONSTRAINT ukat9erbh52e4lg3jw6ai9wkjj9 UNIQUE (domain_repo_id, host_repo_id);
+
+
+--
+-- Name: DomainHistoryHost ukt2e7ae3t8gcsxd13wjx2ka7ij; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."DomainHistoryHost"
+    ADD CONSTRAINT ukt2e7ae3t8gcsxd13wjx2ka7ij UNIQUE (domain_history_history_revision_id, domain_history_domain_repo_id, host_repo_id);
+
+
+--
 -- Name: allocation_token_domain_name_idx; Type: INDEX; Schema: public; Owner: -
 --
 


### PR DESCRIPTION
Add unique constraints on DomainHost (child of DomainBase) and
DomainHistoryHost (child of DomainHistory). DomainHost is non-entity
embedded object and Hibernate does not define indexes automatically.

This should improve read and write performance of the parent entities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/911)
<!-- Reviewable:end -->
