### PR TITLE
Add a presubmit check to require use of templated SQL string literals

### DIFF
--- a/config/presubmits.py
+++ b/config/presubmits.py
@@ -185,29 +185,27 @@ PRESUBMITS = {
     # The rule would forbid invocation of createQuery(Criteria). However, this
     # can be handled by adding a helper method in an exempted class to make
     # the calls.
+    # TODO(b/179158393): enable the 'ConstantName' Java style check to ensure
+    # that non-final variables do not use the UPPER_CASE_UNDERSCORE format.
     PresubmitCheck(
-        r".*\.create(Native)?Query\((?!\s*[A-Z_]+(,|\s*\)))",
+        r'.*\.create(Native)?Query\('
+        '(?!(\s*([A-Z_]+|"([^"]|\\")*"(\s*\+\s*"([^"]|\\")*")*)'
+        '(,|\s*\))))',
         "java",
         # ActivityReportingQueryBuilder deals with Dremel queries
         {"src/test", "ActivityReportingQueryBuilder.java",
-         # TODO(b/179158393): Remove everything below
-         "ClaimsListDao.java",
-         "CursorDao.java",
+         # TODO(b/179158393): Remove everything below, which should be done
+         # using Criteria
          "ForeignKeyIndex.java",
          "HistoryEntryDao.java",
          "JpaTransactionManagerImpl.java",
-         "KmsSecretRevisionSqlDao.java",
-         "PremiumListDao.java",
-         "Registrar.java",
-         "RegistryLockDao.java",
-         "ReservedListSqlDao.java",
-         "SignedMarkRevocationListDao.java",
-         "Spec11ThreatMatchDao.java",
-         "SqlReplayCheckpoint.java",
-         "TmchCrl.java",
          },
     ):
-        "Sql template must be a constant assigned to a static final variable."
+        "The first String parameter to EntityManager.create(Native)Query "
+        "methods must be one of the following:\n"
+        "  - A String literal\n"
+        "  - Concatenation of String literals only\n"
+        "  - The name of a static final String variable"
 }
 
 # Note that this regex only works for one kind of Flyway file.  If we want to

--- a/config/presubmits.py
+++ b/config/presubmits.py
@@ -176,7 +176,38 @@ PRESUBMITS = {
         "js",
         {"/node_modules/", "google/registry/ui/js/util.js", "registrar_bin."},
     ):
-        "JavaScript files should not include console logging."
+        "JavaScript files should not include console logging.",
+    # SQL injection protection rule for java source file:
+    # The sql template passed to createQuery/createNativeQuery methods must be
+    # a variable name in UPPER_CASE_UNDERSCORE format, i.e., a static final
+    # String variable. This forces the use of parameter-binding on all queries
+    # that take parameters.
+    # The rule would forbid invocation of createQuery(Criteria). However, this
+    # can be handled by adding a helper method in an exempted class to make
+    # the calls.
+    PresubmitCheck(
+        r".*\.create(Native)?Query\((?!\s*[A-Z_]+(,|\s*\)))",
+        "java",
+        # ActivityReportingQueryBuilder deals with Dremel queries
+        {"src/test", "ActivityReportingQueryBuilder.java",
+         # TODO(b/179158393): Remove everything below
+         "ClaimsListDao.java",
+         "CursorDao.java",
+         "ForeignKeyIndex.java",
+         "HistoryEntryDao.java",
+         "JpaTransactionManagerImpl.java",
+         "KmsSecretRevisionSqlDao.java",
+         "PremiumListDao.java",
+         "Registrar.java",
+         "RegistryLockDao.java",
+         "ReservedListSqlDao.java",
+         "SignedMarkRevocationListDao.java",
+         "Spec11ThreatMatchDao.java",
+         "SqlReplayCheckpoint.java",
+         "TmchCrl.java",
+         },
+    ):
+        "Sql template must be a constant assigned to a static final variable."
 }
 
 # Note that this regex only works for one kind of Flyway file.  If we want to

--- a/config/presubmits.py
+++ b/config/presubmits.py
@@ -197,8 +197,8 @@ PRESUBMITS = {
         # Line 3: , or the closing parenthesis, marking the end of the first
         #    parameter
         r'.*\.create(Native)?Query\('
-        '(?!(\s*([A-Z_]+|"([^"]|\\")*"(\s*\+\s*"([^"]|\\")*")*)'
-        '(,|\s*\))))',
+        r'(?!(\s*([A-Z_]+|"([^"]|\\")*"(\s*\+\s*"([^"]|\\")*")*)'
+        r'(,|\s*\))))',
         "java",
         # ActivityReportingQueryBuilder deals with Dremel queries
         {"src/test", "ActivityReportingQueryBuilder.java",

--- a/config/presubmits.py
+++ b/config/presubmits.py
@@ -188,12 +188,14 @@ PRESUBMITS = {
     # TODO(b/179158393): enable the 'ConstantName' Java style check to ensure
     # that non-final variables do not use the UPPER_CASE_UNDERSCORE format.
     PresubmitCheck(
-        # Line 1: the method names we check and the opening parenthesis
-        # Line 2: Patterns of the first parameter to exclude:
+        # Line 1: the method names we check and the opening parenthesis, which
+        #    marks the beginning of the first parameter
+        # Line 2: The first parameter is a match if is NOT any of the following:
         #    - final variable name: \s*([A-Z_]+
         #    - string literal: "([^"]|\\")*"
         #    - concatenation of literals: (\s*\+\s*"([^"]|\\")*")*
-        # Line 3: , or the closing parenthesis
+        # Line 3: , or the closing parenthesis, marking the end of the first
+        #    parameter
         r'.*\.create(Native)?Query\('
         '(?!(\s*([A-Z_]+|"([^"]|\\")*"(\s*\+\s*"([^"]|\\")*")*)'
         '(,|\s*\))))',

--- a/config/presubmits.py
+++ b/config/presubmits.py
@@ -188,6 +188,12 @@ PRESUBMITS = {
     # TODO(b/179158393): enable the 'ConstantName' Java style check to ensure
     # that non-final variables do not use the UPPER_CASE_UNDERSCORE format.
     PresubmitCheck(
+        # Line 1: the method names we check and the opening parenthesis
+        # Line 2: Patterns of the first parameter to exclude:
+        #    - final variable name: \s*([A-Z_]+
+        #    - string literal: "([^"]|\\")*"
+        #    - concatenation of literals: (\s*\+\s*"([^"]|\\")*")*
+        # Line 3: , or the closing parenthesis
         r'.*\.create(Native)?Query\('
         '(?!(\s*([A-Z_]+|"([^"]|\\")*"(\s*\+\s*"([^"]|\\")*")*)'
         '(,|\s*\))))',

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -458,6 +458,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
     assertInTransaction();
     EntityType<?> entityType = getEntityType(key.getKind());
     ImmutableSet<EntityId> entityIds = getEntityIdsFromSqlKey(entityType, key.getSqlKey());
+    // TODO(b/179158393): use Criteria for query to leave not doubt about sql injection risk.
     String sql =
         String.format("DELETE FROM %s WHERE %s", entityType.getName(), getAndClause(entityIds));
     Query query = getEntityManager().createQuery(sql);

--- a/core/src/main/java/google/registry/tools/javascrap/BackfillSpec11ThreatMatchesCommand.java
+++ b/core/src/main/java/google/registry/tools/javascrap/BackfillSpec11ThreatMatchesCommand.java
@@ -61,8 +61,6 @@ public class BackfillSpec11ThreatMatchesCommand extends ConfirmingCommand
     implements CommandWithRemoteApi {
 
   private static final LocalDate START_DATE = new LocalDate(2019, 1, 1);
-  private static final String SELECT_DISTINCT_STM_CHECK_DATE_QUERY =
-      "SELECT DISTINCT stm.checkDate FROM Spec11ThreatMatch stm";
 
   @Parameter(
       names = {"-o", "--overwrite_existing_dates"},
@@ -210,7 +208,8 @@ public class BackfillSpec11ThreatMatchesCommand extends ConfirmingCommand
             () ->
                 jpaTm()
                     .getEntityManager()
-                    .createQuery(SELECT_DISTINCT_STM_CHECK_DATE_QUERY, LocalDate.class)
+                    .createQuery(
+                        "SELECT DISTINCT stm.checkDate FROM Spec11ThreatMatch stm", LocalDate.class)
                     .getResultStream()
                     .collect(toImmutableSet()));
   }

--- a/core/src/main/java/google/registry/tools/javascrap/BackfillSpec11ThreatMatchesCommand.java
+++ b/core/src/main/java/google/registry/tools/javascrap/BackfillSpec11ThreatMatchesCommand.java
@@ -61,6 +61,8 @@ public class BackfillSpec11ThreatMatchesCommand extends ConfirmingCommand
     implements CommandWithRemoteApi {
 
   private static final LocalDate START_DATE = new LocalDate(2019, 1, 1);
+  private static final String SELECT_DISTINCT_STM_CHECK_DATE_QUERY =
+      "SELECT DISTINCT stm.checkDate FROM Spec11ThreatMatch stm";
 
   @Parameter(
       names = {"-o", "--overwrite_existing_dates"},
@@ -208,8 +210,7 @@ public class BackfillSpec11ThreatMatchesCommand extends ConfirmingCommand
             () ->
                 jpaTm()
                     .getEntityManager()
-                    .createQuery(
-                        "SELECT DISTINCT stm.checkDate FROM Spec11ThreatMatch stm", LocalDate.class)
+                    .createQuery(SELECT_DISTINCT_STM_CHECK_DATE_QUERY, LocalDate.class)
                     .getResultStream()
                     .collect(toImmutableSet()));
   }


### PR DESCRIPTION
This PR proposes a coding style convention that helps prevent
SQL-injection attacks, and is easy to enforce in the presubmit check.

SQL-injections can be effectively prevented if all parameterized queries
are generated using the proper param-binding methods. In our project
which uses Hibernate exclusively, this can be achieved if we all follow
a simple convention: only use constant sql templates assigned to static
final String variables as the first parameter to creat(Native)Query
methods.

This PR adds a presubmit check to enforce the proposed rule, and
modified one class as a demo. If the team agrees with this proposal, we
will change all other use cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/954)
<!-- Reviewable:end -->
