### PR TITLE
Add SQL queries to RdapNameserverSearchAction

### DIFF
--- a/config/presubmits.py
+++ b/config/presubmits.py
@@ -210,6 +210,7 @@ PRESUBMITS = {
          # CriteriaQueryBuilder is a false positive
          "CriteriaQueryBuilder.java",
          "RdapDomainSearchAction.java",
+         "RdapNameserverSearchAction.java",
          "RdapSearchActionBase.java",
          },
     ):

--- a/core/src/main/java/google/registry/rdap/RdapSearchActionBase.java
+++ b/core/src/main/java/google/registry/rdap/RdapSearchActionBase.java
@@ -214,7 +214,7 @@ public abstract class RdapSearchActionBase extends RdapActionBase {
     }
   }
 
-  private <T extends EppResource> RdapResultSet<T> filterResourcesByVisibility(
+  protected <T extends EppResource> RdapResultSet<T> filterResourcesByVisibility(
       List<T> queryResult, int querySizeLimit) {
     // If we are including deleted resources, we need to check that we're authorized for each one.
     List<T> resources = new ArrayList<>();


### PR DESCRIPTION
This has the same issue as the domain-search action where the database
ordering is not consistent between Objectify and SQL -- as a result,
there is one test that we have to duplicate in order to account for the
two sort orders.

In addition, there isn't a way to query @Convert-ed fields in Postgres
via the standard Hibernate / JPA query language, meaning we have to use
a raw Postgres query for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/987)
<!-- Reviewable:end -->
