### PR TITLE
Convert Strings to X509 Certificates before validating

### DIFF
--- a/core/src/main/java/google/registry/flows/TlsCredentials.java
+++ b/core/src/main/java/google/registry/flows/TlsCredentials.java
@@ -16,6 +16,7 @@ package google.registry.flows;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static google.registry.request.RequestParameters.extractOptionalHeader;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -32,7 +33,12 @@ import google.registry.flows.certs.CertificateChecker.InsecureCertificateExcepti
 import google.registry.model.registrar.Registrar;
 import google.registry.request.Header;
 import google.registry.util.CidrAddressBlock;
+import java.io.ByteArrayInputStream;
 import java.net.InetAddress;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
@@ -149,14 +155,30 @@ public class TlsCredentials implements TransportCredentials {
           "Request from registrar %s did not include X-SSL-Full-Certificate.",
           registrar.getClientId());
     } else {
+      X509Certificate passedCert;
+      X509Certificate storedCert;
+      X509Certificate storedFailoverCert;
+
+      try {
+        storedCert = stringToCert(registrar.getClientCertificate());
+        storedFailoverCert = stringToCert(registrar.getFailoverClientCertificate());
+        passedCert = encodedCertStringToCert(clientCertificate.get());
+      } catch (Exception e) {
+        //TODO(Sarahbot@): remove this catch once we know it's working
+        logger.atWarning().log(
+            "Error converting certificate string to certificate for %s: %s",
+            registrar.getClientId(), e);
+        validateCertificateHash(registrar);
+        return;
+      }
+
       // Check if the certificate is equal to the one on file for the registrar.
-      if (clientCertificate.equals(registrar.getClientCertificate())
-          || clientCertificate.equals(registrar.getFailoverClientCertificate())) {
+      if (passedCert.equals(storedCert) || passedCert.equals(storedFailoverCert)) {
         // Check certificate for any requirement violations
         // TODO(Sarahbot@): Throw exceptions instead of just logging once requirement enforcement
         // begins
         try {
-          certificateChecker.validateCertificate(clientCertificate.get());
+          certificateChecker.validateCertificate(passedCert);
         } catch (InsecureCertificateException e) {
           // throw exception in unit tests and Sandbox
           if (RegistryEnvironment.get().equals(RegistryEnvironment.UNITTEST)
@@ -176,7 +198,8 @@ public class TlsCredentials implements TransportCredentials {
       // Log an error and validate using certificate hash instead
       // TODO(sarahbot): throw a BadRegistrarCertificateException once hash is no longer used as
       // failover
-      logger.atWarning().log("Non-matching certificate for registrar %s.", registrar.getClientId());
+      logger.atWarning().log(
+          "Non-matching certificate for registrar %s.", registrar.getClientId());
     }
     validateCertificateHash(registrar);
   }
@@ -218,6 +241,25 @@ public class TlsCredentials implements TransportCredentials {
     if (!registrar.verifyPassword(password)) {
       throw new BadRegistrarPasswordException();
     }
+  }
+
+  private X509Certificate stringToCert(Optional<String> certificateString)
+      throws CertificateException {
+    if (certificateString.isPresent()) {
+      ByteArrayInputStream inputStream =
+          new ByteArrayInputStream(certificateString.get().getBytes(UTF_8));
+      CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+      return (X509Certificate) certificateFactory.generateCertificate(inputStream);
+    }
+    return null;
+  }
+
+  private X509Certificate encodedCertStringToCert(String encodedCertString)
+      throws CertificateException {
+    byte decodedCert[] = Base64.getDecoder().decode(encodedCertString);
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(decodedCert);
+    CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+    return (X509Certificate) certificateFactory.generateCertificate(inputStream);
   }
 
   @Override

--- a/core/src/main/java/google/registry/flows/TlsCredentials.java
+++ b/core/src/main/java/google/registry/flows/TlsCredentials.java
@@ -16,6 +16,7 @@ package google.registry.flows;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static google.registry.request.RequestParameters.extractOptionalHeader;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -32,7 +33,12 @@ import google.registry.flows.certs.CertificateChecker.InsecureCertificateExcepti
 import google.registry.model.registrar.Registrar;
 import google.registry.request.Header;
 import google.registry.util.CidrAddressBlock;
+import java.io.ByteArrayInputStream;
 import java.net.InetAddress;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
@@ -149,14 +155,30 @@ public class TlsCredentials implements TransportCredentials {
           "Request from registrar %s did not include X-SSL-Full-Certificate.",
           registrar.getClientId());
     } else {
+      X509Certificate passedCert;
+      X509Certificate storedCert;
+      X509Certificate storedFailoverCert;
+
+      try {
+        storedCert = stringToCert(registrar.getClientCertificate());
+        storedFailoverCert = stringToCert(registrar.getFailoverClientCertificate());
+        passedCert = encodedCertStringToCert(clientCertificate.get());
+      } catch (Exception e) {
+        // TODO(Sarahbot@): remove this catch once we know it's working
+        logger.atWarning().log(
+            "Error converting certificate string to certificate for %s: %s",
+            registrar.getClientId(), e);
+        validateCertificateHash(registrar);
+        return;
+      }
+
       // Check if the certificate is equal to the one on file for the registrar.
-      if (clientCertificate.equals(registrar.getClientCertificate())
-          || clientCertificate.equals(registrar.getFailoverClientCertificate())) {
+      if (passedCert.equals(storedCert) || passedCert.equals(storedFailoverCert)) {
         // Check certificate for any requirement violations
         // TODO(Sarahbot@): Throw exceptions instead of just logging once requirement enforcement
         // begins
         try {
-          certificateChecker.validateCertificate(clientCertificate.get());
+          certificateChecker.validateCertificate(passedCert);
         } catch (InsecureCertificateException e) {
           // throw exception in unit tests and Sandbox
           if (RegistryEnvironment.get().equals(RegistryEnvironment.UNITTEST)
@@ -218,6 +240,25 @@ public class TlsCredentials implements TransportCredentials {
     if (!registrar.verifyPassword(password)) {
       throw new BadRegistrarPasswordException();
     }
+  }
+
+  private X509Certificate stringToCert(Optional<String> certificateString)
+      throws CertificateException {
+    if (certificateString.isPresent()) {
+      ByteArrayInputStream inputStream =
+          new ByteArrayInputStream(certificateString.get().getBytes(UTF_8));
+      CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+      return (X509Certificate) certificateFactory.generateCertificate(inputStream);
+    }
+    return null;
+  }
+
+  private X509Certificate encodedCertStringToCert(String encodedCertString)
+      throws CertificateException {
+    byte decodedCert[] = Base64.getDecoder().decode(encodedCertString);
+    ByteArrayInputStream inputStream = new ByteArrayInputStream(decodedCert);
+    CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+    return (X509Certificate) certificateFactory.generateCertificate(inputStream);
   }
 
   @Override

--- a/core/src/main/java/google/registry/flows/TlsCredentials.java
+++ b/core/src/main/java/google/registry/flows/TlsCredentials.java
@@ -164,7 +164,7 @@ public class TlsCredentials implements TransportCredentials {
         storedFailoverCert = stringToCert(registrar.getFailoverClientCertificate());
         passedCert = encodedCertStringToCert(clientCertificate.get());
       } catch (Exception e) {
-        // TODO(Sarahbot@): remove this catch once we know it's working
+        //TODO(Sarahbot@): remove this catch once we know it's working
         logger.atWarning().log(
             "Error converting certificate string to certificate for %s: %s",
             registrar.getClientId(), e);
@@ -198,7 +198,8 @@ public class TlsCredentials implements TransportCredentials {
       // Log an error and validate using certificate hash instead
       // TODO(sarahbot): throw a BadRegistrarCertificateException once hash is no longer used as
       // failover
-      logger.atWarning().log("Non-matching certificate for registrar %s.", registrar.getClientId());
+      logger.atWarning().log(
+          "Non-matching certificate for registrar %s.", registrar.getClientId());
     }
     validateCertificateHash(registrar);
   }

--- a/core/src/main/java/google/registry/flows/TlsCredentials.java
+++ b/core/src/main/java/google/registry/flows/TlsCredentials.java
@@ -16,7 +16,7 @@ package google.registry.flows;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static google.registry.request.RequestParameters.extractOptionalHeader;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static google.registry.util.X509Utils.loadCertificate;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -36,7 +36,6 @@ import google.registry.util.CidrAddressBlock;
 import java.io.ByteArrayInputStream;
 import java.net.InetAddress;
 import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
 import java.util.Optional;
@@ -247,10 +246,7 @@ public class TlsCredentials implements TransportCredentials {
   private Optional<X509Certificate> deserializePemCert(Optional<String> certificateString)
       throws CertificateException {
     if (certificateString.isPresent()) {
-      ByteArrayInputStream inputStream =
-          new ByteArrayInputStream(certificateString.get().getBytes(UTF_8));
-      CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
-      return Optional.of((X509Certificate) certificateFactory.generateCertificate(inputStream));
+      return Optional.of(loadCertificate(certificateString.get()));
     }
     return Optional.empty();
   }
@@ -259,8 +255,7 @@ public class TlsCredentials implements TransportCredentials {
   private X509Certificate decodeCertString(String encodedCertString) throws CertificateException {
     byte decodedCert[] = Base64.getDecoder().decode(encodedCertString);
     ByteArrayInputStream inputStream = new ByteArrayInputStream(decodedCert);
-    CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
-    return (X509Certificate) certificateFactory.generateCertificate(inputStream);
+    return loadCertificate(inputStream);
   }
 
   @Override

--- a/core/src/main/java/google/registry/flows/TlsCredentials.java
+++ b/core/src/main/java/google/registry/flows/TlsCredentials.java
@@ -164,7 +164,7 @@ public class TlsCredentials implements TransportCredentials {
         storedFailoverCert = stringToCert(registrar.getFailoverClientCertificate());
         passedCert = encodedCertStringToCert(clientCertificate.get());
       } catch (Exception e) {
-        //TODO(Sarahbot@): remove this catch once we know it's working
+        // TODO(Sarahbot@): remove this catch once we know it's working
         logger.atWarning().log(
             "Error converting certificate string to certificate for %s: %s",
             registrar.getClientId(), e);
@@ -198,8 +198,7 @@ public class TlsCredentials implements TransportCredentials {
       // Log an error and validate using certificate hash instead
       // TODO(sarahbot): throw a BadRegistrarCertificateException once hash is no longer used as
       // failover
-      logger.atWarning().log(
-          "Non-matching certificate for registrar %s.", registrar.getClientId());
+      logger.atWarning().log("Non-matching certificate for registrar %s.", registrar.getClientId());
     }
     validateCertificateHash(registrar);
   }

--- a/core/src/main/java/google/registry/flows/certs/CertificateChecker.java
+++ b/core/src/main/java/google/registry/flows/certs/CertificateChecker.java
@@ -101,6 +101,21 @@ public class CertificateChecker {
   }
 
   /**
+   * Checks the given certificate string for violations and throws an exception if any violations
+   * exist.
+   */
+  public void validateCertificate(X509Certificate certificate) throws InsecureCertificateException {
+    ImmutableSet<CertificateViolation> violations = checkCertificate(certificate);
+    if (!violations.isEmpty()) {
+      String displayMessages =
+          violations.stream()
+              .map(violation -> getViolationDisplayMessage(violation))
+              .collect(Collectors.joining("\n"));
+      throw new InsecureCertificateException(violations, displayMessages);
+    }
+  }
+
+  /**
    * Checks a given certificate for violations and returns a list of all the violations the
    * certificate has.
    */

--- a/core/src/main/java/google/registry/flows/certs/CertificateChecker.java
+++ b/core/src/main/java/google/registry/flows/certs/CertificateChecker.java
@@ -90,8 +90,7 @@ public class CertificateChecker {
    * exist.
    */
   public void validateCertificate(String certificateString) throws InsecureCertificateException {
-    ImmutableSet<CertificateViolation> violations = checkCertificate(certificateString);
-    constructAndThrowExceptionIfNeeded(violations);
+    handleCertViolations(checkCertificate(certificateString));
   }
 
   /**
@@ -99,11 +98,10 @@ public class CertificateChecker {
    * exist.
    */
   public void validateCertificate(X509Certificate certificate) throws InsecureCertificateException {
-    ImmutableSet<CertificateViolation> violations = checkCertificate(certificate);
-    constructAndThrowExceptionIfNeeded(violations);
+    handleCertViolations(checkCertificate(certificate));
   }
 
-  private void constructAndThrowExceptionIfNeeded(ImmutableSet<CertificateViolation> violations)
+  private void handleCertViolations(ImmutableSet<CertificateViolation> violations)
       throws InsecureCertificateException {
     if (!violations.isEmpty()) {
       String displayMessages =

--- a/core/src/main/java/google/registry/flows/certs/CertificateChecker.java
+++ b/core/src/main/java/google/registry/flows/certs/CertificateChecker.java
@@ -101,21 +101,6 @@ public class CertificateChecker {
   }
 
   /**
-   * Checks the given certificate string for violations and throws an exception if any violations
-   * exist.
-   */
-  public void validateCertificate(X509Certificate certificate) throws InsecureCertificateException {
-    ImmutableSet<CertificateViolation> violations = checkCertificate(certificate);
-    if (!violations.isEmpty()) {
-      String displayMessages =
-          violations.stream()
-              .map(violation -> getViolationDisplayMessage(violation))
-              .collect(Collectors.joining("\n"));
-      throw new InsecureCertificateException(violations, displayMessages);
-    }
-  }
-
-  /**
    * Checks a given certificate for violations and returns a list of all the violations the
    * certificate has.
    */

--- a/core/src/main/java/google/registry/flows/certs/CertificateChecker.java
+++ b/core/src/main/java/google/registry/flows/certs/CertificateChecker.java
@@ -91,13 +91,7 @@ public class CertificateChecker {
    */
   public void validateCertificate(String certificateString) throws InsecureCertificateException {
     ImmutableSet<CertificateViolation> violations = checkCertificate(certificateString);
-    if (!violations.isEmpty()) {
-      String displayMessages =
-          violations.stream()
-              .map(violation -> getViolationDisplayMessage(violation))
-              .collect(Collectors.joining("\n"));
-      throw new InsecureCertificateException(violations, displayMessages);
-    }
+    constructAndThrowExceptionIfNeeded(violations);
   }
 
   /**
@@ -106,6 +100,11 @@ public class CertificateChecker {
    */
   public void validateCertificate(X509Certificate certificate) throws InsecureCertificateException {
     ImmutableSet<CertificateViolation> violations = checkCertificate(certificate);
+    constructAndThrowExceptionIfNeeded(violations);
+  }
+
+  private void constructAndThrowExceptionIfNeeded(ImmutableSet<CertificateViolation> violations)
+      throws InsecureCertificateException {
     if (!violations.isEmpty()) {
       String displayMessages =
           violations.stream()

--- a/core/src/main/java/google/registry/tools/ValidateLoginCredentialsCommand.java
+++ b/core/src/main/java/google/registry/tools/ValidateLoginCredentialsCommand.java
@@ -28,11 +28,8 @@ import google.registry.flows.TlsCredentials;
 import google.registry.flows.certs.CertificateChecker;
 import google.registry.model.registrar.Registrar;
 import google.registry.tools.params.PathParameter;
-import java.io.ByteArrayInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.cert.CertificateFactory;
-import java.util.Base64;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -82,16 +79,8 @@ final class ValidateLoginCredentialsCommand implements CommandWithRemoteApi {
         "Can't specify both --cert_hash and --cert_file");
     String clientCertificate = "";
     if (clientCertificatePath != null) {
-      byte[] certificateBytes = Files.readAllBytes(clientCertificatePath);
-      // How proxy converts to a string
-      clientCertificate =
-          Base64.getEncoder()
-              .encodeToString(
-                  CertificateFactory.getInstance("X.509")
-                      .generateCertificate(new ByteArrayInputStream(certificateBytes))
-                      .getEncoded());
-      clientCertificateHash =
-          getCertificateHash(loadCertificate(new String(certificateBytes, US_ASCII)));
+      clientCertificate = new String(Files.readAllBytes(clientCertificatePath), US_ASCII);
+      clientCertificateHash = getCertificateHash(loadCertificate(clientCertificate));
     }
     Registrar registrar =
         checkArgumentPresent(

--- a/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
+++ b/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
@@ -305,9 +305,9 @@ class EppLoginTlsTest extends EppTestCase {
             "Bag Attributes\n"
                 + "    localKeyID: 1F 1C 3A 3A 4C 03 EC C4 BC 7A C3 21 A9 F2 13 66 21 B8 7B 26 \n"
                 + "subject=/C=US/ST=New York/L=New"
-                + " York/O=Test/OU=ABC/CN=tester.com/emailAddress=test-certificate@test.com\n"
+                + " York/O=Test/OU=ABC/CN=tester.test/emailAddress=test-certificate@test.test\n"
                 + "issuer=/C=US/ST=NY/L=NYC/O=ABC/OU=TEST CA/CN=TEST"
-                + " CA/emailAddress=testing@test.com\n"
+                + " CA/emailAddress=testing@test.test\n"
                 + "%s",
             CertificateSamples.SAMPLE_CERT3);
 
@@ -329,9 +329,9 @@ class EppLoginTlsTest extends EppTestCase {
             "Bag Attributes\n"
                 + "    localKeyID: 1F 1C 3A 3A 4C 03 EC C4 BC 7A C3 21 A9 F2 13 66 21 B8 7B 26 \n"
                 + "subject=/C=US/ST=New York/L=New"
-                + " York/O=Test/OU=ABC/CN=tester.com/emailAddress=test-certificate@test.com\n"
+                + " York/O=Test/OU=ABC/CN=tester.test/emailAddress=test-certificate@test.test\n"
                 + "issuer=/C=US/ST=NY/L=NYC/O=ABC/OU=TEST CA/CN=TEST"
-                + " CA/emailAddress=testing@test.com\n"
+                + " CA/emailAddress=testing@test.test\n"
                 + "%s",
             CertificateSamples.SAMPLE_CERT);
 

--- a/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
+++ b/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
@@ -30,8 +30,12 @@ import google.registry.testing.AppEngineExtension;
 import google.registry.testing.CertificateSamples;
 import google.registry.testing.SystemPropertyExtension;
 import google.registry.util.SelfSignedCaCertificate;
+import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -43,6 +47,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.shaded.org.bouncycastle.openssl.jcajce.JcaMiscPEMGenerator;
 import org.testcontainers.shaded.org.bouncycastle.util.io.pem.PemObjectGenerator;
 import org.testcontainers.shaded.org.bouncycastle.util.io.pem.PemWriter;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /** Test logging in with TLS credentials. */
 class EppLoginTlsTest extends EppTestCase {
@@ -67,6 +72,8 @@ class EppLoginTlsTest extends EppTestCase {
       Logger.getLogger(TlsCredentials.class.getCanonicalName());
   private final TestLogHandler handler = new TestLogHandler();
 
+  private String encodedCertString;
+
   void setCredentials(String clientCertificateHash, String clientCertificate) {
     setTransportCredentials(
         new TlsCredentials(
@@ -78,7 +85,7 @@ class EppLoginTlsTest extends EppTestCase {
   }
 
   @BeforeEach
-  void beforeEach() {
+  void beforeEach() throws CertificateException {
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()
@@ -91,18 +98,26 @@ class EppLoginTlsTest extends EppTestCase {
             .setClientCertificate(CertificateSamples.SAMPLE_CERT2, DateTime.now(UTC))
             .build());
     loggerToIntercept.addHandler(handler);
+    // How proxy converts to a string
+    encodedCertString =
+        Base64.getEncoder()
+            .encodeToString(
+                CertificateFactory.getInstance("X.509")
+                        .generateCertificate(
+                            new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT3.getBytes(UTF_8)))
+                    .getEncoded());
   }
 
   @Test
   void testLoginLogout() throws Exception {
-    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, CertificateSamples.SAMPLE_CERT3);
+    setCredentials(null, encodedCertString);
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
     assertThatLogoutSucceeds();
   }
 
   @Test
   void testLogin_wrongPasswordFails() throws Exception {
-    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, CertificateSamples.SAMPLE_CERT3);
+    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, encodedCertString);
     // For TLS login, we also check the epp xml password.
     assertThatLogin("NewRegistrar", "incorrect")
         .hasResponse(
@@ -112,7 +127,7 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testMultiLogin() throws Exception {
-    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, CertificateSamples.SAMPLE_CERT3);
+    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, encodedCertString);
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
     assertThatLogoutSucceeds();
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
@@ -126,7 +141,7 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testNonAuthedLogin_fails() throws Exception {
-    setCredentials(CertificateSamples.SAMPLE_CERT_HASH, CertificateSamples.SAMPLE_CERT);
+    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, encodedCertString);
     assertThatLogin("TheRegistrar", "password2")
         .hasResponse(
             "response_error.xml",
@@ -155,7 +170,7 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testGoodPrimaryCertificate() throws Exception {
-    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, CertificateSamples.SAMPLE_CERT3);
+    setCredentials(null, encodedCertString);
     DateTime now = DateTime.now(UTC);
     persistResource(
         loadRegistrar("NewRegistrar")
@@ -168,7 +183,7 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testGoodFailoverCertificate() throws Exception {
-    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, CertificateSamples.SAMPLE_CERT3);
+    setCredentials(null, encodedCertString);
     DateTime now = DateTime.now(UTC);
     persistResource(
         loadRegistrar("NewRegistrar")
@@ -181,7 +196,7 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testMissingPrimaryCertificateButHasFailover_usesFailover() throws Exception {
-    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, CertificateSamples.SAMPLE_CERT3);
+    setCredentials(null, encodedCertString);
     DateTime now = DateTime.now(UTC);
     persistResource(
         loadRegistrar("NewRegistrar")
@@ -210,8 +225,16 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testCertificateDoesNotMeetRequirements_fails() throws Exception {
+    // How proxy converts to a string
+    String proxyEncoded =
+        Base64.getEncoder()
+            .encodeToString(
+                CertificateFactory.getInstance("X.509")
+                        .generateCertificate(
+                            new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT.getBytes(UTF_8)))
+                    .getEncoded());
     // SAMPLE_CERT has a validity period that is too long
-    setCredentials(CertificateSamples.SAMPLE_CERT_HASH, CertificateSamples.SAMPLE_CERT);
+    setCredentials(CertificateSamples.SAMPLE_CERT_HASH, proxyEncoded);
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()
@@ -232,7 +255,6 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testCertificateDoesNotMeetMultipleRequirements_fails() throws Exception {
-
     X509Certificate certificate =
         SelfSignedCaCertificate.create(
                 "test", clock.nowUtc().plusDays(100), clock.nowUtc().plusDays(5000))
@@ -243,9 +265,11 @@ class EppLoginTlsTest extends EppTestCase {
       PemObjectGenerator generator = new JcaMiscPEMGenerator(certificate);
       pw.writeObject(generator);
     }
+    // How proxy converts to a string
+    String proxyEncoded = Base64.getEncoder().encodeToString(certificate.getEncoded());
 
     // SAMPLE_CERT has a validity period that is too long
-    setCredentials(CertificateSamples.SAMPLE_CERT_HASH, sw.toString());
+    setCredentials(null, proxyEncoded);
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()
@@ -270,7 +294,15 @@ class EppLoginTlsTest extends EppTestCase {
   void testCertificateDoesNotMeetRequirementsInProduction_succeeds() throws Exception {
     RegistryEnvironment.PRODUCTION.setup(systemPropertyExtension);
     // SAMPLE_CERT has a validity period that is too long
-    setCredentials(CertificateSamples.SAMPLE_CERT_HASH, CertificateSamples.SAMPLE_CERT);
+    // How proxy converts to a string
+    String proxyEncoded =
+        Base64.getEncoder()
+            .encodeToString(
+                CertificateFactory.getInstance("X.509")
+                        .generateCertificate(
+                            new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT.getBytes(UTF_8)))
+                    .getEncoded());
+    setCredentials(null, proxyEncoded);
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()

--- a/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
+++ b/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
@@ -18,7 +18,6 @@ import static google.registry.testing.DatabaseHelper.loadRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.LogsSubject.assertAboutLogs;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.joda.time.DateTimeZone.UTC;
 
 import com.google.common.collect.ImmutableMap;
@@ -48,6 +47,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.shaded.org.bouncycastle.openssl.jcajce.JcaMiscPEMGenerator;
 import org.testcontainers.shaded.org.bouncycastle.util.io.pem.PemObjectGenerator;
 import org.testcontainers.shaded.org.bouncycastle.util.io.pem.PemWriter;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /** Test logging in with TLS credentials. */
 class EppLoginTlsTest extends EppTestCase {
@@ -103,8 +103,8 @@ class EppLoginTlsTest extends EppTestCase {
         Base64.getEncoder()
             .encodeToString(
                 CertificateFactory.getInstance("X.509")
-                    .generateCertificate(
-                        new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT3.getBytes(UTF_8)))
+                        .generateCertificate(
+                            new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT3.getBytes(UTF_8)))
                     .getEncoded());
   }
 
@@ -230,8 +230,8 @@ class EppLoginTlsTest extends EppTestCase {
         Base64.getEncoder()
             .encodeToString(
                 CertificateFactory.getInstance("X.509")
-                    .generateCertificate(
-                        new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT.getBytes(UTF_8)))
+                        .generateCertificate(
+                            new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT.getBytes(UTF_8)))
                     .getEncoded());
     // SAMPLE_CERT has a validity period that is too long
     setCredentials(CertificateSamples.SAMPLE_CERT_HASH, proxyEncoded);
@@ -299,8 +299,8 @@ class EppLoginTlsTest extends EppTestCase {
         Base64.getEncoder()
             .encodeToString(
                 CertificateFactory.getInstance("X.509")
-                    .generateCertificate(
-                        new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT.getBytes(UTF_8)))
+                        .generateCertificate(
+                            new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT.getBytes(UTF_8)))
                     .getEncoded());
     setCredentials(null, proxyEncoded);
     persistResource(

--- a/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
+++ b/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
@@ -18,6 +18,7 @@ import static google.registry.testing.DatabaseHelper.loadRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.LogsSubject.assertAboutLogs;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.joda.time.DateTimeZone.UTC;
 
 import com.google.common.collect.ImmutableMap;
@@ -30,8 +31,12 @@ import google.registry.testing.AppEngineExtension;
 import google.registry.testing.CertificateSamples;
 import google.registry.testing.SystemPropertyExtension;
 import google.registry.util.SelfSignedCaCertificate;
+import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -67,6 +72,8 @@ class EppLoginTlsTest extends EppTestCase {
       Logger.getLogger(TlsCredentials.class.getCanonicalName());
   private final TestLogHandler handler = new TestLogHandler();
 
+  private String encodedCertString;
+
   void setCredentials(String clientCertificateHash, String clientCertificate) {
     setTransportCredentials(
         new TlsCredentials(
@@ -78,7 +85,7 @@ class EppLoginTlsTest extends EppTestCase {
   }
 
   @BeforeEach
-  void beforeEach() {
+  void beforeEach() throws CertificateException {
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()
@@ -91,18 +98,26 @@ class EppLoginTlsTest extends EppTestCase {
             .setClientCertificate(CertificateSamples.SAMPLE_CERT2, DateTime.now(UTC))
             .build());
     loggerToIntercept.addHandler(handler);
+    // How proxy converts to a string
+    encodedCertString =
+        Base64.getEncoder()
+            .encodeToString(
+                CertificateFactory.getInstance("X.509")
+                    .generateCertificate(
+                        new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT3.getBytes(UTF_8)))
+                    .getEncoded());
   }
 
   @Test
   void testLoginLogout() throws Exception {
-    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, CertificateSamples.SAMPLE_CERT3);
+    setCredentials(null, encodedCertString);
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
     assertThatLogoutSucceeds();
   }
 
   @Test
   void testLogin_wrongPasswordFails() throws Exception {
-    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, CertificateSamples.SAMPLE_CERT3);
+    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, encodedCertString);
     // For TLS login, we also check the epp xml password.
     assertThatLogin("NewRegistrar", "incorrect")
         .hasResponse(
@@ -112,7 +127,7 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testMultiLogin() throws Exception {
-    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, CertificateSamples.SAMPLE_CERT3);
+    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, encodedCertString);
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
     assertThatLogoutSucceeds();
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
@@ -126,7 +141,7 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testNonAuthedLogin_fails() throws Exception {
-    setCredentials(CertificateSamples.SAMPLE_CERT_HASH, CertificateSamples.SAMPLE_CERT);
+    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, encodedCertString);
     assertThatLogin("TheRegistrar", "password2")
         .hasResponse(
             "response_error.xml",
@@ -155,7 +170,7 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testGoodPrimaryCertificate() throws Exception {
-    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, CertificateSamples.SAMPLE_CERT3);
+    setCredentials(null, encodedCertString);
     DateTime now = DateTime.now(UTC);
     persistResource(
         loadRegistrar("NewRegistrar")
@@ -168,7 +183,7 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testGoodFailoverCertificate() throws Exception {
-    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, CertificateSamples.SAMPLE_CERT3);
+    setCredentials(null, encodedCertString);
     DateTime now = DateTime.now(UTC);
     persistResource(
         loadRegistrar("NewRegistrar")
@@ -181,7 +196,7 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testMissingPrimaryCertificateButHasFailover_usesFailover() throws Exception {
-    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, CertificateSamples.SAMPLE_CERT3);
+    setCredentials(null, encodedCertString);
     DateTime now = DateTime.now(UTC);
     persistResource(
         loadRegistrar("NewRegistrar")
@@ -210,8 +225,16 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testCertificateDoesNotMeetRequirements_fails() throws Exception {
+    // How proxy converts to a string
+    String proxyEncoded =
+        Base64.getEncoder()
+            .encodeToString(
+                CertificateFactory.getInstance("X.509")
+                    .generateCertificate(
+                        new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT.getBytes(UTF_8)))
+                    .getEncoded());
     // SAMPLE_CERT has a validity period that is too long
-    setCredentials(CertificateSamples.SAMPLE_CERT_HASH, CertificateSamples.SAMPLE_CERT);
+    setCredentials(CertificateSamples.SAMPLE_CERT_HASH, proxyEncoded);
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()
@@ -232,7 +255,6 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testCertificateDoesNotMeetMultipleRequirements_fails() throws Exception {
-
     X509Certificate certificate =
         SelfSignedCaCertificate.create(
                 "test", clock.nowUtc().plusDays(100), clock.nowUtc().plusDays(5000))
@@ -243,9 +265,11 @@ class EppLoginTlsTest extends EppTestCase {
       PemObjectGenerator generator = new JcaMiscPEMGenerator(certificate);
       pw.writeObject(generator);
     }
+    // How proxy converts to a string
+    String proxyEncoded = Base64.getEncoder().encodeToString(certificate.getEncoded());
 
     // SAMPLE_CERT has a validity period that is too long
-    setCredentials(CertificateSamples.SAMPLE_CERT_HASH, sw.toString());
+    setCredentials(null, proxyEncoded);
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()
@@ -270,7 +294,15 @@ class EppLoginTlsTest extends EppTestCase {
   void testCertificateDoesNotMeetRequirementsInProduction_succeeds() throws Exception {
     RegistryEnvironment.PRODUCTION.setup(systemPropertyExtension);
     // SAMPLE_CERT has a validity period that is too long
-    setCredentials(CertificateSamples.SAMPLE_CERT_HASH, CertificateSamples.SAMPLE_CERT);
+    // How proxy converts to a string
+    String proxyEncoded =
+        Base64.getEncoder()
+            .encodeToString(
+                CertificateFactory.getInstance("X.509")
+                    .generateCertificate(
+                        new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT.getBytes(UTF_8)))
+                    .getEncoded());
+    setCredentials(null, proxyEncoded);
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()

--- a/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
+++ b/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
@@ -18,6 +18,8 @@ import static google.registry.testing.DatabaseHelper.loadRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.LogsSubject.assertAboutLogs;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.X509Utils.encodeX509Certificate;
+import static google.registry.util.X509Utils.encodeX509CertificateFromPemString;
 import static org.joda.time.DateTimeZone.UTC;
 
 import com.google.common.collect.ImmutableMap;

--- a/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
+++ b/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
@@ -18,6 +18,7 @@ import static google.registry.testing.DatabaseHelper.loadRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.LogsSubject.assertAboutLogs;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.joda.time.DateTimeZone.UTC;
 
 import com.google.common.collect.ImmutableMap;
@@ -47,7 +48,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.shaded.org.bouncycastle.openssl.jcajce.JcaMiscPEMGenerator;
 import org.testcontainers.shaded.org.bouncycastle.util.io.pem.PemObjectGenerator;
 import org.testcontainers.shaded.org.bouncycastle.util.io.pem.PemWriter;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 /** Test logging in with TLS credentials. */
 class EppLoginTlsTest extends EppTestCase {
@@ -103,8 +103,8 @@ class EppLoginTlsTest extends EppTestCase {
         Base64.getEncoder()
             .encodeToString(
                 CertificateFactory.getInstance("X.509")
-                        .generateCertificate(
-                            new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT3.getBytes(UTF_8)))
+                    .generateCertificate(
+                        new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT3.getBytes(UTF_8)))
                     .getEncoded());
   }
 
@@ -230,8 +230,8 @@ class EppLoginTlsTest extends EppTestCase {
         Base64.getEncoder()
             .encodeToString(
                 CertificateFactory.getInstance("X.509")
-                        .generateCertificate(
-                            new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT.getBytes(UTF_8)))
+                    .generateCertificate(
+                        new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT.getBytes(UTF_8)))
                     .getEncoded());
     // SAMPLE_CERT has a validity period that is too long
     setCredentials(CertificateSamples.SAMPLE_CERT_HASH, proxyEncoded);
@@ -299,8 +299,8 @@ class EppLoginTlsTest extends EppTestCase {
         Base64.getEncoder()
             .encodeToString(
                 CertificateFactory.getInstance("X.509")
-                        .generateCertificate(
-                            new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT.getBytes(UTF_8)))
+                    .generateCertificate(
+                        new ByteArrayInputStream(CertificateSamples.SAMPLE_CERT.getBytes(UTF_8)))
                     .getEncoded());
     setCredentials(null, proxyEncoded);
     persistResource(

--- a/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
+++ b/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
@@ -303,11 +303,11 @@ class EppLoginTlsTest extends EppTestCase {
     String certPem =
         String.format(
             "Bag Attributes\n"
-                + "    localKeyID: 3F 1B 8A 32 3D 03 EC 54 BC 7A C3 21 A9 FA 19 66 CB B8 72 23 \n"
+                + "    localKeyID: 1F 1C 3A 3A 4C 03 EC C4 BC 7A C3 21 A9 F2 13 66 21 B8 7B 26 \n"
                 + "subject=/C=US/ST=New York/L=New"
-                + " York/O=Google/OU=CRR/CN=CharlestonRoadRegistry.com/emailAddress=domain-registry-alerts-testing@google.com\n"
-                + "issuer=/C=US/ST=NY/L=NYC/O=CRR/OU=TEST CA/CN=TEST"
-                + " CA/emailAddress=domain-registry-eng+testing@google.com\n"
+                + " York/O=Test/OU=ABC/CN=tester.com/emailAddress=test-certificate@test.com\n"
+                + "issuer=/C=US/ST=NY/L=NYC/O=ABC/OU=TEST CA/CN=TEST"
+                + " CA/emailAddress=testing@test.com\n"
                 + "%s",
             CertificateSamples.SAMPLE_CERT3);
 
@@ -327,11 +327,11 @@ class EppLoginTlsTest extends EppTestCase {
     String certPem =
         String.format(
             "Bag Attributes\n"
-                + "    localKeyID: 3F 1B 8A 32 3D 03 EC 54 BC 7A C3 21 A9 FA 19 66 CB B8 72 23 \n"
+                + "    localKeyID: 1F 1C 3A 3A 4C 03 EC C4 BC 7A C3 21 A9 F2 13 66 21 B8 7B 26 \n"
                 + "subject=/C=US/ST=New York/L=New"
-                + " York/O=Google/OU=CRR/CN=CharlestonRoadRegistry.com/emailAddress=domain-registry-alerts-testing@google.com\n"
-                + "issuer=/C=US/ST=NY/L=NYC/O=CRR/OU=TEST CA/CN=TEST"
-                + " CA/emailAddress=domain-registry-eng+testing@google.com\n"
+                + " York/O=Test/OU=ABC/CN=tester.com/emailAddress=test-certificate@test.com\n"
+                + "issuer=/C=US/ST=NY/L=NYC/O=ABC/OU=TEST CA/CN=TEST"
+                + " CA/emailAddress=testing@test.com\n"
                 + "%s",
             CertificateSamples.SAMPLE_CERT);
 

--- a/core/src/test/java/google/registry/flows/EppTestCase.java
+++ b/core/src/test/java/google/registry/flows/EppTestCase.java
@@ -46,12 +46,6 @@ import google.registry.testing.FakeClock;
 import google.registry.testing.FakeHttpSession;
 import google.registry.testing.FakeResponse;
 import google.registry.testing.InjectExtension;
-import java.io.ByteArrayInputStream;
-import java.security.cert.CertificateEncodingException;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.security.cert.X509Certificate;
-import java.util.Base64;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -222,20 +216,6 @@ public class EppTestCase {
         "epp.response.trID.svTRID");
     ofy().clearSessionCache(); // Clear the cache like OfyFilter would.
     return actualOutput;
-  }
-
-  public static String encodeX509CertificateFromPemString(String certificateString)
-      throws CertificateException {
-    X509Certificate certificate =
-        (X509Certificate)
-            CertificateFactory.getInstance("X.509")
-                .generateCertificate(new ByteArrayInputStream(certificateString.getBytes(UTF_8)));
-    return encodeX509Certificate(certificate);
-  }
-
-  static String encodeX509Certificate(X509Certificate certificate)
-      throws CertificateEncodingException {
-    return Base64.getEncoder().encodeToString(certificate.getEncoded());
   }
 
   private FakeResponse executeXmlCommand(String inputXml) throws Exception {

--- a/core/src/test/java/google/registry/flows/EppTestCase.java
+++ b/core/src/test/java/google/registry/flows/EppTestCase.java
@@ -46,6 +46,12 @@ import google.registry.testing.FakeClock;
 import google.registry.testing.FakeHttpSession;
 import google.registry.testing.FakeResponse;
 import google.registry.testing.InjectExtension;
+import java.io.ByteArrayInputStream;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -216,6 +222,20 @@ public class EppTestCase {
         "epp.response.trID.svTRID");
     ofy().clearSessionCache(); // Clear the cache like OfyFilter would.
     return actualOutput;
+  }
+
+  public static String encodeX509CertificateFromPemString(String certificateString)
+      throws CertificateException {
+    X509Certificate certificate =
+        (X509Certificate)
+            CertificateFactory.getInstance("X.509")
+                .generateCertificate(new ByteArrayInputStream(certificateString.getBytes(UTF_8)));
+    return encodeX509Certificate(certificate);
+  }
+
+  static String encodeX509Certificate(X509Certificate certificate)
+      throws CertificateEncodingException {
+    return Base64.getEncoder().encodeToString(certificate.getEncoded());
   }
 
   private FakeResponse executeXmlCommand(String inputXml) throws Exception {

--- a/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
+++ b/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
@@ -17,7 +17,6 @@ package google.registry.flows.session;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.joda.time.DateTimeZone.UTC;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -31,13 +30,8 @@ import google.registry.flows.certs.CertificateChecker;
 import google.registry.model.registrar.Registrar;
 import google.registry.testing.CertificateSamples;
 import google.registry.util.CidrAddressBlock;
-import java.io.ByteArrayInputStream;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.util.Base64;
 import java.util.Optional;
 import org.joda.time.DateTime;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link LoginFlow} when accessed via a TLS transport. */
@@ -60,18 +54,6 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
           2048,
           ImmutableSet.of("secp256r1", "secp384r1"),
           clock);
-  private Optional<String> encodedCertString;
-
-  @BeforeEach
-  void beforeEach() throws CertificateException {
-    String proxyEncoded =
-        Base64.getEncoder()
-            .encodeToString(
-                CertificateFactory.getInstance("X.509")
-                        .generateCertificate(new ByteArrayInputStream(GOOD_CERT.get().getBytes(UTF_8)))
-                    .getEncoded());
-    encodedCertString = Optional.of(proxyEncoded);
-  }
 
   @Override
   protected Registrar.Builder getRegistrarBuilder() {
@@ -84,8 +66,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
   @Test
   void testSuccess_withGoodCredentials() throws Exception {
     persistResource(getRegistrarBuilder().build());
-    credentials =
-        new TlsCredentials(true, GOOD_CERT_HASH, encodedCertString, GOOD_IP, certificateChecker);
+    credentials = new TlsCredentials(true, GOOD_CERT_HASH, GOOD_CERT, GOOD_IP, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
@@ -97,7 +78,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
                 ImmutableList.of(CidrAddressBlock.create("2001:db8:0:0:0:0:1:1/32")))
             .build());
     credentials =
-        new TlsCredentials(true, GOOD_CERT_HASH, encodedCertString, GOOD_IPV6, certificateChecker);
+        new TlsCredentials(true, GOOD_CERT_HASH, GOOD_CERT, GOOD_IPV6, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
@@ -109,7 +90,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
                 ImmutableList.of(CidrAddressBlock.create("2001:db8:0:0:0:0:1:1/32")))
             .build());
     credentials =
-        new TlsCredentials(true, GOOD_CERT_HASH, encodedCertString, GOOD_IPV6, certificateChecker);
+        new TlsCredentials(true, GOOD_CERT_HASH, GOOD_CERT, GOOD_IPV6, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
@@ -119,23 +100,14 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
         getRegistrarBuilder()
             .setIpAddressAllowList(ImmutableList.of(CidrAddressBlock.create("192.168.1.255/24")))
             .build());
-    credentials =
-        new TlsCredentials(true, GOOD_CERT_HASH, encodedCertString, GOOD_IP, certificateChecker);
+    credentials = new TlsCredentials(true, GOOD_CERT_HASH, GOOD_CERT, GOOD_IP, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
   @Test
-  void testFailure_incorrectClientCertificateHash() throws Exception {
+  void testFailure_incorrectClientCertificateHash() {
     persistResource(getRegistrarBuilder().build());
-    String proxyEncoded =
-        Base64.getEncoder()
-            .encodeToString(
-                CertificateFactory.getInstance("X.509")
-                        .generateCertificate(new ByteArrayInputStream(BAD_CERT.get().getBytes(UTF_8)))
-                    .getEncoded());
-    credentials =
-        new TlsCredentials(
-            true, BAD_CERT_HASH, Optional.of(proxyEncoded), GOOD_IP, certificateChecker);
+    credentials = new TlsCredentials(true, BAD_CERT_HASH, BAD_CERT, GOOD_IP, certificateChecker);
     doFailingTest("login_valid.xml", BadRegistrarCertificateException.class);
   }
 

--- a/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
+++ b/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
@@ -16,8 +16,8 @@ package google.registry.flows.session;
 
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
-import static org.joda.time.DateTimeZone.UTC;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.joda.time.DateTimeZone.UTC;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -68,7 +68,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
         Base64.getEncoder()
             .encodeToString(
                 CertificateFactory.getInstance("X.509")
-                        .generateCertificate(new ByteArrayInputStream(GOOD_CERT.get().getBytes(UTF_8)))
+                    .generateCertificate(new ByteArrayInputStream(GOOD_CERT.get().getBytes(UTF_8)))
                     .getEncoded());
     encodedCertString = Optional.of(proxyEncoded);
   }
@@ -131,7 +131,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
         Base64.getEncoder()
             .encodeToString(
                 CertificateFactory.getInstance("X.509")
-                        .generateCertificate(new ByteArrayInputStream(BAD_CERT.get().getBytes(UTF_8)))
+                    .generateCertificate(new ByteArrayInputStream(BAD_CERT.get().getBytes(UTF_8)))
                     .getEncoded());
     credentials =
         new TlsCredentials(

--- a/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
+++ b/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
@@ -16,8 +16,8 @@ package google.registry.flows.session;
 
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.joda.time.DateTimeZone.UTC;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -68,7 +68,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
         Base64.getEncoder()
             .encodeToString(
                 CertificateFactory.getInstance("X.509")
-                    .generateCertificate(new ByteArrayInputStream(GOOD_CERT.get().getBytes(UTF_8)))
+                        .generateCertificate(new ByteArrayInputStream(GOOD_CERT.get().getBytes(UTF_8)))
                     .getEncoded());
     encodedCertString = Optional.of(proxyEncoded);
   }
@@ -131,7 +131,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
         Base64.getEncoder()
             .encodeToString(
                 CertificateFactory.getInstance("X.509")
-                    .generateCertificate(new ByteArrayInputStream(BAD_CERT.get().getBytes(UTF_8)))
+                        .generateCertificate(new ByteArrayInputStream(BAD_CERT.get().getBytes(UTF_8)))
                     .getEncoded());
     credentials =
         new TlsCredentials(

--- a/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
+++ b/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
@@ -16,6 +16,7 @@ package google.registry.flows.session;
 
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.joda.time.DateTimeZone.UTC;
 
 import com.google.common.collect.ImmutableList;
@@ -30,8 +31,13 @@ import google.registry.flows.certs.CertificateChecker;
 import google.registry.model.registrar.Registrar;
 import google.registry.testing.CertificateSamples;
 import google.registry.util.CidrAddressBlock;
+import java.io.ByteArrayInputStream;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.util.Base64;
 import java.util.Optional;
 import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link LoginFlow} when accessed via a TLS transport. */
@@ -54,6 +60,18 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
           2048,
           ImmutableSet.of("secp256r1", "secp384r1"),
           clock);
+  private Optional<String> encodedCertString;
+
+  @BeforeEach
+  void beforeEach() throws CertificateException {
+    String proxyEncoded =
+        Base64.getEncoder()
+            .encodeToString(
+                CertificateFactory.getInstance("X.509")
+                    .generateCertificate(new ByteArrayInputStream(GOOD_CERT.get().getBytes(UTF_8)))
+                    .getEncoded());
+    encodedCertString = Optional.of(proxyEncoded);
+  }
 
   @Override
   protected Registrar.Builder getRegistrarBuilder() {
@@ -66,7 +84,8 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
   @Test
   void testSuccess_withGoodCredentials() throws Exception {
     persistResource(getRegistrarBuilder().build());
-    credentials = new TlsCredentials(true, GOOD_CERT_HASH, GOOD_CERT, GOOD_IP, certificateChecker);
+    credentials =
+        new TlsCredentials(true, GOOD_CERT_HASH, encodedCertString, GOOD_IP, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
@@ -78,7 +97,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
                 ImmutableList.of(CidrAddressBlock.create("2001:db8:0:0:0:0:1:1/32")))
             .build());
     credentials =
-        new TlsCredentials(true, GOOD_CERT_HASH, GOOD_CERT, GOOD_IPV6, certificateChecker);
+        new TlsCredentials(true, GOOD_CERT_HASH, encodedCertString, GOOD_IPV6, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
@@ -90,7 +109,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
                 ImmutableList.of(CidrAddressBlock.create("2001:db8:0:0:0:0:1:1/32")))
             .build());
     credentials =
-        new TlsCredentials(true, GOOD_CERT_HASH, GOOD_CERT, GOOD_IPV6, certificateChecker);
+        new TlsCredentials(true, GOOD_CERT_HASH, encodedCertString, GOOD_IPV6, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
@@ -100,14 +119,23 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
         getRegistrarBuilder()
             .setIpAddressAllowList(ImmutableList.of(CidrAddressBlock.create("192.168.1.255/24")))
             .build());
-    credentials = new TlsCredentials(true, GOOD_CERT_HASH, GOOD_CERT, GOOD_IP, certificateChecker);
+    credentials =
+        new TlsCredentials(true, GOOD_CERT_HASH, encodedCertString, GOOD_IP, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
   @Test
-  void testFailure_incorrectClientCertificateHash() {
+  void testFailure_incorrectClientCertificateHash() throws Exception {
     persistResource(getRegistrarBuilder().build());
-    credentials = new TlsCredentials(true, BAD_CERT_HASH, BAD_CERT, GOOD_IP, certificateChecker);
+    String proxyEncoded =
+        Base64.getEncoder()
+            .encodeToString(
+                CertificateFactory.getInstance("X.509")
+                    .generateCertificate(new ByteArrayInputStream(BAD_CERT.get().getBytes(UTF_8)))
+                    .getEncoded());
+    credentials =
+        new TlsCredentials(
+            true, BAD_CERT_HASH, Optional.of(proxyEncoded), GOOD_IP, certificateChecker);
     doFailingTest("login_valid.xml", BadRegistrarCertificateException.class);
   }
 

--- a/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
+++ b/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
@@ -16,13 +16,13 @@ package google.registry.flows.session;
 
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.joda.time.DateTimeZone.UTC;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.net.InetAddresses;
+import google.registry.flows.EppTestCase;
 import google.registry.flows.TlsCredentials;
 import google.registry.flows.TlsCredentials.BadRegistrarCertificateException;
 import google.registry.flows.TlsCredentials.BadRegistrarIpAddressException;
@@ -31,10 +31,7 @@ import google.registry.flows.certs.CertificateChecker;
 import google.registry.model.registrar.Registrar;
 import google.registry.testing.CertificateSamples;
 import google.registry.util.CidrAddressBlock;
-import java.io.ByteArrayInputStream;
 import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
-import java.util.Base64;
 import java.util.Optional;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,13 +61,8 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
 
   @BeforeEach
   void beforeEach() throws CertificateException {
-    String proxyEncoded =
-        Base64.getEncoder()
-            .encodeToString(
-                CertificateFactory.getInstance("X.509")
-                    .generateCertificate(new ByteArrayInputStream(GOOD_CERT.get().getBytes(UTF_8)))
-                    .getEncoded());
-    encodedCertString = Optional.of(proxyEncoded);
+    encodedCertString =
+        Optional.of(EppTestCase.encodeX509CertificateFromPemString(GOOD_CERT.get()));
   }
 
   @Override
@@ -127,12 +119,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
   @Test
   void testFailure_incorrectClientCertificateHash() throws Exception {
     persistResource(getRegistrarBuilder().build());
-    String proxyEncoded =
-        Base64.getEncoder()
-            .encodeToString(
-                CertificateFactory.getInstance("X.509")
-                    .generateCertificate(new ByteArrayInputStream(BAD_CERT.get().getBytes(UTF_8)))
-                    .getEncoded());
+    String proxyEncoded = EppTestCase.encodeX509CertificateFromPemString(BAD_CERT.get());
     credentials =
         new TlsCredentials(
             true, BAD_CERT_HASH, Optional.of(proxyEncoded), GOOD_IP, certificateChecker);

--- a/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
+++ b/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
@@ -16,13 +16,13 @@ package google.registry.flows.session;
 
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.X509Utils.encodeX509CertificateFromPemString;
 import static org.joda.time.DateTimeZone.UTC;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.net.InetAddresses;
-import google.registry.flows.EppTestCase;
 import google.registry.flows.TlsCredentials;
 import google.registry.flows.TlsCredentials.BadRegistrarCertificateException;
 import google.registry.flows.TlsCredentials.BadRegistrarIpAddressException;
@@ -31,11 +31,18 @@ import google.registry.flows.certs.CertificateChecker;
 import google.registry.model.registrar.Registrar;
 import google.registry.testing.CertificateSamples;
 import google.registry.util.CidrAddressBlock;
+import google.registry.util.SelfSignedCaCertificate;
+import java.io.StringWriter;
 import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
 import java.util.Optional;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.bouncycastle.openssl.jcajce.JcaMiscPEMGenerator;
+import org.testcontainers.shaded.org.bouncycastle.util.io.pem.PemObjectGenerator;
+import org.testcontainers.shaded.org.bouncycastle.util.io.pem.PemWriter;
 
 /** Unit tests for {@link LoginFlow} when accessed via a TLS transport. */
 public class LoginFlowViaTlsTest extends LoginFlowTestCase {
@@ -61,8 +68,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
 
   @BeforeEach
   void beforeEach() throws CertificateException {
-    encodedCertString =
-        Optional.of(EppTestCase.encodeX509CertificateFromPemString(GOOD_CERT.get()));
+    encodedCertString = Optional.of(encodeX509CertificateFromPemString(GOOD_CERT.get()));
   }
 
   @Override
@@ -78,6 +84,34 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
     persistResource(getRegistrarBuilder().build());
     credentials =
         new TlsCredentials(true, GOOD_CERT_HASH, encodedCertString, GOOD_IP, certificateChecker);
+    doSuccessfulTest("login_valid.xml");
+  }
+
+  @Test
+  void testSuccess_withNewlyConstructedCertificate() throws Exception {
+    X509Certificate certificate =
+        SelfSignedCaCertificate.create(
+                "test", clock.nowUtc().minusDays(100), clock.nowUtc().plusDays(150))
+            .cert();
+
+    StringWriter sw = new StringWriter();
+    try (PemWriter pw = new PemWriter(sw)) {
+      PemObjectGenerator generator = new JcaMiscPEMGenerator(certificate);
+      pw.writeObject(generator);
+    }
+
+    persistResource(
+        super.getRegistrarBuilder()
+            .setClientCertificate(sw.toString(), DateTime.now(UTC))
+            .setIpAddressAllowList(
+                ImmutableList.of(
+                    CidrAddressBlock.create(InetAddresses.forString(GOOD_IP.get()), 32)))
+            .build());
+
+    String encodedCertificate = Base64.getEncoder().encodeToString(certificate.getEncoded());
+    credentials =
+        new TlsCredentials(
+            true, Optional.empty(), Optional.of(encodedCertificate), GOOD_IP, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
@@ -119,7 +153,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
   @Test
   void testFailure_incorrectClientCertificateHash() throws Exception {
     persistResource(getRegistrarBuilder().build());
-    String proxyEncoded = EppTestCase.encodeX509CertificateFromPemString(BAD_CERT.get());
+    String proxyEncoded = encodeX509CertificateFromPemString(BAD_CERT.get());
     credentials =
         new TlsCredentials(
             true, BAD_CERT_HASH, Optional.of(proxyEncoded), GOOD_IP, certificateChecker);

--- a/proxy/src/test/java/google/registry/proxy/handler/EppServiceHandlerTest.java
+++ b/proxy/src/test/java/google/registry/proxy/handler/EppServiceHandlerTest.java
@@ -21,6 +21,7 @@ import static google.registry.proxy.TestUtils.assertHttpRequestEquivalent;
 import static google.registry.proxy.TestUtils.makeEppHttpResponse;
 import static google.registry.proxy.handler.ProxyProtocolHandler.REMOTE_ADDRESS_KEY;
 import static google.registry.util.X509Utils.getCertificateHash;
+import static google.registry.util.X509Utils.loadCertificate;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -252,14 +253,8 @@ class EppServiceHandlerTest {
     String encodedCert = request.headers().get("X-SSL-Full-Certificate");
     assertThat(encodedCert).isNotEqualTo(SAMPLE_CERT);
     X509Certificate decodedCert =
-        (X509Certificate)
-            CertificateFactory.getInstance("X.509")
-                .generateCertificate(
-                    new ByteArrayInputStream(Base64.getDecoder().decode(encodedCert)));
-    X509Certificate pemCert =
-        (X509Certificate)
-            CertificateFactory.getInstance("X.509")
-                .generateCertificate(new ByteArrayInputStream(SAMPLE_CERT.getBytes(UTF_8)));
+        loadCertificate(new ByteArrayInputStream(Base64.getDecoder().decode(encodedCert)));
+    X509Certificate pemCert = loadCertificate(SAMPLE_CERT);
     assertThat(decodedCert).isEqualTo(pemCert);
   }
 

--- a/util/src/main/java/google/registry/util/X509Utils.java
+++ b/util/src/main/java/google/registry/util/X509Utils.java
@@ -32,6 +32,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CRLException;
 import java.security.cert.CRLReason;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.CertificateParsingException;
@@ -39,6 +40,7 @@ import java.security.cert.CertificateRevokedException;
 import java.security.cert.X509CRL;
 import java.security.cert.X509CRLEntry;
 import java.security.cert.X509Certificate;
+import java.util.Base64;
 import java.util.Date;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -175,6 +177,16 @@ public final class X509Utils {
       throw new CRLException("CRL has expired.\n" + newCrl);
     }
     newCrl.verify(rootCert.getPublicKey());
+  }
+
+  public static String encodeX509CertificateFromPemString(String certificateString)
+      throws CertificateException {
+    return encodeX509Certificate(loadCertificate(certificateString));
+  }
+
+  public static String encodeX509Certificate(X509Certificate certificate)
+      throws CertificateEncodingException {
+    return Base64.getEncoder().encodeToString(certificate.getEncoded());
   }
 
   private X509Utils() {}

--- a/util/src/main/java/google/registry/util/X509Utils.java
+++ b/util/src/main/java/google/registry/util/X509Utils.java
@@ -179,11 +179,16 @@ public final class X509Utils {
     newCrl.verify(rootCert.getPublicKey());
   }
 
+  /** Constructs an X.509 certificate from a PEM string and encodes it. */
   public static String encodeX509CertificateFromPemString(String certificateString)
       throws CertificateException {
     return encodeX509Certificate(loadCertificate(certificateString));
   }
 
+  /**
+   * Encodes an X.509 certificate in the same form that the proxy encodes a certificate before
+   * passing it via an HTTP header.
+   */
   public static String encodeX509Certificate(X509Certificate certificate)
       throws CertificateEncodingException {
     return Base64.getEncoder().encodeToString(certificate.getEncoded());


### PR DESCRIPTION
This prevents the issue seen in Sandbox where the encoded certificate string passed from the proxy is not in the same format as the certificate String stored in the Registrar object. By converting both strings to certificates, we can check equality of the actual certificates rather than the String representation of them which always have a potential to be different due to separate formatting, extra spaces, etc. See b/178530285 for more info.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/948)
<!-- Reviewable:end -->
