### PR TITLE
Convert ofy -> tm for two more classes

### DIFF
--- a/core/src/main/java/google/registry/persistence/VKey.java
+++ b/core/src/main/java/google/registry/persistence/VKey.java
@@ -64,7 +64,7 @@ public class VKey<T> extends ImmutableObject implements Serializable {
   }
 
   /** Creates a {@link VKey} which only contains the ofy primary key. */
-  public static <T> VKey<T> createOfy(Class<T> kind, Key<T> ofyKey) {
+  public static <T> VKey<T> createOfy(Class<? extends T> kind, Key<T> ofyKey) {
     checkArgumentNotNull(kind, "kind must not be null");
     checkArgumentNotNull(ofyKey, "ofyKey must not be null");
     return new VKey<T>(kind, ofyKey, null);

--- a/core/src/main/java/google/registry/tools/ReadEntityFromKeyPathCommand.java
+++ b/core/src/main/java/google/registry/tools/ReadEntityFromKeyPathCommand.java
@@ -26,6 +26,7 @@ import com.google.common.io.Files;
 import com.googlecode.objectify.Key;
 import google.registry.model.ImmutableObject;
 import google.registry.model.domain.DomainBase;
+import google.registry.persistence.VKey;
 import google.registry.util.NonFinalForTesting;
 import google.registry.util.TypeUtils.TypeInstantiator;
 import java.io.File;
@@ -147,5 +148,19 @@ abstract class ReadEntityFromKeyPathCommand<T> extends MutatingCommand {
           String.format("Expected a Key<DomainBase> but got %s", grandParent));
     }
     return (Key<DomainBase>) grandParent;
+  }
+
+  static VKey<DomainBase> getGrandParentAsDomain(VKey<?> key) {
+    Key<DomainBase> grandParent;
+    try {
+      grandParent = key.getOfyKey().getParent().getParent();
+    } catch (Throwable e) {
+      throw new IllegalArgumentException("Error retrieving grand parent key", e);
+    }
+    if (!isKind(grandParent, DomainBase.class)) {
+      throw new IllegalArgumentException(
+          String.format("Expected a Key<DomainBase> but got %s", grandParent));
+    }
+    return VKey.create(DomainBase.class, grandParent.getName(), grandParent);
   }
 }

--- a/core/src/test/java/google/registry/tools/DedupeOneTimeBillingEventIdsCommandTest.java
+++ b/core/src/test/java/google/registry/tools/DedupeOneTimeBillingEventIdsCommandTest.java
@@ -38,11 +38,12 @@ import org.joda.money.Money;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link DedupeOneTimeBillingEventIdsCommand}.
+/**
+ * Unit tests for {@link DedupeOneTimeBillingEventIdsCommand}.
  *
- * <p>Note that these are _not_ dual database tests even though the action has been converted.  The
- * dedupe was strictly a one-time event that needed to be done prior to moving to SQL.  It should
- * no longer be necessary and we may want to simply remove the command.
+ * <p>Note that these are _not_ dual database tests even though the action has been converted. The
+ * dedupe was strictly a one-time event that needed to be done prior to moving to SQL. It should no
+ * longer be necessary and we may want to simply remove the command.
  */
 class DedupeOneTimeBillingEventIdsCommandTest
     extends CommandTestCase<DedupeOneTimeBillingEventIdsCommand> {

--- a/core/src/test/java/google/registry/tools/DedupeOneTimeBillingEventIdsCommandTest.java
+++ b/core/src/test/java/google/registry/tools/DedupeOneTimeBillingEventIdsCommandTest.java
@@ -15,8 +15,8 @@
 package google.registry.tools;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.testing.DatabaseHelper.createTld;
+import static google.registry.testing.DatabaseHelper.loadAllOf;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -38,7 +38,12 @@ import org.joda.money.Money;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link DedupeOneTimeBillingEventIdsCommand}. */
+/** Unit tests for {@link DedupeOneTimeBillingEventIdsCommand}.
+ *
+ * <p>Note that these are _not_ dual database tests even though the action has been converted.  The
+ * dedupe was strictly a one-time event that needed to be done prior to moving to SQL.  It should
+ * no longer be necessary and we may want to simply remove the command.
+ */
 class DedupeOneTimeBillingEventIdsCommandTest
     extends CommandTestCase<DedupeOneTimeBillingEventIdsCommand> {
 
@@ -64,8 +69,7 @@ class DedupeOneTimeBillingEventIdsCommandTest
         writeToNamedTmpFile("keypath.txt", getKeyPathLiteral(billingEventToResave)));
 
     int count = 0;
-    for (BillingEvent.OneTime billingEvent :
-        ofy().load().type(BillingEvent.OneTime.class).ancestor(historyEntry)) {
+    for (BillingEvent.OneTime billingEvent : loadAllOf(BillingEvent.OneTime.class)) {
       count++;
       assertThat(billingEvent.getId()).isNotEqualTo(billingEventToResave.getId());
       assertThat(billingEvent.asBuilder().setId(billingEventToResave.getId()).build())

--- a/core/src/test/java/google/registry/tools/MutatingCommandTest.java
+++ b/core/src/test/java/google/registry/tools/MutatingCommandTest.java
@@ -116,9 +116,10 @@ public class MutatingCommandTest {
 
   @Test
   void testSuccess_create() throws Exception {
-    ImmutableList<VKey<?>> keys = Arrays.asList(host1, host2, registrar1, registrar2).stream()
-        .map(entity -> VKey.from(Key.create(entity)))
-        .collect(toImmutableList());
+    ImmutableList<VKey<?>> keys =
+        Arrays.asList(host1, host2, registrar1, registrar2).stream()
+            .map(entity -> VKey.from(Key.create(entity)))
+            .collect(toImmutableList());
     tm().transact(() -> tm().deleteWithoutBackup(keys));
     MutatingCommand command = new MutatingCommand() {
       @Override

--- a/core/src/test/java/google/registry/tools/MutatingCommandTest.java
+++ b/core/src/test/java/google/registry/tools/MutatingCommandTest.java
@@ -14,18 +14,23 @@
 
 package google.registry.tools;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.deleteResource;
+import static google.registry.testing.DatabaseHelper.loadByEntity;
 import static google.registry.testing.DatabaseHelper.persistActiveHost;
 import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.common.collect.ImmutableList;
+import com.googlecode.objectify.Key;
 import google.registry.model.host.HostResource;
 import google.registry.model.registrar.Registrar;
+import google.registry.persistence.VKey;
 import google.registry.testing.AppEngineExtension;
 import java.util.Arrays;
 import org.joda.time.DateTime;
@@ -103,15 +108,18 @@ public class MutatingCommandTest {
             + "blockPremiumNames: false -> true\n");
     String results = command.execute();
     assertThat(results).isEqualTo("Updated 4 entities.\n");
-    assertThat(ofy().load().entity(host1).now()).isEqualTo(newHost1);
-    assertThat(ofy().load().entity(host2).now()).isEqualTo(newHost2);
-    assertThat(ofy().load().entity(registrar1).now()).isEqualTo(newRegistrar1);
-    assertThat(ofy().load().entity(registrar2).now()).isEqualTo(newRegistrar2);
+    assertThat(loadByEntity(host1)).isEqualTo(newHost1);
+    assertThat(loadByEntity(host2)).isEqualTo(newHost2);
+    assertThat(loadByEntity(registrar1)).isEqualTo(newRegistrar1);
+    assertThat(loadByEntity(registrar2)).isEqualTo(newRegistrar2);
   }
 
   @Test
   void testSuccess_create() throws Exception {
-    ofy().deleteWithoutBackup().entities(Arrays.asList(host1, host2, registrar1, registrar2)).now();
+    ImmutableList<VKey<?>> keys = Arrays.asList(host1, host2, registrar1, registrar2).stream()
+        .map(entity -> VKey.from(Key.create(entity)))
+        .collect(toImmutableList());
+    tm().transact(() -> tm().deleteWithoutBackup(keys));
     MutatingCommand command = new MutatingCommand() {
       @Override
       protected void init() {
@@ -137,10 +145,10 @@ public class MutatingCommandTest {
             + newRegistrar2 + "\n");
     String results = command.execute();
     assertThat(results).isEqualTo("Updated 4 entities.\n");
-    assertThat(ofy().load().entity(newHost1).now()).isEqualTo(newHost1);
-    assertThat(ofy().load().entity(newHost2).now()).isEqualTo(newHost2);
-    assertThat(ofy().load().entity(newRegistrar1).now()).isEqualTo(newRegistrar1);
-    assertThat(ofy().load().entity(newRegistrar2).now()).isEqualTo(newRegistrar2);
+    assertThat(loadByEntity(newHost1)).isEqualTo(newHost1);
+    assertThat(loadByEntity(newHost2)).isEqualTo(newHost2);
+    assertThat(loadByEntity(newRegistrar1)).isEqualTo(newRegistrar1);
+    assertThat(loadByEntity(newRegistrar2)).isEqualTo(newRegistrar2);
   }
 
   @Test
@@ -170,10 +178,10 @@ public class MutatingCommandTest {
             + registrar2 + "\n");
     String results = command.execute();
     assertThat(results).isEqualTo("Updated 4 entities.\n");
-    assertThat(ofy().load().entity(host1).now()).isNull();
-    assertThat(ofy().load().entity(host2).now()).isNull();
-    assertThat(ofy().load().entity(registrar1).now()).isNull();
-    assertThat(ofy().load().entity(registrar2).now()).isNull();
+    assertThat(loadByEntity(host1)).isNull();
+    assertThat(loadByEntity(host2)).isNull();
+    assertThat(loadByEntity(registrar1)).isNull();
+    assertThat(loadByEntity(registrar2)).isNull();
   }
 
   @Test
@@ -196,8 +204,8 @@ public class MutatingCommandTest {
             + "[no changes]\n");
     String results = command.execute();
     assertThat(results).isEqualTo("Updated 2 entities.\n");
-    assertThat(ofy().load().entity(host1).now()).isEqualTo(host1);
-    assertThat(ofy().load().entity(registrar1).now()).isEqualTo(registrar1);
+    assertThat(loadByEntity(host1)).isEqualTo(host1);
+    assertThat(loadByEntity(registrar1)).isEqualTo(registrar1);
   }
 
   @Test
@@ -230,10 +238,10 @@ public class MutatingCommandTest {
             + "blockPremiumNames: false -> true\n");
     String results = command.execute();
     assertThat(results).isEqualTo("Updated 4 entities.\n");
-    assertThat(ofy().load().entity(host1).now()).isNull();
-    assertThat(ofy().load().entity(host2).now()).isEqualTo(newHost2);
-    assertThat(ofy().load().entity(registrar1).now()).isNull();
-    assertThat(ofy().load().entity(registrar2).now()).isEqualTo(newRegistrar2);
+    assertThat(loadByEntity(host1)).isNull();
+    assertThat(loadByEntity(host2)).isEqualTo(newHost2);
+    assertThat(loadByEntity(registrar1)).isNull();
+    assertThat(loadByEntity(registrar2)).isEqualTo(newRegistrar2);
   }
 
   @Test
@@ -271,11 +279,11 @@ public class MutatingCommandTest {
 
     IllegalStateException thrown = assertThrows(IllegalStateException.class, command::execute);
     assertThat(thrown).hasMessageThat().contains("Entity changed since init() was called.");
-    assertThat(ofy().load().entity(host1).now()).isNull();
-    assertThat(ofy().load().entity(host2).now()).isEqualTo(newHost2);
+    assertThat(loadByEntity(host1)).isNull();
+    assertThat(loadByEntity(host2)).isEqualTo(newHost2);
     // These two shouldn't've changed.
-    assertThat(ofy().load().entity(registrar1).now()).isEqualTo(registrar1);
-    assertThat(ofy().load().entity(registrar2).now()).isEqualTo(registrar2);
+    assertThat(loadByEntity(registrar1)).isEqualTo(registrar1);
+    assertThat(loadByEntity(registrar2)).isEqualTo(registrar2);
   }
 
   @Test


### PR DESCRIPTION
Convert ofy -> tm for MutatingCommand and DedupeOneTimeBillingEventIdsCommand.

Note that DedupeOneTimeBillingEventIdsCommand will not be needed after
migration, so this conversion is just to remove the ofy uses from the
codebase.  We don't update the test (other than to keep it working) and it
wouldn't currently work in SQL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1049)
<!-- Reviewable:end -->
