### PR TITLE
Closing the bug regarding Cloud SQL connection configs

### DIFF
--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -207,18 +207,13 @@ hibernate:
 
   # Connection pool configurations.
   hikariConnectionTimeout: 20000
-  # We occasionally received "Connection is not available, request timed out"
-  # exception when setting minimumIdle to 0 and it turned out it is a bug (See
-  # https://github.com/brettwooldridge/HikariCP/issues/1212) in HikariCP.
-  #
-  # We tried to use a fixed size pool but ran into an issue(See b/155383029),
-  # so we need further investigation to figure out the proper size of the pool.
-  #
-  # HikariCP also recommends not setting minimumIdle for maximum performance
-  # and responsiveness to spike demands (See
-  # https://github.com/brettwooldridge/HikariCP).
-  #
-  # TODO(b/154720215): Investigate the long term fix.
+  # Cloud SQL connections are a relatively scarce resource (maximum is 1000 as
+  # of March 2021). The minimumIdle should be a small value so that machines may
+  # release connections after a demand spike. The maximumPoolSize is set to 10
+  # because that is the maximum number of concurrent requests a Nomulus server
+  # instance can handle (as limited by AppEngine for basic/manual scaling). Note
+  # that BEAM pipelines are not subject to the maximumPoolSize value defined
+  # here. See PersistenceModule.java for more information.
   hikariMinimumIdle: 1
   hikariMaximumPoolSize: 10
   hikariIdleTimeout: 300000


### PR DESCRIPTION
I believe the similarity in trace to https://github.com/brettwooldridge/HikariCP/issues/1212
is misleading.

The real cause of the exceptions may be that we ran out of connections. At the
time, the production Cloud SQL server could handle 500 connections at the
maximum. That number was within reach of a busy Nomulus server.

The maximum connection in production has been increased to 1000. We
haven't encountered this issue for a long time. All connection problems
are due to Cloud SQL maintenance or other GCP related issues.

This issue is tracked by b/154720215, which is being closed with this
PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1012)
<!-- Reviewable:end -->
