### PR TITLE
Clear autorenew end time when a domain is restored

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
@@ -233,6 +233,9 @@ public final class DomainRestoreRequestFlow implements TransactionalFlow  {
         .setDeletePollMessage(null)
         .setAutorenewBillingEvent(autorenewEvent.createVKey())
         .setAutorenewPollMessage(autorenewPollMessage.createVKey())
+        // Clear the autorenew end time so if it had expired but is now explicitly being restored,
+        // it won't immediately be deleted again.
+        .setAutorenewEndTime(Optional.empty())
         .setLastEppUpdateTime(now)
         .setLastEppUpdateClientId(clientId)
         .build();

--- a/core/src/main/java/google/registry/model/domain/DomainContent.java
+++ b/core/src/main/java/google/registry/model/domain/DomainContent.java
@@ -302,12 +302,6 @@ public class DomainContent extends EppResource
 
   @OnLoad
   void load() {
-    // Back fill with correct END_OF_TIME sentinel value.
-    // TODO(mcilwain): Remove this once back-filling is complete.
-    if (autorenewEndTime == null) {
-      autorenewEndTime = END_OF_TIME;
-    }
-
     // Reconstitute all of the contacts so that they have VKeys.
     allContacts =
         allContacts.stream().map(DesignatedContact::reconstitute).collect(toImmutableSet());
@@ -443,12 +437,7 @@ public class DomainContent extends EppResource
    * purposes of more legible business logic.
    */
   public Optional<DateTime> getAutorenewEndTime() {
-    // TODO(mcilwain): Remove null handling for autorenewEndTime once data migration away from null
-    //                 is complete.
-    return Optional.ofNullable(
-        (autorenewEndTime == null || autorenewEndTime.equals(END_OF_TIME))
-            ? null
-            : autorenewEndTime);
+    return Optional.ofNullable(autorenewEndTime.equals(END_OF_TIME) ? null : autorenewEndTime);
   }
 
   @Override


### PR DESCRIPTION
This allows us to still see in the database which now-deleted domains had
reached expiration, while correctly not re-deleting the domain immediately if
the registrar pays to explicitly restore the domain.

This also resolves some TODOs around data migration for this field on domain so
that it's not null, as said migration has already been completed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1015)
<!-- Reviewable:end -->
