### PR TITLE
Add TODOs regarding cloud sql database name change

### DIFF
--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -225,6 +225,10 @@ hibernate:
 
 cloudSql:
   # jdbc url for the Cloud SQL database.
+  # TODO(b/181693544): change the database name when upgrading postgres version
+  # Using the default 'postgres' is bad practice. See bug for more information.
+  # If jdbcUrl in this file is moved elsewhere, be sure to move this notice
+  # with it until the change is applied.
   jdbcUrl: jdbc:postgresql://localhost
   # Username for the database user.
   username: username


### PR DESCRIPTION
We should choose a different database name for nomulus data since using
'postgres' is bad practice. See b/181693544 more background.

We have decided to delay the db change to the time when we upgrade
postgresql version. This PR adds TODOs to all occurrences of the jdbcUrl
property, including those in the internal-repo. This property will change
when we upgrade, so the TODOs will be noticed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1005)
<!-- Reviewable:end -->
