### PR TITLE
Convert DomainTransferRejectFlow to use tm() methods

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainTransferRejectFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferRejectFlow.java
@@ -25,7 +25,6 @@ import static google.registry.flows.domain.DomainFlowUtils.updateAutorenewRecurr
 import static google.registry.flows.domain.DomainTransferUtils.createGainingTransferPollMessage;
 import static google.registry.flows.domain.DomainTransferUtils.createTransferResponse;
 import static google.registry.model.ResourceTransferUtils.denyPendingTransfer;
-import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.model.reporting.DomainTransactionRecord.TransactionReportField.TRANSFER_NACKED;
 import static google.registry.model.reporting.DomainTransactionRecord.TransactionReportField.TRANSFER_SUCCESSFUL;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
@@ -41,7 +40,6 @@ import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
 import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
-import google.registry.model.ImmutableObject;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.domain.metadata.MetadataExtension;
 import google.registry.model.eppcommon.AuthInfo;
@@ -102,11 +100,11 @@ public final class DomainTransferRejectFlow implements TransactionalFlow {
     }
     DomainBase newDomain =
         denyPendingTransfer(existingDomain, TransferStatus.CLIENT_REJECTED, now, clientId);
-    ofy().save().<ImmutableObject>entities(
-        newDomain,
-        historyEntry,
-        createGainingTransferPollMessage(
-            targetId, newDomain.getTransferData(), null, historyEntry));
+    tm().putAll(
+            newDomain,
+            historyEntry,
+            createGainingTransferPollMessage(
+                targetId, newDomain.getTransferData(), null, historyEntry));
     // Reopen the autorenew event and poll message that we closed for the implicit transfer. This
     // may end up recreating the poll message if it was deleted upon the transfer request.
     updateAutorenewRecurrenceEndTime(existingDomain, END_OF_TIME);

--- a/core/src/main/java/google/registry/model/ResourceTransferUtils.java
+++ b/core/src/main/java/google/registry/model/ResourceTransferUtils.java
@@ -118,9 +118,7 @@ public final class ResourceTransferUtils {
     if (resource.getStatusValues().contains(StatusValue.PENDING_TRANSFER)) {
       TransferData oldTransferData = resource.getTransferData();
       tm().delete(oldTransferData.getServerApproveEntities());
-      ofy()
-          .save()
-          .entity(
+      tm().put(
               new PollMessage.OneTime.Builder()
                   .setClientId(oldTransferData.getGainingClientId())
                   .setEventTime(now)

--- a/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
+++ b/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
@@ -132,6 +132,11 @@ public class DatastoreTransactionManager implements TransactionManager {
   }
 
   @Override
+  public void putAll(Object... entities) {
+    syncIfTransactionless(getOfy().save().entities(entities));
+  }
+
+  @Override
   public void putAll(ImmutableCollection<?> entities) {
     syncIfTransactionless(getOfy().save().entities(entities));
   }

--- a/core/src/main/java/google/registry/model/transfer/DomainTransferData.java
+++ b/core/src/main/java/google/registry/model/transfer/DomainTransferData.java
@@ -14,7 +14,10 @@
 
 package google.registry.model.transfer;
 
+import static google.registry.util.CollectionUtils.forceEmptyToNull;
+
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.annotation.AlsoLoad;
 import com.googlecode.objectify.annotation.Embed;
@@ -34,6 +37,7 @@ import javax.persistence.AttributeOverrides;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.Embedded;
+import javax.persistence.PostLoad;
 import org.joda.time.DateTime;
 
 /** Transfer data for domain. */
@@ -212,6 +216,28 @@ public class DomainTransferData extends TransferData<DomainTransferData.Builder>
   @Nullable
   public Long getServerApproveAutorenewPollMessageHistoryId() {
     return serverApproveAutorenewPollMessageHistoryId;
+  }
+
+  @PostLoad
+  @Override
+  void postLoad() {
+    // The superclass's serverApproveEntities should include the billing events if present
+    super.postLoad();
+    ImmutableSet.Builder<VKey<? extends TransferServerApproveEntity>> serverApproveEntitiesBuilder =
+        new ImmutableSet.Builder<>();
+    if (serverApproveEntities != null) {
+      serverApproveEntitiesBuilder.addAll(serverApproveEntities);
+    }
+    if (serverApproveBillingEvent != null) {
+      serverApproveEntitiesBuilder.add(serverApproveBillingEvent);
+    }
+    if (serverApproveAutorenewEvent != null) {
+      serverApproveEntitiesBuilder.add(serverApproveAutorenewEvent);
+    }
+    if (serverApproveAutorenewPollMessage != null) {
+      serverApproveEntitiesBuilder.add(serverApproveAutorenewPollMessage);
+    }
+    serverApproveEntities = forceEmptyToNull(serverApproveEntitiesBuilder.build());
   }
 
   @Override

--- a/core/src/main/java/google/registry/model/transfer/TransferData.java
+++ b/core/src/main/java/google/registry/model/transfer/TransferData.java
@@ -167,7 +167,7 @@ public abstract class TransferData<
       return;
     }
     Key<? extends EppResource> eppKey;
-    if (getClass().equals(DomainBase.class)) {
+    if (getClass().equals(DomainTransferData.class)) {
       eppKey = Key.create(DomainBase.class, repoId);
     } else {
       eppKey = Key.create(ContactResource.class, repoId);

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -289,6 +289,15 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   }
 
   @Override
+  public void putAll(Object... entities) {
+    checkArgumentNotNull(entities, "entities must be specified");
+    assertInTransaction();
+    for (Object entity : entities) {
+      put(entity);
+    }
+  }
+
+  @Override
   public void putAll(ImmutableCollection<?> entities) {
     checkArgumentNotNull(entities, "entities must be specified");
     assertInTransaction();

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
@@ -123,7 +123,10 @@ public interface TransactionManager {
   /** Persists a new entity or update the existing entity in the database. */
   void put(Object entity);
 
-  /** Persists all new entities or update the existing entities in the database. */
+  /** Persists all new entities or updates the existing entities in the database. */
+  void putAll(Object... entities);
+
+  /** Persists all new entities or updates the existing entities in the database. */
   void putAll(ImmutableCollection<?> entities);
 
   /**

--- a/core/src/test/java/google/registry/model/ImmutableObjectSubject.java
+++ b/core/src/test/java/google/registry/model/ImmutableObjectSubject.java
@@ -21,6 +21,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.truth.Correspondence;
 import com.google.common.truth.Correspondence.BinaryPredicate;
@@ -48,6 +49,11 @@ public final class ImmutableObjectSubject extends Subject {
       FailureMetadata failureMetadata, @Nullable ImmutableObject actual) {
     super(failureMetadata, actual);
     this.actual = actual;
+  }
+
+  public void isEqualExceptFields(
+      @Nullable ImmutableObject expected, Iterable<String> ignoredFields) {
+    isEqualExceptFields(expected, Iterables.toArray(ignoredFields, String.class));
   }
 
   public void isEqualExceptFields(@Nullable ImmutableObject expected, String... ignoredFields) {


### PR DESCRIPTION
This change includes a few other necessary dependencies to converting
DomainTransferRejectFlowTest to be a dual-database test. Namely:

- The basic "use tm() instead of ofy()" and "branching database
selection on what were previously raw ofy queries"
- Modification of the PollMessage convertVKey methods to do what they
say they do
- Filling the generic pending / response fields in PollMessage based on what type of
poll message it is (this has to be done because SQL is not very good at
storing ambiguous superclasses)
- Setting the generic pending / repsonse fields in PollMessage upon
build
- Filling out the serverApproveEntities field in DomainTransferData with
all necessary poll messages / billing events that should be cancelled on
rejection
- Scattered changes in DatabaseHelper to make sure that we're saving and
loading entities correctly where we weren't before

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/977)
<!-- Reviewable:end -->
