### PR TITLE
Enforce existence (or explicitly don't) in txn manager bulk loads

### DIFF
--- a/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
+++ b/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
@@ -16,6 +16,7 @@ package google.registry.model.ofy;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
@@ -23,6 +24,8 @@ import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.Result;
@@ -197,6 +200,21 @@ public class DatastoreTransactionManager implements TransactionManager {
 
   @Override
   public <T> ImmutableMap<VKey<? extends T>, T> load(Iterable<? extends VKey<? extends T>> keys) {
+    ImmutableMap<VKey<? extends T>, T> result = loadExisting(keys);
+    ImmutableSet<? extends VKey<? extends T>> missingKeys =
+        Streams.stream(keys).filter(k -> !result.containsKey(k)).collect(toImmutableSet());
+    if (!missingKeys.isEmpty()) {
+      // Ofy ignores nonexistent keys but the method contract specifies to throw if nonexistent
+      throw new NoSuchElementException(
+          String.format(
+              "Expected to find the following VKeys but they were missing: %s.", missingKeys));
+    }
+    return result;
+  }
+
+  @Override
+  public <T> ImmutableMap<VKey<? extends T>, T> loadExisting(
+      Iterable<? extends VKey<? extends T>> keys) {
     // Keep track of the Key -> VKey mapping so we can translate them back.
     ImmutableMap<Key<T>, VKey<? extends T>> keyMap =
         StreamSupport.stream(keys.spliterator(), false)
@@ -217,6 +235,16 @@ public class DatastoreTransactionManager implements TransactionManager {
 
   @Override
   public <T> ImmutableList<T> loadAll(Iterable<T> entities) {
+    ImmutableList<T> result = loadAllExisting(entities);
+    if (result.size() != Iterables.size(entities)) {
+      throw new NoSuchElementException(
+          String.format("Attempted to load entities, some of which are missing: %s", entities));
+    }
+    return result;
+  }
+
+  @Override
+  public <T> ImmutableList<T> loadAllExisting(Iterable<T> entities) {
     return ImmutableList.copyOf(getOfy().load().entities(entities).values());
   }
 

--- a/core/src/main/java/google/registry/model/registrar/Registrar.java
+++ b/core/src/main/java/google/registry/model/registrar/Registrar.java
@@ -815,7 +815,8 @@ public class Registrar extends ImmutableObject
               .map(Registry::createVKey)
               .collect(toImmutableSet());
       Set<VKey<Registry>> missingTldKeys =
-          Sets.difference(newTldKeys, transactIfJpaTm(() -> tm().load(newTldKeys)).keySet());
+          Sets.difference(
+              newTldKeys, transactIfJpaTm(() -> tm().loadExisting(newTldKeys)).keySet());
       checkArgument(missingTldKeys.isEmpty(), "Trying to set nonexisting TLDs: %s", missingTldKeys);
       getInstance().allowedTlds = ImmutableSortedSet.copyOf(allowedTlds);
       return this;

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
@@ -200,6 +200,9 @@ public interface TransactionManager {
    */
   <T> ImmutableMap<VKey<? extends T>, T> load(Iterable<? extends VKey<? extends T>> keys);
 
+  /** Loads the set of entities by their key id, nonexistent entiites are ignored. */
+  <T> ImmutableMap<VKey<? extends T>, T> loadExisting(Iterable<? extends VKey<? extends T>> keys);
+
   /** Loads all entities of the given type, returns empty if there is no such entity. */
   <T> ImmutableList<T> loadAll(Class<T> clazz);
 
@@ -207,6 +210,9 @@ public interface TransactionManager {
    * Loads all given entities from the database, throws NoSuchElementException if it doesn't exist.
    */
   <T> ImmutableList<T> loadAll(Iterable<T> entities);
+
+  /** Loads all given entities from the database if possible, nonexistent entiites are ignored. */
+  <T> ImmutableList<T> loadAllExisting(Iterable<T> entities);
 
   /** Deletes the entity by its id. */
   void delete(VKey<?> key);

--- a/core/src/main/java/google/registry/tools/GenerateAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateAllocationTokensCommand.java
@@ -293,7 +293,7 @@ class GenerateAllocationTokensCommand implements CommandWithRemoteApi {
             .collect(toImmutableSet());
     return transactIfJpaTm(
         () ->
-            tm().load(existingTokenKeys).values().stream()
+            tm().loadExisting(existingTokenKeys).values().stream()
                 .map(AllocationToken::getToken)
                 .collect(toImmutableSet()));
   }

--- a/core/src/main/java/google/registry/tools/GetAllocationTokenCommand.java
+++ b/core/src/main/java/google/registry/tools/GetAllocationTokenCommand.java
@@ -49,7 +49,7 @@ final class GetAllocationTokenCommand implements CommandWithRemoteApi {
           tokens.stream()
               .map(t -> VKey.create(AllocationToken.class, t))
               .collect(toImmutableList());
-      tm().load(tokenKeys).forEach((k, v) -> builder.put(k.getSqlKey().toString(), v));
+      tm().loadExisting(tokenKeys).forEach((k, v) -> builder.put(k.getSqlKey().toString(), v));
     }
     ImmutableMap<String, AllocationToken> loadedTokens = builder.build();
     ImmutableMap<VKey<DomainBase>, DomainBase> domains = loadRedeemedDomains(loadedTokens.values());

--- a/core/src/test/java/google/registry/tools/AckPollMessagesCommandTest.java
+++ b/core/src/test/java/google/registry/tools/AckPollMessagesCommandTest.java
@@ -60,7 +60,7 @@ public class AckPollMessagesCommandTest extends CommandTestCase<AckPollMessagesC
         persistPollMessage(123L, DateTime.parse("2015-09-01T22:33:44Z"), "notme");
     VKey<OneTime> pm4 = futurePollMessage.createVKey();
     runCommand("-c", "TheRegistrar");
-    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3, pm4)).values())
+    assertThat(tm().loadExisting(ImmutableList.of(pm1, pm2, pm3, pm4)).values())
         .containsExactly(futurePollMessage);
     assertInStdout(
         "1-FSDGS-TLD-2406-624-2013,2013-05-01T22:33:44.000Z,ninelives",
@@ -90,7 +90,8 @@ public class AckPollMessagesCommandTest extends CommandTestCase<AckPollMessagesC
         autorenew.asBuilder().setEventTime(DateTime.parse("2012-04-15T22:33:44Z")).build();
     VKey<Autorenew> pm3 = autorenew.createVKey();
     runCommand("-c", "TheRegistrar");
-    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3)).values()).containsExactly(resaved);
+    assertThat(tm().loadExisting(ImmutableList.of(pm1, pm2, pm3)).values())
+        .containsExactly(resaved);
     assertInStdout(
         "1-AAFSGS-TLD-99406-624-2011,2011-04-15T22:33:44.000Z,autorenew",
         "1-FSDGS-TLD-2406-624-2013,2013-05-01T22:33:44.000Z,ninelives",
@@ -117,7 +118,7 @@ public class AckPollMessagesCommandTest extends CommandTestCase<AckPollMessagesC
                 .build());
     VKey<Autorenew> pm3 = autorenew.createVKey();
     runCommand("-c", "TheRegistrar");
-    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3))).isEmpty();
+    assertThat(tm().loadExisting(ImmutableList.of(pm1, pm2, pm3))).isEmpty();
     assertInStdout(
         "1-AAFSGS-TLD-99406-624-2011,2011-04-15T22:33:44.000Z,autorenew",
         "1-FSDGS-TLD-2406-624-2013,2013-05-01T22:33:44.000Z,ninelives",
@@ -138,7 +139,7 @@ public class AckPollMessagesCommandTest extends CommandTestCase<AckPollMessagesC
         persistPollMessage(123L, DateTime.parse("2015-09-01T22:33:44Z"), "time flies");
     VKey<OneTime> pm4 = notMatched2.createVKey();
     runCommand("-c", "TheRegistrar", "-m", "food");
-    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3, pm4)).values())
+    assertThat(tm().loadExisting(ImmutableList.of(pm1, pm2, pm3, pm4)).values())
         .containsExactly(notMatched1, notMatched2);
   }
 
@@ -163,7 +164,8 @@ public class AckPollMessagesCommandTest extends CommandTestCase<AckPollMessagesC
                 .build());
     VKey<OneTime> pm3 = notMatched.createVKey();
     runCommand("-c", "TheRegistrar");
-    assertThat(tm().load(ImmutableList.of(pm1, pm2, pm3)).values()).containsExactly(notMatched);
+    assertThat(tm().loadExisting(ImmutableList.of(pm1, pm2, pm3)).values())
+        .containsExactly(notMatched);
   }
 
   @Test


### PR DESCRIPTION
The contract of load(Iterable<VKey>) specifies that the method will
throw a NoSuchElementException if any of the specified keys don't exist.
We don't do that before this PR.

This also adds loadExisting and loadAllExisting methods that explicitly do not throw a NSEE in these cases, but rather only return the elements that we could find. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/914)
<!-- Reviewable:end -->
