### PR TITLE
Remove grace period ID @OnLoads now that migration is complete

### DIFF
--- a/core/src/main/java/google/registry/model/domain/DomainContent.java
+++ b/core/src/main/java/google/registry/model/domain/DomainContent.java
@@ -321,9 +321,6 @@ public class DomainContent extends EppResource
         nullToEmptyImmutableCopy(gracePeriods).stream()
             .map(gracePeriod -> gracePeriod.cloneAfterOfyLoad(getRepoId()))
             .collect(toImmutableSet());
-    // TODO(b/169873747): Remove this method after explicitly re-saving all domain entities.
-    // See also: GradePeriod.onLoad.
-    gracePeriods.forEach(GracePeriod::onLoad);
 
     // Restore history record ids.
     autorenewPollMessageHistoryId = getHistoryId(autorenewPollMessage);

--- a/core/src/main/java/google/registry/model/domain/GracePeriod.java
+++ b/core/src/main/java/google/registry/model/domain/GracePeriod.java
@@ -54,17 +54,6 @@ public class GracePeriod extends GracePeriodBase implements DatastoreAndSqlEntit
     return super.getGracePeriodId();
   }
 
-  // TODO(b/169873747): Remove this method after explicitly re-saving all domain entities.
-  // This method is invoked from DomainContent.load(): Objectify's @OnLoad annotation
-  // apparently does not work on embedded objects inside an entity.
-  // Changing signature to void onLoad(@AlsoLoad("gracePeriodId") Long gracePeriodId)
-  // would not work. Method is not called if gracePeriodId is null.
-  void onLoad() {
-    if (gracePeriodId == null) {
-      gracePeriodId = ObjectifyService.allocateId();
-    }
-  }
-
   private static GracePeriod createInternal(
       GracePeriodStatus type,
       String domainRepoId,

--- a/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
@@ -19,8 +19,6 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static google.registry.model.EppResourceUtils.loadByForeignKey;
-import static google.registry.model.ofy.ObjectifyService.ofy;
-import static google.registry.persistence.transaction.TransactionManagerFactory.ofyTm;
 import static google.registry.testing.DatabaseHelper.cloneAndSetAutoTimestamps;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.newDomainBase;
@@ -32,7 +30,6 @@ import static org.joda.money.CurrencyUnit.USD;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.google.appengine.api.datastore.Entity;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
@@ -165,15 +162,6 @@ public class DomainBaseTest extends EntityTestCase {
                             null))
                     .setAutorenewEndTime(Optional.of(fakeClock.nowUtc().plusYears(2)))
                     .build()));
-  }
-
-  @Test
-  void testGracePeriod_nullIdFromOfy() {
-    Entity entity = ofyTm().transact(() -> ofy().save().toEntity(domain));
-    entity.setUnindexedProperty("gracePeriods.gracePeriodId", null);
-    DomainBase domainFromEntity = ofyTm().transact(() -> ofy().load().fromEntity(entity));
-    GracePeriod gracePeriod = domainFromEntity.getGracePeriods().iterator().next();
-    assertThat(gracePeriod.gracePeriodId).isNotNull();
   }
 
   @Test


### PR DESCRIPTION
I verified in BigQuery that all grace period IDs are now allocated (as expected
given that the re-save all EPP resource mapreduce has been run several times
since this migration started last year). The query I used for verification is:

SELECT fullyQualifiedDomainName, gp, ot
FROM `domain-registry.latest_datastore_export.DomainBase`
JOIN UNNEST(gracePeriods.billingEventRecurring) AS gp
JOIN UNNEST(gracePeriods.billingEventOneTime) AS ot
WHERE gp.id IS NULL or ot.id IS NULL

BUG=169873747

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1016)
<!-- Reviewable:end -->
