### PR TITLE
Add GetPremiumListCommand

### DIFF
--- a/core/src/main/java/google/registry/export/ExportPremiumTermsAction.java
+++ b/core/src/main/java/google/registry/export/ExportPremiumTermsAction.java
@@ -31,6 +31,7 @@ import com.google.common.flogger.FluentLogger;
 import com.google.common.net.MediaType;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.model.registry.Registry;
+import google.registry.model.registry.label.PremiumList.PremiumListEntry;
 import google.registry.model.registry.label.PremiumListDualDao;
 import google.registry.request.Action;
 import google.registry.request.Parameter;
@@ -141,7 +142,7 @@ public class ExportPremiumTermsAction implements Runnable {
         PremiumListDualDao.exists(premiumListName), "Could not load premium list for " + tld);
     SortedSet<String> premiumTerms =
         Streams.stream(PremiumListDualDao.loadAllPremiumListEntries(premiumListName))
-            .map(entry -> Joiner.on(",").join(entry.getLabel(), entry.getValue()))
+            .map(PremiumListEntry::toString)
             .collect(ImmutableSortedSet.toImmutableSortedSet(String::compareTo));
 
     return Joiner.on("\n")

--- a/core/src/main/java/google/registry/model/registry/label/PremiumList.java
+++ b/core/src/main/java/google/registry/model/registry/label/PremiumList.java
@@ -209,6 +209,12 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
     }
 
     @Override
+    public String toString() {
+      // Don't include the comment so that we can use this when exporting the premium list
+      return String.format("%s,%s", label, price);
+    }
+
+    @Override
     public Builder asBuilder() {
       return new Builder(clone(this));
     }

--- a/core/src/main/java/google/registry/tools/GetPremiumListCommand.java
+++ b/core/src/main/java/google/registry/tools/GetPremiumListCommand.java
@@ -1,0 +1,49 @@
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.tools;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.google.common.collect.Streams;
+import google.registry.model.registry.label.PremiumList.PremiumListEntry;
+import google.registry.model.registry.label.PremiumListDualDao;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Retrieves and prints one or more premium lists. */
+@Parameters(separators = " =", commandDescription = "Show one or more premium lists")
+public class GetPremiumListCommand implements CommandWithRemoteApi {
+
+  @Parameter(description = "Name(s) of the premium list(s) to retrieve", required = true)
+  private List<String> mainParameters;
+
+  @Override
+  public void run() throws Exception {
+    for (String premiumListName : mainParameters) {
+      if (PremiumListDualDao.exists(premiumListName)) {
+        System.out.printf(
+            "%s:\n%s\n",
+            premiumListName,
+            Streams.stream(PremiumListDualDao.loadAllPremiumListEntries(premiumListName))
+                .sorted(Comparator.comparing(PremiumListEntry::getLabel))
+                .map(PremiumListEntry::toString)
+                .collect(Collectors.joining("\n")));
+      } else {
+        System.out.println(String.format("No list found with name %s.", premiumListName));
+      }
+    }
+  }
+}

--- a/core/src/main/java/google/registry/tools/RegistryTool.java
+++ b/core/src/main/java/google/registry/tools/RegistryTool.java
@@ -76,6 +76,7 @@ public final class RegistryTool {
           .put("get_host", GetHostCommand.class)
           .put("get_keyring_secret", GetKeyringSecretCommand.class)
           .put("get_operation_status", GetOperationStatusCommand.class)
+          .put("get_premium_list", GetPremiumListCommand.class)
           .put("get_registrar", GetRegistrarCommand.class)
           .put("get_resource_by_key", GetResourceByKeyCommand.class)
           .put("get_routing_map", GetRoutingMapCommand.class)

--- a/core/src/test/java/google/registry/tools/GetPremiumListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetPremiumListCommandTest.java
@@ -1,0 +1,71 @@
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.tools;
+
+import static google.registry.testing.DatabaseHelper.createTld;
+import static org.junit.Assert.assertThrows;
+
+import com.beust.jcommander.ParameterException;
+import google.registry.testing.DualDatabaseTest;
+import google.registry.testing.TestOfyAndSql;
+import org.junit.jupiter.api.BeforeEach;
+
+@DualDatabaseTest
+public class GetPremiumListCommandTest extends CommandTestCase<GetPremiumListCommand> {
+
+  private static final String BASE_LIST_CONTENTS =
+      "tld:\n"
+          + "aluminum,USD 11.00\n"
+          + "brass,USD 20.00\n"
+          + "copper,USD 15.00\n"
+          + "diamond,USD 1000000.00\n"
+          + "gold,USD 24317.00\n"
+          + "iridium,USD 13117.00\n"
+          + "palladium,USD 877.00\n"
+          + "platinum,USD 87741.00\n"
+          + "rhodium,USD 88415.00\n"
+          + "rich,USD 100.00\n"
+          + "richer,USD 1000.00\n"
+          + "silver,USD 588.00\n";
+
+  @BeforeEach
+  void beforeEach() {
+    createTld("tld");
+  }
+
+  @TestOfyAndSql
+  void testSuccess_list() throws Exception {
+    runCommand("tld");
+    assertStdoutIs(BASE_LIST_CONTENTS);
+  }
+
+  @TestOfyAndSql
+  void testSuccess_onlyOneExists() throws Exception {
+    runCommand("tld", "nonexistent");
+    assertStdoutIs(BASE_LIST_CONTENTS + "No list found with name nonexistent.\n");
+  }
+
+  @TestOfyAndSql
+  void testFailure_nonexistent() throws Exception {
+    runCommand("nonexistent", "othernonexistent");
+    assertStdoutIs(
+        "No list found with name nonexistent.\nNo list found with name othernonexistent.\n");
+  }
+
+  @TestOfyAndSql
+  void testFailure_noArgs() {
+    assertThrows(ParameterException.class, this::runCommand);
+  }
+}


### PR DESCRIPTION
When testing the premium list refactor, it would have been nice and
convenient to have this. Currently we have no way of inspecting premium
list contents that I'm aware of that doesn't involve manually looking
at the Datastore or SQL entries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/972)
<!-- Reviewable:end -->
