### PR TITLE
Add SQL searching to RdapEntitySearchAction and RdapSearchActionBase

### DIFF
--- a/config/presubmits.py
+++ b/config/presubmits.py
@@ -207,6 +207,9 @@ PRESUBMITS = {
          "ForeignKeyIndex.java",
          "HistoryEntryDao.java",
          "JpaTransactionManagerImpl.java",
+         # CriteriaQueryBuilder is a false positive
+         "CriteriaQueryBuilder.java",
+         "RdapSearchActionBase.java",
          },
     ):
         "The first String parameter to EntityManager.create(Native)Query "

--- a/core/src/main/java/google/registry/model/common/DatabaseTransitionSchedule.java
+++ b/core/src/main/java/google/registry/model/common/DatabaseTransitionSchedule.java
@@ -62,6 +62,8 @@ public class DatabaseTransitionSchedule extends ImmutableObject implements Datas
     DOMAIN_LABEL_LISTS,
     /** The schedule for the migration of the {@link SignedMarkRevocationList} entity. */
     SIGNED_MARK_REVOCATION_LIST,
+    /** The schedule for all asynchronously-replayed entities, ones not dually-written. */
+    REPLAYED_ENTITIES,
   }
 
   /**

--- a/core/src/main/java/google/registry/persistence/transaction/CriteriaQueryBuilder.java
+++ b/core/src/main/java/google/registry/persistence/transaction/CriteriaQueryBuilder.java
@@ -1,0 +1,97 @@
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.persistence.transaction;
+
+import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collection;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Order;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+/**
+ * An extension of {@link CriteriaQuery} that uses a Builder-style pattern when adding "WHERE"
+ * and/or "ORDER BY" clauses.
+ *
+ * <p>{@link CriteriaQuery}, as is, requires that all clauses must be passed in at once -- if one
+ * calls "WHERE" multiple times, the later call overwrites the earlier call.
+ */
+public class CriteriaQueryBuilder<T> {
+
+  /** Functional interface that defines the 'where' operator, e.g. {@link CriteriaBuilder#equal}. */
+  public interface WhereClause<U> {
+    Predicate predicate(Expression<U> expression, U object);
+  }
+
+  /** Functional interface that defines the order-by operator, e.g. {@link CriteriaBuilder#asc}. */
+  public interface OrderByClause<U> {
+    Order order(Expression<U> expression);
+  }
+
+  private final CriteriaQuery<T> query;
+  private final Root<T> root;
+  private final ImmutableList.Builder<Predicate> predicates = new ImmutableList.Builder<>();
+  private final ImmutableList.Builder<Order> orders = new ImmutableList.Builder<>();
+
+  private CriteriaQueryBuilder(CriteriaQuery<T> query, Root<T> root) {
+    this.query = query;
+    this.root = root;
+  }
+
+  /** Adds a WHERE clause to the query, given the specified operation, field, and value. */
+  public <V> CriteriaQueryBuilder<T> where(WhereClause<V> whereClause, String fieldName, V value) {
+    Expression<V> expression = root.get(fieldName);
+    return where(whereClause.predicate(expression, value));
+  }
+
+  /** Adds a WHERE clause to the query specifying that a value must be in the given collection. */
+  public CriteriaQueryBuilder<T> whereFieldIsIn(String fieldName, Collection<?> values) {
+    return where(root.get(fieldName).in(values));
+  }
+
+  /** Orders the result by the given operation applied to the given field. */
+  public <U> CriteriaQueryBuilder<T> orderBy(OrderByClause<U> orderByClause, String fieldName) {
+    Expression<U> expression = root.get(fieldName);
+    return orderBy(orderByClause.order(expression));
+  }
+
+  /** Builds and returns the query, applying all WHERE and ORDER BY clauses at once. */
+  public CriteriaQuery<T> build() {
+    Predicate[] predicateArray = predicates.build().toArray(new Predicate[0]);
+    return query.where(predicateArray).orderBy(orders.build());
+  }
+
+  private CriteriaQueryBuilder<T> where(Predicate predicate) {
+    predicates.add(predicate);
+    return this;
+  }
+
+  private CriteriaQueryBuilder<T> orderBy(Order order) {
+    orders.add(order);
+    return this;
+  }
+
+  /** Creates a query builder that will SELECT from the given class. */
+  public static <T> CriteriaQueryBuilder<T> create(Class<T> clazz) {
+    CriteriaQuery<T> query = jpaTm().getEntityManager().getCriteriaBuilder().createQuery(clazz);
+    Root<T> root = query.from(clazz);
+    query = query.select(root);
+    return new CriteriaQueryBuilder<>(query, root);
+  }
+}

--- a/core/src/test/java/google/registry/persistence/transaction/CriteriaQueryBuilderTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/CriteriaQueryBuilderTest.java
@@ -1,0 +1,202 @@
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.persistence.transaction;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+
+import com.google.common.collect.ImmutableList;
+import google.registry.model.ImmutableObject;
+import google.registry.persistence.transaction.JpaTestRules.JpaUnitTestExtension;
+import google.registry.testing.FakeClock;
+import java.util.List;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.criteria.CriteriaQuery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Tests for {@link CriteriaQueryBuilder}. */
+class CriteriaQueryBuilderTest {
+
+  private final FakeClock fakeClock = new FakeClock();
+
+  private CriteriaQueryBuilderTestEntity entity1 =
+      new CriteriaQueryBuilderTestEntity("name1", "data");
+  private CriteriaQueryBuilderTestEntity entity2 =
+      new CriteriaQueryBuilderTestEntity("name2", "zztz");
+  private CriteriaQueryBuilderTestEntity entity3 = new CriteriaQueryBuilderTestEntity("zzz", "aaa");
+
+  @RegisterExtension
+  final JpaUnitTestExtension jpaExtension =
+      new JpaTestRules.Builder()
+          .withClock(fakeClock)
+          .withEntityClass(CriteriaQueryBuilderTestEntity.class)
+          .buildUnitTestRule();
+
+  @BeforeEach
+  void beforeEach() {
+    jpaTm().transact(() -> jpaTm().putAll(ImmutableList.of(entity1, entity2, entity3)));
+  }
+
+  @Test
+  void testSuccess_noWhereClause() {
+    assertThat(
+            jpaTm()
+                .transact(
+                    () ->
+                        jpaTm()
+                            .getEntityManager()
+                            .createQuery(
+                                CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
+                                    .build())
+                            .getResultList()))
+        .containsExactly(entity1, entity2, entity3)
+        .inOrder();
+  }
+
+  @Test
+  void testSuccess_where_exactlyOne() {
+    List<CriteriaQueryBuilderTestEntity> result =
+        jpaTm()
+            .transact(
+                () -> {
+                  CriteriaQuery<CriteriaQueryBuilderTestEntity> query =
+                      CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
+                          .where(
+                              jpaTm().getEntityManager().getCriteriaBuilder()::equal,
+                              "data",
+                              "zztz")
+                          .build();
+                  return jpaTm().getEntityManager().createQuery(query).getResultList();
+                });
+    assertThat(result).containsExactly(entity2);
+  }
+
+  @Test
+  void testSuccess_where_like_oneResult() {
+    List<CriteriaQueryBuilderTestEntity> result =
+        jpaTm()
+            .transact(
+                () -> {
+                  CriteriaQuery<CriteriaQueryBuilderTestEntity> query =
+                      CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
+                          .where(
+                              jpaTm().getEntityManager().getCriteriaBuilder()::like, "data", "a%")
+                          .build();
+                  return jpaTm().getEntityManager().createQuery(query).getResultList();
+                });
+    assertThat(result).containsExactly(entity3);
+  }
+
+  @Test
+  void testSuccess_where_like_twoResults() {
+    List<CriteriaQueryBuilderTestEntity> result =
+        jpaTm()
+            .transact(
+                () -> {
+                  CriteriaQuery<CriteriaQueryBuilderTestEntity> query =
+                      CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
+                          .where(
+                              jpaTm().getEntityManager().getCriteriaBuilder()::like, "data", "%a%")
+                          .build();
+                  return jpaTm().getEntityManager().createQuery(query).getResultList();
+                });
+    assertThat(result).containsExactly(entity1, entity3).inOrder();
+  }
+
+  @Test
+  void testSuccess_multipleWheres() {
+    List<CriteriaQueryBuilderTestEntity> result =
+        jpaTm()
+            .transact(
+                () -> {
+                  CriteriaQuery<CriteriaQueryBuilderTestEntity> query =
+                      CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
+                          // first "where" matches 1 and 3
+                          .where(
+                              jpaTm().getEntityManager().getCriteriaBuilder()::like, "data", "%a%")
+                          // second "where" matches 1 and 2
+                          .where(
+                              jpaTm().getEntityManager().getCriteriaBuilder()::like, "data", "%t%")
+                          .build();
+                  return jpaTm().getEntityManager().createQuery(query).getResultList();
+                });
+    assertThat(result).containsExactly(entity1);
+  }
+
+  @Test
+  void testSuccess_where_in_oneResult() {
+    List<CriteriaQueryBuilderTestEntity> result =
+        jpaTm()
+            .transact(
+                () -> {
+                  CriteriaQuery<CriteriaQueryBuilderTestEntity> query =
+                      CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
+                          .whereFieldIsIn("data", ImmutableList.of("aaa", "bbb"))
+                          .build();
+                  return jpaTm().getEntityManager().createQuery(query).getResultList();
+                });
+    assertThat(result).containsExactly(entity3).inOrder();
+  }
+
+  @Test
+  void testSuccess_where_in_twoResults() {
+    List<CriteriaQueryBuilderTestEntity> result =
+        jpaTm()
+            .transact(
+                () -> {
+                  CriteriaQuery<CriteriaQueryBuilderTestEntity> query =
+                      CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
+                          .whereFieldIsIn("data", ImmutableList.of("aaa", "bbb", "data"))
+                          .build();
+                  return jpaTm().getEntityManager().createQuery(query).getResultList();
+                });
+    assertThat(result).containsExactly(entity1, entity3).inOrder();
+  }
+
+  @Test
+  void testSuccess_orderBy() {
+    List<CriteriaQueryBuilderTestEntity> result =
+        jpaTm()
+            .transact(
+                () -> {
+                  CriteriaQuery<CriteriaQueryBuilderTestEntity> query =
+                      CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
+                          .orderBy(jpaTm().getEntityManager().getCriteriaBuilder()::asc, "data")
+                          .where(
+                              jpaTm().getEntityManager().getCriteriaBuilder()::like, "data", "%a%")
+                          .build();
+                  return jpaTm().getEntityManager().createQuery(query).getResultList();
+                });
+    assertThat(result).containsExactly(entity3, entity1).inOrder();
+  }
+
+  @Entity(name = "CriteriaQueryBuilderTestEntity")
+  private static class CriteriaQueryBuilderTestEntity extends ImmutableObject {
+    @Id private String name;
+
+    @SuppressWarnings("unused")
+    private String data;
+
+    private CriteriaQueryBuilderTestEntity() {}
+
+    private CriteriaQueryBuilderTestEntity(String name, String data) {
+      this.name = name;
+      this.data = data;
+    }
+  }
+}


### PR DESCRIPTION
- Adds a CriteriaQueryBuilder class that allows us to build
CriteriaQuery objects with sane and modular WHERE and ORDER BY clauses.
CriteriaQuery requires that all WHERE and ORDER BY clauses be specified
at the same time (else later ones will overwrite the earlier ones) so in
order to have a proper builder pattern we need to wait to build the
query object until we are done adding clauses.

- In addition, encapsulating the query logic in the CriteriaQueryBuilder
class means that we don't need to deal with the complicated Root/Path
branching, otherwise we'd have to keep track of CriteriaQuery and Root
objects everywhere.

- Adds the logic to use that query builder in RdapSearchActionBase to query SQL for the items we want to search for.

- Adds a REPLAYED_ENTITIES TransitionId that will represent all
replayed entities, e.g. EppResources. Also sets this, by default, to
always be CLOUD_SQL if we're using the SQL transaction manager in tests.

- Adds branching logic in RdapEntitySearchAction based on that transition
ID that determines whether we do the existing ofy query logic or JPA
logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/969)
<!-- Reviewable:end -->
