### PR TITLE
Remove cert hash checks

### DIFF
--- a/core/src/main/java/google/registry/flows/TlsCredentials.java
+++ b/core/src/main/java/google/registry/flows/TlsCredentials.java
@@ -65,6 +65,7 @@ public class TlsCredentials implements TransportCredentials {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   private final boolean requireSslCertificates;
+  private final Optional<String> clientCertificateHash;
   private final Optional<String> clientCertificate;
   private final Optional<InetAddress> clientInetAddr;
   private final CertificateChecker certificateChecker;
@@ -72,10 +73,12 @@ public class TlsCredentials implements TransportCredentials {
   @Inject
   public TlsCredentials(
       @Config("requireSslCertificates") boolean requireSslCertificates,
+      @Header(ProxyHttpHeaders.CERTIFICATE_HASH) Optional<String> clientCertificateHash,
       @Header(ProxyHttpHeaders.FULL_CERTIFICATE) Optional<String> clientCertificate,
       @Header(ProxyHttpHeaders.IP_ADDRESS) Optional<String> clientAddress,
       CertificateChecker certificateChecker) {
     this.requireSslCertificates = requireSslCertificates;
+    this.clientCertificateHash = clientCertificateHash;
     this.clientCertificate = clientCertificate;
     this.clientInetAddr = clientAddress.map(TlsCredentials::parseInetAddress);
     this.certificateChecker = certificateChecker;
@@ -204,6 +207,7 @@ public class TlsCredentials implements TransportCredentials {
   public String toString() {
     return toStringHelper(getClass())
         .add("clientCertificate", clientCertificate.orElse(null))
+        .add("clientCertificateHash", clientCertificateHash.orElse(null))
         .add("clientAddress", clientInetAddr.orElse(null))
         .toString();
   }

--- a/core/src/main/java/google/registry/tools/ValidateLoginCredentialsCommand.java
+++ b/core/src/main/java/google/registry/tools/ValidateLoginCredentialsCommand.java
@@ -17,6 +17,8 @@ package google.registry.tools;
 import static com.google.common.base.Preconditions.checkState;
 import static google.registry.util.PreconditionsUtils.checkArgumentPresent;
 import static google.registry.util.X509Utils.encodeX509CertificateFromPemString;
+import static google.registry.util.X509Utils.getCertificateHash;
+import static google.registry.util.X509Utils.loadCertificate;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
 import com.beust.jcommander.Parameter;
@@ -76,6 +78,7 @@ final class ValidateLoginCredentialsCommand implements CommandWithRemoteApi {
             Registrar.loadByClientId(clientId), "Registrar %s not found", clientId);
     new TlsCredentials(
             true,
+            Optional.ofNullable(getCertificateHash(loadCertificate(clientCertificatePath))),
             Optional.ofNullable(encodedCertificate),
             Optional.ofNullable(clientIpAddress),
             certificateChecker)

--- a/core/src/main/java/google/registry/tools/ValidateLoginCredentialsCommand.java
+++ b/core/src/main/java/google/registry/tools/ValidateLoginCredentialsCommand.java
@@ -17,8 +17,6 @@ package google.registry.tools;
 import static com.google.common.base.Preconditions.checkState;
 import static google.registry.util.PreconditionsUtils.checkArgumentPresent;
 import static google.registry.util.X509Utils.encodeX509CertificateFromPemString;
-import static google.registry.util.X509Utils.getCertificateHash;
-import static google.registry.util.X509Utils.loadCertificate;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
 import com.beust.jcommander.Parameter;
@@ -78,11 +76,9 @@ final class ValidateLoginCredentialsCommand implements CommandWithRemoteApi {
             Registrar.loadByClientId(clientId), "Registrar %s not found", clientId);
     new TlsCredentials(
             true,
-            Optional.ofNullable(getCertificateHash(loadCertificate(clientCertificatePath))),
             Optional.ofNullable(encodedCertificate),
             Optional.ofNullable(clientIpAddress),
-            certificateChecker,
-            clock)
+            certificateChecker)
         .validate(registrar, password);
     checkState(
         registrar.isLive(), "Registrar %s has non-live state: %s", clientId, registrar.getState());

--- a/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
+++ b/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
@@ -73,6 +73,7 @@ class EppLoginTlsTest extends EppTestCase {
     setTransportCredentials(
         new TlsCredentials(
             true,
+            Optional.empty(),
             Optional.ofNullable(clientCertificate),
             Optional.of("192.168.1.100:54321"),
             certificateChecker));

--- a/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
+++ b/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
@@ -69,15 +69,13 @@ class EppLoginTlsTest extends EppTestCase {
 
   private String encodedCertString;
 
-  void setCredentials(String clientCertificateHash, String clientCertificate) {
+  void setCredentials(String clientCertificate) {
     setTransportCredentials(
         new TlsCredentials(
             true,
-            Optional.ofNullable(clientCertificateHash),
             Optional.ofNullable(clientCertificate),
             Optional.of("192.168.1.100:54321"),
-            certificateChecker,
-            clock));
+            certificateChecker));
   }
 
   @BeforeEach
@@ -99,14 +97,14 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testLoginLogout() throws Exception {
-    setCredentials(null, encodedCertString);
+    setCredentials(encodedCertString);
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
     assertThatLogoutSucceeds();
   }
 
   @Test
   void testLogin_wrongPasswordFails() throws Exception {
-    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, encodedCertString);
+    setCredentials(encodedCertString);
     // For TLS login, we also check the epp xml password.
     assertThatLogin("NewRegistrar", "incorrect")
         .hasResponse(
@@ -116,7 +114,7 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testMultiLogin() throws Exception {
-    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, encodedCertString);
+    setCredentials(encodedCertString);
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
     assertThatLogoutSucceeds();
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
@@ -130,7 +128,7 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testNonAuthedLogin_fails() throws Exception {
-    setCredentials(CertificateSamples.SAMPLE_CERT3_HASH, encodedCertString);
+    setCredentials(encodedCertString);
     assertThatLogin("TheRegistrar", "password2")
         .hasResponse(
             "response_error.xml",
@@ -141,7 +139,7 @@ class EppLoginTlsTest extends EppTestCase {
   @Test
   void testBadCertificate_failsBadCertificate2200() throws Exception {
     String proxyEncoded = encodeX509CertificateFromPemString(CertificateSamples.SAMPLE_CERT);
-    setCredentials("laffo", proxyEncoded);
+    setCredentials(proxyEncoded);
     assertThatLogin("NewRegistrar", "foo-BAR2")
         .hasResponse(
             "response_error.xml",
@@ -151,7 +149,7 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testGfeDidntProvideClientCertificate_failsMissingCertificate2200() throws Exception {
-    setCredentials(null, null);
+    setCredentials(null);
     assertThatLogin("NewRegistrar", "foo-BAR2")
         .hasResponse(
             "response_error.xml",
@@ -160,7 +158,7 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testGoodPrimaryCertificate() throws Exception {
-    setCredentials(null, encodedCertString);
+    setCredentials(encodedCertString);
     DateTime now = DateTime.now(UTC);
     persistResource(
         loadRegistrar("NewRegistrar")
@@ -173,7 +171,7 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testGoodFailoverCertificate() throws Exception {
-    setCredentials(null, encodedCertString);
+    setCredentials(encodedCertString);
     DateTime now = DateTime.now(UTC);
     persistResource(
         loadRegistrar("NewRegistrar")
@@ -186,7 +184,7 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testMissingPrimaryCertificateButHasFailover_usesFailover() throws Exception {
-    setCredentials(null, encodedCertString);
+    setCredentials(encodedCertString);
     DateTime now = DateTime.now(UTC);
     persistResource(
         loadRegistrar("NewRegistrar")
@@ -199,7 +197,7 @@ class EppLoginTlsTest extends EppTestCase {
 
   @Test
   void testRegistrarHasNoCertificatesOnFile_fails() throws Exception {
-    setCredentials("laffo", "cert");
+    setCredentials("cert");
     DateTime now = DateTime.now(UTC);
     persistResource(
         loadRegistrar("NewRegistrar")
@@ -217,7 +215,7 @@ class EppLoginTlsTest extends EppTestCase {
   void testCertificateDoesNotMeetRequirements_fails() throws Exception {
     String proxyEncoded = encodeX509CertificateFromPemString(CertificateSamples.SAMPLE_CERT);
     // SAMPLE_CERT has a validity period that is too long
-    setCredentials(CertificateSamples.SAMPLE_CERT_HASH, proxyEncoded);
+    setCredentials(proxyEncoded);
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()
@@ -252,7 +250,7 @@ class EppLoginTlsTest extends EppTestCase {
     String proxyEncoded = encodeX509Certificate(certificate);
 
     // SAMPLE_CERT has a validity period that is too long
-    setCredentials(null, proxyEncoded);
+    setCredentials(proxyEncoded);
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()
@@ -285,7 +283,7 @@ class EppLoginTlsTest extends EppTestCase {
                 + "%s",
             CertificateSamples.SAMPLE_CERT3);
 
-    setCredentials(null, encodeX509CertificateFromPemString(certPem));
+    setCredentials(encodeX509CertificateFromPemString(certPem));
     DateTime now = DateTime.now(UTC);
     persistResource(
         loadRegistrar("NewRegistrar")
@@ -309,7 +307,7 @@ class EppLoginTlsTest extends EppTestCase {
                 + "%s",
             CertificateSamples.SAMPLE_CERT);
 
-    setCredentials(null, encodeX509CertificateFromPemString(certPem));
+    setCredentials(encodeX509CertificateFromPemString(certPem));
     DateTime now = DateTime.now(UTC);
     persistResource(
         loadRegistrar("NewRegistrar")

--- a/core/src/test/java/google/registry/flows/FlowRunnerTest.java
+++ b/core/src/test/java/google/registry/flows/FlowRunnerTest.java
@@ -153,17 +153,10 @@ class FlowRunnerTest {
   void testRun_loggingStatement_tlsCredentials() throws Exception {
     flowRunner.credentials =
         new TlsCredentials(
-            true,
-            Optional.of("abc123def"),
-            Optional.of("cert046F5A3"),
-            Optional.of("127.0.0.1"),
-            certificateChecker,
-            clock);
+            true, Optional.of("cert046F5A3"), Optional.of("127.0.0.1"), certificateChecker);
     flowRunner.run(eppMetricBuilder);
     assertThat(Splitter.on("\n\t").split(findFirstLogMessageByPrefix(handler, "EPP Command\n\t")))
-        .contains(
-            "TlsCredentials{clientCertificate=cert046F5A3, clientCertificateHash=abc123def,"
-                + " clientAddress=/127.0.0.1}");
+        .contains("TlsCredentials{clientCertificate=cert046F5A3, clientAddress=/127.0.0.1}");
   }
 
   @Test

--- a/core/src/test/java/google/registry/flows/FlowRunnerTest.java
+++ b/core/src/test/java/google/registry/flows/FlowRunnerTest.java
@@ -153,10 +153,16 @@ class FlowRunnerTest {
   void testRun_loggingStatement_tlsCredentials() throws Exception {
     flowRunner.credentials =
         new TlsCredentials(
-            true, Optional.of("cert046F5A3"), Optional.of("127.0.0.1"), certificateChecker);
+            true,
+            Optional.of("abc123def"),
+            Optional.of("cert046F5A3"),
+            Optional.of("127.0.0.1"),
+            certificateChecker);
     flowRunner.run(eppMetricBuilder);
     assertThat(Splitter.on("\n\t").split(findFirstLogMessageByPrefix(handler, "EPP Command\n\t")))
-        .contains("TlsCredentials{clientCertificate=cert046F5A3, clientAddress=/127.0.0.1}");
+        .contains(
+            "TlsCredentials{clientCertificate=cert046F5A3, clientCertificateHash=abc123def,"
+                + " clientAddress=/127.0.0.1}");
   }
 
   @Test

--- a/core/src/test/java/google/registry/flows/TlsCredentialsTest.java
+++ b/core/src/test/java/google/registry/flows/TlsCredentialsTest.java
@@ -67,13 +67,7 @@ final class TlsCredentialsTest {
   @Test
   void testClientCertificateAndHash_missing() {
     TlsCredentials tls =
-        new TlsCredentials(
-            true,
-            Optional.empty(),
-            Optional.empty(),
-            Optional.of("192.168.1.1"),
-            certificateChecker,
-            clock);
+        new TlsCredentials(true, Optional.empty(), Optional.of("192.168.1.1"), certificateChecker);
     persistResource(
         loadRegistrar("TheRegistrar")
             .asBuilder()
@@ -87,13 +81,7 @@ final class TlsCredentialsTest {
   @Test
   void test_missingIpAddress_doesntAllowAccess() {
     TlsCredentials tls =
-        new TlsCredentials(
-            false,
-            Optional.of("certHash"),
-            Optional.empty(),
-            Optional.empty(),
-            certificateChecker,
-            clock);
+        new TlsCredentials(false, Optional.empty(), Optional.empty(), certificateChecker);
     persistResource(
         loadRegistrar("TheRegistrar")
             .asBuilder()
@@ -109,12 +97,7 @@ final class TlsCredentialsTest {
   void test_validateCertificate_canBeConfiguredToBypassCertHashes() throws Exception {
     TlsCredentials tls =
         new TlsCredentials(
-            false,
-            Optional.of("certHash"),
-            Optional.of("cert"),
-            Optional.of("192.168.1.1"),
-            certificateChecker,
-            clock);
+            false, Optional.of("cert"), Optional.of("192.168.1.1"), certificateChecker);
     persistResource(
         loadRegistrar("TheRegistrar")
             .asBuilder()
@@ -137,12 +120,7 @@ final class TlsCredentialsTest {
   void testClientCertificate_notConfigured() {
     TlsCredentials tls =
         new TlsCredentials(
-            true,
-            Optional.of("hash"),
-            Optional.of(SAMPLE_CERT),
-            Optional.of("192.168.1.1"),
-            certificateChecker,
-            clock);
+            true, Optional.of(SAMPLE_CERT), Optional.of("192.168.1.1"), certificateChecker);
     persistResource(loadRegistrar("TheRegistrar").asBuilder().build());
     assertThrows(
         RegistrarCertificateNotConfiguredException.class,
@@ -153,12 +131,7 @@ final class TlsCredentialsTest {
   void test_validateCertificate_canBeConfiguredToBypassCerts() throws Exception {
     TlsCredentials tls =
         new TlsCredentials(
-            false,
-            Optional.of("certHash"),
-            Optional.of("cert"),
-            Optional.of("192.168.1.1"),
-            certificateChecker,
-            clock);
+            false, Optional.of("cert"), Optional.of("192.168.1.1"), certificateChecker);
     persistResource(
         loadRegistrar("TheRegistrar")
             .asBuilder()

--- a/core/src/test/java/google/registry/flows/TlsCredentialsTest.java
+++ b/core/src/test/java/google/registry/flows/TlsCredentialsTest.java
@@ -67,7 +67,12 @@ final class TlsCredentialsTest {
   @Test
   void testClientCertificateAndHash_missing() {
     TlsCredentials tls =
-        new TlsCredentials(true, Optional.empty(), Optional.of("192.168.1.1"), certificateChecker);
+        new TlsCredentials(
+            true,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of("192.168.1.1"),
+            certificateChecker);
     persistResource(
         loadRegistrar("TheRegistrar")
             .asBuilder()
@@ -81,7 +86,8 @@ final class TlsCredentialsTest {
   @Test
   void test_missingIpAddress_doesntAllowAccess() {
     TlsCredentials tls =
-        new TlsCredentials(false, Optional.empty(), Optional.empty(), certificateChecker);
+        new TlsCredentials(
+            false, Optional.empty(), Optional.empty(), Optional.empty(), certificateChecker);
     persistResource(
         loadRegistrar("TheRegistrar")
             .asBuilder()
@@ -97,7 +103,11 @@ final class TlsCredentialsTest {
   void test_validateCertificate_canBeConfiguredToBypassCertHashes() throws Exception {
     TlsCredentials tls =
         new TlsCredentials(
-            false, Optional.of("cert"), Optional.of("192.168.1.1"), certificateChecker);
+            false,
+            Optional.empty(),
+            Optional.of("cert"),
+            Optional.of("192.168.1.1"),
+            certificateChecker);
     persistResource(
         loadRegistrar("TheRegistrar")
             .asBuilder()
@@ -120,7 +130,11 @@ final class TlsCredentialsTest {
   void testClientCertificate_notConfigured() {
     TlsCredentials tls =
         new TlsCredentials(
-            true, Optional.of(SAMPLE_CERT), Optional.of("192.168.1.1"), certificateChecker);
+            true,
+            Optional.empty(),
+            Optional.of(SAMPLE_CERT),
+            Optional.of("192.168.1.1"),
+            certificateChecker);
     persistResource(loadRegistrar("TheRegistrar").asBuilder().build());
     assertThrows(
         RegistrarCertificateNotConfiguredException.class,
@@ -131,7 +145,11 @@ final class TlsCredentialsTest {
   void test_validateCertificate_canBeConfiguredToBypassCerts() throws Exception {
     TlsCredentials tls =
         new TlsCredentials(
-            false, Optional.of("cert"), Optional.of("192.168.1.1"), certificateChecker);
+            false,
+            Optional.empty(),
+            Optional.of("cert"),
+            Optional.of("192.168.1.1"),
+            certificateChecker);
     persistResource(
         loadRegistrar("TheRegistrar")
             .asBuilder()

--- a/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
+++ b/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
@@ -78,7 +78,8 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
   @Test
   void testSuccess_withGoodCredentials() throws Exception {
     persistResource(getRegistrarBuilder().build());
-    credentials = new TlsCredentials(true, encodedCertString, GOOD_IP, certificateChecker);
+    credentials =
+        new TlsCredentials(true, Optional.empty(), encodedCertString, GOOD_IP, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
@@ -105,7 +106,8 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
 
     String encodedCertificate = Base64.getEncoder().encodeToString(certificate.getEncoded());
     credentials =
-        new TlsCredentials(true, Optional.of(encodedCertificate), GOOD_IP, certificateChecker);
+        new TlsCredentials(
+            true, Optional.empty(), Optional.of(encodedCertificate), GOOD_IP, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
@@ -116,7 +118,9 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
             .setIpAddressAllowList(
                 ImmutableList.of(CidrAddressBlock.create("2001:db8:0:0:0:0:1:1/32")))
             .build());
-    credentials = new TlsCredentials(true, encodedCertString, GOOD_IPV6, certificateChecker);
+    credentials =
+        new TlsCredentials(
+            true, Optional.empty(), encodedCertString, GOOD_IPV6, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
@@ -127,7 +131,9 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
             .setIpAddressAllowList(
                 ImmutableList.of(CidrAddressBlock.create("2001:db8:0:0:0:0:1:1/32")))
             .build());
-    credentials = new TlsCredentials(true, encodedCertString, GOOD_IPV6, certificateChecker);
+    credentials =
+        new TlsCredentials(
+            true, Optional.empty(), encodedCertString, GOOD_IPV6, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
@@ -137,7 +143,8 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
         getRegistrarBuilder()
             .setIpAddressAllowList(ImmutableList.of(CidrAddressBlock.create("192.168.1.255/24")))
             .build());
-    credentials = new TlsCredentials(true, encodedCertString, GOOD_IP, certificateChecker);
+    credentials =
+        new TlsCredentials(true, Optional.empty(), encodedCertString, GOOD_IP, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
@@ -145,14 +152,17 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
   void testFailure_incorrectClientCertificate() throws Exception {
     persistResource(getRegistrarBuilder().build());
     String proxyEncoded = encodeX509CertificateFromPemString(BAD_CERT.get());
-    credentials = new TlsCredentials(true, Optional.of(proxyEncoded), GOOD_IP, certificateChecker);
+    credentials =
+        new TlsCredentials(
+            true, Optional.empty(), Optional.of(proxyEncoded), GOOD_IP, certificateChecker);
     doFailingTest("login_valid.xml", BadRegistrarCertificateException.class);
   }
 
   @Test
   void testFailure_missingClientCertificateAndHash() {
     persistResource(getRegistrarBuilder().build());
-    credentials = new TlsCredentials(true, Optional.empty(), GOOD_IP, certificateChecker);
+    credentials =
+        new TlsCredentials(true, Optional.empty(), Optional.empty(), GOOD_IP, certificateChecker);
     doFailingTest("login_valid.xml", MissingRegistrarCertificateException.class);
   }
 
@@ -165,7 +175,8 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
                     CidrAddressBlock.create(InetAddresses.forString("192.168.1.1"), 32),
                     CidrAddressBlock.create(InetAddresses.forString("2001:db8::1"), 128)))
             .build());
-    credentials = new TlsCredentials(true, GOOD_CERT, Optional.empty(), certificateChecker);
+    credentials =
+        new TlsCredentials(true, Optional.empty(), GOOD_CERT, Optional.empty(), certificateChecker);
     doFailingTest("login_valid.xml", BadRegistrarIpAddressException.class);
   }
 
@@ -178,7 +189,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
                     CidrAddressBlock.create(InetAddresses.forString("192.168.1.1"), 32),
                     CidrAddressBlock.create(InetAddresses.forString("2001:db8::1"), 128)))
             .build());
-    credentials = new TlsCredentials(true, GOOD_CERT, BAD_IP, certificateChecker);
+    credentials = new TlsCredentials(true, Optional.empty(), GOOD_CERT, BAD_IP, certificateChecker);
     doFailingTest("login_valid.xml", BadRegistrarIpAddressException.class);
   }
 
@@ -191,7 +202,8 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
                     CidrAddressBlock.create(InetAddresses.forString("192.168.1.1"), 32),
                     CidrAddressBlock.create(InetAddresses.forString("2001:db8::1"), 128)))
             .build());
-    credentials = new TlsCredentials(true, GOOD_CERT, BAD_IPV6, certificateChecker);
+    credentials =
+        new TlsCredentials(true, Optional.empty(), GOOD_CERT, BAD_IPV6, certificateChecker);
     doFailingTest("login_valid.xml", BadRegistrarIpAddressException.class);
   }
 }

--- a/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
+++ b/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
@@ -170,16 +170,6 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
   }
 
   @Test
-  // TODO(Sarahbot): This should fail once hash fallback is removed
-  void testSuccess_missingClientCertificate() throws Exception {
-    persistResource(getRegistrarBuilder().build());
-    credentials =
-        new TlsCredentials(
-            true, GOOD_CERT_HASH, Optional.empty(), GOOD_IP, certificateChecker, clock);
-    doSuccessfulTest("login_valid.xml");
-  }
-
-  @Test
   void testFailure_missingClientCertificateAndHash() {
     persistResource(getRegistrarBuilder().build());
     credentials =

--- a/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
+++ b/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
@@ -48,11 +48,7 @@ import org.testcontainers.shaded.org.bouncycastle.util.io.pem.PemWriter;
 public class LoginFlowViaTlsTest extends LoginFlowTestCase {
 
   private static final Optional<String> GOOD_CERT = Optional.of(CertificateSamples.SAMPLE_CERT3);
-  private static final Optional<String> GOOD_CERT_HASH =
-      Optional.of(CertificateSamples.SAMPLE_CERT3_HASH);
   private static final Optional<String> BAD_CERT = Optional.of(CertificateSamples.SAMPLE_CERT2);
-  private static final Optional<String> BAD_CERT_HASH =
-      Optional.of(CertificateSamples.SAMPLE_CERT2_HASH);
   private static final Optional<String> GOOD_IP = Optional.of("192.168.1.1");
   private static final Optional<String> BAD_IP = Optional.of("1.1.1.1");
   private static final Optional<String> GOOD_IPV6 = Optional.of("2001:db8::1");
@@ -82,9 +78,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
   @Test
   void testSuccess_withGoodCredentials() throws Exception {
     persistResource(getRegistrarBuilder().build());
-    credentials =
-        new TlsCredentials(
-            true, GOOD_CERT_HASH, encodedCertString, GOOD_IP, certificateChecker, clock);
+    credentials = new TlsCredentials(true, encodedCertString, GOOD_IP, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
@@ -111,13 +105,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
 
     String encodedCertificate = Base64.getEncoder().encodeToString(certificate.getEncoded());
     credentials =
-        new TlsCredentials(
-            true,
-            Optional.empty(),
-            Optional.of(encodedCertificate),
-            GOOD_IP,
-            certificateChecker,
-            clock);
+        new TlsCredentials(true, Optional.of(encodedCertificate), GOOD_IP, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
@@ -128,9 +116,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
             .setIpAddressAllowList(
                 ImmutableList.of(CidrAddressBlock.create("2001:db8:0:0:0:0:1:1/32")))
             .build());
-    credentials =
-        new TlsCredentials(
-            true, GOOD_CERT_HASH, encodedCertString, GOOD_IPV6, certificateChecker, clock);
+    credentials = new TlsCredentials(true, encodedCertString, GOOD_IPV6, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
@@ -141,9 +127,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
             .setIpAddressAllowList(
                 ImmutableList.of(CidrAddressBlock.create("2001:db8:0:0:0:0:1:1/32")))
             .build());
-    credentials =
-        new TlsCredentials(
-            true, GOOD_CERT_HASH, encodedCertString, GOOD_IPV6, certificateChecker, clock);
+    credentials = new TlsCredentials(true, encodedCertString, GOOD_IPV6, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
@@ -153,28 +137,22 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
         getRegistrarBuilder()
             .setIpAddressAllowList(ImmutableList.of(CidrAddressBlock.create("192.168.1.255/24")))
             .build());
-    credentials =
-        new TlsCredentials(
-            true, GOOD_CERT_HASH, encodedCertString, GOOD_IP, certificateChecker, clock);
+    credentials = new TlsCredentials(true, encodedCertString, GOOD_IP, certificateChecker);
     doSuccessfulTest("login_valid.xml");
   }
 
   @Test
-  void testFailure_incorrectClientCertificateHash() throws Exception {
+  void testFailure_incorrectClientCertificate() throws Exception {
     persistResource(getRegistrarBuilder().build());
     String proxyEncoded = encodeX509CertificateFromPemString(BAD_CERT.get());
-    credentials =
-        new TlsCredentials(
-            true, BAD_CERT_HASH, Optional.of(proxyEncoded), GOOD_IP, certificateChecker, clock);
+    credentials = new TlsCredentials(true, Optional.of(proxyEncoded), GOOD_IP, certificateChecker);
     doFailingTest("login_valid.xml", BadRegistrarCertificateException.class);
   }
 
   @Test
   void testFailure_missingClientCertificateAndHash() {
     persistResource(getRegistrarBuilder().build());
-    credentials =
-        new TlsCredentials(
-            true, Optional.empty(), Optional.empty(), GOOD_IP, certificateChecker, clock);
+    credentials = new TlsCredentials(true, Optional.empty(), GOOD_IP, certificateChecker);
     doFailingTest("login_valid.xml", MissingRegistrarCertificateException.class);
   }
 
@@ -187,9 +165,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
                     CidrAddressBlock.create(InetAddresses.forString("192.168.1.1"), 32),
                     CidrAddressBlock.create(InetAddresses.forString("2001:db8::1"), 128)))
             .build());
-    credentials =
-        new TlsCredentials(
-            true, GOOD_CERT_HASH, GOOD_CERT, Optional.empty(), certificateChecker, clock);
+    credentials = new TlsCredentials(true, GOOD_CERT, Optional.empty(), certificateChecker);
     doFailingTest("login_valid.xml", BadRegistrarIpAddressException.class);
   }
 
@@ -202,8 +178,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
                     CidrAddressBlock.create(InetAddresses.forString("192.168.1.1"), 32),
                     CidrAddressBlock.create(InetAddresses.forString("2001:db8::1"), 128)))
             .build());
-    credentials =
-        new TlsCredentials(true, GOOD_CERT_HASH, GOOD_CERT, BAD_IP, certificateChecker, clock);
+    credentials = new TlsCredentials(true, GOOD_CERT, BAD_IP, certificateChecker);
     doFailingTest("login_valid.xml", BadRegistrarIpAddressException.class);
   }
 
@@ -216,8 +191,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
                     CidrAddressBlock.create(InetAddresses.forString("192.168.1.1"), 32),
                     CidrAddressBlock.create(InetAddresses.forString("2001:db8::1"), 128)))
             .build());
-    credentials =
-        new TlsCredentials(true, GOOD_CERT_HASH, GOOD_CERT, BAD_IPV6, certificateChecker, clock);
+    credentials = new TlsCredentials(true, GOOD_CERT, BAD_IPV6, certificateChecker);
     doFailingTest("login_valid.xml", BadRegistrarIpAddressException.class);
   }
 }

--- a/core/src/test/java/google/registry/tools/ValidateLoginCredentialsCommandTest.java
+++ b/core/src/test/java/google/registry/tools/ValidateLoginCredentialsCommandTest.java
@@ -35,8 +35,6 @@ import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.Registrar.State;
 import google.registry.testing.CertificateSamples;
 import google.registry.util.CidrAddressBlock;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,7 +43,6 @@ import org.junit.jupiter.api.Test;
 class ValidateLoginCredentialsCommandTest extends CommandTestCase<ValidateLoginCredentialsCommand> {
 
   private static final String PASSWORD = "foo-BAR2";
-  private static final String CERT_HASH = CertificateSamples.SAMPLE_CERT3_HASH;
   private static final String CLIENT_IP = "1.2.3.4";
 
   @BeforeEach
@@ -115,7 +112,7 @@ class ValidateLoginCredentialsCommandTest extends CommandTestCase<ValidateLoginC
   }
 
   @Test
-  void testFailure_loginWithBadCertificateHash() {
+  void testFailure_loginWithBadCertificate() {
     EppException thrown =
         assertThrows(
             EppException.class,
@@ -123,7 +120,7 @@ class ValidateLoginCredentialsCommandTest extends CommandTestCase<ValidateLoginC
                 runCommand(
                     "--client=NewRegistrar",
                     "--password=" + PASSWORD,
-                    "--cert_hash=" + new StringBuilder(CERT_HASH).reverse(),
+                    "--cert_file=" + getCertFilename(CertificateSamples.SAMPLE_CERT2),
                     "--ip_address=" + CLIENT_IP));
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
@@ -137,7 +134,7 @@ class ValidateLoginCredentialsCommandTest extends CommandTestCase<ValidateLoginC
                 runCommand(
                     "--client=NewRegistrar",
                     "--password=" + PASSWORD,
-                    "--cert_hash=" + CERT_HASH,
+                    "--cert_file=" + getCertFilename(CertificateSamples.SAMPLE_CERT3),
                     "--ip_address=" + new StringBuilder(CLIENT_IP).reverse()));
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
@@ -148,7 +145,9 @@ class ValidateLoginCredentialsCommandTest extends CommandTestCase<ValidateLoginC
         ParameterException.class,
         () ->
             runCommand(
-                "--password=" + PASSWORD, "--cert_hash=" + CERT_HASH, "--ip_address=" + CLIENT_IP));
+                "--password=" + PASSWORD,
+                "--cert_file=" + getCertFilename(CertificateSamples.SAMPLE_CERT3),
+                "--ip_address=" + CLIENT_IP));
   }
 
   @Test
@@ -157,7 +156,9 @@ class ValidateLoginCredentialsCommandTest extends CommandTestCase<ValidateLoginC
         ParameterException.class,
         () ->
             runCommand(
-                "--client=NewRegistrar", "--cert_hash=" + CERT_HASH, "--ip_address=" + CLIENT_IP));
+                "--client=NewRegistrar",
+                "--cert_file=" + getCertFilename(CertificateSamples.SAMPLE_CERT3),
+                "--ip_address=" + CLIENT_IP));
   }
 
   @Test
@@ -168,22 +169,7 @@ class ValidateLoginCredentialsCommandTest extends CommandTestCase<ValidateLoginC
             runCommand(
                 "--client=NewRegistrar",
                 "--password=" + PASSWORD,
-                "--cert_hash=" + CERT_HASH,
                 "--ip_address=" + CLIENT_IP,
                 "--unrecognized_flag=foo"));
-  }
-
-  @Test
-  void testFailure_certHashAndCertFile() throws Exception {
-    Path certFile = Files.createFile(tmpDir.resolve("temp.crt"));
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            runCommand(
-                "--client=NewRegistrar",
-                "--password=" + PASSWORD,
-                "--cert_hash=" + CERT_HASH,
-                "--cert_file=" + certFile.toString(),
-                "--ip_address=" + CLIENT_IP));
   }
 }


### PR DESCRIPTION
Cert hash was being used as a fallback if there was any issue with the certificate checks. The logs don't show that the hash fall back was needed at all, so I am removing it. I also removed the hardcoded start date for certificate enforcement since the date has passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1017)
<!-- Reviewable:end -->
