### PR TITLE
Attempt to fix flakey deleteExpiredDomain test

### DIFF
--- a/core/src/test/java/google/registry/batch/DeleteExpiredDomainsActionTest.java
+++ b/core/src/test/java/google/registry/batch/DeleteExpiredDomainsActionTest.java
@@ -127,7 +127,7 @@ class DeleteExpiredDomainsActionTest {
     DomainBase domain3 = persistNonAutorenewingDomain("tarm3.tld");
 
     // action.run() executes a non-transactional query by design but makes this test flaky.
-    // Executing a transaction here seems to force the test Datastore tp become up to date.
+    // Executing a transaction here seems to force the test Datastore to become up to date.
     assertThat(tm().loadByEntity(domain3).getStatusValues()).doesNotContain(PENDING_DELETE);
     action.run();
 

--- a/core/src/test/java/google/registry/batch/DeleteExpiredDomainsActionTest.java
+++ b/core/src/test/java/google/registry/batch/DeleteExpiredDomainsActionTest.java
@@ -126,6 +126,9 @@ class DeleteExpiredDomainsActionTest {
     DomainBase domain2 = persistNonAutorenewingDomain("veee2.tld");
     DomainBase domain3 = persistNonAutorenewingDomain("tarm3.tld");
 
+    // action.run() executes a non-transactional query by design but makes this test flaky.
+    // Executing a transaction here seems to force the test Datastore tp become up to date.
+    assertThat(tm().loadByEntity(domain3).getStatusValues()).doesNotContain(PENDING_DELETE);
     action.run();
 
     assertThat(tm().loadByEntity(domain1).getStatusValues()).contains(PENDING_DELETE);


### PR DESCRIPTION
Though hard to reproduce locally, the test_deletesThreeDomainsInOneRun
test has failed multiple times on Kokoro. The root cause may be the
non-transactional query executed by the Action object, which was by
design. Observing that the other test never fails, this PR follows its behavior
and adds a transactional query before invoking the action.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1022)
<!-- Reviewable:end -->
