### PR TITLE
Add db-compare tests to three more flows

### DIFF
--- a/core/src/main/java/google/registry/model/domain/DomainContent.java
+++ b/core/src/main/java/google/registry/model/domain/DomainContent.java
@@ -337,6 +337,10 @@ public class DomainContent extends EppResource
         nullToEmptyImmutableCopy(dsData).stream()
             .map(dsData -> dsData.cloneWithDomainRepoId(getRepoId()))
             .collect(toImmutableSet());
+
+    if (transferData != null) {
+      transferData.convertVKeys();
+    }
   }
 
   @PostLoad

--- a/core/src/main/java/google/registry/model/poll/PollMessage.java
+++ b/core/src/main/java/google/registry/model/poll/PollMessage.java
@@ -295,7 +295,7 @@ public abstract class PollMessage extends ImmutableObject
     @Transient @ImmutableObject.DoNotCompare
     List<DomainPendingActionNotificationResponse> domainPendingActionNotificationResponses;
 
-    @Transient List<DomainTransferResponse> domainTransferResponses;
+    @Transient @ImmutableObject.DoNotCompare List<DomainTransferResponse> domainTransferResponses;
 
     @Transient List<HostPendingActionNotificationResponse> hostPendingActionNotificationResponses;
 

--- a/core/src/main/java/google/registry/model/transfer/DomainTransferData.java
+++ b/core/src/main/java/google/registry/model/transfer/DomainTransferData.java
@@ -144,6 +144,16 @@ public class DomainTransferData extends TransferData<DomainTransferData.Builder>
             rootKey, serverApproveAutorenewPollMessage, serverApproveAutorenewPollMessageHistoryId);
   }
 
+  /**
+   * Fix the VKey "kind" for the PollMessage keys.
+   *
+   * <p>For use by DomainBase/DomainHistory OnLoad methods ONLY.
+   */
+  public void convertVKeys() {
+    serverApproveAutorenewPollMessage =
+        PollMessage.Autorenew.convertVKey(serverApproveAutorenewPollMessage);
+  }
+
   @SuppressWarnings("unused") // For Hibernate.
   private void loadServerApproveBillingEventHistoryId(
       @AlsoLoad("serverApproveBillingEvent") VKey<BillingEvent.OneTime> val) {

--- a/core/src/main/java/google/registry/model/transfer/TransferData.java
+++ b/core/src/main/java/google/registry/model/transfer/TransferData.java
@@ -15,6 +15,7 @@
 package google.registry.model.transfer;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static google.registry.model.ImmutableObject.DoNotCompare;
 import static google.registry.util.CollectionUtils.isNullOrEmpty;
 import static google.registry.util.CollectionUtils.nullToEmpty;
 import static google.registry.util.CollectionUtils.nullToEmptyImmutableCopy;
@@ -76,6 +77,7 @@ public abstract class TransferData<
    * be deleted.
    */
   @Transient
+  @DoNotCompare
   @IgnoreSave(IfNull.class)
   Set<VKey<? extends TransferServerApproveEntity>> serverApproveEntities;
 

--- a/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
@@ -112,7 +112,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
 
   @Order(value = Order.DEFAULT - 2)
   @RegisterExtension
-  final ReplayExtension replayExtension = ReplayExtension.createWithoutCompare(clock);
+  final ReplayExtension replayExtension = ReplayExtension.createWithCompare(clock);
 
   private DomainBase domain;
   private HistoryEntry earlierHistoryEntry;

--- a/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
@@ -108,7 +108,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, DomainBa
 
   @Order(value = Order.DEFAULT - 2)
   @RegisterExtension
-  final ReplayExtension replayExtension = ReplayExtension.createWithoutCompare(clock);
+  final ReplayExtension replayExtension = ReplayExtension.createWithCompare(clock);
 
   @BeforeEach
   void initDomainTest() {

--- a/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
@@ -117,7 +117,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
 
   @Order(value = Order.DEFAULT - 2)
   @RegisterExtension
-  final ReplayExtension replayExtension = ReplayExtension.createWithoutCompare(clock);
+  final ReplayExtension replayExtension = ReplayExtension.createWithCompare(clock);
 
   @BeforeEach
   void initDomainTest() {


### PR DESCRIPTION
Add database comparison to the replay tests for DomainDeleteFlowTest,
DomainRenewFlowTest and DomainUpdateFlowTest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/963)
<!-- Reviewable:end -->
