### PR TITLE
Convert poll-message-related classes to use SQL as well

### DIFF
--- a/core/src/main/java/google/registry/model/poll/PollMessage.java
+++ b/core/src/main/java/google/registry/model/poll/PollMessage.java
@@ -106,7 +106,7 @@ public abstract class PollMessage extends ImmutableObject
   @Column(name = "poll_message_id")
   Long id;
 
-  @Parent @DoNotHydrate @Transient Key<HistoryEntry> parent;
+  @Parent @DoNotHydrate @Transient Key<? extends HistoryEntry> parent;
 
   /** The registrar that this poll message will be delivered to. */
   @Index
@@ -134,7 +134,7 @@ public abstract class PollMessage extends ImmutableObject
 
   @Ignore Long hostHistoryRevisionId;
 
-  public Key<HistoryEntry> getParentKey() {
+  public Key<? extends HistoryEntry> getParentKey() {
     return parent;
   }
 
@@ -239,7 +239,7 @@ public abstract class PollMessage extends ImmutableObject
       return thisCastToDerived();
     }
 
-    public B setParentKey(Key<HistoryEntry> parentKey) {
+    public B setParentKey(Key<? extends HistoryEntry> parentKey) {
       getInstance().parent = parentKey;
       return thisCastToDerived();
     }

--- a/core/src/test/java/google/registry/flows/poll/PollRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/poll/PollRequestFlowTest.java
@@ -38,14 +38,16 @@ import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.transfer.TransferResponse.ContactTransferResponse;
 import google.registry.model.transfer.TransferResponse.DomainTransferResponse;
 import google.registry.model.transfer.TransferStatus;
+import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.ReplayExtension;
 import google.registry.testing.SetClockExtension;
+import google.registry.testing.TestOfyAndSql;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link PollRequestFlow}. */
+@DualDatabaseTest
 class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
 
   @Order(value = Order.DEFAULT - 3)
@@ -92,14 +94,14 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
             .build());
   }
 
-  @Test
+  @TestOfyAndSql
   void testSuccess_domainTransferApproved() throws Exception {
     persistPendingTransferPollMessage();
     assertTransactionalFlow(false);
     runFlowAssertResponse(loadFile("poll_response_domain_transfer.xml"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testSuccess_clTridNotSpecified() throws Exception {
     setEppInput("poll_no_cltrid.xml");
     persistPendingTransferPollMessage();
@@ -107,7 +109,7 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
     runFlowAssertResponse(loadFile("poll_response_domain_transfer_no_cltrid.xml"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testSuccess_contactTransferPending() throws Exception {
     setClientIdForFlow("TheRegistrar");
     persistResource(
@@ -130,7 +132,7 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
     runFlowAssertResponse(loadFile("poll_response_contact_transfer.xml"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testSuccess_domainPendingActionComplete() throws Exception {
     persistResource(
         new PollMessage.OneTime.Builder()
@@ -145,7 +147,7 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
     runFlowAssertResponse(loadFile("poll_response_domain_pending_notification.xml"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testSuccess_domainAutorenewMessage() throws Exception {
     persistResource(
         new PollMessage.Autorenew.Builder()
@@ -159,12 +161,12 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
     runFlowAssertResponse(loadFile("poll_response_autorenew.xml"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testSuccess_empty() throws Exception {
     runFlowAssertResponse(loadFile("poll_response_empty.xml"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testSuccess_wrongRegistrar() throws Exception {
     persistResource(
         new PollMessage.OneTime.Builder()
@@ -176,7 +178,7 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
     runFlowAssertResponse(loadFile("poll_response_empty.xml"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testSuccess_futurePollMessage() throws Exception {
     persistResource(
         new PollMessage.OneTime.Builder()
@@ -188,7 +190,7 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
     runFlowAssertResponse(loadFile("poll_response_empty.xml"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testSuccess_futureAutorenew() throws Exception {
     persistResource(
         new PollMessage.Autorenew.Builder()
@@ -202,7 +204,7 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
     runFlowAssertResponse(loadFile("poll_response_empty.xml"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testSuccess_contactDelete() throws Exception {
     // Contact delete poll messages do not have any response data, so ensure that no
     // response data block is produced in the poll message.
@@ -223,7 +225,7 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
     runFlowAssertResponse(loadFile("poll_response_contact_delete.xml"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testSuccess_hostDelete() throws Exception {
     // Host delete poll messages do not have any response data, so ensure that no
     // response data block is produced in the poll message.
@@ -245,7 +247,7 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
     runFlowAssertResponse(loadFile("poll_response_host_delete.xml"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testFailure_messageIdProvided() throws Exception {
     setEppInput("poll_with_id.xml");
     assertTransactionalFlow(false);

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -119,6 +119,7 @@ import google.registry.tmch.LordnTaskUtils;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -1207,6 +1208,7 @@ public class DatabaseHelper {
             .setType(getHistoryEntryType(parentResource))
             .setModificationTime(DateTime.now(DateTimeZone.UTC))
             .setParent(parentResource)
+            .setClientId(parentResource.getPersistedCurrentSponsorClientId())
             .build());
   }
 
@@ -1326,6 +1328,20 @@ public class DatabaseHelper {
    */
   public static <T> ImmutableList<T> loadAllOf(Class<T> clazz) {
     return transactIfJpaTm(() -> tm().loadAllOf(clazz));
+  }
+
+  /**
+   * Loads the set of entities by their keys from the DB.
+   *
+   * <p>If the transaction manager is Cloud SQL, then this creates an inner wrapping transaction for
+   * convenience, so you don't need to wrap it in a transaction at the callsite.
+   *
+   * <p>Nonexistent keys / entities are absent from the resulting map, but no {@link
+   * NoSuchElementException} will be thrown.
+   */
+  public static <T> ImmutableMap<VKey<? extends T>, T> loadByKeysIfPresent(
+      Iterable<? extends VKey<? extends T>> keys) {
+    return transactIfJpaTm(() -> tm().loadByKeysIfPresent(keys));
   }
 
   private DatabaseHelper() {}

--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -510,14 +510,14 @@ class google.registry.model.poll.PendingActionNotificationResponse$NameOrId {
 }
 class google.registry.model.poll.PollMessage {
   @Id java.lang.Long id;
-  @Parent com.googlecode.objectify.Key<google.registry.model.reporting.HistoryEntry> parent;
+  @Parent com.googlecode.objectify.Key<? extends google.registry.model.reporting.HistoryEntry> parent;
   java.lang.String clientId;
   java.lang.String msg;
   org.joda.time.DateTime eventTime;
 }
 class google.registry.model.poll.PollMessage$Autorenew {
   @Id java.lang.Long id;
-  @Parent com.googlecode.objectify.Key<google.registry.model.reporting.HistoryEntry> parent;
+  @Parent com.googlecode.objectify.Key<? extends google.registry.model.reporting.HistoryEntry> parent;
   java.lang.String clientId;
   java.lang.String msg;
   java.lang.String targetId;
@@ -526,7 +526,7 @@ class google.registry.model.poll.PollMessage$Autorenew {
 }
 class google.registry.model.poll.PollMessage$OneTime {
   @Id java.lang.Long id;
-  @Parent com.googlecode.objectify.Key<google.registry.model.reporting.HistoryEntry> parent;
+  @Parent com.googlecode.objectify.Key<? extends google.registry.model.reporting.HistoryEntry> parent;
   java.lang.String clientId;
   java.lang.String msg;
   java.util.List<google.registry.model.poll.PendingActionNotificationResponse$ContactPendingActionNotificationResponse> contactPendingActionNotificationResponses;


### PR DESCRIPTION
Two relatively complex parts. The first is that we needed a small
refactor on the AckPollMessagesCommand because we could theoretically be
acking more poll messages than the Datastore transaction size boundary.
This means that the normal flow of "gather the poll messages from the DB
into one collection, then act on it" needs to be changed to a more
functional flow.

The second is that acking the poll message (deleting it in most cases)
reduces the number of remaining poll messages in SQL but not in
Datastore, since in Datastore the deletion does not take effect until
after the transaction is over.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1050)
<!-- Reviewable:end -->
