### PR TITLE
Explicitly set fanout tasks HTTP method to POST

### DIFF
--- a/core/src/main/java/google/registry/cron/TldFanoutAction.java
+++ b/core/src/main/java/google/registry/cron/TldFanoutAction.java
@@ -39,6 +39,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import com.google.appengine.api.taskqueue.Queue;
 import com.google.appengine.api.taskqueue.TaskHandle;
 import com.google.appengine.api.taskqueue.TaskOptions;
+import com.google.appengine.api.taskqueue.TaskOptions.Method;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
@@ -173,6 +174,8 @@ public final class TldFanoutAction implements Runnable {
       // TaskOptions.param() does not accept null values.
       options.param(param, nullToEmpty(getFirst(params.get(param), null)));
     }
+    // Explicitly set the method to POST even though it is the default.
+    options.method(Method.POST);
     return options;
   }
 }

--- a/core/src/test/java/google/registry/cron/TldFanoutActionTest.java
+++ b/core/src/test/java/google/registry/cron/TldFanoutActionTest.java
@@ -120,7 +120,7 @@ class TldFanoutActionTest {
   }
 
   @Test
-  void testSuccess_methodPostIsDefault() {
+  void testSuccess_methodPostIsUsed() {
     run(getParamsMap("runInEmpty", ""));
     assertTasksEnqueued(QUEUE, new TaskMatcher().method("POST"));
   }


### PR DESCRIPTION
For unknown reasons some of the fanout actions triggered by cron use GET
to hit Nomulus endpoints, which only accept POST. This should not have
happened and there's even a test to make sure the default method is
POST. Nevertheless we make the method selection explicit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/978)
<!-- Reviewable:end -->
