### PR TITLE
Add object comparison to replay tests

### DIFF
--- a/core/src/main/java/google/registry/model/EppResource.java
+++ b/core/src/main/java/google/registry/model/EppResource.java
@@ -148,7 +148,7 @@ public abstract class EppResource extends BackupGroupRoot implements Buildable {
    *
    * @see google.registry.model.translators.CommitLogRevisionsTranslatorFactory
    */
-  @Transient
+  @Transient @DoNotCompare
   ImmutableSortedMap<DateTime, Key<CommitLogManifest>> revisions = ImmutableSortedMap.of();
 
   public String getRepoId() {

--- a/core/src/main/java/google/registry/model/domain/DomainContent.java
+++ b/core/src/main/java/google/registry/model/domain/DomainContent.java
@@ -50,6 +50,7 @@ import com.googlecode.objectify.condition.IfNull;
 import google.registry.flows.ResourceFlowUtils;
 import google.registry.model.EppResource;
 import google.registry.model.EppResource.ResourceWithTransferData;
+import google.registry.model.ImmutableObject.EmptySetToNull;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.common.EntityGroupRoot;
 import google.registry.model.contact.ContactResource;
@@ -132,7 +133,7 @@ public class DomainContent extends EppResource
   @Index String tld;
 
   /** References to hosts that are the nameservers for the domain. */
-  @Index @Transient Set<VKey<HostResource>> nsHosts;
+  @EmptySetToNull @Index @Transient Set<VKey<HostResource>> nsHosts;
 
   /**
    * The union of the contacts visible via {@link #getContacts} and {@link #getRegistrant}.
@@ -319,6 +320,11 @@ public class DomainContent extends EppResource
     autorenewPollMessageHistoryId = getHistoryId(autorenewPollMessage);
     autorenewBillingEventHistoryId = getHistoryId(autorenewBillingEvent);
     deletePollMessageHistoryId = getHistoryId(deletePollMessage);
+
+    // Fix PollMessage VKeys.
+    autorenewPollMessage = PollMessage.Autorenew.convertVKey(autorenewPollMessage);
+    deletePollMessage = PollMessage.OneTime.convertVKey(deletePollMessage);
+
     dsData =
         nullToEmptyImmutableCopy(dsData).stream()
             .map(dsData -> dsData.cloneWithDomainRepoId(getRepoId()))

--- a/core/src/main/java/google/registry/model/domain/DomainHistory.java
+++ b/core/src/main/java/google/registry/model/domain/DomainHistory.java
@@ -104,6 +104,7 @@ public class DomainHistory extends HistoryEntry implements SqlEntity {
                 "domain_history_history_revision_id,domain_history_domain_repo_id,host_repo_id",
             unique = true),
       })
+  @ImmutableObject.EmptySetToNull
   @Column(name = "host_repo_id")
   Set<VKey<HostResource>> nsHosts;
 
@@ -180,7 +181,9 @@ public class DomainHistory extends HistoryEntry implements SqlEntity {
    * #getDomainTransactionRecords()}.
    */
   @Access(AccessType.PROPERTY)
-  @OneToMany(cascade = {CascadeType.ALL})
+  @OneToMany(
+      cascade = {CascadeType.ALL},
+      fetch = FetchType.EAGER)
   @JoinColumn(name = "historyRevisionId", referencedColumnName = "historyRevisionId")
   @JoinColumn(name = "domainRepoId", referencedColumnName = "domainRepoId")
   @SuppressWarnings("unused")

--- a/core/src/main/java/google/registry/model/poll/PollMessage.java
+++ b/core/src/main/java/google/registry/model/poll/PollMessage.java
@@ -52,6 +52,7 @@ import google.registry.persistence.WithLongVKey;
 import google.registry.schema.replay.DatastoreAndSqlEntity;
 import java.util.List;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import javax.persistence.AttributeOverride;
 import javax.persistence.AttributeOverrides;
 import javax.persistence.Column;
@@ -185,6 +186,7 @@ public abstract class PollMessage extends ImmutableObject
   @Override
   public abstract VKey<? extends PollMessage> createVKey();
 
+  /** Static VKey factory method for use by VKeyTranslatorFactory. */
   public static VKey<PollMessage> createVKey(Key<PollMessage> key) {
     return VKey.create(PollMessage.class, key.getId(), key);
   }
@@ -289,7 +291,7 @@ public abstract class PollMessage extends ImmutableObject
 
     @Transient List<ContactTransferResponse> contactTransferResponses;
 
-    @Transient
+    @Transient @ImmutableObject.DoNotCompare
     List<DomainPendingActionNotificationResponse> domainPendingActionNotificationResponses;
 
     @Transient List<DomainTransferResponse> domainTransferResponses;
@@ -353,6 +355,11 @@ public abstract class PollMessage extends ImmutableObject
     @Override
     public VKey<OneTime> createVKey() {
       return VKey.create(OneTime.class, getId(), Key.create(this));
+    }
+
+    /** Converts an unspecialized VKey&lt;PollMessage&gt; to a VKey of the derived class. */
+    public static @Nullable VKey<OneTime> convertVKey(@Nullable VKey<OneTime> key) {
+      return key == null ? null : VKey.create(OneTime.class, key.getSqlKey(), key.getOfyKey());
     }
 
     @Override
@@ -454,6 +461,11 @@ public abstract class PollMessage extends ImmutableObject
     @Override
     public VKey<Autorenew> createVKey() {
       return VKey.create(Autorenew.class, getId(), Key.create(this));
+    }
+
+    /** Converts an unspecialized VKey&lt;PollMessage&gt; to a VKey of the derived class. */
+    public static @Nullable VKey<Autorenew> convertVKey(VKey<Autorenew> key) {
+      return key == null ? null : VKey.create(Autorenew.class, key.getSqlKey(), key.getOfyKey());
     }
 
     @Override

--- a/core/src/main/java/google/registry/model/registry/label/PremiumListUtils.java
+++ b/core/src/main/java/google/registry/model/registry/label/PremiumListUtils.java
@@ -111,8 +111,9 @@ public final class PremiumListUtils {
             label, registry.getTldStr(), checkResults.premiumPrice(), priceFromSql);
       }
     } catch (Throwable t) {
-      logger.atSevere().withCause(t).log(
-          "Error loading price of domain %s.%s from Cloud SQL.", label, registry.getTldStr());
+      //      logger.atSevere().withCause(t).log(
+      //          "Error loading price of domain %s.%s from Cloud SQL.", label,
+      // registry.getTldStr());
     }
     return checkResults.premiumPrice();
   }

--- a/core/src/main/java/google/registry/model/registry/label/PremiumListUtils.java
+++ b/core/src/main/java/google/registry/model/registry/label/PremiumListUtils.java
@@ -111,9 +111,8 @@ public final class PremiumListUtils {
             label, registry.getTldStr(), checkResults.premiumPrice(), priceFromSql);
       }
     } catch (Throwable t) {
-      //      logger.atSevere().withCause(t).log(
-      //          "Error loading price of domain %s.%s from Cloud SQL.", label,
-      // registry.getTldStr());
+      logger.atSevere().withCause(t).log(
+          "Error loading price of domain %s.%s from Cloud SQL.", label, registry.getTldStr());
     }
     return checkResults.premiumPrice();
   }

--- a/core/src/main/java/google/registry/model/reporting/DomainTransactionRecord.java
+++ b/core/src/main/java/google/registry/model/reporting/DomainTransactionRecord.java
@@ -49,7 +49,9 @@ public class DomainTransactionRecord extends ImmutableObject
 
   @Id
   @Ignore
+  @ImmutableObject.DoNotCompare
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @ImmutableObject.Insignificant
   Long id;
 
   /** The TLD this record operates on. */

--- a/core/src/main/java/google/registry/model/reporting/HistoryEntry.java
+++ b/core/src/main/java/google/registry/model/reporting/HistoryEntry.java
@@ -198,6 +198,7 @@ public class HistoryEntry extends ImmutableObject implements Buildable, Datastor
    * transaction counts (such as contact or host mutations).
    */
   @Transient // domain-specific
+  @ImmutableObject.EmptySetToNull
   protected Set<DomainTransactionRecord> domainTransactionRecords;
 
   public long getId() {

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -184,7 +184,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Order(value = Order.DEFAULT - 2)
   @RegisterExtension
-  final ReplayExtension replayExtension = new ReplayExtension(clock, true);
+  final ReplayExtension replayExtension = ReplayExtension.createWithCompare(clock);
 
   DomainCreateFlowTest() {
     setEppInput("domain_create.xml", ImmutableMap.of("DOMAIN", "example.tld"));

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -184,7 +184,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Order(value = Order.DEFAULT - 2)
   @RegisterExtension
-  final ReplayExtension replayExtension = new ReplayExtension(clock);
+  final ReplayExtension replayExtension = new ReplayExtension(clock, true);
 
   DomainCreateFlowTest() {
     setEppInput("domain_create.xml", ImmutableMap.of("DOMAIN", "example.tld"));

--- a/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
@@ -112,7 +112,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
 
   @Order(value = Order.DEFAULT - 2)
   @RegisterExtension
-  final ReplayExtension replayExtension = new ReplayExtension(clock, false);
+  final ReplayExtension replayExtension = ReplayExtension.createWithoutCompare(clock);
 
   private DomainBase domain;
   private HistoryEntry earlierHistoryEntry;

--- a/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
@@ -112,7 +112,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
 
   @Order(value = Order.DEFAULT - 2)
   @RegisterExtension
-  final ReplayExtension replayExtension = new ReplayExtension(clock);
+  final ReplayExtension replayExtension = new ReplayExtension(clock, false);
 
   private DomainBase domain;
   private HistoryEntry earlierHistoryEntry;

--- a/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
@@ -108,7 +108,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, DomainBa
 
   @Order(value = Order.DEFAULT - 2)
   @RegisterExtension
-  final ReplayExtension replayExtension = new ReplayExtension(clock, false);
+  final ReplayExtension replayExtension = ReplayExtension.createWithoutCompare(clock);
 
   @BeforeEach
   void initDomainTest() {

--- a/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
@@ -108,7 +108,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, DomainBa
 
   @Order(value = Order.DEFAULT - 2)
   @RegisterExtension
-  final ReplayExtension replayExtension = new ReplayExtension(clock);
+  final ReplayExtension replayExtension = new ReplayExtension(clock, false);
 
   @BeforeEach
   void initDomainTest() {

--- a/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
@@ -117,7 +117,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
 
   @Order(value = Order.DEFAULT - 2)
   @RegisterExtension
-  final ReplayExtension replayExtension = new ReplayExtension(clock, false);
+  final ReplayExtension replayExtension = ReplayExtension.createWithoutCompare(clock);
 
   @BeforeEach
   void initDomainTest() {

--- a/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
@@ -117,7 +117,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
 
   @Order(value = Order.DEFAULT - 2)
   @RegisterExtension
-  final ReplayExtension replayExtension = new ReplayExtension(clock);
+  final ReplayExtension replayExtension = new ReplayExtension(clock, false);
 
   @BeforeEach
   void initDomainTest() {

--- a/core/src/test/java/google/registry/testing/ReplayExtension.java
+++ b/core/src/test/java/google/registry/testing/ReplayExtension.java
@@ -47,9 +47,17 @@ public class ReplayExtension implements BeforeEachCallback, AfterEachCallback {
   FakeClock clock;
   boolean compare;
 
-  public ReplayExtension(FakeClock clock, boolean compare) {
+  private ReplayExtension(FakeClock clock, boolean compare) {
     this.clock = clock;
     this.compare = compare;
+  }
+
+  public static ReplayExtension createWithCompare(FakeClock clock) {
+    return new ReplayExtension(clock, true);
+  }
+
+  public static ReplayExtension createWithoutCompare(FakeClock clock) {
+    return new ReplayExtension(clock, false);
   }
 
   @Override

--- a/core/src/test/java/google/registry/testing/ReplayExtension.java
+++ b/core/src/test/java/google/registry/testing/ReplayExtension.java
@@ -14,7 +14,19 @@
 
 package google.registry.testing;
 
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
+import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.ofyTm;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.googlecode.objectify.Key;
+import google.registry.model.ImmutableObject;
 import google.registry.model.ofy.ReplayQueue;
+import google.registry.model.ofy.TransactionInfo;
+import google.registry.persistence.VKey;
+import java.util.Optional;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -26,13 +38,18 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * that extension are also replayed. If AppEngineExtension is not used,
  * JpaTransactionManagerExtension must be, and this extension should be ordered _after_
  * JpaTransactionManagerExtension so that writes to SQL work.
+ *
+ * <p>If the "compare" flag is set in the constructor, this will also compare all touched objects in
+ * both databases after performing the replay.
  */
 public class ReplayExtension implements BeforeEachCallback, AfterEachCallback {
 
   FakeClock clock;
+  boolean compare;
 
-  public ReplayExtension(FakeClock clock) {
+  public ReplayExtension(FakeClock clock, boolean compare) {
     this.clock = clock;
+    this.compare = compare;
   }
 
   @Override
@@ -51,8 +68,48 @@ public class ReplayExtension implements BeforeEachCallback, AfterEachCallback {
     replayToSql();
   }
 
+  private static ImmutableSet<String> NON_REPLICATED_TYPES =
+      ImmutableSet.of(
+          "PremiumList",
+          "PremiumListRevision",
+          "PremiumListEntry",
+          "ReservedList",
+          "RdeRevision",
+          "KmsSecretRevision",
+          "ServerSecret",
+          "SignedMarkRevocationList",
+          "ClaimsListShard",
+          "TmchCrl",
+          "EppResourceIndex",
+          "ForeignKeyIndex",
+          "ForeignKeyHostIndex",
+          "ForeignKeyContactIndex",
+          "ForeignKeyDomainIndex");
+
   public void replayToSql() {
     DatabaseHelper.setAlwaysSaveWithBackup(false);
-    ReplayQueue.replay();
+    ImmutableMap<Key<?>, Object> changes = ReplayQueue.replay();
+
+    // Compare JPA to OFY, if requested.
+    if (compare) {
+      for (ImmutableMap.Entry<Key<?>, Object> entry : changes.entrySet()) {
+        // Don't verify non-replicated types.
+        if (NON_REPLICATED_TYPES.contains(entry.getKey().getKind())) {
+          continue;
+        }
+
+        VKey<?> vkey = VKey.from(entry.getKey());
+        Optional<?> ofyValue = ofyTm().transact(() -> ofyTm().loadByKeyIfPresent(vkey));
+        Optional<?> jpaValue = jpaTm().transact(() -> jpaTm().loadByKeyIfPresent(vkey));
+        if (entry.getValue().equals(TransactionInfo.Delete.SENTINEL)) {
+          assertThat(jpaValue.isPresent()).isFalse();
+          assertThat(ofyValue.isPresent()).isFalse();
+        } else {
+          assertAboutImmutableObjects()
+              .that((ImmutableObject) jpaValue.get())
+              .isEqualAcrossDatabases((ImmutableObject) ofyValue.get());
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Allow optional object comparison in the replay test extension and enable it
for the DomainCreateFlow test.

To faciliate this, add two new field annotations to ImmutableObject:
DoNotCompare, to be used for fields that are not relevant to either database,
and Insignificant, to be used for fields that are mutated after they have been                                                                    
accessed and therefore violate immutability (there is currently only one of                                                                       
these, however we might discover more in the course of adding more comparisons
to the replay test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/925)
<!-- Reviewable:end -->
