### PR TITLE
Revert BEAM pipeline back to SQL credential file

### DIFF
--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -215,11 +215,11 @@ public abstract class PersistenceModule {
       if (!Objects.equals(username, credential.login())) {
         logger.atWarning().log(
             "Wrong login for nomulus. Expecting %s, found %s.", username, credential.login());
-      }
-      if (!Objects.equals(password, credential.password())) {
+      } else if (!Objects.equals(password, credential.password())) {
         logger.atWarning().log("Wrong password for nomulus.");
+      } else {
+        logger.atWarning().log("Credentials in the kerying and the secret manager match.");
       }
-      logger.atWarning().log("Credentials in the kerying and the secret manager match.");
     } catch (Exception e) {
       logger.atWarning().withCause(e).log("Failed to get SQL credential from Secret Manager");
     }

--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -214,7 +214,7 @@ public abstract class PersistenceModule {
       SqlCredential credential = credentialStore.getCredential(new RobotUser(RobotId.NOMULUS));
       if (!Objects.equals(username, credential.login())) {
         logger.atWarning().log(
-            "Wrong login for nomulus. Expecting %s, found %s.", username, credential.login());
+            "Wrong username for nomulus. Expecting %s, found %s.", username, credential.login());
       } else if (!Objects.equals(password, credential.password())) {
         logger.atWarning().log("Wrong password for nomulus.");
       } else {
@@ -296,7 +296,7 @@ public abstract class PersistenceModule {
       overrides.put(Environment.PASS, credential.password());
       logger.atWarning().log("Credentials in the kerying and the secret manager match.");
     } catch (Throwable e) {
-      logger.atWarning().withCause(e).log("Failed to get SQL credential from Secret Manager");
+      logger.atSevere().withCause(e).log("Failed to get SQL credential from Secret Manager");
     }
   }
 

--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -221,7 +221,7 @@ public abstract class PersistenceModule {
         logger.atWarning().log("Credentials in the kerying and the secret manager match.");
       }
     } catch (Exception e) {
-      logger.atWarning().withCause(e).log("Failed to get SQL credential from Secret Manager");
+      logger.atWarning().withCause(e).log("Failed to get SQL credential from Secret Manager.");
     }
     return new JpaTransactionManagerImpl(create(overrides), clock);
   }

--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -46,6 +46,7 @@ import java.lang.annotation.Documented;
 import java.sql.Connection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.inject.Provider;
@@ -204,9 +205,24 @@ public abstract class PersistenceModule {
       Clock clock) {
     HashMap<String, String> overrides = Maps.newHashMap(cloudSqlConfigs);
     overrides.put(HIKARI_MAXIMUM_POOL_SIZE, String.valueOf(hikariMaximumPoolSize));
+    overrides.put(Environment.USER, username);
+    overrides.put(Environment.PASS, password);
     // TODO(b/175700623): consider assigning different logins to pipelines
-    validateAndSetCredential(
-        credentialStore, new RobotUser(RobotId.NOMULUS), overrides, username, password);
+    // TODO(b/179839014): Make SqlCredentialStore injectable in BEAM
+    // Note: the logs below appear in the pipeline's Worker logs, not the Job log.
+    try {
+      SqlCredential credential = credentialStore.getCredential(new RobotUser(RobotId.NOMULUS));
+      if (!Objects.equals(username, credential.login())) {
+        logger.atWarning().log(
+            "Wrong login for nomulus. Expecting %s, found %s.", username, credential.login());
+      }
+      if (!Objects.equals(password, credential.password())) {
+        logger.atWarning().log("Wrong password for nomulus.");
+      }
+      logger.atWarning().log("Credentials in the kerying and the secret manager match.");
+    } catch (Exception e) {
+      logger.atWarning().withCause(e).log("Failed to get SQL credential from Secret Manager");
+    }
     return new JpaTransactionManagerImpl(create(overrides), clock);
   }
 
@@ -280,7 +296,7 @@ public abstract class PersistenceModule {
       overrides.put(Environment.PASS, credential.password());
       logger.atWarning().log("Credentials in the kerying and the secret manager match.");
     } catch (Throwable e) {
-      logger.atWarning().log(e.getMessage());
+      logger.atWarning().withCause(e).log("Failed to get SQL credential from Secret Manager");
     }
   }
 


### PR DESCRIPTION
Stop using the SecretManager for SQL credential in BEAM for now. The
SecretManager cannot be injected into the code on pipeline workers
because RegistryEnvironment is not set.

See b/179839014 for details.

The SecretManager is verified to work with Registry server and Nomulus tool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/961)
<!-- Reviewable:end -->
