### PR TITLE
Fix ContactTransferData SQL loads

### DIFF
--- a/core/src/main/java/google/registry/model/poll/PollMessage.java
+++ b/core/src/main/java/google/registry/model/poll/PollMessage.java
@@ -406,22 +406,20 @@ public abstract class PollMessage extends ImmutableObject
                     pendingActionNotificationResponse.processedDate));
       }
       if (contactId != null && transferResponse != null) {
-        contactTransferResponses =
-            ImmutableList.of(
-                new ContactTransferResponse.Builder()
-                    .setContactId(contactId)
-                    .setGainingClientId(transferResponse.getGainingClientId())
-                    .setLosingClientId(transferResponse.getLosingClientId())
-                    .setTransferStatus(transferResponse.getTransferStatus())
-                    .setTransferRequestTime(transferResponse.getTransferRequestTime())
-                    .setPendingTransferExpirationTime(
-                        transferResponse.getPendingTransferExpirationTime())
-                    .build());
-
-        // The transferResponse is currently an unspecialized TransferResponse instance, use the
-        // ContactTransferResponse that we just created so that the value is consistently
-        // specialized.
-        transferResponse = contactTransferResponses.get(0);
+        // The transferResponse is currently an unspecialized TransferResponse instance, create a
+        // ContactTransferResponse so that the value is consistently specialized and store it in the
+        // list representation for datastore.
+        transferResponse =
+            new ContactTransferResponse.Builder()
+                .setContactId(contactId)
+                .setGainingClientId(transferResponse.getGainingClientId())
+                .setLosingClientId(transferResponse.getLosingClientId())
+                .setTransferStatus(transferResponse.getTransferStatus())
+                .setTransferRequestTime(transferResponse.getTransferRequestTime())
+                .setPendingTransferExpirationTime(
+                    transferResponse.getPendingTransferExpirationTime())
+                .build();
+        contactTransferResponses = ImmutableList.of((ContactTransferResponse) transferResponse);
       }
     }
 

--- a/core/src/main/java/google/registry/model/poll/PollMessage.java
+++ b/core/src/main/java/google/registry/model/poll/PollMessage.java
@@ -417,6 +417,11 @@ public abstract class PollMessage extends ImmutableObject
                     .setPendingTransferExpirationTime(
                         transferResponse.getPendingTransferExpirationTime())
                     .build());
+
+        // The transferResponse is currently an unspecialized TransferResponse instance, use the
+        // ContactTransferResponse that we just created so that the value is consistently
+        // specialized.
+        transferResponse = contactTransferResponses.get(0);
       }
     }
 

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferApproveFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferApproveFlowTest.java
@@ -41,13 +41,20 @@ import google.registry.model.transfer.TransferData;
 import google.registry.model.transfer.TransferResponse;
 import google.registry.model.transfer.TransferStatus;
 import google.registry.testing.DualDatabaseTest;
+import google.registry.testing.ReplayExtension;
 import google.registry.testing.TestOfyAndSql;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link ContactTransferApproveFlow}. */
 @DualDatabaseTest
 class ContactTransferApproveFlowTest
     extends ContactTransferFlowTestCase<ContactTransferApproveFlow, ContactResource> {
+
+  @Order(value = Order.DEFAULT - 2)
+  @RegisterExtension
+  final ReplayExtension replayExtension = ReplayExtension.createWithCompare(clock);
 
   @BeforeEach
   void setUp() {


### PR DESCRIPTION
ContactTransferData is currently loaded back from SQL as an unspecialized
TransferData object.  Replace it with the ContactTransferData object that we
use it to reconstitute.

It's likely that this could be done more straightforwardly with a schema
change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/967)
<!-- Reviewable:end -->
