### PR TITLE
Convert DomainTransferRequestFlow to tm() calls

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
@@ -31,7 +31,6 @@ import static google.registry.flows.domain.DomainTransferUtils.createPendingTran
 import static google.registry.flows.domain.DomainTransferUtils.createTransferResponse;
 import static google.registry.flows.domain.DomainTransferUtils.createTransferServerApproveEntities;
 import static google.registry.model.eppoutput.Result.Code.SUCCESS_WITH_ACTION_PENDING;
-import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.google.common.collect.ImmutableList;
@@ -227,12 +226,11 @@ public final class DomainTransferRequestFlow implements TransactionalFlow {
             .setLastEppUpdateClientId(gainingClientId)
             .build();
     asyncTaskEnqueuer.enqueueAsyncResave(newDomain, now, automaticTransferTime);
-    ofy().save()
-        .entities(new ImmutableSet.Builder<>()
-            .add(newDomain, historyEntry, requestPollMessage)
-            .addAll(serverApproveEntities)
-            .build())
-        .now();
+    tm().putAll(
+            new ImmutableSet.Builder<>()
+                .add(newDomain, historyEntry, requestPollMessage)
+                .addAll(serverApproveEntities)
+                .build());
     return responseBuilder
         .setResultFromCode(SUCCESS_WITH_ACTION_PENDING)
         .setResData(createResponse(period, existingDomain, newDomain, now))

--- a/core/src/test/java/google/registry/flows/FlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/FlowTestCase.java
@@ -22,6 +22,7 @@ import static com.google.common.truth.Truth.assertWithMessage;
 import static google.registry.model.eppcommon.EppXmlTransformer.marshal;
 import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.persistence.transaction.TransactionManagerUtil.transactIfJpaTm;
 import static google.registry.testing.DatabaseHelper.stripBillingEventId;
 import static google.registry.xml.XmlTestUtils.assertXmlEquals;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -203,9 +204,12 @@ public abstract class FlowTestCase<F extends Flow> {
     assertWithMessage("Billing event is present for grace period: " + gracePeriod)
         .that(gracePeriod.hasBillingEvent())
         .isTrue();
-    return tm().loadByKey(
-            firstNonNull(
-                gracePeriod.getOneTimeBillingEvent(), gracePeriod.getRecurringBillingEvent()));
+    return transactIfJpaTm(
+        () ->
+            tm().loadByKey(
+                    firstNonNull(
+                        gracePeriod.getOneTimeBillingEvent(),
+                        gracePeriod.getRecurringBillingEvent())));
   }
 
   /**


### PR DESCRIPTION
Besides the standard ofy-to-tm conversions this includes storing the
billing event cancellation VKey in the DomainTransferData object so that
we know to handle it on process / cancellation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1002)
<!-- Reviewable:end -->
