### PR TITLE
Convert DomainTAF and DomainFlowUtils to SQL

### DIFF
--- a/core/src/test/java/google/registry/flows/domain/DomainFlowUtilsTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainFlowUtilsTest.java
@@ -33,9 +33,11 @@ import google.registry.flows.domain.DomainFlowUtils.TldDoesNotExistException;
 import google.registry.flows.domain.DomainFlowUtils.TrailingDashException;
 import google.registry.model.domain.DomainBase;
 import google.registry.testing.AppEngineExtension;
+import google.registry.testing.DualDatabaseTest;
+import google.registry.testing.TestOfyAndSql;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
+@DualDatabaseTest
 class DomainFlowUtilsTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase> {
 
   @BeforeEach
@@ -45,12 +47,12 @@ class DomainFlowUtilsTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBas
     persistResource(AppEngineExtension.makeRegistrar1().asBuilder().build());
   }
 
-  @Test
+  @TestOfyAndSql
   void testValidateDomainNameAcceptsValidName() throws EppException {
     assertThat(DomainFlowUtils.validateDomainName("example.tld")).isNotNull();
   }
 
-  @Test
+  @TestOfyAndSql
   void testValidateDomainName_IllegalCharacters() {
     BadDomainNameCharacterException thrown =
         assertThrows(
@@ -62,7 +64,7 @@ class DomainFlowUtilsTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBas
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
-  @Test
+  @TestOfyAndSql
   void testValidateDomainName_DomainNameWithEmptyParts() {
     EmptyDomainNamePartException thrown =
         assertThrows(
@@ -72,7 +74,7 @@ class DomainFlowUtilsTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBas
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
-  @Test
+  @TestOfyAndSql
   void testValidateDomainName_DomainNameWithLessThanTwoParts() {
     BadDomainNamePartsCountException thrown =
         assertThrows(
@@ -84,7 +86,7 @@ class DomainFlowUtilsTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBas
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
-  @Test
+  @TestOfyAndSql
   void testValidateDomainName_invalidTLD() {
     TldDoesNotExistException thrown =
         assertThrows(
@@ -96,7 +98,7 @@ class DomainFlowUtilsTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBas
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
-  @Test
+  @TestOfyAndSql
   void testValidateDomainName_DomainNameIsTooLong() {
     DomainLabelTooLongException thrown =
         assertThrows(
@@ -110,7 +112,7 @@ class DomainFlowUtilsTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBas
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
-  @Test
+  @TestOfyAndSql
   void testValidateDomainName_leadingDash() {
     LeadingDashException thrown =
         assertThrows(
@@ -119,7 +121,7 @@ class DomainFlowUtilsTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBas
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
-  @Test
+  @TestOfyAndSql
   void testValidateDomainName_trailingDash() {
     TrailingDashException thrown =
         assertThrows(
@@ -128,7 +130,7 @@ class DomainFlowUtilsTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBas
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
-  @Test
+  @TestOfyAndSql
   void testValidateDomainName_invalidIDN() {
     InvalidPunycodeException thrown =
         assertThrows(
@@ -140,7 +142,7 @@ class DomainFlowUtilsTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBas
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
-  @Test
+  @TestOfyAndSql
   void testValidateDomainName_containsInvalidDashes() {
     DashesInThirdAndFourthException thrown =
         assertThrows(

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferFlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferFlowTestCase.java
@@ -23,12 +23,14 @@ import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.deleteResource;
 import static google.registry.testing.DatabaseHelper.getBillingEvents;
 import static google.registry.testing.DatabaseHelper.getOnlyHistoryEntryOfType;
+import static google.registry.testing.DatabaseHelper.loadAllOf;
 import static google.registry.testing.DatabaseHelper.persistActiveContact;
 import static google.registry.testing.DatabaseHelper.persistDomainWithDependentResources;
 import static google.registry.testing.DatabaseHelper.persistDomainWithPendingTransfer;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DomainBaseSubject.assertAboutDomains;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
 import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableSet;
@@ -45,6 +47,7 @@ import google.registry.model.host.HostResource;
 import google.registry.model.poll.PollMessage;
 import google.registry.model.registry.Registry;
 import google.registry.model.reporting.HistoryEntry;
+import google.registry.model.reporting.HistoryEntryDao;
 import google.registry.model.transfer.TransferData;
 import google.registry.model.transfer.TransferStatus;
 import google.registry.testing.AppEngineExtension;
@@ -168,8 +171,9 @@ abstract class DomainTransferFlowTestCase<F extends Flow, R extends EppResource>
    */
   void deleteTestDomain(DomainBase domain) {
     Iterable<BillingEvent> billingEvents = getBillingEvents();
-    Iterable<HistoryEntry> historyEntries = tm().loadAllOf(HistoryEntry.class);
-    Iterable<PollMessage> pollMessages = tm().loadAllOf(PollMessage.class);
+    Iterable<? extends HistoryEntry> historyEntries =
+        HistoryEntryDao.loadAllHistoryObjects(START_OF_TIME, END_OF_TIME);
+    Iterable<PollMessage> pollMessages = loadAllOf(PollMessage.class);
     tm().transact(
             () -> {
               deleteResource(domain);


### PR DESCRIPTION
The only tricky part to this is that the order of entities that we're
saving during the DomainTransferApproveFlow matters -- some entities
have dependencies on others so we need to save the latter first. We
change `entitiesToSave` to be a list to reinforce this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1045)
<!-- Reviewable:end -->
