### PR TITLE
Add a jpaTm().query(...) convenience method

### DIFF
--- a/config/presubmits.py
+++ b/config/presubmits.py
@@ -196,7 +196,7 @@ PRESUBMITS = {
         #    - concatenation of literals: (\s*\+\s*"([^"]|\\")*")*
         # Line 3: , or the closing parenthesis, marking the end of the first
         #    parameter
-        r'.*\.create(Native)?Query\('
+        r'.*\.(query|createQuery|createNativeQuery)\('
         r'(?!(\s*([A-Z_]+|"([^"]|\\")*"(\s*\+\s*"([^"]|\\")*")*)'
         r'(,|\s*\))))',
         "java",
@@ -206,6 +206,7 @@ PRESUBMITS = {
          # using Criteria
          "ForeignKeyIndex.java",
          "HistoryEntryDao.java",
+         "JpaTransactionManager.java",
          "JpaTransactionManagerImpl.java",
          # CriteriaQueryBuilder is a false positive
          "CriteriaQueryBuilder.java",

--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -1093,8 +1093,7 @@ public class DomainFlowUtils {
           .list();
     } else {
       return jpaTm()
-          .getEntityManager()
-          .createQuery(
+          .query(
               "FROM DomainHistory WHERE modificationTime >= :beginning "
                   + "ORDER BY modificationTime ASC",
               DomainHistory.class)

--- a/core/src/main/java/google/registry/mapreduce/inputs/CommitLogManifestReader.java
+++ b/core/src/main/java/google/registry/mapreduce/inputs/CommitLogManifestReader.java
@@ -58,16 +58,16 @@ class CommitLogManifestReader
 
   @Override
   public QueryResultIterator<Key<CommitLogManifest>> getQueryIterator(@Nullable Cursor cursor) {
-    return startQueryAt(query(), cursor).keys().iterator();
+    return startQueryAt(createBucketQuery(), cursor).keys().iterator();
   }
 
   @Override
   public int getTotal() {
-    return query().count();
+    return createBucketQuery().count();
   }
 
   /** Query for children of this bucket. */
-  Query<CommitLogManifest> query() {
+  Query<CommitLogManifest> createBucketQuery() {
     Query<CommitLogManifest> query = ofy().load().type(CommitLogManifest.class).ancestor(bucketKey);
     if (olderThan != null) {
       query = query.filterKey(

--- a/core/src/main/java/google/registry/model/EppResourceUtils.java
+++ b/core/src/main/java/google/registry/model/EppResourceUtils.java
@@ -418,8 +418,7 @@ public final class EppResourceUtils {
                 if (isContactKey) {
                   query =
                       jpaTm()
-                          .getEntityManager()
-                          .createQuery(CONTACT_LINKED_DOMAIN_QUERY, String.class)
+                          .query(CONTACT_LINKED_DOMAIN_QUERY, String.class)
                           .setParameter("fkRepoId", key)
                           .setParameter("now", now);
                 } else {

--- a/core/src/main/java/google/registry/model/domain/DomainContent.java
+++ b/core/src/main/java/google/registry/model/domain/DomainContent.java
@@ -378,13 +378,11 @@ public class DomainContent extends EppResource
   public static void beforeSqlDelete(VKey<DomainBase> key) {
     // Delete all grace periods associated with the domain.
     jpaTm()
-        .getEntityManager()
-        .createQuery("DELETE FROM GracePeriod WHERE domain_repo_id = :repo_id")
+        .query("DELETE FROM GracePeriod WHERE domain_repo_id = :repo_id")
         .setParameter("repo_id", key.getSqlKey())
         .executeUpdate();
     jpaTm()
-        .getEntityManager()
-        .createQuery("DELETE FROM DelegationSignerData WHERE domain_repo_id = :repo_id")
+        .query("DELETE FROM DelegationSignerData WHERE domain_repo_id = :repo_id")
         .setParameter("repo_id", key.getSqlKey())
         .executeUpdate();
   }

--- a/core/src/main/java/google/registry/model/index/ForeignKeyIndex.java
+++ b/core/src/main/java/google/registry/model/index/ForeignKeyIndex.java
@@ -204,8 +204,7 @@ public abstract class ForeignKeyIndex<E extends EppResource> extends BackupGroup
                     String entityName =
                         jpaTm().getEntityManager().getMetamodel().entity(clazz).getName();
                     return jpaTm()
-                        .getEntityManager()
-                        .createQuery(
+                        .query(
                             String.format(
                                 "FROM %s WHERE %s IN :propertyValue and deletionTime > :now ",
                                 entityName, property),

--- a/core/src/main/java/google/registry/model/registrar/Registrar.java
+++ b/core/src/main/java/google/registry/model/registrar/Registrar.java
@@ -651,8 +651,7 @@ public class Registrar extends ImmutableObject
       return tm().transact(
               () ->
                   jpaTm()
-                      .getEntityManager()
-                      .createQuery(
+                      .query(
                           "FROM RegistrarPoc WHERE registrarId = :registrarId",
                           RegistrarContact.class)
                       .setParameter("registrarId", clientIdentifier)

--- a/core/src/main/java/google/registry/model/registry/label/ReservedListSqlDao.java
+++ b/core/src/main/java/google/registry/model/registry/label/ReservedListSqlDao.java
@@ -50,8 +50,7 @@ public class ReservedListSqlDao {
         .transact(
             () ->
                 jpaTm()
-                    .getEntityManager()
-                    .createQuery(
+                    .query(
                         "FROM ReservedList rl LEFT JOIN FETCH rl.reservedListMap WHERE"
                             + " rl.revisionId IN (SELECT MAX(revisionId) FROM ReservedList subrl"
                             + " WHERE subrl.name = :name)",
@@ -71,8 +70,7 @@ public class ReservedListSqlDao {
         .transact(
             () ->
                 jpaTm()
-                        .getEntityManager()
-                        .createQuery("SELECT 1 FROM ReservedList WHERE name = :name", Integer.class)
+                        .query("SELECT 1 FROM ReservedList WHERE name = :name", Integer.class)
                         .setParameter("name", reservedListName)
                         .setMaxResults(1)
                         .getResultList()

--- a/core/src/main/java/google/registry/model/reporting/HistoryEntryDao.java
+++ b/core/src/main/java/google/registry/model/reporting/HistoryEntryDao.java
@@ -31,7 +31,6 @@ import google.registry.model.host.HostHistory;
 import google.registry.model.host.HostResource;
 import google.registry.persistence.VKey;
 import java.util.Comparator;
-import javax.persistence.EntityManager;
 import org.joda.time.DateTime;
 
 /**
@@ -90,15 +89,14 @@ public class HistoryEntryDao {
       VKey<? extends EppResource> parentKey, DateTime afterTime, DateTime beforeTime) {
     Class<? extends HistoryEntry> historyClass = getHistoryClassFromParent(parentKey.getKind());
     String repoIdFieldName = getRepoIdFieldNameFromHistoryClass(historyClass);
-    EntityManager entityManager = jpaTm().getEntityManager();
-    String tableName = entityManager.getMetamodel().entity(historyClass).getName();
+    String tableName = jpaTm().getEntityManager().getMetamodel().entity(historyClass).getName();
     String queryString =
         String.format(
             "SELECT entry FROM %s entry WHERE entry.modificationTime >= :afterTime AND "
                 + "entry.modificationTime <= :beforeTime AND entry.%s = :parentKey",
             tableName, repoIdFieldName);
-    return entityManager
-        .createQuery(queryString, historyClass)
+    return jpaTm()
+        .query(queryString, historyClass)
         .setParameter("afterTime", afterTime)
         .setParameter("beforeTime", beforeTime)
         .setParameter("parentKey", parentKey.getSqlKey().toString())
@@ -129,13 +127,12 @@ public class HistoryEntryDao {
 
   private static Iterable<? extends HistoryEntry> loadAllHistoryObjectsFromSql(
       Class<? extends HistoryEntry> historyClass, DateTime afterTime, DateTime beforeTime) {
-    EntityManager entityManager = jpaTm().getEntityManager();
-    return entityManager
-        .createQuery(
+    return jpaTm()
+        .query(
             String.format(
                 "SELECT entry FROM %s entry WHERE entry.modificationTime >= :afterTime AND "
                     + "entry.modificationTime <= :beforeTime",
-                entityManager.getMetamodel().entity(historyClass).getName()),
+                jpaTm().getEntityManager().getMetamodel().entity(historyClass).getName()),
             historyClass)
         .setParameter("afterTime", afterTime)
         .setParameter("beforeTime", beforeTime)

--- a/core/src/main/java/google/registry/model/reporting/Spec11ThreatMatchDao.java
+++ b/core/src/main/java/google/registry/model/reporting/Spec11ThreatMatchDao.java
@@ -32,8 +32,7 @@ public class Spec11ThreatMatchDao {
   public static void deleteEntriesByDate(JpaTransactionManager jpaTm, LocalDate date) {
     jpaTm.assertInTransaction();
     jpaTm
-        .getEntityManager()
-        .createQuery("DELETE FROM Spec11ThreatMatch WHERE check_date = :date")
+        .query("DELETE FROM Spec11ThreatMatch WHERE check_date = :date")
         .setParameter("date", DateTimeUtils.toSqlDate(date), TemporalType.DATE)
         .executeUpdate();
   }
@@ -44,8 +43,7 @@ public class Spec11ThreatMatchDao {
     jpaTm.assertInTransaction();
     return ImmutableList.copyOf(
         jpaTm
-            .getEntityManager()
-            .createQuery(
+            .query(
                 "SELECT match FROM Spec11ThreatMatch match WHERE match.checkDate = :date",
                 Spec11ThreatMatch.class)
             .setParameter("date", date)

--- a/core/src/main/java/google/registry/model/server/KmsSecretRevisionSqlDao.java
+++ b/core/src/main/java/google/registry/model/server/KmsSecretRevisionSqlDao.java
@@ -42,8 +42,7 @@ public class KmsSecretRevisionSqlDao {
     checkArgument(!isNullOrEmpty(secretName), "secretName cannot be null or empty");
     jpaTm().assertInTransaction();
     return jpaTm()
-        .getEntityManager()
-        .createQuery(
+        .query(
             "FROM KmsSecret ks WHERE ks.revisionKey IN (SELECT MAX(revisionKey) FROM "
                 + "KmsSecret subKs WHERE subKs.secretName = :secretName)",
             KmsSecretRevision.class)

--- a/core/src/main/java/google/registry/model/tmch/ClaimsListSqlDao.java
+++ b/core/src/main/java/google/registry/model/tmch/ClaimsListSqlDao.java
@@ -17,14 +17,13 @@ package google.registry.model.tmch;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 
 import java.util.Optional;
-import javax.persistence.EntityManager;
 
 /** Data access object for {@link ClaimsListShard}. */
 public class ClaimsListSqlDao {
 
   /** Saves the given {@link ClaimsListShard} to Cloud SQL. */
   static void save(ClaimsListShard claimsList) {
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(claimsList));
+    jpaTm().transact(() -> jpaTm().insert(claimsList));
   }
 
   /**
@@ -35,11 +34,12 @@ public class ClaimsListSqlDao {
     return jpaTm()
         .transact(
             () -> {
-              EntityManager em = jpaTm().getEntityManager();
               Long revisionId =
-                  em.createQuery("SELECT MAX(revisionId) FROM ClaimsList", Long.class)
+                  jpaTm()
+                      .query("SELECT MAX(revisionId) FROM ClaimsList", Long.class)
                       .getSingleResult();
-              return em.createQuery(
+              return jpaTm()
+                  .query(
                       "FROM ClaimsList cl LEFT JOIN FETCH cl.labelsToKeys WHERE cl.revisionId ="
                           + " :revisionId",
                       ClaimsListShard.class)

--- a/core/src/main/java/google/registry/model/tmch/TmchCrl.java
+++ b/core/src/main/java/google/registry/model/tmch/TmchCrl.java
@@ -79,10 +79,7 @@ public final class TmchCrl extends CrossTldSingleton implements NonReplicatedEnt
                   .transactNew(
                       () -> {
                         // Delete the old one and insert the new one
-                        jpaTm()
-                            .getEntityManager()
-                            .createQuery("DELETE FROM TmchCrl")
-                            .executeUpdate();
+                        jpaTm().query("DELETE FROM TmchCrl").executeUpdate();
                         jpaTm().putWithoutBackup(tmchCrl);
                       });
             });

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManager.java
@@ -17,12 +17,30 @@ package google.registry.persistence.transaction;
 import google.registry.persistence.VKey;
 import java.util.function.Supplier;
 import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import javax.persistence.TypedQuery;
 
 /** Sub-interface of {@link TransactionManager} which defines JPA related methods. */
 public interface JpaTransactionManager extends TransactionManager {
 
   /** Returns the {@link EntityManager} for the current request. */
   EntityManager getEntityManager();
+
+  /**
+   * Creates a JPA SQL query for the given query string and result class.
+   *
+   * <p>This is a convenience method for the longer <code>
+   * jpaTm().getEntityManager().createQuery(...)</code>.
+   */
+  <T> TypedQuery<T> query(String sqlString, Class<T> resultClass);
+
+  /**
+   * Creates a JPA SQL query for the given query string (which does not return results).
+   *
+   * <p>This is a convenience method for the longer <code>
+   * jpaTm().getEntityManager().createQuery(...)</code>.
+   */
+  Query query(String sqlString);
 
   /** Executes the work in a transaction with no retries and returns the result. */
   <T> T transactNoRetry(Supplier<T> work);

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -105,6 +105,16 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   }
 
   @Override
+  public <T> TypedQuery<T> query(String sqlString, Class<T> resultClass) {
+    return getEntityManager().createQuery(sqlString, resultClass);
+  }
+
+  @Override
+  public Query query(String sqlString) {
+    return getEntityManager().createQuery(sqlString);
+  }
+
+  @Override
   public boolean inTransaction() {
     return transactionInfo.get().inTransaction;
   }
@@ -365,8 +375,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   private boolean exists(String entityName, ImmutableSet<EntityId> entityIds) {
     assertInTransaction();
     TypedQuery<Integer> query =
-        getEntityManager()
-            .createQuery(
+        query(
                 String.format("SELECT 1 FROM %s WHERE %s", entityName, getAndClause(entityIds)),
                 Integer.class)
             .setMaxResults(1);
@@ -470,7 +479,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
     // TODO(b/179158393): use Criteria for query to leave not doubt about sql injection risk.
     String sql =
         String.format("DELETE FROM %s WHERE %s", entityType.getName(), getAndClause(entityIds));
-    Query query = getEntityManager().createQuery(sql);
+    Query query = query(sql);
     entityIds.forEach(entityId -> query.setParameter(entityId.name, entityId.value));
     transactionInfo.get().addDelete(key);
     return query.executeUpdate();

--- a/core/src/main/java/google/registry/reporting/icann/IcannReportingStager.java
+++ b/core/src/main/java/google/registry/reporting/icann/IcannReportingStager.java
@@ -106,14 +106,17 @@ public class IcannReportingStager {
       throws ExecutionException, InterruptedException {
     // Later views depend on the results of earlier ones, so query everything synchronously
     logger.atInfo().log("Generating intermediary view %s", queryName);
-    bigquery.query(
-        query,
-        bigquery.buildDestinationTable(queryName)
-            .description(String.format(
-                "An intermediary view to generate %s reports for this month.", reportType))
-            .type(TableType.VIEW)
-            .build()
-    ).get();
+    bigquery
+        .startQuery(
+            query,
+            bigquery
+                .buildDestinationTable(queryName)
+                .description(
+                    String.format(
+                        "An intermediary view to generate %s reports for this month.", reportType))
+                .type(TableType.VIEW)
+                .build())
+        .get();
   }
 
   private Iterable<String> getHeaders(ImmutableSet<TableFieldSchema> fields) {

--- a/core/src/main/java/google/registry/schema/replay/ReplicateToDatastoreAction.java
+++ b/core/src/main/java/google/registry/schema/replay/ReplicateToDatastoreAction.java
@@ -57,8 +57,7 @@ class ReplicateToDatastoreAction implements Runnable {
           .transact(
               () ->
                   jpaTm()
-                      .getEntityManager()
-                      .createQuery(
+                      .query(
                           "SELECT txn FROM TransactionEntity txn WHERE id >"
                               + " :lastId ORDER BY id")
                       .setParameter("lastId", lastSqlTxnBeforeBatch.getTransactionId())

--- a/core/src/main/java/google/registry/schema/replay/SqlReplayCheckpoint.java
+++ b/core/src/main/java/google/registry/schema/replay/SqlReplayCheckpoint.java
@@ -39,8 +39,7 @@ public class SqlReplayCheckpoint implements SqlEntity {
   public static DateTime get() {
     jpaTm().assertInTransaction();
     return jpaTm()
-        .getEntityManager()
-        .createQuery("FROM SqlReplayCheckpoint", SqlReplayCheckpoint.class)
+        .query("FROM SqlReplayCheckpoint", SqlReplayCheckpoint.class)
         .setMaxResults(1)
         .getResultStream()
         .findFirst()

--- a/core/src/main/java/google/registry/schema/server/LockDao.java
+++ b/core/src/main/java/google/registry/schema/server/LockDao.java
@@ -33,7 +33,7 @@ public class LockDao {
     jpaTm()
         .transact(
             () -> {
-              jpaTm().getEntityManager().merge(lock);
+              jpaTm().put(lock);
             });
   }
 
@@ -68,7 +68,7 @@ public class LockDao {
             () -> {
               Optional<Lock> loadedLock = load(resourceName, tld);
               if (loadedLock.isPresent()) {
-                jpaTm().getEntityManager().remove(loadedLock.get());
+                jpaTm().delete(loadedLock.get());
               }
             });
   }

--- a/core/src/main/java/google/registry/schema/tld/PremiumListSqlDao.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumListSqlDao.java
@@ -159,7 +159,7 @@ public class PremiumListSqlDao {
   }
 
   public static PremiumList save(PremiumList premiumList) {
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(premiumList));
+    jpaTm().transact(() -> jpaTm().insert(premiumList));
     premiumListCache.invalidate(premiumList.getName());
     return premiumList;
   }
@@ -174,8 +174,7 @@ public class PremiumListSqlDao {
         .transact(
             () ->
                 jpaTm()
-                    .getEntityManager()
-                    .createQuery(
+                    .query(
                         "FROM PremiumList WHERE name = :name ORDER BY revisionId DESC",
                         PremiumList.class)
                     .setParameter("name", premiumListName)
@@ -194,8 +193,7 @@ public class PremiumListSqlDao {
         .transact(
             () ->
                 jpaTm()
-                    .getEntityManager()
-                    .createQuery(
+                    .query(
                         "FROM PremiumEntry pe WHERE pe.revisionId = :revisionId",
                         PremiumEntry.class)
                     .setParameter("revisionId", premiumList.getRevisionId())
@@ -211,8 +209,7 @@ public class PremiumListSqlDao {
         .transact(
             () ->
                 jpaTm()
-                    .getEntityManager()
-                    .createQuery(
+                    .query(
                         "SELECT pe.price FROM PremiumEntry pe WHERE pe.revisionId = :revisionId"
                             + " AND pe.domainLabel = :label",
                         BigDecimal.class)

--- a/core/src/main/java/google/registry/tools/LoadSnapshotCommand.java
+++ b/core/src/main/java/google/registry/tools/LoadSnapshotCommand.java
@@ -79,12 +79,14 @@ final class LoadSnapshotCommand extends BigqueryCommand {
 
   /** Starts a load job for the specified kind name, sourcing data from the given GCS file. */
   private ListenableFuture<?> loadSnapshotFile(String filename, String kindName) {
-    return bigquery().load(
-        bigquery().buildDestinationTable(kindName)
-            .description("Datastore snapshot import for " + kindName + ".")
-            .build(),
-        SourceFormat.DATASTORE_BACKUP,
-        ImmutableList.of(filename));
+    return bigquery()
+        .startLoad(
+            bigquery()
+                .buildDestinationTable(kindName)
+                .description("Datastore snapshot import for " + kindName + ".")
+                .build(),
+            SourceFormat.DATASTORE_BACKUP,
+            ImmutableList.of(filename));
   }
 
   /**

--- a/core/src/main/java/google/registry/tools/javascrap/BackfillSpec11ThreatMatchesCommand.java
+++ b/core/src/main/java/google/registry/tools/javascrap/BackfillSpec11ThreatMatchesCommand.java
@@ -207,8 +207,7 @@ public class BackfillSpec11ThreatMatchesCommand extends ConfirmingCommand
         .transact(
             () ->
                 jpaTm()
-                    .getEntityManager()
-                    .createQuery(
+                    .query(
                         "SELECT DISTINCT stm.checkDate FROM Spec11ThreatMatch stm", LocalDate.class)
                     .getResultStream()
                     .collect(toImmutableSet()));

--- a/core/src/test/java/google/registry/model/registry/label/ReservedListSqlDaoTest.java
+++ b/core/src/test/java/google/registry/model/registry/label/ReservedListSqlDaoTest.java
@@ -71,8 +71,7 @@ public class ReservedListSqlDaoTest {
             () -> {
               ReservedList persistedList =
                   jpaTm()
-                      .getEntityManager()
-                      .createQuery("FROM ReservedList WHERE name = :name", ReservedList.class)
+                      .query("FROM ReservedList WHERE name = :name", ReservedList.class)
                       .setParameter("name", "testlist")
                       .getSingleResult();
               assertThat(persistedList.getReservedListEntries())

--- a/core/src/test/java/google/registry/model/server/ServerSecretTest.java
+++ b/core/src/test/java/google/registry/model/server/ServerSecretTest.java
@@ -74,8 +74,7 @@ public class ServerSecretTest extends EntityTestCase {
         .transact(
             () ->
                 jpaTm()
-                    .getEntityManager()
-                    .createQuery("FROM ServerSecret", ServerSecret.class)
+                    .query("FROM ServerSecret", ServerSecret.class)
                     .setMaxResults(1)
                     .getResultStream()
                     .findFirst()

--- a/core/src/test/java/google/registry/model/smd/SignedMarkRevocationListTest.java
+++ b/core/src/test/java/google/registry/model/smd/SignedMarkRevocationListTest.java
@@ -149,10 +149,7 @@ public class SignedMarkRevocationListTest {
     }
     jpaTm()
         .transact(
-            () ->
-                jpaTm()
-                    .getEntityManager()
-                    .persist(SignedMarkRevocationList.create(clock.nowUtc(), revokes.build())));
+            () -> jpaTm().insert(SignedMarkRevocationList.create(clock.nowUtc(), revokes.build())));
     RuntimeException thrown =
         assertThrows(RuntimeException.class, () -> SignedMarkRevocationList.get());
     assertThat(thrown).hasMessageThat().contains("Unequal SignedMarkRevocationList detected:");

--- a/core/src/test/java/google/registry/model/tmch/TmchCrlTest.java
+++ b/core/src/test/java/google/registry/model/tmch/TmchCrlTest.java
@@ -57,10 +57,7 @@ public class TmchCrlTest extends EntityTestCase {
         .transact(
             () ->
                 assertThat(
-                        jpaTm()
-                            .getEntityManager()
-                            .createQuery("SELECT COUNT(*) FROM TmchCrl", Long.class)
-                            .getSingleResult())
+                        jpaTm().query("SELECT COUNT(*) FROM TmchCrl", Long.class).getSingleResult())
                     .isEqualTo(1L));
   }
 
@@ -69,8 +66,7 @@ public class TmchCrlTest extends EntityTestCase {
         .transact(
             () ->
                 jpaTm()
-                    .getEntityManager()
-                    .createQuery("FROM TmchCrl", TmchCrl.class)
+                    .query("FROM TmchCrl", TmchCrl.class)
                     .setMaxResults(1)
                     .getResultStream()
                     .findFirst()

--- a/core/src/test/java/google/registry/persistence/EntityCallbacksListenerTest.java
+++ b/core/src/test/java/google/registry/persistence/EntityCallbacksListenerTest.java
@@ -74,7 +74,7 @@ class EntityCallbacksListenerTest {
             .transact(
                 () -> {
                   TestEntity removed = jpaTm().loadByKey(VKey.createSql(TestEntity.class, "id"));
-                  jpaTm().getEntityManager().remove(removed);
+                  jpaTm().delete(removed);
                   return removed;
                 });
     checkAll(testRemove, 0, 0, 1, 1);

--- a/core/src/test/java/google/registry/persistence/converter/AllocationTokenStatusTransitionConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/AllocationTokenStatusTransitionConverterTest.java
@@ -59,7 +59,7 @@ public class AllocationTokenStatusTransitionConverterTest {
         TimedTransitionProperty.fromValueMap(values, TokenStatusTransition.class);
     AllocationTokenStatusTransitionConverterTestEntity testEntity =
         new AllocationTokenStatusTransitionConverterTestEntity(timedTransitionProperty);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     AllocationTokenStatusTransitionConverterTestEntity persisted =
         jpaTm()
             .transact(

--- a/core/src/test/java/google/registry/persistence/converter/BillingCostTransitionConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/BillingCostTransitionConverterTest.java
@@ -54,7 +54,7 @@ public class BillingCostTransitionConverterTest {
     TimedTransitionProperty<Money, BillingCostTransition> timedTransitionProperty =
         TimedTransitionProperty.fromValueMap(values, BillingCostTransition.class);
     TestEntity testEntity = new TestEntity(timedTransitionProperty);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.timedTransitionProperty).containsExactlyEntriesIn(timedTransitionProperty);

--- a/core/src/test/java/google/registry/persistence/converter/BloomFilterConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/BloomFilterConverterTest.java
@@ -41,7 +41,7 @@ class BloomFilterConverterTest {
     BloomFilter<String> bloomFilter = BloomFilter.create(stringFunnel(US_ASCII), 3);
     ImmutableSet.of("foo", "bar", "baz").forEach(bloomFilter::put);
     TestEntity entity = new TestEntity(bloomFilter);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(entity));
+    jpaTm().transact(() -> jpaTm().insert(entity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.bloomFilter).isEqualTo(bloomFilter);

--- a/core/src/test/java/google/registry/persistence/converter/CidrAddressBlockListConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/CidrAddressBlockListConverterTest.java
@@ -45,7 +45,7 @@ public class CidrAddressBlockListConverterTest {
             CidrAddressBlock.create("8000::/1"),
             CidrAddressBlock.create("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128"));
     TestEntity testEntity = new TestEntity(addresses);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.addresses).isEqualTo(addresses);

--- a/core/src/test/java/google/registry/persistence/converter/CreateAutoTimestampConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/CreateAutoTimestampConverterTest.java
@@ -45,7 +45,7 @@ public class CreateAutoTimestampConverterTest {
     CreateAutoTimestamp ts = CreateAutoTimestamp.create(DateTime.parse("2019-09-9T11:39:00Z"));
     TestEntity ent = new TestEntity("myinst", ts);
 
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(ent));
+    jpaTm().transact(() -> jpaTm().insert(ent));
     TestEntity result =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "myinst"));
     assertThat(result).isEqualTo(new TestEntity("myinst", ts));
@@ -56,7 +56,7 @@ public class CreateAutoTimestampConverterTest {
     CreateAutoTimestamp ts = CreateAutoTimestamp.create(null);
     TestEntity ent = new TestEntity("autoinit", ts);
 
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(ent));
+    jpaTm().transact(() -> jpaTm().insert(ent));
 
     TestEntity result =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "autoinit"));

--- a/core/src/test/java/google/registry/persistence/converter/CurrencyToBillingConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/CurrencyToBillingConverterTest.java
@@ -48,7 +48,7 @@ public class CurrencyToBillingConverterTest {
             CurrencyUnit.of("CNY"),
             new BillingAccountEntry(CurrencyUnit.of("CNY"), "accountId2"));
     TestEntity testEntity = new TestEntity(currencyToBilling);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.currencyToBilling).containsExactlyEntriesIn(currencyToBilling);

--- a/core/src/test/java/google/registry/persistence/converter/CurrencyUnitConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/CurrencyUnitConverterTest.java
@@ -39,7 +39,7 @@ public class CurrencyUnitConverterTest {
   @Test
   void roundTripConversion() {
     TestEntity entity = new TestEntity(CurrencyUnit.EUR);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(entity));
+    jpaTm().transact(() -> jpaTm().insert(entity));
     assertThat(
             jpaTm()
                 .transact(

--- a/core/src/test/java/google/registry/persistence/converter/DateTimeConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/DateTimeConverterTest.java
@@ -69,7 +69,7 @@ public class DateTimeConverterTest {
   void converter_generatesTimestampWithNormalizedZone() {
     DateTime dt = parseDateTime("2019-09-01T01:01:01Z");
     TestEntity entity = new TestEntity("normalized_utc_time", dt);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(entity));
+    jpaTm().transact(() -> jpaTm().insert(entity));
     TestEntity retrievedEntity =
         jpaTm()
             .transact(
@@ -82,7 +82,7 @@ public class DateTimeConverterTest {
     DateTime dt = parseDateTime("2019-09-01T01:01:01-05:00");
     TestEntity entity = new TestEntity("new_york_time", dt);
 
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(entity));
+    jpaTm().transact(() -> jpaTm().insert(entity));
     TestEntity retrievedEntity =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "new_york_time"));
     assertThat(retrievedEntity.dt.toString()).isEqualTo("2019-09-01T06:01:01.000Z");

--- a/core/src/test/java/google/registry/persistence/converter/JodaMoneyConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/JodaMoneyConverterTest.java
@@ -71,7 +71,7 @@ public class JodaMoneyConverterTest {
   void roundTripConversion() {
     Money money = Money.of(CurrencyUnit.USD, 100);
     TestEntity entity = new TestEntity(money);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(entity));
+    jpaTm().transact(() -> jpaTm().insert(entity));
     List<?> result =
         jpaTm()
             .transact(
@@ -101,7 +101,7 @@ public class JodaMoneyConverterTest {
             "dos", Money.ofMajor(CurrencyUnit.JPY, 2000),
             "tres", Money.of(CurrencyUnit.GBP, 20));
     ComplexTestEntity entity = new ComplexTestEntity(moneyMap, myMoney, yourMoney);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(entity));
+    jpaTm().transact(() -> jpaTm().insert(entity));
     List<?> result =
         jpaTm()
             .transact(

--- a/core/src/test/java/google/registry/persistence/converter/LongVKeyConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/LongVKeyConverterTest.java
@@ -46,7 +46,7 @@ public class LongVKeyConverterTest {
         new TestLongEntity(
             VKey.createSql(TestLongEntity.class, 10L),
             VKey.createSql(CompositeKeyTestLongEntity.class, 20L));
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(original));
+    jpaTm().transact(() -> jpaTm().insert(original));
 
     TestLongEntity retrieved =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestLongEntity.class, "id"));

--- a/core/src/test/java/google/registry/persistence/converter/PremiumListKeyConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/PremiumListKeyConverterTest.java
@@ -67,7 +67,7 @@ class PremiumListKeyConverterTest {
   void testRoundTrip() {
     Key<PremiumList> key = Key.create(getCrossTldKey(), PremiumList.class, "test");
     PremiumListEntity testEntity = new PremiumListEntity(key);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     PremiumListEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(PremiumListEntity.class, "test"));
     assertThat(persisted.premiumList).isEqualTo(key);

--- a/core/src/test/java/google/registry/persistence/converter/ReservedListKeySetConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/ReservedListKeySetConverterTest.java
@@ -47,7 +47,7 @@ class ReservedListKeySetConverterTest {
 
     Set<Key<ReservedList>> reservedLists = ImmutableSet.of(key1, key2, key3);
     ReservedListSetEntity testEntity = new ReservedListSetEntity(reservedLists);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     ReservedListSetEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(ReservedListSetEntity.class, "id"));
     assertThat(persisted.reservedList).containsExactly(key1, key2, key3);
@@ -56,7 +56,7 @@ class ReservedListKeySetConverterTest {
   @Test
   void testNullValue_writesAndReadsNullSuccessfully() {
     ReservedListSetEntity testEntity = new ReservedListSetEntity(null);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     ReservedListSetEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(ReservedListSetEntity.class, "id"));
     assertThat(persisted.reservedList).isNull();
@@ -65,7 +65,7 @@ class ReservedListKeySetConverterTest {
   @Test
   void testEmptyCollection_writesAndReadsEmptyCollectionSuccessfully() {
     ReservedListSetEntity testEntity = new ReservedListSetEntity(ImmutableSet.of());
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     ReservedListSetEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(ReservedListSetEntity.class, "id"));
     assertThat(persisted.reservedList).isEmpty();

--- a/core/src/test/java/google/registry/persistence/converter/StatusValueSetConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StatusValueSetConverterTest.java
@@ -39,7 +39,7 @@ public class StatusValueSetConverterTest {
     Set<StatusValue> enums = ImmutableSet.of(StatusValue.INACTIVE, StatusValue.PENDING_DELETE);
     TestEntity obj = new TestEntity("foo", enums);
 
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(obj));
+    jpaTm().transact(() -> jpaTm().insert(obj));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "foo"));
     assertThat(persisted.data).isEqualTo(enums);

--- a/core/src/test/java/google/registry/persistence/converter/StringListConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringListConverterTest.java
@@ -40,7 +40,7 @@ public class StringListConverterTest {
   void roundTripConversion_returnsSameStringList() {
     List<String> tlds = ImmutableList.of("app", "dev", "how");
     TestEntity testEntity = new TestEntity(tlds);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).containsExactly("app", "dev", "how");
@@ -50,7 +50,7 @@ public class StringListConverterTest {
   void testMerge_succeeds() {
     List<String> tlds = ImmutableList.of("app", "dev", "how");
     TestEntity testEntity = new TestEntity(tlds);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     persisted.tlds = ImmutableList.of("com", "gov");
@@ -63,7 +63,7 @@ public class StringListConverterTest {
   @Test
   void testNullValue_writesAndReadsNullSuccessfully() {
     TestEntity testEntity = new TestEntity(null);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).isNull();
@@ -72,7 +72,7 @@ public class StringListConverterTest {
   @Test
   void testEmptyCollection_writesAndReadsEmptyCollectionSuccessfully() {
     TestEntity testEntity = new TestEntity(ImmutableList.of());
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).isEmpty();

--- a/core/src/test/java/google/registry/persistence/converter/StringMapConverterBaseTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringMapConverterBaseTest.java
@@ -50,7 +50,7 @@ public class StringMapConverterBaseTest {
   @Test
   void roundTripConversion_returnsSameMap() {
     TestEntity testEntity = new TestEntity(MAP);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.map).containsExactlyEntriesIn(MAP);
@@ -59,7 +59,7 @@ public class StringMapConverterBaseTest {
   @Test
   void testUpdateColumn_succeeds() {
     TestEntity testEntity = new TestEntity(MAP);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.map).containsExactlyEntriesIn(MAP);
@@ -73,7 +73,7 @@ public class StringMapConverterBaseTest {
   @Test
   void testNullValue_writesAndReadsNullSuccessfully() {
     TestEntity testEntity = new TestEntity(null);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.map).isNull();
@@ -82,7 +82,7 @@ public class StringMapConverterBaseTest {
   @Test
   void testEmptyMap_writesAndReadsEmptyCollectionSuccessfully() {
     TestEntity testEntity = new TestEntity(ImmutableMap.of());
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.map).isEmpty();

--- a/core/src/test/java/google/registry/persistence/converter/StringSetConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringSetConverterTest.java
@@ -38,7 +38,7 @@ public class StringSetConverterTest {
   void roundTripConversion_returnsSameStringList() {
     Set<String> tlds = ImmutableSet.of("app", "dev", "how");
     TestEntity testEntity = new TestEntity(tlds);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).containsExactly("app", "dev", "how");
@@ -47,7 +47,7 @@ public class StringSetConverterTest {
   @Test
   void testNullValue_writesAndReadsNullSuccessfully() {
     TestEntity testEntity = new TestEntity(null);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).isNull();
@@ -56,7 +56,7 @@ public class StringSetConverterTest {
   @Test
   void testEmptyCollection_writesAndReadsEmptyCollectionSuccessfully() {
     TestEntity testEntity = new TestEntity(ImmutableSet.of());
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).isEmpty();

--- a/core/src/test/java/google/registry/persistence/converter/StringVKeyConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringVKeyConverterTest.java
@@ -47,7 +47,7 @@ public class StringVKeyConverterTest {
             "TheRealSpartacus",
             VKey.createSql(TestStringEntity.class, "ImSpartacus!"),
             VKey.createSql(CompositeKeyTestStringEntity.class, "NoImSpartacus!"));
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(original));
+    jpaTm().transact(() -> jpaTm().insert(original));
 
     TestStringEntity retrieved =
         jpaTm()

--- a/core/src/test/java/google/registry/persistence/converter/StringValueEnumeratedTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringValueEnumeratedTest.java
@@ -38,7 +38,7 @@ public class StringValueEnumeratedTest {
   @Test
   void roundTripConversion_returnsSameEnum() {
     TestEntity testEntity = new TestEntity(State.ACTIVE);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.state).isEqualTo(State.ACTIVE);
@@ -47,7 +47,7 @@ public class StringValueEnumeratedTest {
   @Test
   void testNativeQuery_succeeds() {
     TestEntity testEntity = new TestEntity(State.DISABLED);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
 
     assertThat(
             jpaTm()

--- a/core/src/test/java/google/registry/persistence/converter/TimedTransitionPropertyConverterBaseTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/TimedTransitionPropertyConverterBaseTest.java
@@ -60,7 +60,7 @@ class TimedTransitionPropertyConverterBaseTest {
   @Test
   void roundTripConversion_returnsSameTimedTransitionProperty() {
     TestEntity testEntity = new TestEntity(TIMED_TRANSITION_PROPERTY);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.property).containsExactlyEntriesIn(TIMED_TRANSITION_PROPERTY);
@@ -69,7 +69,7 @@ class TimedTransitionPropertyConverterBaseTest {
   @Test
   void testUpdateColumn_succeeds() {
     TestEntity testEntity = new TestEntity(TIMED_TRANSITION_PROPERTY);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.property).containsExactlyEntriesIn(TIMED_TRANSITION_PROPERTY);
@@ -84,7 +84,7 @@ class TimedTransitionPropertyConverterBaseTest {
   @Test
   void testNullValue_writesAndReadsNullSuccessfully() {
     TestEntity testEntity = new TestEntity(null);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.property).isNull();

--- a/core/src/test/java/google/registry/persistence/converter/TldStateTransitionConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/TldStateTransitionConverterTest.java
@@ -57,7 +57,7 @@ class TldStateTransitionConverterTest {
     TimedTransitionProperty<TldState, TldStateTransition> timedTransitionProperty =
         TimedTransitionProperty.fromValueMap(values, TldStateTransition.class);
     TestEntity testEntity = new TestEntity(timedTransitionProperty);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(testEntity));
+    jpaTm().transact(() -> jpaTm().insert(testEntity));
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.timedTransitionProperty).containsExactlyEntriesIn(timedTransitionProperty);

--- a/core/src/test/java/google/registry/persistence/converter/UpdateAutoTimestampConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/UpdateAutoTimestampConverterTest.java
@@ -43,7 +43,7 @@ public class UpdateAutoTimestampConverterTest {
   void testTypeConversion() {
     TestEntity ent = new TestEntity("myinst", null);
 
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(ent));
+    jpaTm().transact(() -> jpaTm().insert(ent));
 
     TestEntity result =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "myinst"));
@@ -56,7 +56,7 @@ public class UpdateAutoTimestampConverterTest {
   void testTimeChangesOnSubsequentTransactions() {
     TestEntity ent1 = new TestEntity("myinst1", null);
 
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(ent1));
+    jpaTm().transact(() -> jpaTm().insert(ent1));
 
     TestEntity result1 =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "myinst1"));
@@ -65,7 +65,7 @@ public class UpdateAutoTimestampConverterTest {
 
     TestEntity ent2 = new TestEntity("myinst2", result1.uat);
 
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(ent2));
+    jpaTm().transact(() -> jpaTm().insert(ent2));
 
     TestEntity result2 =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "myinst2"));

--- a/core/src/test/java/google/registry/persistence/converter/ZonedDateTimeConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/ZonedDateTimeConverterTest.java
@@ -66,7 +66,7 @@ public class ZonedDateTimeConverterTest {
   void converter_generatesTimestampWithNormalizedZone() {
     ZonedDateTime zdt = ZonedDateTime.parse("2019-09-01T01:01:01Z");
     TestEntity entity = new TestEntity("normalized_utc_time", zdt);
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(entity));
+    jpaTm().transact(() -> jpaTm().insert(entity));
     TestEntity retrievedEntity =
         jpaTm()
             .transact(
@@ -79,7 +79,7 @@ public class ZonedDateTimeConverterTest {
     ZonedDateTime zdt = ZonedDateTime.parse("2019-09-01T01:01:01Z[UTC]");
     TestEntity entity = new TestEntity("non_normalized_utc_time", zdt);
 
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(entity));
+    jpaTm().transact(() -> jpaTm().insert(entity));
     TestEntity retrievedEntity =
         jpaTm()
             .transact(
@@ -92,7 +92,7 @@ public class ZonedDateTimeConverterTest {
     ZonedDateTime zdt = ZonedDateTime.parse("2019-09-01T01:01:01+05:00");
     TestEntity entity = new TestEntity("new_york_time", zdt);
 
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(entity));
+    jpaTm().transact(() -> jpaTm().insert(entity));
     TestEntity retrievedEntity =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "new_york_time"));
     assertThat(retrievedEntity.zdt.toString()).isEqualTo("2019-08-31T20:01:01Z");

--- a/core/src/test/java/google/registry/persistence/transaction/JpaEntityCoverageExtension.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaEntityCoverageExtension.java
@@ -106,8 +106,7 @@ public class JpaEntityCoverageExtension implements BeforeEachCallback, AfterEach
               .transact(
                   () ->
                       jpaTm()
-                          .getEntityManager()
-                          .createQuery(
+                          .query(
                               String.format("SELECT e FROM %s e", getJpaEntityName(entityType)),
                               entityType)
                           .setMaxResults(1)

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerRuleTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerRuleTest.java
@@ -66,7 +66,7 @@ public class JpaTransactionManagerRuleTest {
     // This test verifies that 1) withEntityClass() has registered TestEntity and 2) The table
     // has been created, implying withProperty(HBM2DDL_AUTO, "update") worked.
     TestEntity original = new TestEntity("key", "value");
-    jpaTm().transact(() -> jpaTm().getEntityManager().persist(original));
+    jpaTm().transact(() -> jpaTm().insert(original));
     TestEntity retrieved =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "key"));
     assertThat(retrieved).isEqualTo(original);

--- a/core/src/test/java/google/registry/reporting/icann/IcannReportingStagerTest.java
+++ b/core/src/test/java/google/registry/reporting/icann/IcannReportingStagerTest.java
@@ -70,7 +70,8 @@ class IcannReportingStagerTest {
   }
 
   private void setUpBigquery() {
-    when(bigquery.query(any(String.class), any(DestinationTable.class))).thenReturn(fakeFuture());
+    when(bigquery.startQuery(any(String.class), any(DestinationTable.class)))
+        .thenReturn(fakeFuture());
     DestinationTable.Builder tableBuilder =
         new DestinationTable.Builder()
             .datasetId("testdataset")

--- a/core/src/test/java/google/registry/schema/replay/SqlReplayCheckpointTest.java
+++ b/core/src/test/java/google/registry/schema/replay/SqlReplayCheckpointTest.java
@@ -53,8 +53,7 @@ public class SqlReplayCheckpointTest extends EntityTestCase {
             () ->
                 assertThat(
                         jpaTm()
-                            .getEntityManager()
-                            .createQuery("SELECT COUNT(*) FROM SqlReplayCheckpoint", Long.class)
+                            .query("SELECT COUNT(*) FROM SqlReplayCheckpoint", Long.class)
                             .getSingleResult())
                     .isEqualTo(1L));
   }

--- a/core/src/test/java/google/registry/tools/CreateOrUpdateReservedListCommandTestCase.java
+++ b/core/src/test/java/google/registry/tools/CreateOrUpdateReservedListCommandTestCase.java
@@ -30,7 +30,6 @@ import google.registry.model.registry.label.ReservedList.ReservedListEntry;
 import google.registry.model.registry.label.ReservedListSqlDao;
 import java.io.File;
 import java.io.IOException;
-import javax.persistence.EntityManager;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -118,14 +117,15 @@ abstract class CreateOrUpdateReservedListCommandTestCase<
     return jpaTm()
         .transact(
             () -> {
-              EntityManager em = jpaTm().getEntityManager();
               long revisionId =
-                  em.createQuery(
+                  jpaTm()
+                      .query(
                           "SELECT MAX(rl.revisionId) FROM ReservedList rl WHERE name = :name",
                           Long.class)
                       .setParameter("name", name)
                       .getSingleResult();
-              return em.createQuery(
+              return jpaTm()
+                  .query(
                       "FROM ReservedList rl LEFT JOIN FETCH rl.reservedListMap WHERE"
                           + " rl.revisionId = :revisionId",
                       ReservedList.class)


### PR DESCRIPTION
This replaces the more ungainly jpaTm().getEntityManager().createQuery(...).

Note that this is in JpaTransactionManager, not the parent TransactionManager,
because this is not an operation that Datastore can support. Once we finish
migrating away from Datastore this won't matter anyway because
JpaTransactionManager will be merged into TransactionManager and then deleted.

In the process of writing this PR I discovered several other methods available
on the EntityManager that may merit their own convenience methods if we start
using them enough. The more commonly used ones will be addressed in subsequent
PRs. They are:

jpaTm().getEntityManager().getMetamodel().entity(...).getName()
jpaTm().getEntityManager().getCriteriaBuilder().createQuery(...)
jpaTm().getEntityManager().createNativeQuery(...)
jpaTm().getEntityManager().find(...)

This PR also addresses some existing callsites that were calling
getEntityManager() rather than using extant convenience methods, such as
jpa().insert(...).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1023)
<!-- Reviewable:end -->
