### PR TITLE
Partially convert RDAP ofy calls to tm calls

### DIFF
--- a/core/src/main/java/google/registry/model/registrar/Registrar.java
+++ b/core/src/main/java/google/registry/model/registrar/Registrar.java
@@ -996,6 +996,13 @@ public class Registrar extends ImmutableObject
     return CACHE_BY_CLIENT_ID.get().values();
   }
 
+  /** Loads all registrar keys using an in-memory cache. */
+  public static ImmutableSet<VKey<Registrar>> loadAllKeysCached() {
+    return CACHE_BY_CLIENT_ID.get().keySet().stream()
+        .map(Registrar::createVKey)
+        .collect(toImmutableSet());
+  }
+
   /** Loads and returns a registrar entity by its client id directly from Datastore. */
   public static Optional<Registrar> loadByClientId(String clientId) {
     checkArgument(!Strings.isNullOrEmpty(clientId), "clientId must be specified");

--- a/core/src/main/java/google/registry/rdap/RdapSearchActionBase.java
+++ b/core/src/main/java/google/registry/rdap/RdapSearchActionBase.java
@@ -392,22 +392,6 @@ public abstract class RdapSearchActionBase extends RdapActionBase {
     return setOtherQueryAttributes(query, deletedItemHandling, resultSetMaxSize);
   }
 
-  /** Handles searches by key using a simple string. */
-  static <T extends EppResource> Query<T> queryItemsByKey(
-      Class<T> clazz,
-      String queryString,
-      DeletedItemHandling deletedItemHandling,
-      int resultSetMaxSize) {
-    if (queryString.length() < RdapSearchPattern.MIN_INITIAL_STRING_LENGTH) {
-      throw new UnprocessableEntityException(
-          String.format(
-              "Initial search string must be at least %d characters",
-              RdapSearchPattern.MIN_INITIAL_STRING_LENGTH));
-    }
-    Query<T> query = ofy().load().type(clazz).filterKey("=", Key.create(clazz, queryString));
-    return setOtherQueryAttributes(query, deletedItemHandling, resultSetMaxSize);
-  }
-
   static <T extends EppResource> Query<T> setOtherQueryAttributes(
       Query<T> query, DeletedItemHandling deletedItemHandling, int resultSetMaxSize) {
     if (deletedItemHandling != DeletedItemHandling.INCLUDE) {

--- a/core/src/test/java/google/registry/rdap/RdapEntityActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapEntityActionTest.java
@@ -38,12 +38,14 @@ import google.registry.rdap.RdapMetrics.SearchType;
 import google.registry.rdap.RdapMetrics.WildcardType;
 import google.registry.rdap.RdapSearchResults.IncompletenessWarningType;
 import google.registry.request.Action;
+import google.registry.testing.DualDatabaseTest;
+import google.registry.testing.TestOfyAndSql;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link RdapEntityAction}. */
+@DualDatabaseTest
 class RdapEntityActionTest extends RdapActionBaseTestCase<RdapEntityAction> {
 
   RdapEntityActionTest() {
@@ -187,35 +189,35 @@ class RdapEntityActionTest extends RdapActionBaseTestCase<RdapEntityAction> {
     assertThat(response.getStatus()).isEqualTo(404);
   }
 
-  @Test
+  @TestOfyAndSql
   void testUnknownEntity_RoidPattern_notFound() {
     runNotFoundTest("_MISSING-ENTITY_");
   }
 
-  @Test
+  @TestOfyAndSql
   void testUnknownEntity_IanaPattern_notFound() {
     runNotFoundTest("123");
   }
 
-  @Test
+  @TestOfyAndSql
   void testUnknownEntity_notRoidNotIana_notFound() {
     // Since we allow search by registrar name, every string is a possible name
     runNotFoundTest("some,random,string");
   }
 
-  @Test
+  @TestOfyAndSql
   void testValidRegistrantContact_works() {
     login("evilregistrar");
     runSuccessfulHandleTest(registrant.getRepoId(), "rdap_associated_contact.json");
   }
 
-  @Test
+  @TestOfyAndSql
   void testValidRegistrantContact_found_asAdministrator() {
     loginAsAdmin();
     runSuccessfulHandleTest(registrant.getRepoId(), "rdap_associated_contact.json");
   }
 
-  @Test
+  @TestOfyAndSql
   void testValidRegistrantContact_found_notLoggedIn() {
     runSuccessfulHandleTest(
         registrant.getRepoId(),
@@ -225,7 +227,7 @@ class RdapEntityActionTest extends RdapActionBaseTestCase<RdapEntityAction> {
         "rdap_associated_contact_no_personal_data.json");
   }
 
-  @Test
+  @TestOfyAndSql
   void testValidRegistrantContact_found_loggedInAsOtherRegistrar() {
     login("otherregistrar");
     runSuccessfulHandleTest(
@@ -236,49 +238,49 @@ class RdapEntityActionTest extends RdapActionBaseTestCase<RdapEntityAction> {
         "rdap_associated_contact_no_personal_data.json");
   }
 
-  @Test
+  @TestOfyAndSql
   void testValidAdminContact_works() {
     login("evilregistrar");
     runSuccessfulHandleTest(adminContact.getRepoId(), "rdap_associated_contact.json");
   }
 
-  @Test
+  @TestOfyAndSql
   void testValidTechContact_works() {
     login("evilregistrar");
     runSuccessfulHandleTest(techContact.getRepoId(), "rdap_associated_contact.json");
   }
 
-  @Test
+  @TestOfyAndSql
   void testValidDisconnectedContact_works() {
     login("evilregistrar");
     runSuccessfulHandleTest(disconnectedContact.getRepoId(), "rdap_contact.json");
   }
 
-  @Test
+  @TestOfyAndSql
   void testDeletedContact_notFound() {
     runNotFoundTest(deletedContact.getRepoId());
   }
 
-  @Test
+  @TestOfyAndSql
   void testDeletedContact_notFound_includeDeletedSetFalse() {
     action.includeDeletedParam = Optional.of(false);
     runNotFoundTest(deletedContact.getRepoId());
   }
 
-  @Test
+  @TestOfyAndSql
   void testDeletedContact_notFound_notLoggedIn() {
     action.includeDeletedParam = Optional.of(true);
     runNotFoundTest(deletedContact.getRepoId());
   }
 
-  @Test
+  @TestOfyAndSql
   void testDeletedContact_notFound_loggedInAsDifferentRegistrar() {
     login("idnregistrar");
     action.includeDeletedParam = Optional.of(true);
     runNotFoundTest(deletedContact.getRepoId());
   }
 
-  @Test
+  @TestOfyAndSql
   void testDeletedContact_found_loggedInAsCorrectRegistrar() {
     login("evilregistrar");
     action.includeDeletedParam = Optional.of(true);
@@ -290,7 +292,7 @@ class RdapEntityActionTest extends RdapActionBaseTestCase<RdapEntityAction> {
         "rdap_contact_deleted.json");
   }
 
-  @Test
+  @TestOfyAndSql
   void testDeletedContact_found_loggedInAsAdmin() {
     loginAsAdmin();
     action.includeDeletedParam = Optional.of(true);
@@ -302,12 +304,12 @@ class RdapEntityActionTest extends RdapActionBaseTestCase<RdapEntityAction> {
         "rdap_contact_deleted.json");
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrar_found() {
     runSuccessfulHandleTest("101", "Yes Virginia <script>", "rdap_registrar.json");
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrarByName_found() {
     assertThat(generateActualJson("IDN%20Registrar"))
         .isEqualTo(
@@ -316,28 +318,28 @@ class RdapEntityActionTest extends RdapActionBaseTestCase<RdapEntityAction> {
     assertThat(response.getStatus()).isEqualTo(200);
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrar102_works() {
     runSuccessfulHandleTest("102", "IDN Registrar", "rdap_registrar.json");
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrar103_works() {
     runSuccessfulHandleTest("103", "Multilevel Registrar", "rdap_registrar.json");
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrar104_notFound() {
     runNotFoundTest("104");
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrar104_notFound_deletedFlagWhenNotLoggedIn() {
     action.includeDeletedParam = Optional.of(true);
     runNotFoundTest("104");
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrar104_found_deletedFlagWhenLoggedIn() {
     login("deletedregistrar");
     action.includeDeletedParam = Optional.of(true);
@@ -345,14 +347,14 @@ class RdapEntityActionTest extends RdapActionBaseTestCase<RdapEntityAction> {
         "104", "Yes Virginia <script>", "inactive", null, "rdap_registrar.json");
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrar104_notFound_deletedFlagWhenLoggedInAsOther() {
     login("1tldregistrar");
     action.includeDeletedParam = Optional.of(true);
     runNotFoundTest("104");
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrar104_found_deletedFlagWhenLoggedInAsAdmin() {
     loginAsAdmin();
     action.includeDeletedParam = Optional.of(true);
@@ -360,12 +362,12 @@ class RdapEntityActionTest extends RdapActionBaseTestCase<RdapEntityAction> {
         "104", "Yes Virginia <script>", "inactive", null, "rdap_registrar.json");
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrar105_doesNotExist() {
     runNotFoundTest("105");
   }
 
-  @Test
+  @TestOfyAndSql
   void testQueryParameter_ignored() {
     login("evilregistrar");
     assertThat(generateActualJson(techContact.getRepoId() + "?key=value")).isEqualTo(
@@ -374,7 +376,7 @@ class RdapEntityActionTest extends RdapActionBaseTestCase<RdapEntityAction> {
     assertThat(response.getStatus()).isEqualTo(200);
   }
 
-  @Test
+  @TestOfyAndSql
   void testMetrics() {
     generateActualJson(registrant.getRepoId());
     verify(rdapMetrics)

--- a/core/src/test/java/google/registry/rdap/RdapJsonFormatterTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapJsonFormatterTest.java
@@ -47,14 +47,16 @@ import google.registry.rdap.RdapObjectClasses.RdapEntity;
 import google.registry.rdap.RdapObjectClasses.ReplyPayloadBase;
 import google.registry.rdap.RdapObjectClasses.TopLevelReplyObject;
 import google.registry.testing.AppEngineExtension;
+import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.FakeClock;
 import google.registry.testing.InjectExtension;
+import google.registry.testing.TestOfyAndSql;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link RdapJsonFormatter}. */
+@DualDatabaseTest
 class RdapJsonFormatterTest {
 
   @RegisterExtension
@@ -300,41 +302,41 @@ class RdapJsonFormatterTest {
     return new Gson().fromJson(loadFile(this.getClass(), expectedFileName), JsonObject.class);
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrar() {
     assertThat(rdapJsonFormatter.createRdapRegistrarEntity(registrar, OutputDataType.FULL).toJson())
         .isEqualTo(loadJson("rdapjson_registrar.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrar_summary() {
     assertThat(
             rdapJsonFormatter.createRdapRegistrarEntity(registrar, OutputDataType.SUMMARY).toJson())
         .isEqualTo(loadJson("rdapjson_registrar_summary.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testHost_ipv4() {
     assertThat(
             rdapJsonFormatter.createRdapNameserver(hostResourceIpv4, OutputDataType.FULL).toJson())
         .isEqualTo(loadJson("rdapjson_host_ipv4.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testHost_ipv6() {
     assertThat(
             rdapJsonFormatter.createRdapNameserver(hostResourceIpv6, OutputDataType.FULL).toJson())
         .isEqualTo(loadJson("rdapjson_host_ipv6.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testHost_both() {
     assertThat(
             rdapJsonFormatter.createRdapNameserver(hostResourceBoth, OutputDataType.FULL).toJson())
         .isEqualTo(loadJson("rdapjson_host_both.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testHost_both_summary() {
     assertThat(
             rdapJsonFormatter
@@ -343,7 +345,7 @@ class RdapJsonFormatterTest {
         .isEqualTo(loadJson("rdapjson_host_both_summary.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testHost_noAddresses() {
     assertThat(
             rdapJsonFormatter
@@ -352,7 +354,7 @@ class RdapJsonFormatterTest {
         .isEqualTo(loadJson("rdapjson_host_no_addresses.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testHost_notLinked() {
     assertThat(
             rdapJsonFormatter
@@ -361,7 +363,7 @@ class RdapJsonFormatterTest {
         .isEqualTo(loadJson("rdapjson_host_not_linked.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testHost_superordinateHasPendingTransfer() {
     assertThat(
             rdapJsonFormatter
@@ -370,7 +372,7 @@ class RdapJsonFormatterTest {
         .isEqualTo(loadJson("rdapjson_host_pending_transfer.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrant() {
     assertThat(
             rdapJsonFormatter
@@ -382,7 +384,7 @@ class RdapJsonFormatterTest {
         .isEqualTo(loadJson("rdapjson_registrant.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrant_summary() {
     assertThat(
             rdapJsonFormatter
@@ -394,7 +396,7 @@ class RdapJsonFormatterTest {
         .isEqualTo(loadJson("rdapjson_registrant_summary.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrant_loggedOut() {
     rdapJsonFormatter.rdapAuthorization = RdapAuthorization.PUBLIC_AUTHORIZATION;
     assertThat(
@@ -407,7 +409,7 @@ class RdapJsonFormatterTest {
         .isEqualTo(loadJson("rdapjson_registrant_logged_out.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrant_baseHasNoTrailingSlash() {
     // First, make sure we have a trailing slash at the end by default!
     // This test tries to change the default state, if the default doesn't have a /, then this test
@@ -426,7 +428,7 @@ class RdapJsonFormatterTest {
         .isEqualTo(loadJson("rdapjson_registrant.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testAdmin() {
     assertThat(
             rdapJsonFormatter
@@ -438,7 +440,7 @@ class RdapJsonFormatterTest {
         .isEqualTo(loadJson("rdapjson_admincontact.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testTech() {
     assertThat(
             rdapJsonFormatter
@@ -448,7 +450,7 @@ class RdapJsonFormatterTest {
         .isEqualTo(loadJson("rdapjson_techcontact.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testRolelessContact() {
     assertThat(
             rdapJsonFormatter
@@ -458,7 +460,7 @@ class RdapJsonFormatterTest {
         .isEqualTo(loadJson("rdapjson_rolelesscontact.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testUnlinkedContact() {
     assertThat(
             rdapJsonFormatter
@@ -468,26 +470,26 @@ class RdapJsonFormatterTest {
         .isEqualTo(loadJson("rdapjson_unlinkedcontact.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testDomain_full() {
     assertThat(rdapJsonFormatter.createRdapDomain(domainBaseFull, OutputDataType.FULL).toJson())
         .isEqualTo(loadJson("rdapjson_domain_full.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testDomain_summary() {
     assertThat(rdapJsonFormatter.createRdapDomain(domainBaseFull, OutputDataType.SUMMARY).toJson())
         .isEqualTo(loadJson("rdapjson_domain_summary.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testDomain_logged_out() {
     rdapJsonFormatter.rdapAuthorization = RdapAuthorization.PUBLIC_AUTHORIZATION;
     assertThat(rdapJsonFormatter.createRdapDomain(domainBaseFull, OutputDataType.FULL).toJson())
         .isEqualTo(loadJson("rdapjson_domain_logged_out.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testDomain_noNameserversNoTransfersMultipleRoleContact() {
     assertThat(
             rdapJsonFormatter
@@ -496,7 +498,7 @@ class RdapJsonFormatterTest {
         .isEqualTo(loadJson("rdapjson_domain_no_nameservers.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testError() {
     assertThat(
             RdapObjectClasses.ErrorResponse.create(
@@ -505,7 +507,7 @@ class RdapJsonFormatterTest {
         .isEqualTo(loadJson("rdapjson_error.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testTopLevel() {
     assertThat(
             TopLevelReplyObject.create(
@@ -517,7 +519,7 @@ class RdapJsonFormatterTest {
         .isEqualTo(loadJson("rdapjson_toplevel.json"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testTopLevel_domain() {
     assertThat(
             TopLevelReplyObject.create(


### PR DESCRIPTION
This converts the simple retrieval actions but does not touch the more
complicated search actions -- those use some ofy() query searching logic
and will likely end up being significantly more complicated than this
change. Here, though, we are just changing the calls that can be
converted easily to tm() lookups.

To change in future PRs:
- RdapDomainSearchAction
- RdapEntitySearchAction
- RdapNameserverSearchAction
- RdapSearchActionBase

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/964)
<!-- Reviewable:end -->
