### PR TITLE
Use Java toolchains to configure version of Java used to compile

### DIFF
--- a/java_common.gradle
+++ b/java_common.gradle
@@ -18,6 +18,13 @@ apply plugin: 'net.ltgt.errorprone'
 apply plugin: 'checkstyle'
 apply plugin: 'jacoco'
 
+// Use Java 11 to compile.
+java {
+  toolchain {
+    languageVersion.set(JavaLanguageVersion.of(11))
+  }
+}
+
 // Checkstyle should run as part of the testing task
 tasks.test.dependsOn tasks.checkstyleMain
 tasks.test.dependsOn tasks.checkstyleTest


### PR DESCRIPTION
This is recommended in https://blog.gradle.org/java-toolchains and it
makes it easier to ensure that the same version of Java is used for this
project wherever it compiles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/996)
<!-- Reviewable:end -->
