### PR TITLE
Allow BEAM pipeline to choose JDBC isolation levels

### DIFF
--- a/core/src/main/java/google/registry/beam/initsql/BeamJpaModule.java
+++ b/core/src/main/java/google/registry/beam/initsql/BeamJpaModule.java
@@ -30,7 +30,7 @@ import google.registry.keyring.kms.KmsModule;
 import google.registry.persistence.PersistenceModule;
 import google.registry.persistence.PersistenceModule.JdbcJpaTm;
 import google.registry.persistence.PersistenceModule.SocketFactoryJpaTm;
-import google.registry.persistence.PersistenceModule.TransactionIsolation;
+import google.registry.persistence.PersistenceModule.TransactionIsolationLevel;
 import google.registry.persistence.transaction.JpaTransactionManager;
 import google.registry.privileges.secretmanager.SecretManagerModule;
 import google.registry.util.UtilsModule;
@@ -58,7 +58,7 @@ public class BeamJpaModule {
 
   @Nullable private final String sqlAccessInfoFile;
   @Nullable private final String cloudKmsProjectId;
-  @Nullable private final TransactionIsolation isolationOverride;
+  @Nullable private final TransactionIsolationLevel isolationOverride;
 
   /**
    * Constructs a new instance of {@link BeamJpaModule}.
@@ -81,7 +81,7 @@ public class BeamJpaModule {
   public BeamJpaModule(
       @Nullable String sqlAccessInfoFile,
       @Nullable String cloudKmsProjectId,
-      @Nullable TransactionIsolation isolationOverride) {
+      @Nullable TransactionIsolationLevel isolationOverride) {
     this.sqlAccessInfoFile = sqlAccessInfoFile;
     this.cloudKmsProjectId = cloudKmsProjectId;
     this.isolationOverride = isolationOverride;
@@ -169,7 +169,7 @@ public class BeamJpaModule {
   @Provides
   @Config("beamIsolationOverride")
   @Nullable
-  TransactionIsolation providesIsolationOverride() {
+  TransactionIsolationLevel providesIsolationOverride() {
     return isolationOverride;
   }
 

--- a/core/src/main/java/google/registry/beam/initsql/BeamJpaModule.java
+++ b/core/src/main/java/google/registry/beam/initsql/BeamJpaModule.java
@@ -30,6 +30,7 @@ import google.registry.keyring.kms.KmsModule;
 import google.registry.persistence.PersistenceModule;
 import google.registry.persistence.PersistenceModule.JdbcJpaTm;
 import google.registry.persistence.PersistenceModule.SocketFactoryJpaTm;
+import google.registry.persistence.PersistenceModule.TransactionIsolation;
 import google.registry.persistence.transaction.JpaTransactionManager;
 import google.registry.privileges.secretmanager.SecretManagerModule;
 import google.registry.util.UtilsModule;
@@ -57,6 +58,7 @@ public class BeamJpaModule {
 
   @Nullable private final String sqlAccessInfoFile;
   @Nullable private final String cloudKmsProjectId;
+  @Nullable private final TransactionIsolation isolationOverride;
 
   /**
    * Constructs a new instance of {@link BeamJpaModule}.
@@ -73,10 +75,20 @@ public class BeamJpaModule {
    *     real encrypted file on GCS as returned by {@link
    *     BackupPaths#getCloudSQLCredentialFilePatterns} or an unencrypted file on local filesystem
    *     with credentials to a test database.
+   * @param cloudKmsProjectId the GCP project where the credential decryption key can be found
+   * @param isolationOverride the desired Transaction Isolation level for all JDBC connections
    */
-  public BeamJpaModule(@Nullable String sqlAccessInfoFile, @Nullable String cloudKmsProjectId) {
+  public BeamJpaModule(
+      @Nullable String sqlAccessInfoFile,
+      @Nullable String cloudKmsProjectId,
+      @Nullable TransactionIsolation isolationOverride) {
     this.sqlAccessInfoFile = sqlAccessInfoFile;
     this.cloudKmsProjectId = cloudKmsProjectId;
+    this.isolationOverride = isolationOverride;
+  }
+
+  public BeamJpaModule(@Nullable String sqlAccessInfoFile, @Nullable String cloudKmsProjectId) {
+    this(sqlAccessInfoFile, cloudKmsProjectId, null);
   }
 
   /** Returns true if the credential file is on GCS (and therefore expected to be encrypted). */
@@ -152,6 +164,13 @@ public class BeamJpaModule {
   @Config("beamCloudKmsKeyRing")
   static String keyRingName() {
     return "nomulus-tool-keyring";
+  }
+
+  @Provides
+  @Config("beamIsolationOverride")
+  @Nullable
+  TransactionIsolation providesIsolationOverride() {
+    return isolationOverride;
   }
 
   @Provides

--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -286,7 +286,7 @@ public abstract class PersistenceModule {
    * Transaction isolation levels supported by Cloud SQL (mysql and postgresql).
    *
    * <p>Enum names may be used for property-based configuration, and must match the corresponding
-   * variable names in {@link java.sql.Connection}.
+   * variable names in {@link Connection}.
    */
   public enum TransactionIsolationLevel {
     TRANSACTION_READ_UNCOMMITTED,

--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -299,11 +299,11 @@ public abstract class PersistenceModule {
     TransactionIsolationLevel() {
       try {
         // name() is final in parent class (Enum.java), therefore safe to call in constructor.
-        value = Connection.class.getDeclaredField(name()).getInt(null);
+        value = Connection.class.getField(name()).getInt(null);
       } catch (Exception e) {
         throw new IllegalStateException(
             String.format(
-                "%s Enum name %s has no matching declaration in java.sql.Connection.",
+                "%s Enum name %s has no matching public field in java.sql.Connection.",
                 getClass().getSimpleName(), name()));
       }
     }

--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -27,6 +27,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.flogger.FluentLogger;
+import dagger.BindsOptionalOf;
 import dagger.Module;
 import dagger.Provides;
 import google.registry.config.RegistryConfig.Config;
@@ -44,6 +45,9 @@ import google.registry.util.Clock;
 import java.lang.annotation.Documented;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import javax.inject.Provider;
 import javax.inject.Qualifier;
 import javax.inject.Singleton;
 import javax.persistence.EntityManagerFactory;
@@ -52,7 +56,7 @@ import org.hibernate.cfg.Environment;
 
 /** Dagger module class for the persistence layer. */
 @Module
-public class PersistenceModule {
+public abstract class PersistenceModule {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   // This name must be the same as the one defined in persistence.xml.
@@ -102,8 +106,21 @@ public class PersistenceModule {
       @Config("cloudSqlJdbcUrl") String jdbcUrl,
       @Config("cloudSqlInstanceConnectionName") String instanceConnectionName,
       @DefaultHibernateConfigs ImmutableMap<String, String> defaultConfigs) {
-    return createPartialSqlConfigs(jdbcUrl, instanceConnectionName, defaultConfigs);
+    return createPartialSqlConfigs(
+        jdbcUrl, instanceConnectionName, defaultConfigs, Optional.empty());
   }
+
+  /**
+   * Optionally overrides the isolation level in the config file.
+   *
+   * <p>The binding for {@link TransactionIsolation} may be {@link Nullable}. As a result, it is a
+   * compile-time error to inject {@code Optional<TransactionIsolation>} (See {@link
+   * BindsOptionalOf} for more information). User should inject {@code
+   * Optional<Provider<TransactionIsolation>>} instead.
+   */
+  @BindsOptionalOf
+  @Config("beamIsolationOverride")
+  abstract TransactionIsolation bindBeamIsolationOverride();
 
   @Provides
   @Singleton
@@ -111,16 +128,25 @@ public class PersistenceModule {
   static ImmutableMap<String, String> provideBeamPipelineCloudSqlConfigs(
       @Config("beamCloudSqlJdbcUrl") String jdbcUrl,
       @Config("beamCloudSqlInstanceConnectionName") String instanceConnectionName,
-      @DefaultHibernateConfigs ImmutableMap<String, String> defaultConfigs) {
-    return createPartialSqlConfigs(jdbcUrl, instanceConnectionName, defaultConfigs);
+      @DefaultHibernateConfigs ImmutableMap<String, String> defaultConfigs,
+      @Config("beamIsolationOverride") Optional<Provider<TransactionIsolation>> isolationOverride) {
+    return createPartialSqlConfigs(
+        jdbcUrl, instanceConnectionName, defaultConfigs, isolationOverride);
   }
 
-  private static ImmutableMap<String, String> createPartialSqlConfigs(
-      String jdbcUrl, String instanceConnectionName, ImmutableMap<String, String> defaultConfigs) {
+  @VisibleForTesting
+  static ImmutableMap<String, String> createPartialSqlConfigs(
+      String jdbcUrl,
+      String instanceConnectionName,
+      ImmutableMap<String, String> defaultConfigs,
+      Optional<Provider<TransactionIsolation>> isolationOverride) {
     HashMap<String, String> overrides = Maps.newHashMap(defaultConfigs);
     overrides.put(Environment.URL, jdbcUrl);
     overrides.put(HIKARI_DS_SOCKET_FACTORY, "com.google.cloud.sql.postgres.SocketFactory");
     overrides.put(HIKARI_DS_CLOUD_SQL_INSTANCE, instanceConnectionName);
+    isolationOverride
+        .map(Provider::get)
+        .ifPresent(override -> overrides.put(Environment.ISOLATION, override.name()));
     return ImmutableMap.copyOf(overrides);
   }
 
@@ -252,6 +278,18 @@ public class PersistenceModule {
     } catch (Throwable e) {
       logger.atWarning().log(e.getMessage());
     }
+  }
+
+  /**
+   * Transaction isolation levels supported by Cloud SQL (mysql and postgresql).
+   *
+   * <p>Enum names must match the corresponding variable names in {@link java.sql.Connection}.
+   */
+  public enum TransactionIsolation {
+    TRANSACTION_READ_UNCOMMITTED,
+    TRANSACTION_READ_COMMITTED,
+    TRANSACTION_REPEATABLE_READ,
+    TRANSACTION_SERIALIZABLE
   }
 
   /** Dagger qualifier for {@link JpaTransactionManager} used for App Engine application. */

--- a/core/src/test/java/google/registry/persistence/PersistenceModuleTest.java
+++ b/core/src/test/java/google/registry/persistence/PersistenceModuleTest.java
@@ -15,10 +15,24 @@
 package google.registry.persistence;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 
+import dagger.Component;
+import google.registry.beam.initsql.BeamJpaModule;
+import google.registry.config.CredentialModule;
+import google.registry.config.RegistryConfig.Config;
+import google.registry.config.RegistryConfig.ConfigModule;
+import google.registry.keyring.kms.KmsModule;
+import google.registry.persistence.PersistenceModule.TransactionIsolation;
+import google.registry.privileges.secretmanager.SecretManagerModule;
 import google.registry.testing.DatastoreEntityExtension;
+import google.registry.util.UtilsModule;
+import java.util.Optional;
+import javax.inject.Provider;
+import javax.inject.Singleton;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
+import org.hibernate.cfg.Environment;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,7 +43,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 /** Unit tests for {@link PersistenceModule}. */
 @Testcontainers
-public class PersistenceModuleTest {
+class PersistenceModuleTest {
 
   @Container
   private final PostgreSQLContainer database =
@@ -63,5 +77,60 @@ public class PersistenceModuleTest {
     EntityManager em = emf.createEntityManager();
     assertThat(em.isOpen()).isTrue();
     em.close();
+  }
+
+  @Test
+  void appengineIsolation() {
+    assertThat(PersistenceModule.provideDefaultDatabaseConfigs().get(Environment.ISOLATION))
+        .isEqualTo(TransactionIsolation.TRANSACTION_SERIALIZABLE.name());
+  }
+
+  @Test
+  void beamIsolation_default() {
+    Optional<Provider<TransactionIsolation>> injected =
+        DaggerPersistenceModuleTest_BeamConfigTestComponent.builder()
+            .beamJpaModule(new BeamJpaModule(null, null))
+            .build()
+            .getIsolationOverride();
+    assertThat(injected).isNotNull();
+    assertThat(injected.get().get()).isNull();
+    assertThat(
+            PersistenceModule.provideBeamPipelineCloudSqlConfigs(
+                    "", "", PersistenceModule.provideDefaultDatabaseConfigs(), injected)
+                .get(Environment.ISOLATION))
+        .isEqualTo(TransactionIsolation.TRANSACTION_SERIALIZABLE.name());
+  }
+
+  @Test
+  void beamIsolation_override() {
+    Optional<Provider<TransactionIsolation>> injected =
+        DaggerPersistenceModuleTest_BeamConfigTestComponent.builder()
+            .beamJpaModule(
+                new BeamJpaModule(null, null, TransactionIsolation.TRANSACTION_READ_UNCOMMITTED))
+            .build()
+            .getIsolationOverride();
+    assertThat(injected).isNotNull();
+    assertThat(injected.get().get()).isEqualTo(TransactionIsolation.TRANSACTION_READ_UNCOMMITTED);
+    assertThat(
+            PersistenceModule.provideBeamPipelineCloudSqlConfigs(
+                    "", "", PersistenceModule.provideDefaultDatabaseConfigs(), injected)
+                .get(Environment.ISOLATION))
+        .isEqualTo(TransactionIsolation.TRANSACTION_READ_UNCOMMITTED.name());
+  }
+
+  @Singleton
+  @Component(
+      modules = {
+        BeamJpaModule.class,
+        ConfigModule.class,
+        CredentialModule.class,
+        KmsModule.class,
+        PersistenceModule.class,
+        SecretManagerModule.class,
+        UtilsModule.class
+      })
+  public interface BeamConfigTestComponent {
+    @Config("beamIsolationOverride")
+    Optional<Provider<TransactionIsolation>> getIsolationOverride();
   }
 }


### PR DESCRIPTION
Some BEAM pipelines may only perform READ-ONLY (e.g., reporting) or
blind-write (datastore to sql data migration) operations, which do not
need the default TRANSACTION_SERIALIZABLE isolation level. In such
cases, a less strict level allows better performance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/916)
<!-- Reviewable:end -->
