### PR TITLE
Print JAVA_HOME and PATH in the java format checker task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -401,6 +401,8 @@ def createGetBuildSrcDirectDepsTask(outputFileName) {
 
 rootProject.ext {
   invokeJavaDiffFormatScript = { action ->
+    println("JAVA_HOME=${System.env.JAVA_HOME}")
+    println("PATH=${System.env.PATH}")
     def scriptDir = rootDir.path.endsWith('buildSrc')
             ? "${rootDir}/../java-format"
             : "${rootDir}/java-format"


### PR DESCRIPTION
This allows is to identify if the java version is incompatible with the
formater checker jar file.