### PR TITLE
Allow nom_build to run in Cloudbuild

### DIFF
--- a/release/builder/build.sh
+++ b/release/builder/build.sh
@@ -23,6 +23,10 @@ apt-get upgrade -y
 apt-get install openjdk-11-jdk-headless -y
 # Install Python
 apt-get install python -y
+# As of March 2021 python3 is at v3.6. Get pip then install dataclasses
+# (introduced in 3.7) for nom_build
+apt-get install python3-pip -y
+python3 -m pip install dataclasses
 # Install Node
 curl -sL https://deb.nodesource.com/setup_current.x | bash -
 apt-get install -y nodejs


### PR DESCRIPTION
Our builder comes with python3.6 and cannot support nom_build out of
box. Nom_build requires dataclasses which is introduced in v3.7.

I haven't found an easy way to get python3.7+ without changing the base
linux image. This PR explicitly installs dataclasses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1021)
<!-- Reviewable:end -->
