### PR TITLE
Fix typo in header name in Client Certificate Provider

### DIFF
--- a/core/src/main/java/google/registry/flows/TlsCredentials.java
+++ b/core/src/main/java/google/registry/flows/TlsCredentials.java
@@ -288,7 +288,7 @@ public class TlsCredentials implements TransportCredentials {
     static Optional<String> provideClientCertificate(HttpServletRequest req) {
       // Note: This header is actually required, we just want to handle its absence explicitly
       // by throwing an EPP exception rather than a generic Bad Request exception.
-      return extractOptionalHeader(req, "X-SSL-Full_Certificate");
+      return extractOptionalHeader(req, "X-SSL-Full-Certificate");
     }
 
     @Provides

--- a/core/src/test/java/google/registry/flows/TlsCredentialsTest.java
+++ b/core/src/test/java/google/registry/flows/TlsCredentialsTest.java
@@ -118,10 +118,11 @@ final class TlsCredentialsTest {
     tls.validateCertificate(Registrar.loadByClientId("TheRegistrar").get());
   }
 
+  @Test
   void testProvideClientCertificate() {
     HttpServletRequest req = mock(HttpServletRequest.class);
     when(req.getHeader("X-SSL-Full-Certificate")).thenReturn("data");
-    assertThat(TlsCredentials.EppTlsModule.provideClientCertificate(req)).isEqualTo("data");
+    assertThat(TlsCredentials.EppTlsModule.provideClientCertificate(req)).hasValue("data");
   }
 
   @Test


### PR DESCRIPTION
Hopefully this will fix the issue with the cert requirements rollout to sandbox. This header is a magic string and should be specified in only one place to prevent future issues like this. I will fix this in a follow up PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/946)
<!-- Reviewable:end -->
