### PR TITLE
Add clientCertificate to TlsCredentials.toString()

### DIFF
--- a/core/src/main/java/google/registry/flows/TlsCredentials.java
+++ b/core/src/main/java/google/registry/flows/TlsCredentials.java
@@ -223,6 +223,7 @@ public class TlsCredentials implements TransportCredentials {
   @Override
   public String toString() {
     return toStringHelper(getClass())
+        .add("clientCertificate", clientCertificate.orElse(null))
         .add("clientCertificateHash", clientCertificateHash.orElse(null))
         .add("clientAddress", clientInetAddr.orElse(null))
         .toString();

--- a/core/src/test/java/google/registry/flows/FlowRunnerTest.java
+++ b/core/src/test/java/google/registry/flows/FlowRunnerTest.java
@@ -155,12 +155,14 @@ class FlowRunnerTest {
         new TlsCredentials(
             true,
             Optional.of("abc123def"),
-            Optional.of("cert"),
+            Optional.of("cert046F5A3"),
             Optional.of("127.0.0.1"),
             certificateChecker);
     flowRunner.run(eppMetricBuilder);
     assertThat(Splitter.on("\n\t").split(findFirstLogMessageByPrefix(handler, "EPP Command\n\t")))
-        .contains("TlsCredentials{clientCertificateHash=abc123def, clientAddress=/127.0.0.1}");
+        .contains(
+            "TlsCredentials{clientCertificate=cert046F5A3, clientCertificateHash=abc123def,"
+                + " clientAddress=/127.0.0.1}");
   }
 
   @Test


### PR DESCRIPTION
FlowRunner.run() logs these credentials to the GAE logs by implicitly using the
toString() method, so we need to add it if we want it to appear in the logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/945)
<!-- Reviewable:end -->
