### PR TITLE
Fix another "extra parens" warning

### DIFF
--- a/core/src/test/java/google/registry/model/contact/ContactCommandTest.java
+++ b/core/src/test/java/google/registry/model/contact/ContactCommandTest.java
@@ -71,7 +71,7 @@ public class ContactCommandTest {
     EppLoader eppLoader = new EppLoader(this, "contact_update.xml");
     Update command =
         (Update)
-            ((ResourceCommandWrapper) (eppLoader.getEpp().getCommandWrapper().getCommand()))
+            ((ResourceCommandWrapper) eppLoader.getEpp().getCommandWrapper().getCommand())
                 .getResourceCommand();
     Change change = command.getInnerChange();
     assertThat(change.getInternationalizedPostalInfo().getAddress())


### PR DESCRIPTION
Same place as the last one, but I missed it :-(

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/938)
<!-- Reviewable:end -->
