### PR TITLE
Print out env variables in java format

### DIFF
--- a/java-format/google-java-format-diff.py
+++ b/java-format/google-java-format-diff.py
@@ -56,6 +56,8 @@ def main():
   parser.add_argument('-b', '--binary', help='path to google-java-format binary')
   parser.add_argument('--google-java-format-jar', metavar='ABSOLUTE_PATH', default=None,
                       help='use a custom google-java-format jar')
+  parser.add_argument('-j', '--java-binary', default='java',
+                      help='path to the java binary')
 
   args = parser.parse_args()
 
@@ -92,9 +94,7 @@ def main():
   if args.binary:
     base_command = [args.binary]
   elif args.google_java_format_jar:
-    print >>sys.stderr, 'JAVA_HOME = %r' % os.environ['JAVA_HOME']
-    print >>sys.stderr, 'PATH = %r' % os.environ['PATH']
-    base_command = ['java', '-jar', args.google_java_format_jar]
+    base_command = [args.java_binary, '-jar', args.google_java_format_jar]
   else:
     binary = find_executable('google-java-format') or '/usr/bin/google-java-format'
     base_command = [binary]

--- a/java-format/google-java-format-diff.py
+++ b/java-format/google-java-format-diff.py
@@ -27,7 +27,6 @@ import re
 import string
 import subprocess
 import io
-import os
 import sys
 from distutils.spawn import find_executable
 

--- a/java-format/google-java-format-diff.py
+++ b/java-format/google-java-format-diff.py
@@ -27,6 +27,7 @@ import re
 import string
 import subprocess
 import io
+import os
 import sys
 from distutils.spawn import find_executable
 
@@ -91,6 +92,8 @@ def main():
   if args.binary:
     base_command = [args.binary]
   elif args.google_java_format_jar:
+    print >>sys.stderr, 'JAVA_HOME = %r' % os.environ['JAVA_HOME']
+    print >>sys.stderr, 'PATH = %r' % os.environ['PATH']
     base_command = ['java', '-jar', args.google_java_format_jar]
   else:
     binary = find_executable('google-java-format') or '/usr/bin/google-java-format'

--- a/java-format/google-java-format-git-diff.sh
+++ b/java-format/google-java-format-git-diff.sh
@@ -63,6 +63,7 @@ function callGoogleJavaFormatDiff() {
       showNoncompliantFiles "$forkPoint" "\033[1mNeeds formatting: "
       callResult=$(git diff -U0 ${forkPoint} | \
           ${SCRIPT_DIR}/google-java-format-diff.py \
+          --java-binary "$JAVA_HOME/bin/java" \
           --google-java-format-jar "${SCRIPT_DIR}/${JAR_NAME}" \
           -p1 | wc -l)
       ;;
@@ -70,12 +71,14 @@ function callGoogleJavaFormatDiff() {
       showNoncompliantFiles "$forkPoint" "\033[1mReformatting: "
       callResult=$(git diff -U0 ${forkPoint} | \
           ${SCRIPT_DIR}/google-java-format-diff.py \
+          --java-binary "$JAVA_HOME/bin/java" \
           --google-java-format-jar "${SCRIPT_DIR}/${JAR_NAME}" \
           -p1 -i)
       ;;
     "show")
       callResult=$(git diff -U0 ${forkPoint} | \
           ${SCRIPT_DIR}/google-java-format-diff.py \
+          --java-binary "$JAVA_HOME/bin/java" \
           --google-java-format-jar "${SCRIPT_DIR}/${JAR_NAME}" \
           -p1)
       ;;


### PR DESCRIPTION
Print out JAVA_HOME and PATH variable in the google-java-format-diff.py script
immediately prior to running the underlying java program that does the actual
format checking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/998)
<!-- Reviewable:end -->
