### PR TITLE
Add schema_deployer SQL user to SecretManager

### DIFF
--- a/core/src/main/java/google/registry/privileges/secretmanager/SqlUser.java
+++ b/core/src/main/java/google/registry/privileges/secretmanager/SqlUser.java
@@ -49,6 +49,7 @@ public abstract class SqlUser {
   /** Enumerates the {@link RobotUser RobotUsers} in the system. */
   public enum RobotId {
     NOMULUS,
+    SCHEMA_DEPLOYER,
     /**
      * Credential for RegistryTool. This is temporary, and will be removed when tool users are
      * assigned their personal credentials.

--- a/db/src/main/resources/sql/user/create_schema_deployer_user.sql
+++ b/db/src/main/resources/sql/user/create_schema_deployer_user.sql
@@ -1,0 +1,24 @@
+-- Copyright 2019 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+--
+-- Script to create a user with read-only permission to all tables. The
+-- initialize_roles.sql script creates the readonly role used here.
+
+-- Comment out line below if user already exists:
+CREATE USER schema_deployer ENCRYPTED PASSWORD :'password';
+-- Comment out line above and uncomment line below if user has been created
+-- from Cloud Dashboard:
+-- ALTER USER :username NOCREATEDB NOCREATEROLE;
+GRANT CONNECT ON DATABASE postgres TO schema_deployer;
+GRANT CREATE, USAGE ON SCHEMA public TO schema_deployer;


### PR DESCRIPTION
Add the 'schema_deployer' user to the SecretManager so that its
credential can be set up. The schema deployment process will use this
user instead of the 'postgres' user.

Changed the output of the get_sql_credential command for the schema
deployment process.

Added a sql script that documents the privileges granted to
'schema_deployer'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1018)
<!-- Reviewable:end -->
