### PR TITLE
Add replay to remaining (non-trivial) flow tests

### DIFF
--- a/core/src/test/java/google/registry/flows/contact/ContactUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactUpdateFlowTest.java
@@ -42,11 +42,18 @@ import google.registry.model.contact.PostalInfo;
 import google.registry.model.contact.PostalInfo.Type;
 import google.registry.model.eppcommon.StatusValue;
 import google.registry.testing.DualDatabaseTest;
+import google.registry.testing.ReplayExtension;
 import google.registry.testing.TestOfyAndSql;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link ContactUpdateFlow}. */
 @DualDatabaseTest
 class ContactUpdateFlowTest extends ResourceFlowTestCase<ContactUpdateFlow, ContactResource> {
+
+  @Order(value = Order.DEFAULT - 2)
+  @RegisterExtension
+  final ReplayExtension replayExtension = ReplayExtension.createWithCompare(clock);
 
   ContactUpdateFlowTest() {
     setEppInput("contact_update.xml");

--- a/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
@@ -72,6 +72,7 @@ import google.registry.model.registry.Registry.TldState;
 import google.registry.model.registry.label.ReservedList;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.testing.ReplayExtension;
+import google.registry.testing.SetClockExtension;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
@@ -79,8 +80,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link DomainCheckFlow}. */
@@ -88,7 +87,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
 
   @Order(value = Order.DEFAULT - 3)
   @RegisterExtension
-  final SetClockExtension setClockExtension = new SetClockExtension();
+  final SetClockExtension setClockExtension = new SetClockExtension(clock, "2009-01-01T10:00:00Z");
 
   @Order(value = Order.DEFAULT - 2)
   @RegisterExtension
@@ -1350,13 +1349,5 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setRegistrationExpirationTime(clock.nowUtc().minusDays(1))
             .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
             .build());
-  }
-
-  class SetClockExtension implements BeforeEachCallback {
-    @Override
-    public void beforeEach(ExtensionContext context) {
-      // Kick the clock back to before the earliest date that we set the clock to.
-      clock.setTo(DateTime.parse("2009-01-01T10:00:00Z"));
-    }
   }
 }

--- a/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
@@ -66,12 +66,11 @@ import google.registry.model.reporting.HistoryEntry;
 import google.registry.persistence.VKey;
 import google.registry.testing.AppEngineExtension;
 import google.registry.testing.ReplayExtension;
+import google.registry.testing.SetClockExtension;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link DomainInfoFlow}. */
@@ -79,7 +78,8 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
 
   @Order(value = Order.DEFAULT - 3)
   @RegisterExtension
-  final SetClockExtension setClockExtension = new SetClockExtension();
+  final SetClockExtension setClockExtension =
+      new SetClockExtension(clock, "2005-03-03T22:00:00.000Z");
 
   @Order(value = Order.DEFAULT - 2)
   @RegisterExtension
@@ -972,13 +972,5 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
     runFlow();
     assertIcannReportingActivityFieldLogged("srs-dom-info");
     assertTldsFieldLogged("tld");
-  }
-
-  class SetClockExtension implements BeforeEachCallback {
-    @Override
-    public void beforeEach(ExtensionContext context) {
-      // Kick the clock back to before the earliest date that we set the clock to.
-      clock.setTo(DateTime.parse("2005-03-03T22:00:00.000Z"));
-    }
   }
 }

--- a/core/src/test/java/google/registry/flows/host/HostCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostCreateFlowTest.java
@@ -55,12 +55,19 @@ import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.host.HostResource;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.testing.DualDatabaseTest;
+import google.registry.testing.ReplayExtension;
 import google.registry.testing.TestOfyAndSql;
 import org.joda.time.DateTime;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link HostCreateFlow}. */
 @DualDatabaseTest
 class HostCreateFlowTest extends ResourceFlowTestCase<HostCreateFlow, HostResource> {
+
+  @Order(value = Order.DEFAULT - 2)
+  @RegisterExtension
+  final ReplayExtension replayExtension = ReplayExtension.createWithCompare(clock);
 
   private void setEppHostCreateInput(String hostName, String hostAddrs) {
     setEppInput(

--- a/core/src/test/java/google/registry/flows/host/HostDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostDeleteFlowTest.java
@@ -47,13 +47,20 @@ import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.transfer.DomainTransferData;
 import google.registry.model.transfer.TransferStatus;
 import google.registry.testing.DualDatabaseTest;
+import google.registry.testing.ReplayExtension;
 import google.registry.testing.TestOfyAndSql;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link HostDeleteFlow}. */
 @DualDatabaseTest
 class HostDeleteFlowTest extends ResourceFlowTestCase<HostDeleteFlow, HostResource> {
+
+  @Order(value = Order.DEFAULT - 2)
+  @RegisterExtension
+  final ReplayExtension replayExtension = ReplayExtension.createWithCompare(clock);
 
   @BeforeEach
   void initFlowTest() {

--- a/core/src/test/java/google/registry/flows/host/HostInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostInfoFlowTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static google.registry.testing.DatabaseHelper.assertNoBillingEvents;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.newDomainBase;
+import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -34,13 +35,20 @@ import google.registry.flows.host.HostFlowUtils.HostNameNotPunyCodedException;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.host.HostResource;
+import google.registry.testing.ReplayExtension;
 import javax.annotation.Nullable;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link HostInfoFlow}. */
 class HostInfoFlowTest extends ResourceFlowTestCase<HostInfoFlow, HostResource> {
+
+  @Order(value = Order.DEFAULT - 2)
+  @RegisterExtension
+  final ReplayExtension replayExtension = ReplayExtension.createWithCompare(clock);
 
   HostInfoFlowTest() {
     setEppInput("host_info.xml", ImmutableMap.of("HOSTNAME", "ns1.example.tld"));
@@ -105,6 +113,7 @@ class HostInfoFlowTest extends ResourceFlowTestCase<HostInfoFlow, HostResource> 
 
   private void runTest_superordinateDomain(
       DateTime domainTransferTime, @Nullable DateTime lastSuperordinateChange) throws Exception {
+    persistNewRegistrar("superclientid");
     DomainBase domain =
         persistResource(
             newDomainBase("parent.foobar")

--- a/core/src/test/java/google/registry/flows/poll/PollAckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/poll/PollAckFlowTest.java
@@ -32,12 +32,19 @@ import google.registry.flows.poll.PollAckFlow.NotAuthorizedToAckMessageException
 import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.poll.PollMessage;
+import google.registry.testing.ReplayExtension;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link PollAckFlow}. */
 class PollAckFlowTest extends FlowTestCase<PollAckFlow> {
+
+  @Order(value = Order.DEFAULT - 2)
+  @RegisterExtension
+  final ReplayExtension replayExtension = ReplayExtension.createWithCompare(clock);
 
   /** This is the message id being sent in the ACK request. */
   private static final long MESSAGE_ID = 3;

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -1168,7 +1168,12 @@ public class DatabaseHelper {
 
   public static <T extends EppResource> HistoryEntry createHistoryEntryForEppResource(
       T parentResource) {
-    return persistResource(new HistoryEntry.Builder().setParent(parentResource).build());
+    return persistResource(
+        new HistoryEntry.Builder()
+            .setType(getHistoryEntryType(parentResource))
+            .setModificationTime(DateTime.now(DateTimeZone.UTC))
+            .setParent(parentResource)
+            .build());
   }
 
   /** Persists a single Objectify resource, without adjusting foreign resources or keys. */

--- a/core/src/test/java/google/registry/testing/SetClockExtension.java
+++ b/core/src/test/java/google/registry/testing/SetClockExtension.java
@@ -1,0 +1,47 @@
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.testing;
+
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Extension used for tests that a) set the clock to a specific time and b) make use of
+ * ReplayExtension or any other test feature that requires writing to a commit log from test
+ * utilities that aren't controlled by the ultimate test class (e.g. AppEngineExtension).
+ */
+public class SetClockExtension implements BeforeEachCallback {
+
+  private FakeClock clock;
+  private DateTime dateTime;
+
+  /** Construct from a DateTime, that being the time to set the clock to. */
+  public SetClockExtension(FakeClock clock, DateTime dateTime) {
+    this.clock = clock;
+    this.dateTime = dateTime;
+  }
+
+  /** Construct from a dateTime (the time to set the clock to) represented as a string. */
+  public SetClockExtension(FakeClock clock, String dateTime) {
+    this.clock = clock;
+    this.dateTime = DateTime.parse(dateTime);
+  }
+
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    clock.setTo(dateTime);
+  }
+}

--- a/core/src/test/resources/google/registry/flows/poll/poll_response_contact_transfer.xml
+++ b/core/src/test/resources/google/registry/flows/poll/poll_response_contact_transfer.xml
@@ -3,8 +3,8 @@
     <result code="1301">
       <msg>Command completed successfully; ack to dequeue</msg>
     </result>
-    <msgQ count="1" id="2-2-ROID-5-3-2000">
-      <qDate>2000-06-08T22:00:00Z</qDate>
+    <msgQ count="1" id="2-2-ROID-5-3-2010">
+      <qDate>2010-12-28T01:01:01Z</qDate>
       <msg>Transfer requested.</msg>
     </msgQ>
     <resData>
@@ -12,9 +12,9 @@
         <contact:id>sh8013</contact:id>
         <contact:trStatus>pending</contact:trStatus>
         <contact:reID>TheRegistrar</contact:reID>
-        <contact:reDate>2000-06-08T22:00:00.0Z</contact:reDate>
+        <contact:reDate>2010-12-28T01:01:01Z</contact:reDate>
         <contact:acID>NewRegistrar</contact:acID>
-        <contact:acDate>2000-06-13T22:00:00.0Z</contact:acDate>
+        <contact:acDate>2011-01-02T01:01:01Z</contact:acDate>
       </contact:trnData>
     </resData>
     <trID>

--- a/db/src/main/resources/sql/er_diagram/brief_er_diagram.html
+++ b/db/src/main/resources/sql/er_diagram/brief_er_diagram.html
@@ -261,11 +261,11 @@ td.section {
     </tr> 
     <tr> 
      <td class="property_name">generated on</td> 
-     <td class="property_value">2021-03-18 19:08:16.381352</td> 
+     <td class="property_value">2021-03-19 12:31:33.396532</td> 
     </tr> 
     <tr>
      <td class="property_name">last flyway file</td>
-     <td id="lastFlywayFile" class="property_value">V88__transfer_billing_cancellation_history_id.sql</td>
+     <td id="lastFlywayFile" class="property_value">V89__host_history_host_deferred.sql</td>
     </tr>
    </tbody>
   </table> 
@@ -284,7 +284,7 @@ td.section {
      generated on
     </text> 
     <text text-anchor="start" x="4027.94" y="-10.8" font-family="Helvetica,sans-Serif" font-size="14.00">
-     2021-03-18 19:08:16.381352
+     2021-03-19 12:31:33.396532
     </text> 
     <polygon fill="none" stroke="#888888" points="3940.44,-4 3940.44,-44 4205.44,-44 4205.44,-4 3940.44,-4" /> <!-- allocationtoken_a08ccbef --> 
     <g id="node1" class="node"> 
@@ -2484,8 +2484,8 @@ td.section {
      <polyline fill="none" stroke="black" points="191.5,-646.68 195.4,-643.55 " /> 
      <polygon fill="black" stroke="black" points="199.31,-646.82 193.05,-639.02 194.61,-637.77 200.87,-645.57 199.31,-646.82" /> 
      <polyline fill="none" stroke="black" points="195.4,-643.55 199.3,-640.42 " /> 
-     <text text-anchor="start" x="1178.5" y="-280.48" font-family="Helvetica,sans-Serif" font-size="14.00">
-      fk3d09knnmxrt6iniwnp8j2ykga
+     <text text-anchor="start" x="1203" y="-280.48" font-family="Helvetica,sans-Serif" font-size="14.00">
+      fk_history_registrar_id
      </text> 
     </g> <!-- kmssecret_f3b28857 --> 
     <g id="node22" class="node"> 
@@ -5357,7 +5357,7 @@ td.section {
      <td colspan="3"></td> 
     </tr> 
     <tr> 
-     <td colspan="2" class="name">fk3d09knnmxrt6iniwnp8j2ykga</td> 
+     <td colspan="2" class="name">fk_history_registrar_id</td> 
      <td class="description right">[foreign key, with no action]</td> 
     </tr> 
     <tr> 
@@ -6110,7 +6110,7 @@ td.section {
      <td colspan="3"></td> 
     </tr> 
     <tr> 
-     <td colspan="2" class="name">fk3d09knnmxrt6iniwnp8j2ykga</td> 
+     <td colspan="2" class="name">fk_history_registrar_id</td> 
      <td class="description right">[foreign key, with no action]</td> 
     </tr> 
     <tr> 

--- a/db/src/main/resources/sql/er_diagram/full_er_diagram.html
+++ b/db/src/main/resources/sql/er_diagram/full_er_diagram.html
@@ -261,11 +261,11 @@ td.section {
     </tr> 
     <tr> 
      <td class="property_name">generated on</td> 
-     <td class="property_value">2021-03-18 19:08:14.574191</td> 
+     <td class="property_value">2021-03-19 12:31:31.233378</td> 
     </tr> 
     <tr>
      <td class="property_name">last flyway file</td>
-     <td id="lastFlywayFile" class="property_value">V88__transfer_billing_cancellation_history_id.sql</td>
+     <td id="lastFlywayFile" class="property_value">V89__host_history_host_deferred.sql</td>
     </tr>
    </tbody>
   </table> 
@@ -284,7 +284,7 @@ td.section {
      generated on
     </text> 
     <text text-anchor="start" x="4626.68" y="-10.8" font-family="Helvetica,sans-Serif" font-size="14.00">
-     2021-03-18 19:08:14.574191
+     2021-03-19 12:31:31.233378
     </text> 
     <polygon fill="none" stroke="#888888" points="4539.18,-4 4539.18,-44 4804.18,-44 4804.18,-4 4539.18,-4" /> <!-- allocationtoken_a08ccbef --> 
     <g id="node1" class="node"> 
@@ -5580,8 +5580,8 @@ td.section {
      <polyline fill="none" stroke="black" points="298,-1144.89 302.29,-1142.32 " /> 
      <polygon fill="black" stroke="black" points="305.72,-1146.1 300.58,-1137.52 302.3,-1136.49 307.43,-1145.08 305.72,-1146.1" /> 
      <polyline fill="none" stroke="black" points="302.29,-1142.32 306.58,-1139.76 " /> 
-     <text text-anchor="start" x="1422" y="-485.69" font-family="Helvetica,sans-Serif" font-size="14.00">
-      fk3d09knnmxrt6iniwnp8j2ykga
+     <text text-anchor="start" x="1446.5" y="-485.69" font-family="Helvetica,sans-Serif" font-size="14.00">
+      fk_history_registrar_id
      </text> 
     </g> <!-- kmssecret_f3b28857 --> 
     <g id="node22" class="node"> 
@@ -11079,7 +11079,7 @@ td.section {
      <td colspan="3"></td> 
     </tr> 
     <tr> 
-     <td colspan="2" class="name">fk3d09knnmxrt6iniwnp8j2ykga</td> 
+     <td colspan="2" class="name">fk_history_registrar_id</td> 
      <td class="description right">[foreign key, with no action]</td> 
     </tr> 
     <tr> 
@@ -12436,7 +12436,7 @@ td.section {
      <td colspan="3"></td> 
     </tr> 
     <tr> 
-     <td colspan="2" class="name">fk3d09knnmxrt6iniwnp8j2ykga</td> 
+     <td colspan="2" class="name">fk_history_registrar_id</td> 
      <td class="description right">[foreign key, with no action]</td> 
     </tr> 
     <tr> 

--- a/db/src/main/resources/sql/flyway.txt
+++ b/db/src/main/resources/sql/flyway.txt
@@ -86,3 +86,4 @@ V85__add_required_columns_in_transfer_data.sql
 V86__third_poll_message.sql
 V87__fix_super_domain_fk.sql
 V88__transfer_billing_cancellation_history_id.sql
+V89__host_history_host_deferred.sql

--- a/db/src/main/resources/sql/flyway/V89__host_history_host_deferred.sql
+++ b/db/src/main/resources/sql/flyway/V89__host_history_host_deferred.sql
@@ -1,0 +1,25 @@
+-- Copyright 2021 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+ALTER TABLE "HostHistory" DROP CONSTRAINT fk3d09knnmxrt6iniwnp8j2ykga;
+ALTER TABLE "HostHistory" DROP CONSTRAINT fk_hosthistory_host;
+ALTER TABLE "HostHistory" ADD CONSTRAINT fk_history_registrar_id
+    FOREIGN KEY (history_registrar_id)
+    REFERENCES "Registrar"(registrar_id)
+    DEFERRABLE INITIALLY DEFERRED;
+ALTER TABLE "HostHistory" ADD CONSTRAINT fk_hosthistory_host
+    FOREIGN KEY (host_repo_id)
+    REFERENCES "Host"(repo_id)
+    DEFERRABLE INITIALLY DEFERRED;
+

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -1868,14 +1868,6 @@ ALTER TABLE ONLY public."Domain"
 
 
 --
--- Name: HostHistory fk3d09knnmxrt6iniwnp8j2ykga; Type: FK CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public."HostHistory"
-    ADD CONSTRAINT fk3d09knnmxrt6iniwnp8j2ykga FOREIGN KEY (history_registrar_id) REFERENCES public."Registrar"(registrar_id);
-
-
---
 -- Name: SignedMarkRevocationEntry fk5ivlhvs3121yx2li5tqh54u4; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2172,6 +2164,14 @@ ALTER TABLE ONLY public."GracePeriod"
 
 
 --
+-- Name: HostHistory fk_history_registrar_id; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."HostHistory"
+    ADD CONSTRAINT fk_history_registrar_id FOREIGN KEY (history_registrar_id) REFERENCES public."Registrar"(registrar_id) DEFERRABLE INITIALLY DEFERRED;
+
+
+--
 -- Name: Host fk_host_creation_registrar_id; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2208,7 +2208,7 @@ ALTER TABLE ONLY public."Host"
 --
 
 ALTER TABLE ONLY public."HostHistory"
-    ADD CONSTRAINT fk_hosthistory_host FOREIGN KEY (host_repo_id) REFERENCES public."Host"(repo_id);
+    ADD CONSTRAINT fk_hosthistory_host FOREIGN KEY (host_repo_id) REFERENCES public."Host"(repo_id) DEFERRABLE INITIALLY DEFERRED;
 
 
 --


### PR DESCRIPTION
Convert all remaining flow tests to do replay/compare testing.  In the course
of this:
- Move the class specific SetClock extension into its own place.
- Fix another "cyclic" foreign key (there may be another solution in this case
  because HostHistory is actually different from HistoryEntry, but that would
  require changing the way we establish priority since HostHistory is not
  distinguished from HistoryEntry in the current methodology)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1020)
<!-- Reviewable:end -->
