### PR TITLE
Change java.util.Optional.isEmpty() to !isPresent()

### DIFF
--- a/core/src/main/java/google/registry/backup/ReplayCommitLogsToSqlAction.java
+++ b/core/src/main/java/google/registry/backup/ReplayCommitLogsToSqlAction.java
@@ -85,7 +85,7 @@ public class ReplayCommitLogsToSqlAction implements Runnable {
     Optional<Lock> lock =
         Lock.acquire(
             this.getClass().getSimpleName(), null, LEASE_LENGTH, requestStatusChecker, false);
-    if (lock.isEmpty()) {
+    if (!lock.isPresent()) {
       String message = "Can't acquire SQL commit log replay lock, aborting.";
       logger.atSevere().log(message);
       // App Engine will retry on any non-2xx status code, which we don't want in this case.
@@ -182,7 +182,7 @@ public class ReplayCommitLogsToSqlAction implements Runnable {
   }
 
   private static int compareByWeight(VersionedEntity a, VersionedEntity b) {
-    return getEntityPriority(a.key().getKind(), a.getEntity().isEmpty())
-        - getEntityPriority(b.key().getKind(), b.getEntity().isEmpty());
+    return getEntityPriority(a.key().getKind(), !a.getEntity().isPresent())
+        - getEntityPriority(b.key().getKind(), !b.getEntity().isPresent());
   }
 }

--- a/core/src/main/java/google/registry/flows/domain/token/AllocationTokenFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/token/AllocationTokenFlowUtils.java
@@ -154,7 +154,7 @@ public class AllocationTokenFlowUtils {
     }
     Optional<AllocationToken> maybeTokenEntity =
         tm().loadByKeyIfPresent(VKey.create(AllocationToken.class, token));
-    if (maybeTokenEntity.isEmpty()) {
+    if (!maybeTokenEntity.isPresent()) {
       throw new InvalidAllocationTokenException();
     }
     if (maybeTokenEntity.get().isRedeemed()) {

--- a/core/src/main/java/google/registry/tools/DeleteAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/DeleteAllocationTokensCommand.java
@@ -76,7 +76,7 @@ final class DeleteAllocationTokensCommand extends UpdateOrDeleteAllocationTokens
     // since the query ran. This also filters out per-domain tokens if they're not to be deleted.
     ImmutableSet<VKey<AllocationToken>> tokensToDelete =
         tm().loadByKeys(batch).values().stream()
-            .filter(t -> withDomains || t.getDomainName().isEmpty())
+            .filter(t -> withDomains || !t.getDomainName().isPresent())
             .filter(t -> SINGLE_USE.equals(t.getTokenType()))
             .filter(t -> !t.isRedeemed())
             .map(AllocationToken::createVKey)

--- a/core/src/main/java/google/registry/tools/GetAllocationTokenCommand.java
+++ b/core/src/main/java/google/registry/tools/GetAllocationTokenCommand.java
@@ -59,7 +59,7 @@ final class GetAllocationTokenCommand implements CommandWithRemoteApi {
       if (loadedTokens.containsKey(token)) {
         AllocationToken loadedToken = loadedTokens.get(token);
         System.out.println(loadedToken.toString());
-        if (loadedToken.getRedemptionHistoryEntry().isEmpty()) {
+        if (!loadedToken.getRedemptionHistoryEntry().isPresent()) {
           System.out.printf("Token %s was not redeemed.\n", token);
         } else {
           Key<DomainBase> domainOfyKey =


### PR DESCRIPTION
isEmpty() is not available in the version of Java GAE uses and is throwing
runtime errors (!!). I think these got into our codebases because people don't
have the language version set correctly in IntelliJ; they show as outright
errors for me (I'm on language level 8).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/934)
<!-- Reviewable:end -->
