### PR TITLE
Convert (most) HistoryEntry ofy calls to tm

### DIFF
--- a/core/src/main/java/google/registry/model/reporting/HistoryEntryDao.java
+++ b/core/src/main/java/google/registry/model/reporting/HistoryEntryDao.java
@@ -1,0 +1,144 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.model.reporting;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.util.DateTimeUtils.END_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_OF_TIME;
+
+import com.google.common.collect.Iterables;
+import google.registry.model.EppResource;
+import google.registry.model.contact.ContactHistory;
+import google.registry.model.contact.ContactResource;
+import google.registry.model.domain.DomainBase;
+import google.registry.model.domain.DomainHistory;
+import google.registry.model.host.HostHistory;
+import google.registry.model.host.HostResource;
+import google.registry.persistence.VKey;
+import java.util.Comparator;
+import javax.persistence.EntityManager;
+import org.joda.time.DateTime;
+
+/**
+ * Retrieves {@link HistoryEntry} descendants (e.g. {@link DomainHistory}).
+ *
+ * <p>This class is configured to retrieve either from Datastore or SQL, depending on which database
+ * is currently considered the primary database.
+ */
+public class HistoryEntryDao {
+
+  /** Loads all history objects in the times specified, including all types. */
+  public static Iterable<? extends HistoryEntry> loadAllHistoryObjects(
+      DateTime afterTime, DateTime beforeTime) {
+    if (tm().isOfy()) {
+      return ofy()
+          .load()
+          .type(HistoryEntry.class)
+          .order("modificationTime")
+          .filter("modificationTime >=", afterTime)
+          .filter("modificationTime <=", beforeTime);
+    } else {
+      return jpaTm()
+          .transact(
+              () ->
+                  Iterables.concat(
+                      loadAllHistoryObjectsFromSql(ContactHistory.class, afterTime, beforeTime),
+                      loadAllHistoryObjectsFromSql(DomainHistory.class, afterTime, beforeTime),
+                      loadAllHistoryObjectsFromSql(HostHistory.class, afterTime, beforeTime)));
+    }
+  }
+
+  /** Loads all history objects corresponding to the given {@link EppResource}. */
+  public static Iterable<? extends HistoryEntry> loadHistoryObjectsForResource(
+      VKey<? extends EppResource> parentKey) {
+    return loadHistoryObjectsForResource(parentKey, START_OF_TIME, END_OF_TIME);
+  }
+
+  /** Loads all history objects in the time period specified for the given {@link EppResource}. */
+  public static Iterable<? extends HistoryEntry> loadHistoryObjectsForResource(
+      VKey<? extends EppResource> parentKey, DateTime afterTime, DateTime beforeTime) {
+    if (tm().isOfy()) {
+      return ofy()
+          .load()
+          .type(HistoryEntry.class)
+          .ancestor(parentKey.getOfyKey())
+          .order("modificationTime")
+          .filter("modificationTime >=", afterTime)
+          .filter("modificationTime <=", beforeTime);
+    } else {
+      return jpaTm()
+          .transact(() -> loadHistoryObjectsForResourceFromSql(parentKey, afterTime, beforeTime));
+    }
+  }
+
+  private static Iterable<? extends HistoryEntry> loadHistoryObjectsForResourceFromSql(
+      VKey<? extends EppResource> parentKey, DateTime afterTime, DateTime beforeTime) {
+    Class<? extends HistoryEntry> historyClass = getHistoryClassFromParent(parentKey.getKind());
+    String repoIdFieldName = getRepoIdFieldNameFromHistoryClass(historyClass);
+    EntityManager entityManager = jpaTm().getEntityManager();
+    String tableName = entityManager.getMetamodel().entity(historyClass).getName();
+    String queryString =
+        String.format(
+            "SELECT entry FROM %s entry WHERE entry.modificationTime >= :afterTime AND "
+                + "entry.modificationTime <= :beforeTime AND entry.%s = :parentKey",
+            tableName, repoIdFieldName);
+    return entityManager
+        .createQuery(queryString, historyClass)
+        .setParameter("afterTime", afterTime)
+        .setParameter("beforeTime", beforeTime)
+        .setParameter("parentKey", parentKey.getSqlKey().toString())
+        .getResultStream()
+        .sorted(Comparator.comparing(HistoryEntry::getModificationTime))
+        .collect(toImmutableList());
+  }
+
+  private static Class<? extends HistoryEntry> getHistoryClassFromParent(
+      Class<? extends EppResource> parent) {
+    if (parent.equals(ContactResource.class)) {
+      return ContactHistory.class;
+    } else if (parent.equals(DomainBase.class)) {
+      return DomainHistory.class;
+    } else if (parent.equals(HostResource.class)) {
+      return HostHistory.class;
+    }
+    throw new IllegalArgumentException(
+        String.format("Unknown history type for parent %s", parent.getName()));
+  }
+
+  private static String getRepoIdFieldNameFromHistoryClass(
+      Class<? extends HistoryEntry> historyClass) {
+    return historyClass.equals(ContactHistory.class)
+        ? "contactRepoId"
+        : historyClass.equals(DomainHistory.class) ? "domainRepoId" : "hostRepoId";
+  }
+
+  private static Iterable<? extends HistoryEntry> loadAllHistoryObjectsFromSql(
+      Class<? extends HistoryEntry> historyClass, DateTime afterTime, DateTime beforeTime) {
+    EntityManager entityManager = jpaTm().getEntityManager();
+    return entityManager
+        .createQuery(
+            String.format(
+                "SELECT entry FROM %s entry WHERE entry.modificationTime >= :afterTime AND "
+                    + "entry.modificationTime <= :beforeTime",
+                entityManager.getMetamodel().entity(historyClass).getName()),
+            historyClass)
+        .setParameter("afterTime", afterTime)
+        .setParameter("beforeTime", beforeTime)
+        .getResultList();
+  }
+}

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -525,8 +525,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     clock.advanceOneMilli();
     runFlow();
     assertSuccessfulCreate("tld", ImmutableSet.of(), token);
-    HistoryEntry historyEntry =
-        ofy().load().type(HistoryEntry.class).ancestor(reloadResourceByForeignKey()).first().now();
+    HistoryEntry historyEntry = getHistoryEntries(reloadResourceByForeignKey()).get(0);
     assertThat(ofy().load().entity(token).now().getRedemptionHistoryEntry())
         .hasValue(HistoryEntry.createVKey(Key.create(historyEntry)));
   }

--- a/core/src/test/java/google/registry/model/reporting/HistoryEntryDaoTest.java
+++ b/core/src/test/java/google/registry/model/reporting/HistoryEntryDaoTest.java
@@ -1,0 +1,127 @@
+// Copyright 2020 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.model.reporting;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.model.ImmutableObjectSubject.immutableObjectCorrespondence;
+import static google.registry.persistence.transaction.TransactionManagerUtil.transactIfJpaTm;
+import static google.registry.testing.DatabaseHelper.createTld;
+import static google.registry.testing.DatabaseHelper.newDomainBase;
+import static google.registry.testing.DatabaseHelper.persistActiveDomain;
+import static google.registry.testing.DatabaseHelper.persistResource;
+import static google.registry.util.DateTimeUtils.END_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.collect.ImmutableSet;
+import google.registry.model.EntityTestCase;
+import google.registry.model.domain.DomainBase;
+import google.registry.model.domain.DomainHistory;
+import google.registry.model.domain.Period;
+import google.registry.model.eppcommon.Trid;
+import google.registry.model.reporting.DomainTransactionRecord.TransactionReportField;
+import google.registry.testing.DualDatabaseTest;
+import google.registry.testing.TestOfyAndSql;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+
+@DualDatabaseTest
+public class HistoryEntryDaoTest extends EntityTestCase {
+
+  private DomainBase domain;
+  private HistoryEntry historyEntry;
+
+  @BeforeEach
+  void beforeEach() {
+    fakeClock.setTo(DateTime.parse("2020-10-01T00:00:00Z"));
+    createTld("foobar");
+    domain = persistActiveDomain("foo.foobar");
+    DomainTransactionRecord transactionRecord =
+        new DomainTransactionRecord.Builder()
+            .setTld("foobar")
+            .setReportingTime(fakeClock.nowUtc())
+            .setReportField(TransactionReportField.NET_ADDS_1_YR)
+            .setReportAmount(1)
+            .build();
+    // Set up a new persisted HistoryEntry entity.
+    historyEntry =
+        new DomainHistory.Builder()
+            .setParent(domain)
+            .setType(HistoryEntry.Type.DOMAIN_CREATE)
+            .setPeriod(Period.create(1, Period.Unit.YEARS))
+            .setXmlBytes("<xml></xml>".getBytes(UTF_8))
+            .setModificationTime(fakeClock.nowUtc())
+            .setClientId("TheRegistrar")
+            .setOtherClientId("otherClient")
+            .setTrid(Trid.create("ABC-123", "server-trid"))
+            .setBySuperuser(false)
+            .setReason("reason")
+            .setRequestedByRegistrar(false)
+            .setDomainTransactionRecords(ImmutableSet.of(transactionRecord))
+            .build();
+    persistResource(historyEntry);
+  }
+
+  @TestOfyAndSql
+  void testSimpleLoadAll() {
+    assertThat(HistoryEntryDao.loadAllHistoryObjects(START_OF_TIME, END_OF_TIME))
+        .comparingElementsUsing(immutableObjectCorrespondence("nsHosts"))
+        .containsExactly(historyEntry);
+  }
+
+  @TestOfyAndSql
+  void testSkips_tooEarly() {
+    assertThat(HistoryEntryDao.loadAllHistoryObjects(fakeClock.nowUtc().plusMillis(1), END_OF_TIME))
+        .isEmpty();
+  }
+
+  @TestOfyAndSql
+  void testSkips_tooLate() {
+    assertThat(
+            HistoryEntryDao.loadAllHistoryObjects(START_OF_TIME, fakeClock.nowUtc().minusMillis(1)))
+        .isEmpty();
+  }
+
+  @TestOfyAndSql
+  void testLoadByResource() {
+    transactIfJpaTm(
+        () ->
+            assertThat(HistoryEntryDao.loadHistoryObjectsForResource(domain.createVKey()))
+                .comparingElementsUsing(immutableObjectCorrespondence("nsHosts"))
+                .containsExactly(historyEntry));
+  }
+
+  @TestOfyAndSql
+  void testLoadByResource_skips_tooEarly() {
+    assertThat(
+            HistoryEntryDao.loadHistoryObjectsForResource(
+                domain.createVKey(), fakeClock.nowUtc().plusMillis(1), END_OF_TIME))
+        .isEmpty();
+  }
+
+  @TestOfyAndSql
+  void testLoadByResource_skips_tooLate() {
+    assertThat(
+            HistoryEntryDao.loadHistoryObjectsForResource(
+                domain.createVKey(), START_OF_TIME, fakeClock.nowUtc().minusMillis(1)))
+        .isEmpty();
+  }
+
+  @TestOfyAndSql
+  void testLoadByResource_noEntriesForResource() {
+    DomainBase newDomain = persistResource(newDomainBase("new.foobar"));
+    assertThat(HistoryEntryDao.loadHistoryObjectsForResource(newDomain.createVKey())).isEmpty();
+  }
+}

--- a/core/src/test/java/google/registry/rdap/RdapDomainActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapDomainActionTest.java
@@ -95,7 +95,7 @@ class RdapDomainActionTest extends RdapActionBaseTestCase<RdapDomainAction> {
                 registrarLol)
             .asBuilder()
             .setCreationTimeForTest(clock.nowUtc().minusYears(3))
-            .setCreationClientId("foo")
+            .setCreationClientId("TheRegistrar")
             .build());
 
     // deleted domain in lol
@@ -128,7 +128,7 @@ class RdapDomainActionTest extends RdapActionBaseTestCase<RdapDomainAction> {
                     registrarLol)
                 .asBuilder()
                 .setCreationTimeForTest(clock.nowUtc().minusYears(3))
-                .setCreationClientId("foo")
+                .setCreationClientId("TheRegistrar")
                 .setDeletionTime(clock.nowUtc().minusDays(1))
                 .build());
     // cat.みんな
@@ -168,7 +168,7 @@ class RdapDomainActionTest extends RdapActionBaseTestCase<RdapDomainAction> {
                 registrarIdn)
             .asBuilder()
             .setCreationTimeForTest(clock.nowUtc().minusYears(3))
-            .setCreationClientId("foo")
+            .setCreationClientId("TheRegistrar")
             .build());
 
     // 1.tld
@@ -208,7 +208,7 @@ class RdapDomainActionTest extends RdapActionBaseTestCase<RdapDomainAction> {
                 registrar1Tld)
             .asBuilder()
             .setCreationTimeForTest(clock.nowUtc().minusYears(3))
-            .setCreationClientId("foo")
+            .setCreationClientId("TheRegistrar")
             .build());
 
     // history entries

--- a/core/src/test/java/google/registry/rdap/RdapDomainSearchActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapDomainSearchActionTest.java
@@ -176,7 +176,7 @@ class RdapDomainSearchActionTest extends RdapSearchActionTestCase<RdapDomainSear
                 .asBuilder()
                 .setSubordinateHosts(ImmutableSet.of("ns1.cat.lol", "ns2.cat.lol"))
                 .setCreationTimeForTest(clock.nowUtc().minusYears(3))
-                .setCreationClientId("foo")
+                .setCreationClientId("TheRegistrar")
                 .build());
     persistResource(
         hostNs1CatLol.asBuilder().setSuperordinateDomain(domainCatLol.createVKey()).build());
@@ -216,7 +216,7 @@ class RdapDomainSearchActionTest extends RdapSearchActionTestCase<RdapDomainSear
                     registrar)
                 .asBuilder()
                 .setCreationTimeForTest(clock.nowUtc().minusYears(3))
-                .setCreationClientId("foo")
+                .setCreationClientId("TheRegistrar")
                 .build());
     // cat.example
     createTld("example");
@@ -255,7 +255,7 @@ class RdapDomainSearchActionTest extends RdapSearchActionTestCase<RdapDomainSear
                     registrar)
                 .asBuilder()
                 .setCreationTimeForTest(clock.nowUtc().minusYears(3))
-                .setCreationClientId("foo")
+                .setCreationClientId("TheRegistrar")
                 .build());
     // cat.みんな
     createTld("xn--q9jyb4c");
@@ -294,7 +294,7 @@ class RdapDomainSearchActionTest extends RdapSearchActionTestCase<RdapDomainSear
                     registrar)
                 .asBuilder()
                 .setCreationTimeForTest(clock.nowUtc().minusYears(3))
-                .setCreationClientId("foo")
+                .setCreationClientId("TheRegistrar")
                 .build());
     // cat.1.test
     createTld("1.test");
@@ -334,7 +334,7 @@ class RdapDomainSearchActionTest extends RdapSearchActionTestCase<RdapDomainSear
                 .asBuilder()
                 .setSubordinateHosts(ImmutableSet.of("ns1.cat.1.test"))
                 .setCreationTimeForTest(clock.nowUtc().minusYears(3))
-                .setCreationClientId("foo")
+                .setCreationClientId("TheRegistrar")
                 .build());
 
     persistResource(makeRegistrar("otherregistrar", "other", Registrar.State.ACTIVE));
@@ -430,7 +430,7 @@ class RdapDomainSearchActionTest extends RdapSearchActionTestCase<RdapDomainSear
               .asBuilder()
               .setNameservers(hostKeys)
               .setCreationTimeForTest(clock.nowUtc().minusYears(3))
-              .setCreationClientId("foo");
+              .setCreationClientId("TheRegistrar");
       if (domainName.equals(mainDomainName)) {
         builder.setSubordinateHosts(subordinateHostnamesBuilder.build());
       }

--- a/core/src/test/java/google/registry/rdap/RdapJsonFormatterTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapJsonFormatterTest.java
@@ -191,7 +191,6 @@ class RdapJsonFormatterTest {
                     hostResourceIpv6,
                     registrar)
                 .asBuilder()
-                .setCreationClientId("foo")
                 .setCreationTimeForTest(clock.nowUtc().minusMonths(4))
                 .setLastEppUpdateTime(clock.nowUtc().minusMonths(3))
                 .build());
@@ -206,7 +205,6 @@ class RdapJsonFormatterTest {
                     null,
                     registrar)
                 .asBuilder()
-                .setCreationClientId("foo")
                 .setCreationTimeForTest(clock.nowUtc())
                 .setLastEppUpdateTime(null)
                 .build());

--- a/core/src/test/java/google/registry/rdap/RdapTestHelper.java
+++ b/core/src/test/java/google/registry/rdap/RdapTestHelper.java
@@ -313,7 +313,7 @@ class RdapTestHelper {
       }
       builder.append(
           String.format(
-              "Different: %s -> %s\ninstead of %s\n\n",
+              "Actual: %s -> %s\nExpected: %s\n\n",
               name, jsonifyAndIndent(actual), jsonifyAndIndent(expected)));
     }
   }

--- a/core/src/test/java/google/registry/testing/FullFieldsTestEntityHelper.java
+++ b/core/src/test/java/google/registry/testing/FullFieldsTestEntityHelper.java
@@ -398,7 +398,7 @@ public final class FullFieldsTestEntityHelper {
         .setPeriod(period)
         .setXmlBytes("<xml></xml>".getBytes(UTF_8))
         .setModificationTime(modificationTime)
-        .setClientId("foo")
+        .setClientId(resource.getPersistedCurrentSponsorClientId())
         .setTrid(Trid.create("ABC-123", "server-trid"))
         .setBySuperuser(false)
         .setReason(reason)

--- a/core/src/test/resources/google/registry/rdap/rdap_domain.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain.json
@@ -33,7 +33,7 @@
   "events": [
     {
       "eventAction": "registration",
-      "eventActor": "foo",
+      "eventActor": "TheRegistrar",
       "eventDate": "1997-01-01T00:00:00.000Z"
     },
     {

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_cat2.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_cat2.json
@@ -33,7 +33,7 @@
   "events": [
     {
       "eventAction": "registration",
-      "eventActor": "foo",
+      "eventActor": "TheRegistrar",
       "eventDate": "1997-01-01T00:00:00.000Z"
     },
     {

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_deleted.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_deleted.json
@@ -34,7 +34,7 @@
   "events": [
     {
       "eventAction": "registration",
-      "eventActor": "foo",
+      "eventActor": "TheRegistrar",
       "eventDate": "1997-01-01T00:00:00.000Z"
     },
     {
@@ -47,7 +47,7 @@
     },
     {
       "eventAction": "deletion",
-      "eventActor": "foo",
+      "eventActor": "evilregistrar",
       "eventDate": "1999-07-01T00:00:00.000Z"
     },
     {

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_no_contacts_with_remark.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_no_contacts_with_remark.json
@@ -33,7 +33,7 @@
   "events": [
     {
       "eventAction": "registration",
-      "eventActor": "foo",
+      "eventActor": "TheRegistrar",
       "eventDate": "1997-01-01T00:00:00.000Z"
     },
     {

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_unicode.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_unicode.json
@@ -34,7 +34,7 @@
   "events": [
     {
       "eventAction": "registration",
-      "eventActor": "foo",
+      "eventActor": "TheRegistrar",
       "eventDate": "1997-01-01T00:00:00.000Z"
     },
     {

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_unicode_no_contacts_with_remark.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_unicode_no_contacts_with_remark.json
@@ -34,7 +34,7 @@
   "events": [
     {
       "eventAction": "registration",
-      "eventActor": "foo",
+      "eventActor": "TheRegistrar",
       "eventDate": "1997-01-01T00:00:00.000Z"
     },
     {

--- a/core/src/test/resources/google/registry/rdap/rdapjson_domain_full.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_domain_full.json
@@ -31,7 +31,7 @@
   "events": [
     {
       "eventAction": "registration",
-      "eventActor": "foo",
+      "eventActor": "unicoderegistrar",
       "eventDate": "1999-09-01T00:00:00.000Z"
     },
     {
@@ -44,7 +44,7 @@
     },
     {
       "eventAction": "transfer",
-      "eventActor": "foo",
+      "eventActor": "unicoderegistrar",
       "eventDate": "1999-12-01T00:00:00.000Z"
     },
     {

--- a/core/src/test/resources/google/registry/rdap/rdapjson_domain_logged_out.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_domain_logged_out.json
@@ -31,7 +31,7 @@
   "events": [
     {
       "eventAction": "registration",
-      "eventActor": "foo",
+      "eventActor": "unicoderegistrar",
       "eventDate": "1999-09-01T00:00:00.000Z"
     },
     {
@@ -44,7 +44,7 @@
     },
     {
       "eventAction": "transfer",
-      "eventActor": "foo",
+      "eventActor": "unicoderegistrar",
       "eventDate": "1999-12-01T00:00:00.000Z"
     },
     {

--- a/core/src/test/resources/google/registry/rdap/rdapjson_domain_no_nameservers.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_domain_no_nameservers.json
@@ -32,7 +32,7 @@
   "events": [
     {
       "eventAction": "registration",
-      "eventActor": "foo",
+      "eventActor": "unicoderegistrar",
       "eventDate": "2000-01-01T00:00:00.000Z"
     },
     {

--- a/core/src/test/resources/google/registry/rdap/rdapjson_registrant_nobase.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_registrant_nobase.json
@@ -14,7 +14,7 @@
   "events": [
     {
       "eventAction": "registration",
-      "eventActor": "foo",
+      "eventActor": "TheRegistrar",
       "eventDate": "1999-01-01T00:00:00.000Z"
     },
     {


### PR DESCRIPTION
As part of this change, it was necessary to do changes in the JPATM that
are similar (but the opposite) of the changes that we did in
DatastoreTM with regards to converting HistoryEntries to and from the
*History classes.

We leave the ofy() calls in the MapReduce ResaveAllHistoryEntriesAction
for now; that can be converted during the Beam pipeline transition.

Some other tests required registrar-name fixes as well -- because
*History objects have a foreign key on the Registrar table, we have to
use a "real" registrar name in tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/933)
<!-- Reviewable:end -->
