### PR TITLE
Clean up Gradle Flyway tasks in :db

### DIFF
--- a/config/nom_build.py
+++ b/config/nom_build.py
@@ -111,8 +111,8 @@ PROPERTIES = [
 
     # Cloud SQL properties
     Property('dbServer',
-             'A registry environment name (e.g., "alpha") or a host[:port] '
-             'string'),
+             'The host[:port] of a database that accepts direct IP access. '
+             'This is typically used with a testing database.'),
     Property('dbName',
              'Database name to use in connection.',
              'postgres'),

--- a/db/build.gradle
+++ b/db/build.gradle
@@ -20,8 +20,6 @@ plugins {
 ext {
   Set restrictedDbEnv =
       [ 'sandbox', 'production' ].asUnmodifiable()
-  Set allDbEnv =
-      [ 'alpha', 'crash' ].plus(restrictedDbEnv).asUnmodifiable()
 
   def dbServerProperty = 'dbServer'
   def dbNameProperty = 'dbName'
@@ -57,12 +55,12 @@ ext {
   }
 
   getJdbcAccessInfo = {
-    if (allDbEnv.contains(dbServer)) {
-      return getSocketFactoryAccessInfo(dbServer)
+    if (rootProject.projects.keySet().contains(environment)) {
+      return getSocketFactoryAccessInfo(environment)
     } else if (!dbServer.isEmpty()) {
       return getAccessInfoByHostPort(dbServer)
     } else {
-      // Not connecting to a database. Return a dummy object for Flyway config.
+      // Not running flyway tasks. Return a dummy object for Flyway config.
       return [ url: '', user: '', password: '' ]
     }
   }
@@ -136,6 +134,16 @@ publishing {
     }
   }
 }
+
+// Adds flyway tasks such as: flywayInfo, flywayValidate, flywayMigrate (deploying the schema in
+// local repository), and flywayClean (dropping all data in the database). The latter two commands
+// are disallowed in environments listed in ext.restrictedDbEnv.
+//
+// Examples:
+// Get info in alpha: nom_build :db:flywayInfo --environment=alpha
+// Deploy schema to a local test instance and override the database name:
+// nom_build :db:flywayMigrate --dbServer=localhost:5432 --dbName=not-default \
+//    --dbUser=... --dbPassword=...
 
 flyway {
   def accessInfo = project.ext.getJdbcAccessInfo()


### PR DESCRIPTION
Simplified the command line by revising the semantics of some
properties.

Added examples of Flyway task invocations.

This script still uses the GCS file-based credential. We will migrate it
to the Secret Manager soon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/990)
<!-- Reviewable:end -->
