### PR TITLE
Update RegistrarSettingsAction and RegistrarContact to SQL calls

### DIFF
--- a/core/src/main/java/google/registry/model/UpdateAutoTimestamp.java
+++ b/core/src/main/java/google/registry/model/UpdateAutoTimestamp.java
@@ -58,7 +58,8 @@ public class UpdateAutoTimestamp extends ImmutableObject {
   @PreUpdate
   void setTimestamp() {
     if (autoUpdateEnabled() || lastUpdateTime == null) {
-      lastUpdateTime = DateTimeUtils.toZonedDateTime(jpaTm().getTransactionTime());
+      timestamp = jpaTm().getTransactionTime();
+      lastUpdateTime = DateTimeUtils.toZonedDateTime(timestamp);
     }
   }
 

--- a/core/src/main/java/google/registry/ui/server/registrar/ConsoleRegistrarCreatorAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/ConsoleRegistrarCreatorAction.java
@@ -19,7 +19,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static google.registry.model.common.GaeUserIdConverter.convertEmailAddressToGaeUserId;
-import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.ui.server.SoyTemplateUtils.CSS_RENAMING_MAP_SUPPLIER;
 import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
@@ -234,14 +233,13 @@ public final class ConsoleRegistrarCreatorAction extends HtmlAction {
               .setEmailAddress(consoleUserEmail.get())
               .setGaeUserId(gaeUserId)
               .build();
-      tm()
-          .transact(
+      tm().transact(
               () -> {
                 checkState(
                     !Registrar.loadByClientId(registrar.getClientId()).isPresent(),
                     "Registrar with client ID %s already exists",
                     registrar.getClientId());
-                ofy().save().entities(registrar, contact);
+                tm().putAll(registrar, contact);
               });
       data.put("password", password);
       data.put("passcode", phonePasscode);

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistrarSettingsActionTestCase.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistrarSettingsActionTestCase.java
@@ -75,9 +75,15 @@ public abstract class RegistrarSettingsActionTestCase {
 
   static final String CLIENT_ID = "TheRegistrar";
 
+  final FakeClock clock = new FakeClock(DateTime.parse("2014-01-01T00:00:00Z"));
+
   @RegisterExtension
   public final AppEngineExtension appEngine =
-      AppEngineExtension.builder().withDatastoreAndCloudSql().withTaskQueue().build();
+      AppEngineExtension.builder()
+          .withDatastoreAndCloudSql()
+          .withClock(clock)
+          .withTaskQueue()
+          .build();
 
   @RegisterExtension public final InjectExtension inject = new InjectExtension();
 
@@ -88,7 +94,6 @@ public abstract class RegistrarSettingsActionTestCase {
 
   final RegistrarSettingsAction action = new RegistrarSettingsAction();
   private final StringWriter writer = new StringWriter();
-  final FakeClock clock = new FakeClock(DateTime.parse("2014-01-01T00:00:00Z"));
 
   RegistrarContact techContact;
 


### PR DESCRIPTION
Relevant potentially-unclear changes:
- Making sure the last update time is always correct and up to date in
the auto timestamp object
- Reloading the domain upon return when updating in a new transaction to
make sure that we use the properly-updated last update time (SQL returns
the correct result if retrieved within the same txn but DS does not)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1042)
<!-- Reviewable:end -->
