### PR TITLE
Use END_OF_TIME as sentinel value for domain's autorenewEndTime

### DIFF
--- a/core/src/test/java/google/registry/testing/FullFieldsTestEntityHelper.java
+++ b/core/src/test/java/google/registry/testing/FullFieldsTestEntityHelper.java
@@ -392,17 +392,18 @@ public final class FullFieldsTestEntityHelper {
       Period period,
       String reason,
       DateTime modificationTime) {
-    HistoryEntry.Builder builder = new HistoryEntry.Builder()
-        .setParent(resource)
-        .setType(type)
-        .setPeriod(period)
-        .setXmlBytes("<xml></xml>".getBytes(UTF_8))
-        .setModificationTime(modificationTime)
-        .setClientId(resource.getPersistedCurrentSponsorClientId())
-        .setTrid(Trid.create("ABC-123", "server-trid"))
-        .setBySuperuser(false)
-        .setReason(reason)
-        .setRequestedByRegistrar(false);
+    HistoryEntry.Builder builder =
+        new HistoryEntry.Builder()
+            .setParent(resource)
+            .setType(type)
+            .setPeriod(period)
+            .setXmlBytes("<xml></xml>".getBytes(UTF_8))
+            .setModificationTime(modificationTime)
+            .setClientId(resource.getPersistedCurrentSponsorClientId())
+            .setTrid(Trid.create("ABC-123", "server-trid"))
+            .setBySuperuser(false)
+            .setReason(reason)
+            .setRequestedByRegistrar(false);
     return builder.build();
   }
 }


### PR DESCRIPTION
Datastore inequality queries don't work correctly for null; null is treated as
the lowest value possible which is definitely the opposite of the intended
meaning here.

This includes an @OnLoad for backfilling purposes using the ResaveAll mapreduce.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/949)
<!-- Reviewable:end -->
