### PR TITLE
Make cross database comparison recursive

### DIFF
--- a/core/src/test/java/google/registry/model/ImmutableObjectSubject.java
+++ b/core/src/test/java/google/registry/model/ImmutableObjectSubject.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertAbout;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.testing.truth.TruthUtils.assertNullnessParity;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.truth.Correspondence;
 import com.google.common.truth.Correspondence.BinaryPredicate;
@@ -26,6 +27,10 @@ import com.google.common.truth.SimpleSubjectBuilder;
 import com.google.common.truth.Subject;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -56,6 +61,24 @@ public final class ImmutableObjectSubject extends Subject {
     }
   }
 
+  private static String formatItems(String prefix, Iterator<?> iter) {
+    StringBuilder message = new StringBuilder(prefix);
+    boolean first = true;
+    while (iter.hasNext()) {
+      if (!first) {
+        message.append(", ");
+      }
+      message.append(iter.next());
+      first = false;
+    }
+    return message.toString();
+  }
+
+  /** Null-safe function to get the class name. */
+  private static String getClassName(Object object) {
+    return object != null ? object.getClass().getName() : "null";
+  }
+
   /**
    * Checks that {@code expected} has the same contents as {@code actual} except for fields that are
    * marked with {@link ImmutableObject.DoNotCompare}.
@@ -63,13 +86,276 @@ public final class ImmutableObjectSubject extends Subject {
    * <p>This is used to verify that entities stored in both cloud SQL and Datastore are identical.
    */
   public void isEqualAcrossDatabases(@Nullable ImmutableObject expected) {
-    assertNullnessParity(actual, expected);
-    if (actual != null) {
-      Map<Field, Object> actualFields = filterFields(actual, ImmutableObject.DoNotCompare.class);
-      Map<Field, Object> expectedFields =
-          filterFields(expected, ImmutableObject.DoNotCompare.class);
-      assertThat(actualFields).containsExactlyEntriesIn(expectedFields);
+    checkObjectAcrossDatabases(actual, expected, getClassName(actual));
+  }
+
+  // The following "check" methods implement a recursive check of immutable object equality across
+  // databases.  All of them function in both assertive and predicate modes: if "{@code path}" is
+  // provided (not null) then they throw {@link AssertionError}'s with detailed error messages.  If
+  // it is null, they return true for equal objects and false for inequal ones.
+
+  @VisibleForTesting
+  static boolean checkObjectAcrossDatabases(
+      @Nullable Object actual, @Nullable Object expected, @Nullable String path) {
+    if (actual != expected && (actual == null || !actual.equals(expected))) {
+      // They're different, do a more detailed comparison.
+
+      // Check for null first
+      if (actual == null && expected != null) {
+        if (path != null) {
+          throw new AssertionError("At " + path + ": expected " + expected + "got null.");
+        } else {
+          return false;
+        }
+      } else if (actual != null && expected == null) {
+        if (path != null) {
+          throw new AssertionError("At " + path + ": expected null, got " + actual);
+        } else {
+          return false;
+        }
+
+        // For immutable objects, we have to recurse since the contained
+        // object could have DoNotCompare fields, too.
+      } else if (expected instanceof ImmutableObject) {
+        // We only verify that actual is an ImmutableObject so we get a good error message instead
+        // of a context-less ClassCastException.
+        if (!(actual instanceof ImmutableObject)) {
+          if (path != null) {
+            throw new AssertionError("At " + path + ": " + actual + " is not an immutable object.");
+          } else {
+            return false;
+          }
+        }
+
+        if (!checkImmutableAcrossDatabases(
+            (ImmutableObject) actual, (ImmutableObject) expected, path)) {
+          return false;
+        }
+      } else if (expected instanceof Map) {
+        if (!(actual instanceof Map)) {
+          if (path != null) {
+            throw new AssertionError("At " + path + ": " + actual + " is not a Map.");
+          } else {
+            return false;
+          }
+        }
+
+        // We could do better performance-wise by assuming that keys can be compared across
+        // databases using .equals() -- then we could just iterate over the entries and verify that
+        // the key has the same value in the other set.  However, there is currently no way for us
+        // to guard against the invalidation of this assumption, and it's less code to simply reuse
+        // the set comparison.  As long as the performance is adequate in the context of a test, it
+        // doesn't seem like a good idea to try to optimize this.
+        if (!checkSetAcrossDatabases(
+            ((Map<?, ?>) actual).entrySet(), ((Map<?, ?>) expected).entrySet(), path, "Map")) {
+          return false;
+        }
+      } else if (expected instanceof Set) {
+        if (!(actual instanceof Set)) {
+          if (path != null) {
+            throw new AssertionError("At " + path + ": " + actual + " is not a Set.");
+          } else {
+            return false;
+          }
+        }
+
+        if (!checkSetAcrossDatabases((Set<?>) actual, (Set<?>) expected, path, "Set")) {
+          return false;
+        }
+      } else if (expected instanceof Collection) {
+        if (!(actual instanceof Collection)) {
+          if (path != null) {
+            throw new AssertionError("At " + path + ": " + actual + " is not a Collection.");
+          } else {
+            return false;
+          }
+        }
+
+        if (!checkListAcrossDatabases((Collection<?>) actual, (Collection<?>) expected, path)) {
+          return false;
+        }
+
+        // Give Map.Entry special treatment to facilitate the use of Set comparison for verification
+        // of Map.
+      } else if (expected instanceof Map.Entry) {
+        if (!(actual instanceof Map.Entry)) {
+          if (path != null) {
+            throw new AssertionError("At " + path + ": " + actual + " is not a Map.Entry.");
+          } else {
+            return false;
+          }
+        }
+
+        if (!checkObjectAcrossDatabases(
+                ((Map.Entry<?, ?>) actual).getKey(), ((Map.Entry<?, ?>) expected).getKey(), path)
+            || !checkObjectAcrossDatabases(
+                ((Map.Entry<?, ?>) actual).getValue(),
+                ((Map.Entry<?, ?>) expected).getValue(),
+                path)) {
+          return false;
+        }
+      } else {
+        if (!actual.equals(expected)) {
+          if (path != null) {
+            throw new AssertionError("At " + path + ": " + actual + " is not equal to " + expected);
+          } else {
+            return false;
+          }
+        }
+      }
     }
+
+    return true;
+  }
+
+  private static boolean checkSetAcrossDatabases(
+      Set<?> actual, Set<?> expected, String path, String type) {
+    // Unfortunately, we can't just check to see whether one set "contains" all of the elements of
+    // the other, as the cross database checks don't require strict equality.  Instead we have to do
+    // an N^2 comparison to search for an equivalent element.
+
+    // Objects in expected that aren't in actual.
+    Set<Object> missing = new HashSet<>();
+
+    // Objects from actual that have matching elements in equal.
+    Set<Object> found = new HashSet<>();
+
+    // Build missing and found.
+    for (Object expectedElem : expected) {
+      boolean gotMatch = false;
+      for (Object actualElem : actual) {
+        if (checkObjectAcrossDatabases(actualElem, expectedElem, null)) {
+          gotMatch = true;
+          found.add(actualElem);
+          break;
+        }
+      }
+
+      if (!gotMatch) {
+        if (path == null) {
+          return false;
+        }
+        missing.add(expectedElem);
+      }
+    }
+
+    // Build a set of all objects in actual that don't have counterparts in expected.
+    Set<Object> unexpected = path != null ? new HashSet<>() : null;
+    for (Object actualElem : actual) {
+      if (!found.contains(actualElem)) {
+        if (path != null) {
+          unexpected.add(actualElem);
+        } else {
+          return false;
+        }
+      }
+    }
+
+    if (!missing.isEmpty() || (unexpected != null && !unexpected.isEmpty())) {
+      if (path != null) {
+        String message = "At " + path + ": " + type + " does not contain the expected contents.";
+        if (!missing.isEmpty()) {
+          message += formatItems("  It is missing: ", missing.iterator());
+        }
+
+        if (!unexpected.isEmpty()) {
+          message += formatItems("  It contains additional elements: ", unexpected.iterator());
+        }
+
+        throw new AssertionError(message);
+      } else {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private static boolean checkListAcrossDatabases(
+      Collection<?> actual, Collection<?> expected, @Nullable String path) {
+    Iterator<?> actualIter = actual.iterator();
+    Iterator<?> expectedIter = expected.iterator();
+    int index = 0;
+    while (actualIter.hasNext() && expectedIter.hasNext()) {
+      Object actualItem = actualIter.next();
+      Object expectedItem = expectedIter.next();
+      if (!checkObjectAcrossDatabases(
+          actualItem, expectedItem, path != null ? path + "[" + index + "]" : null)) {
+        return false;
+      }
+      ++index;
+    }
+
+    if (actualIter.hasNext()) {
+      if (path != null) {
+        throw new AssertionError(
+            formatItems("At " + path + ": has additional items: ", actualIter));
+      } else {
+        return false;
+      }
+    }
+
+    if (expectedIter.hasNext()) {
+      if (path != null) {
+        throw new AssertionError(formatItems("At " + path + ": missing items: ", expectedIter));
+      } else {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /** Recursive helper for isEqualAcrossDatabases. */
+  private static boolean checkImmutableAcrossDatabases(
+      ImmutableObject actual, ImmutableObject expected, String path) {
+    Map<Field, Object> actualFields = filterFields(actual, ImmutableObject.DoNotCompare.class);
+    Map<Field, Object> expectedFields = filterFields(expected, ImmutableObject.DoNotCompare.class);
+
+    for (Map.Entry<Field, Object> entry : expectedFields.entrySet()) {
+      if (!actualFields.containsKey(entry.getKey())) {
+        if (path != null) {
+          throw new AssertionError("At " + path + ": is missing field " + entry.getKey().getName());
+        } else {
+          return false;
+        }
+      }
+
+      // Verify that the field values are the same.  We can use "equals()" as a quick check.
+      Object expectedFieldValue = entry.getValue();
+      Object actualFieldValue = actualFields.get(entry.getKey());
+      if (!checkObjectAcrossDatabases(
+          actualFieldValue,
+          expectedFieldValue,
+          path != null ? path + "." + entry.getKey().getName() : null)) {
+        return false;
+      }
+    }
+
+    // Check for fields in actual that are not in expected.
+    for (Map.Entry<Field, Object> entry : actualFields.entrySet()) {
+      if (!expectedFields.containsKey(entry.getKey())) {
+        if (path != null) {
+          throw new AssertionError(
+              "At " + path + ": has additional field " + entry.getKey().getName());
+        } else {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Checks that the hash value reported by {@code actual} is correct.
+   *
+   * <p>This is used in the replay tests to ensure that hibernate hasn't modified any fields that
+   * are not marked as @Insignificant while loading.
+   */
+  public void hasCorrectHashValue() {
+    assertThat(Arrays.hashCode(actual.getSignificantFields().values().toArray()))
+        .isEqualTo(actual.hashCode());
   }
 
   public static Correspondence<ImmutableObject, ImmutableObject> immutableObjectCorrespondence(

--- a/core/src/test/java/google/registry/model/ImmutableObjectSubject.java
+++ b/core/src/test/java/google/registry/model/ImmutableObjectSubject.java
@@ -17,7 +17,6 @@ package google.registry.model;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.testing.truth.TruthUtils.assertNullnessParity;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;

--- a/core/src/test/java/google/registry/model/ImmutableObjectSubject.java
+++ b/core/src/test/java/google/registry/model/ImmutableObjectSubject.java
@@ -230,7 +230,7 @@ public final class ImmutableObjectSubject extends Subject {
                         return result;
                       }));
 
-      if (!missing.isEmpty() || (unexpected != null && !unexpected.isEmpty())) {
+      if (!missing.isEmpty() || !unexpected.isEmpty()) {
         String message = type + " does not contain the expected contents.";
         if (!missing.isEmpty()) {
           message += "  It is missing: " + formatItems(missing.iterator());

--- a/core/src/test/java/google/registry/model/ImmutableObjectSubjectTest.java
+++ b/core/src/test/java/google/registry/model/ImmutableObjectSubjectTest.java
@@ -1,0 +1,423 @@
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.model;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
+import static google.registry.model.ImmutableObjectSubject.checkObjectAcrossDatabases;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+import org.junit.jupiter.api.Test;
+
+public class ImmutableObjectSubjectTest {
+
+  // Unique id to assign to the "ignored" field so that it always gets a unique value.
+  private static int uniqueId = 0;
+
+  @Test
+  void testCrossDatabase_nulls() {
+    assertAboutImmutableObjects().that(null).isEqualAcrossDatabases(null);
+    assertAboutImmutableObjects()
+        .that(makeTestAtom(null))
+        .isEqualAcrossDatabases(makeTestAtom(null));
+
+    assertThat(checkObjectAcrossDatabases(null, makeTestAtom("foo"), null)).isFalse();
+    assertThat(checkObjectAcrossDatabases(null, makeTestAtom("foo"), null)).isFalse();
+  }
+
+  @Test
+  void testCrossDatabase_equalObjects() {
+    TestImmutableObject actual = makeTestObj();
+    assertAboutImmutableObjects().that(actual).isEqualAcrossDatabases(actual);
+    assertAboutImmutableObjects().that(actual).isEqualAcrossDatabases(makeTestObj());
+    assertThat(checkObjectAcrossDatabases(makeTestObj(), makeTestObj(), null)).isTrue();
+  }
+
+  @Test
+  void testCrossDatabase_simpleFieldFailure() {
+    AssertionError e =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                assertAboutImmutableObjects()
+                    .that(makeTestObj())
+                    .isEqualAcrossDatabases(makeTestObj().withStringField("bar")));
+    assertThat(e)
+        .hasMessageThat()
+        .contains(
+            "At google.registry.model.ImmutableObjectSubjectTest$TestImmutableObject.stringField:");
+    assertThat(checkObjectAcrossDatabases(makeTestObj(), makeTestObj().withStringField(null), null))
+        .isFalse();
+  }
+
+  @Test
+  void testCrossDatabase_nestedImmutableFailure() {
+    // Repeat the null checks to verify that the attribute path is preserved.
+    AssertionError e =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                assertAboutImmutableObjects()
+                    .that(makeTestObj())
+                    .isEqualAcrossDatabases(makeTestObj().withNested(null)));
+    assertThat(e)
+        .hasMessageThat()
+        .contains(
+            "At google.registry.model.ImmutableObjectSubjectTest$TestImmutableObject.nested:"
+                + " expected null, got TestImmutableObject");
+    e =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                assertAboutImmutableObjects()
+                    .that(makeTestObj().withNested(null))
+                    .isEqualAcrossDatabases(makeTestObj()));
+    assertThat(e)
+        .hasMessageThat()
+        .contains(
+            "At google.registry.model.ImmutableObjectSubjectTest$TestImmutableObject.nested:"
+                + " expected TestImmutableObject");
+    assertThat(e).hasMessageThat().contains("got null.");
+
+    // Test with a field difference.
+    e =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                assertAboutImmutableObjects()
+                    .that(makeTestObj())
+                    .isEqualAcrossDatabases(
+                        makeTestObj().withNested(makeTestObj().withNested(null))));
+    assertThat(e)
+        .hasMessageThat()
+        .contains(
+            "At google.registry.model.ImmutableObjectSubjectTest$"
+                + "TestImmutableObject.nested.stringField:");
+    assertThat(checkObjectAcrossDatabases(makeTestObj(), makeTestObj().withNested(null), null))
+        .isFalse();
+  }
+
+  @Test
+  void testCrossDatabase_listFailure() {
+    AssertionError e =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                assertAboutImmutableObjects()
+                    .that(makeTestObj())
+                    .isEqualAcrossDatabases(makeTestObj().withList(null)));
+    assertThat(e)
+        .hasMessageThat()
+        .contains(
+            "At google.registry.model.ImmutableObjectSubjectTest$" + "TestImmutableObject.list:");
+    e =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                assertAboutImmutableObjects()
+                    .that(makeTestObj())
+                    .isEqualAcrossDatabases(
+                        makeTestObj().withList(ImmutableList.of(makeTestAtom("wack")))));
+    assertThat(e)
+        .hasMessageThat()
+        .contains(
+            "At google.registry.model.ImmutableObjectSubjectTest$"
+                + "TestImmutableObject.list[0].stringField:");
+    e =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                assertAboutImmutableObjects()
+                    .that(makeTestObj())
+                    .isEqualAcrossDatabases(
+                        makeTestObj()
+                            .withList(
+                                ImmutableList.of(
+                                    makeTestAtom("baz"),
+                                    makeTestAtom("bot"),
+                                    makeTestAtom("boq")))));
+    assertThat(e)
+        .hasMessageThat()
+        .contains(
+            "At google.registry.model.ImmutableObjectSubjectTest$"
+                + "TestImmutableObject.list: missing items");
+    // Make sure multiple additional items get formatted nicely.
+    assertThat(e).hasMessageThat().contains("}, TestImmutableObject");
+    e =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                assertAboutImmutableObjects()
+                    .that(makeTestObj())
+                    .isEqualAcrossDatabases(makeTestObj().withList(ImmutableList.of())));
+    assertThat(e)
+        .hasMessageThat()
+        .contains(
+            "At google.registry.model.ImmutableObjectSubjectTest$"
+                + "TestImmutableObject.list: has additional items");
+    assertThat(
+            checkObjectAcrossDatabases(
+                makeTestObj(),
+                makeTestObj()
+                    .withList(ImmutableList.of(makeTestAtom("baz"), makeTestAtom("gauze"))),
+                null))
+        .isFalse();
+    assertThat(
+            checkObjectAcrossDatabases(
+                makeTestObj(), makeTestObj().withList(ImmutableList.of()), null))
+        .isFalse();
+    assertThat(
+            checkObjectAcrossDatabases(
+                makeTestObj(),
+                makeTestObj().withList(ImmutableList.of(makeTestAtom("gauze"))),
+                null))
+        .isFalse();
+  }
+
+  @Test
+  void testCrossDatabase_setFailure() {
+    AssertionError e =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                assertAboutImmutableObjects()
+                    .that(makeTestObj())
+                    .isEqualAcrossDatabases(makeTestObj().withSet(null)));
+    assertThat(e)
+        .hasMessageThat()
+        .contains(
+            "At google.registry.model.ImmutableObjectSubjectTest$"
+                + "TestImmutableObject.set: expected null, got ");
+
+    e =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                assertAboutImmutableObjects()
+                    .that(makeTestObj())
+                    .isEqualAcrossDatabases(
+                        makeTestObj().withSet(ImmutableSet.of(makeTestAtom("jim")))));
+    assertThat(e)
+        .hasMessageThat()
+        .containsMatch(
+            Pattern.compile(
+                "Set does not contain the expected contents.  "
+                    + "It is missing: .*jim.*  It contains additional elements: .*bob",
+                Pattern.DOTALL));
+    assertThat(
+            checkObjectAcrossDatabases(
+                makeTestObj(),
+                makeTestObj().withSet(ImmutableSet.of(makeTestAtom("bob"), makeTestAtom("robert"))),
+                null))
+        .isFalse();
+    assertThat(
+            checkObjectAcrossDatabases(
+                makeTestObj(), makeTestObj().withSet(ImmutableSet.of()), null))
+        .isFalse();
+  }
+
+  @Test
+  void testCrossDatabase_mapFailure() {
+    AssertionError e =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                assertAboutImmutableObjects()
+                    .that(makeTestObj())
+                    .isEqualAcrossDatabases(makeTestObj().withMap(null)));
+    assertThat(e)
+        .hasMessageThat()
+        .contains(
+            "At google.registry.model.ImmutableObjectSubjectTest$"
+                + "TestImmutableObject.map: expected null, got ");
+
+    e =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                assertAboutImmutableObjects()
+                    .that(makeTestObj())
+                    .isEqualAcrossDatabases(
+                        makeTestObj()
+                            .withMap(ImmutableMap.of(makeTestAtom("difk"), makeTestAtom("difv")))));
+    assertThat(e)
+        .hasMessageThat()
+        .containsMatch(
+            Pattern.compile(
+                "Map does not contain the expected contents.  "
+                    + "It is missing: .*difk.*difv.*  It contains additional elements: .*key.*val",
+                Pattern.DOTALL));
+    assertThat(
+            checkObjectAcrossDatabases(
+                makeTestObj(),
+                makeTestObj()
+                    .withMap(
+                        ImmutableMap.of(
+                            makeTestAtom("key"), makeTestAtom("val"),
+                            makeTestAtom("otherk"), makeTestAtom("otherv"))),
+                null))
+        .isFalse();
+    assertThat(
+            checkObjectAcrossDatabases(
+                makeTestObj(), makeTestObj().withMap(ImmutableMap.of()), null))
+        .isFalse();
+  }
+
+  @Test
+  void testCrossDatabase_typeChecks() {
+    AssertionError e =
+        assertThrows(
+            AssertionError.class, () -> checkObjectAcrossDatabases("blech", makeTestObj(), "xxx"));
+    assertThat(e).hasMessageThat().contains("At xxx: blech is not an immutable object.");
+    assertThat(checkObjectAcrossDatabases("blech", makeTestObj(), null)).isFalse();
+
+    e =
+        assertThrows(
+            AssertionError.class,
+            () -> checkObjectAcrossDatabases("blech", ImmutableMap.of(), "xxx"));
+    assertThat(e).hasMessageThat().contains("At xxx: blech is not a Map.");
+    assertThat(checkObjectAcrossDatabases("blech", ImmutableMap.of(), null)).isFalse();
+
+    e =
+        assertThrows(
+            AssertionError.class,
+            () -> checkObjectAcrossDatabases("blech", ImmutableList.of(), "xxx"));
+    assertThat(e).hasMessageThat().contains("At xxx: blech is not a Collection.");
+    assertThat(checkObjectAcrossDatabases("blech", ImmutableList.of(), null)).isFalse();
+
+    for (ImmutableMap.Entry<String, String> entry : ImmutableMap.of("foo", "bar").entrySet()) {
+      e =
+          assertThrows(
+              AssertionError.class, () -> checkObjectAcrossDatabases("blech", entry, "xxx"));
+      assertThat(e).hasMessageThat().contains("At xxx: blech is not a Map.Entry.");
+      assertThat(checkObjectAcrossDatabases("blech", entry, null)).isFalse();
+    }
+  }
+
+  @Test
+  void testCrossDatabase_checkAdditionalFields() {
+    AssertionError e =
+        assertThrows(
+            AssertionError.class,
+            () ->
+                assertAboutImmutableObjects()
+                    .that(DerivedImmutableObject.create())
+                    .isEqualAcrossDatabases(makeTestAtom(null)));
+    assertThat(e)
+        .hasMessageThat()
+        .contains(
+            "At google.registry.model.ImmutableObjectSubjectTest$DerivedImmutableObject: "
+                + "has additional field extraField");
+    assertThat(
+            checkObjectAcrossDatabases(DerivedImmutableObject.create(), makeTestAtom(null), null))
+        .isFalse();
+  }
+
+  @Test
+  void testHasCorrectHashValue() {
+    TestImmutableObject object = makeTestObj();
+    assertAboutImmutableObjects().that(object).hasCorrectHashValue();
+
+    object.stringField = "changed value!";
+    assertThrows(
+        AssertionError.class,
+        () -> assertAboutImmutableObjects().that(object).hasCorrectHashValue());
+  }
+
+  /** Make a test object with all fields set up. */
+  TestImmutableObject makeTestObj() {
+    return TestImmutableObject.create(
+        "foo",
+        makeTestAtom("bar"),
+        ImmutableList.of(makeTestAtom("baz")),
+        ImmutableSet.of(makeTestAtom("bob")),
+        ImmutableMap.of(makeTestAtom("key"), makeTestAtom("val")));
+  }
+
+  /** Make a test object without the collection fields. */
+  TestImmutableObject makeTestAtom(String stringField) {
+    return TestImmutableObject.create(stringField, null, null, null, null);
+  }
+
+  static class TestImmutableObject extends ImmutableObject {
+    String stringField;
+    TestImmutableObject nested;
+    ImmutableList<TestImmutableObject> list;
+    ImmutableSet<TestImmutableObject> set;
+    ImmutableMap<TestImmutableObject, TestImmutableObject> map;
+
+    @ImmutableObject.DoNotCompare int ignored;
+
+    static TestImmutableObject create(
+        String stringField,
+        TestImmutableObject nested,
+        ImmutableList<TestImmutableObject> list,
+        ImmutableSet<TestImmutableObject> set,
+        ImmutableMap<TestImmutableObject, TestImmutableObject> map) {
+      TestImmutableObject instance = new TestImmutableObject();
+      instance.stringField = stringField;
+      instance.nested = nested;
+      instance.list = list;
+      instance.set = set;
+      instance.map = map;
+      instance.ignored = ++uniqueId;
+      return instance;
+    }
+
+    TestImmutableObject withStringField(@Nullable String stringField) {
+      TestImmutableObject result = ImmutableObject.clone(this);
+      result.stringField = stringField;
+      return result;
+    }
+
+    TestImmutableObject withNested(@Nullable TestImmutableObject nested) {
+      TestImmutableObject result = ImmutableObject.clone(this);
+      result.nested = nested;
+      return result;
+    }
+
+    TestImmutableObject withList(@Nullable ImmutableList<TestImmutableObject> list) {
+      TestImmutableObject result = ImmutableObject.clone(this);
+      result.list = list;
+      return result;
+    }
+
+    TestImmutableObject withSet(@Nullable ImmutableSet<TestImmutableObject> set) {
+      TestImmutableObject result = ImmutableObject.clone(this);
+      result.set = set;
+      return result;
+    }
+
+    TestImmutableObject withMap(
+        @Nullable ImmutableMap<TestImmutableObject, TestImmutableObject> map) {
+      TestImmutableObject result = ImmutableObject.clone(this);
+      result.map = map;
+      return result;
+    }
+  }
+
+  static class DerivedImmutableObject extends TestImmutableObject {
+    String extraField;
+
+    static DerivedImmutableObject create() {
+      return new DerivedImmutableObject();
+    }
+  }
+}


### PR DESCRIPTION
Cross-database comparison was previously just a shallow check: fields marked
with DoNotCompare on nested objects were still compared.  This causes problems
in some cases where there are nested immutable objects.

This change introduces recursive comparison.  It also provides a
hasCorrectHashCode() method that verifies that an object has not been mutated
since the hash code was calculated, which has been a problem in certain cases.

Finally, this also fixes the problem of objects that are mutated in multiple
transactions: we were previously comparing against the value in datastore, but
this doesn't work in these cases because the object in datastore may have
changed since the transaction that we are verifying.  Instead, check against
the value that we would have persisted in the original transaction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/942)
<!-- Reviewable:end -->
