### PR TITLE
Add a CompareReservedListCommand

### DIFF
--- a/core/src/main/java/google/registry/tools/CompareReservedListsCommand.java
+++ b/core/src/main/java/google/registry/tools/CompareReservedListsCommand.java
@@ -49,19 +49,14 @@ final class CompareReservedListsCommand implements CommandWithRemoteApi {
                         .map(ReservedList::getName)
                         .collect(toImmutableSet()));
 
-    ImmutableSet<String> notInCloudSql =
-        Sets.difference(datastoreLists, cloudSqlLists).immutableCopy();
-    ImmutableSet<String> notInDatastore =
-        Sets.difference(cloudSqlLists, datastoreLists).immutableCopy();
-
     int listsWithDiffs = 0;
 
-    for (String listName : notInCloudSql) {
+    for (String listName : Sets.difference(datastoreLists, cloudSqlLists).immutableCopy()) {
       listsWithDiffs++;
       System.out.printf(
           "ReservedList '%s' is present in Datastore, but not in Cloud SQL.%n", listName);
     }
-    for (String listName : notInDatastore) {
+    for (String listName : Sets.difference(cloudSqlLists, datastoreLists).immutableCopy()) {
       listsWithDiffs++;
       System.out.printf(
           "ReservedList '%s' is present in Cloud SQL, but not in Datastore.%n", listName);

--- a/core/src/main/java/google/registry/tools/CompareReservedListsCommand.java
+++ b/core/src/main/java/google/registry/tools/CompareReservedListsCommand.java
@@ -51,12 +51,12 @@ final class CompareReservedListsCommand implements CommandWithRemoteApi {
 
     int listsWithDiffs = 0;
 
-    for (String listName : Sets.difference(datastoreLists, cloudSqlLists).immutableCopy()) {
+    for (String listName : Sets.difference(datastoreLists, cloudSqlLists)) {
       listsWithDiffs++;
       System.out.printf(
           "ReservedList '%s' is present in Datastore, but not in Cloud SQL.%n", listName);
     }
-    for (String listName : Sets.difference(cloudSqlLists, datastoreLists).immutableCopy()) {
+    for (String listName : Sets.difference(cloudSqlLists, datastoreLists)) {
       listsWithDiffs++;
       System.out.printf(
           "ReservedList '%s' is present in Cloud SQL, but not in Datastore.%n", listName);

--- a/core/src/main/java/google/registry/tools/CompareReservedListsCommand.java
+++ b/core/src/main/java/google/registry/tools/CompareReservedListsCommand.java
@@ -61,7 +61,7 @@ final class CompareReservedListsCommand implements CommandWithRemoteApi {
       if (!sqlList.isPresent()) {
         listsWithDiffs++;
         System.out.printf(
-            "ReservedList with name %s is present in Datastore, but not in Cloud SQL%n",
+            "ReservedList '%s' is present in Datastore, but not in Cloud SQL.%n",
             datastoreList.getName());
       } else {
         ImmutableMap<String, ReservedListEntry> namesInSql =
@@ -79,7 +79,7 @@ final class CompareReservedListsCommand implements CommandWithRemoteApi {
         if (!namesInDatastore.equals(namesInSql)) {
           listsWithDiffs++;
           System.out.printf(
-              "ReservedList with name %s has different entries in each database%n",
+              "ReservedList '%s' has different entries in each database.%n",
               datastoreList.getName());
         }
       }
@@ -91,11 +91,11 @@ final class CompareReservedListsCommand implements CommandWithRemoteApi {
       if (!datastoreList.isPresent()) {
         listsWithDiffs++;
         System.out.printf(
-            "ReservedList with name %s is present in Cloud SQL, but not in Datastore%n",
+            "ReservedList '%s' is present in Cloud SQL, but not in Datastore.%n",
             sqlList.getName());
       }
     }
 
-    System.out.printf("Found %s unequal list(s).%n", listsWithDiffs);
+    System.out.printf("Found %d unequal list(s).%n", listsWithDiffs);
   }
 }

--- a/core/src/main/java/google/registry/tools/CompareReservedListsCommand.java
+++ b/core/src/main/java/google/registry/tools/CompareReservedListsCommand.java
@@ -1,0 +1,112 @@
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.tools;
+
+import static com.google.common.collect.ImmutableSortedSet.toImmutableSortedSet;
+import static google.registry.model.common.EntityGroupRoot.getCrossTldKey;
+import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+
+import com.beust.jcommander.Parameters;
+import com.google.appengine.repackaged.com.google.common.collect.Streams;
+import com.google.common.collect.ImmutableSet;
+import google.registry.model.registry.label.ReservedList;
+import google.registry.model.registry.label.ReservedList.ReservedListEntry;
+import google.registry.model.registry.label.ReservedListDatastoreDao;
+import google.registry.model.registry.label.ReservedListSqlDao;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/** Command to compare all ReservedLists in Datastore to all ReservedLists in Cloud SQL. */
+@Parameters(
+    separators = " =",
+    commandDescription = "Compare all the ReservedLists in Datastore to those in Cloud SQL.")
+final class CompareReservedListsCommand implements CommandWithRemoteApi {
+
+  @Override
+  public void run() {
+    ImmutableSet<ReservedList> datastoreLists =
+        ImmutableSet.copyOf(
+            ofy().load().type(ReservedList.class).ancestor(getCrossTldKey()).list());
+
+    ImmutableSet<ReservedList> cloudSqlLists =
+        jpaTm()
+            .transact(
+                () ->
+                    jpaTm().loadAllOf(ReservedList.class).stream()
+                        .map(ReservedList::getName)
+                        .map(ReservedListSqlDao::getLatestRevision)
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .collect(
+                            toImmutableSortedSet(Comparator.comparing(ReservedList::getName))));
+
+    int listsWithDiffs = 0;
+
+    for (ReservedList datastoreList : datastoreLists) {
+      Optional<ReservedList> sqlList =
+          ReservedListSqlDao.getLatestRevision(datastoreList.getName());
+      if (!sqlList.isPresent()) {
+        listsWithDiffs++;
+        System.out.printf(
+            "ReservedList with name %s is present in Datastore, but not in Cloud SQL%n",
+            datastoreList.getName());
+      } else {
+        String datastoreListString =
+            Streams.stream(
+                    ReservedListDatastoreDao.getLatestRevision(datastoreList.getName())
+                        .get()
+                        .getReservedListEntries()
+                        .values())
+                .sorted(Comparator.comparing(ReservedListEntry::getLabel))
+                .map(ReservedListEntry::toString)
+                .collect(Collectors.joining("\n"));
+
+        String sqlListString =
+            Streams.stream(
+                    ReservedListSqlDao.getLatestRevision(datastoreList.getName())
+                        .get()
+                        .getReservedListEntries()
+                        .values())
+                .sorted(Comparator.comparing(ReservedListEntry::getLabel))
+                .map(ReservedListEntry::toString)
+                .collect(Collectors.joining("\n"));
+
+        // This will only print out the name of the unequal list. GetReservedListCommand should be
+        // used to determine what the actual differences are.
+        if (!datastoreListString.equals(sqlListString)) {
+          listsWithDiffs++;
+          System.out.printf(
+              "ReservedList with name %s has different entries in each database%n",
+              datastoreList.getName());
+        }
+      }
+    }
+
+    for (ReservedList sqlList : cloudSqlLists) {
+      Optional<ReservedList> datastoreList =
+          ReservedListDatastoreDao.getLatestRevision(sqlList.getName());
+      if (!datastoreList.isPresent()) {
+        listsWithDiffs++;
+        System.out.printf(
+            "ReservedList with name %s is present in Cloud SQL, but not in Datastore%n",
+            sqlList.getName());
+      }
+    }
+
+    System.out.printf("Found %s unequal lists.%n", listsWithDiffs);
+  }
+}

--- a/core/src/main/java/google/registry/tools/CompareReservedListsCommand.java
+++ b/core/src/main/java/google/registry/tools/CompareReservedListsCommand.java
@@ -14,7 +14,7 @@
 
 package google.registry.tools;
 
-import static com.google.common.collect.ImmutableSortedSet.toImmutableSortedSet;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static google.registry.model.common.EntityGroupRoot.getCrossTldKey;
 import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
@@ -22,12 +22,11 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import com.beust.jcommander.Parameters;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 import google.registry.model.registry.label.ReservedList;
 import google.registry.model.registry.label.ReservedList.ReservedListEntry;
 import google.registry.model.registry.label.ReservedListDatastoreDao;
 import google.registry.model.registry.label.ReservedListSqlDao;
-import java.util.Comparator;
-import java.util.Optional;
 
 /** Command to compare all ReservedLists in Datastore to all ReservedLists in Cloud SQL. */
 @Parameters(
@@ -37,62 +36,49 @@ final class CompareReservedListsCommand implements CommandWithRemoteApi {
 
   @Override
   public void run() {
-    ImmutableSet<ReservedList> datastoreLists =
-        ImmutableSet.copyOf(
-            ofy().load().type(ReservedList.class).ancestor(getCrossTldKey()).list());
+    ImmutableSet<String> datastoreLists =
+        ofy().load().type(ReservedList.class).ancestor(getCrossTldKey()).list().stream()
+            .map(ReservedList::getName)
+            .collect(toImmutableSet());
 
-    ImmutableSet<ReservedList> cloudSqlLists =
+    ImmutableSet<String> cloudSqlLists =
         jpaTm()
             .transact(
                 () ->
                     jpaTm().loadAllOf(ReservedList.class).stream()
                         .map(ReservedList::getName)
-                        .map(ReservedListSqlDao::getLatestRevision)
-                        .filter(Optional::isPresent)
-                        .map(Optional::get)
-                        .collect(
-                            toImmutableSortedSet(Comparator.comparing(ReservedList::getName))));
+                        .collect(toImmutableSet()));
+
+    ImmutableSet<String> notInCloudSql =
+        Sets.difference(datastoreLists, cloudSqlLists).immutableCopy();
+    ImmutableSet<String> notInDatastore =
+        Sets.difference(cloudSqlLists, datastoreLists).immutableCopy();
 
     int listsWithDiffs = 0;
 
-    for (ReservedList datastoreList : datastoreLists) {
-      Optional<ReservedList> sqlList =
-          ReservedListSqlDao.getLatestRevision(datastoreList.getName());
-      if (!sqlList.isPresent()) {
-        listsWithDiffs++;
-        System.out.printf(
-            "ReservedList '%s' is present in Datastore, but not in Cloud SQL.%n",
-            datastoreList.getName());
-      } else {
-        ImmutableMap<String, ReservedListEntry> namesInSql =
-            ReservedListSqlDao.getLatestRevision(datastoreList.getName())
-                .get()
-                .getReservedListEntries();
-
-        ImmutableMap<String, ReservedListEntry> namesInDatastore =
-            ReservedListDatastoreDao.getLatestRevision(datastoreList.getName())
-                .get()
-                .getReservedListEntries();
-
-        // This will only print out the name of the unequal list. GetReservedListCommand should be
-        // used to determine what the actual differences are.
-        if (!namesInDatastore.equals(namesInSql)) {
-          listsWithDiffs++;
-          System.out.printf(
-              "ReservedList '%s' has different entries in each database.%n",
-              datastoreList.getName());
-        }
-      }
+    for (String listName : notInCloudSql) {
+      listsWithDiffs++;
+      System.out.printf(
+          "ReservedList '%s' is present in Datastore, but not in Cloud SQL.%n", listName);
+    }
+    for (String listName : notInDatastore) {
+      listsWithDiffs++;
+      System.out.printf(
+          "ReservedList '%s' is present in Cloud SQL, but not in Datastore.%n", listName);
     }
 
-    for (ReservedList sqlList : cloudSqlLists) {
-      Optional<ReservedList> datastoreList =
-          ReservedListDatastoreDao.getLatestRevision(sqlList.getName());
-      if (!datastoreList.isPresent()) {
+    for (String listName : Sets.intersection(datastoreLists, cloudSqlLists)) {
+      ImmutableMap<String, ReservedListEntry> namesInSql =
+          ReservedListSqlDao.getLatestRevision(listName).get().getReservedListEntries();
+
+      ImmutableMap<String, ReservedListEntry> namesInDatastore =
+          ReservedListDatastoreDao.getLatestRevision(listName).get().getReservedListEntries();
+
+      // This will only print out the name of the unequal list. GetReservedListCommand should be
+      // used to determine what the actual differences are.
+      if (!namesInDatastore.equals(namesInSql)) {
         listsWithDiffs++;
-        System.out.printf(
-            "ReservedList '%s' is present in Cloud SQL, but not in Datastore.%n",
-            sqlList.getName());
+        System.out.printf("ReservedList '%s' has different entries in each database.%n", listName);
       }
     }
 

--- a/core/src/main/java/google/registry/tools/RegistryTool.java
+++ b/core/src/main/java/google/registry/tools/RegistryTool.java
@@ -37,6 +37,7 @@ public final class RegistryTool {
           .put("canonicalize_labels", CanonicalizeLabelsCommand.class)
           .put("check_domain", CheckDomainCommand.class)
           .put("check_domain_claims", CheckDomainClaimsCommand.class)
+          .put("compare_reserved_lists", CompareReservedListsCommand.class)
           .put("convert_idn", ConvertIdnCommand.class)
           .put("count_domains", CountDomainsCommand.class)
           .put("create_anchor_tenant", CreateAnchorTenantCommand.class)

--- a/core/src/test/java/google/registry/tools/CompareReservedListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CompareReservedListCommandTest.java
@@ -108,8 +108,8 @@ public class CompareReservedListCommandTest extends CommandTestCase<CompareReser
     runCommand();
     assertThat(getStdoutAsString())
         .isEqualTo(
-            "ReservedList 'testlist' has different entries in each database.\n"
-                + "ReservedList 'testlist2' is present in Cloud SQL, but not in Datastore.\n"
+            "ReservedList 'testlist2' is present in Cloud SQL, but not in Datastore.\n"
+                + "ReservedList 'testlist' has different entries in each database.\n"
                 + "Found 2 unequal list(s).\n");
   }
 }

--- a/core/src/test/java/google/registry/tools/CompareReservedListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CompareReservedListCommandTest.java
@@ -30,31 +30,24 @@ import org.junit.jupiter.api.Test;
 /** Unit tests for {@link CompareReservedListsCommand}. */
 public class CompareReservedListCommandTest extends CommandTestCase<CompareReservedListsCommand> {
 
-  private ImmutableMap<String, ReservedListEntry> reservations;
-  private ImmutableMap<String, ReservedListEntry> reservations2;
-
   private ReservedList reservedList;
   private ReservedList reservedList2;
 
   @BeforeEach
   void setUp() {
-    reservations =
-        ImmutableMap.of(
-            "food",
-            ReservedListEntry.create("food", ReservationType.RESERVED_FOR_SPECIFIC_USE, null),
-            "music",
-            ReservedListEntry.create("music", ReservationType.FULLY_BLOCKED, "fully blocked"));
-
-    reservations2 =
-        ImmutableMap.of(
-            "candy", ReservedListEntry.create("candy", ReservationType.ALLOWED_IN_SUNRISE, null));
-
     reservedList =
         new ReservedList.Builder()
             .setName("testlist")
             .setLastUpdateTime(fakeClock.nowUtc())
             .setShouldPublish(false)
-            .setReservedListMap(reservations)
+            .setReservedListMap(
+                ImmutableMap.of(
+                    "food",
+                    ReservedListEntry.create(
+                        "food", ReservationType.RESERVED_FOR_SPECIFIC_USE, null),
+                    "music",
+                    ReservedListEntry.create(
+                        "music", ReservationType.FULLY_BLOCKED, "fully blocked")))
             .build();
 
     reservedList2 =
@@ -62,7 +55,10 @@ public class CompareReservedListCommandTest extends CommandTestCase<CompareReser
             .setName("testlist2")
             .setLastUpdateTime(fakeClock.nowUtc())
             .setShouldPublish(false)
-            .setReservedListMap(reservations2)
+            .setReservedListMap(
+                ImmutableMap.of(
+                    "candy",
+                    ReservedListEntry.create("candy", ReservationType.ALLOWED_IN_SUNRISE, null)))
             .build();
 
     ReservedListDualDatabaseDao.save(reservedList);
@@ -73,7 +69,7 @@ public class CompareReservedListCommandTest extends CommandTestCase<CompareReser
   void test_success() throws Exception {
     runCommand();
     String stdout = getStdoutAsString();
-    assertThat(stdout).isEqualTo("Found 0 unequal lists.\n");
+    assertThat(stdout).isEqualTo("Found 0 unequal list(s).\n");
   }
 
   @Test
@@ -84,7 +80,7 @@ public class CompareReservedListCommandTest extends CommandTestCase<CompareReser
     assertThat(stdout)
         .isEqualTo(
             "ReservedList with name testlist is present in Datastore, but not in Cloud SQL\n"
-                + "Found 1 unequal lists.\n");
+                + "Found 1 unequal list(s).\n");
   }
 
   @Test
@@ -95,7 +91,7 @@ public class CompareReservedListCommandTest extends CommandTestCase<CompareReser
     assertThat(stdout)
         .isEqualTo(
             "ReservedList with name testlist is present in Cloud SQL, but not in Datastore\n"
-                + "Found 1 unequal lists.\n");
+                + "Found 1 unequal list(s).\n");
   }
 
   @Test
@@ -117,7 +113,7 @@ public class CompareReservedListCommandTest extends CommandTestCase<CompareReser
     assertThat(stdout)
         .isEqualTo(
             "ReservedList with name testlist has different entries in each database\n"
-                + "Found 1 unequal lists.\n");
+                + "Found 1 unequal list(s).\n");
   }
 
   @Test
@@ -141,6 +137,6 @@ public class CompareReservedListCommandTest extends CommandTestCase<CompareReser
         .isEqualTo(
             "ReservedList with name testlist has different entries in each database\n"
                 + "ReservedList with name testlist2 is present in Cloud SQL, but not in Datastore\n"
-                + "Found 2 unequal lists.\n");
+                + "Found 2 unequal list(s).\n");
   }
 }

--- a/core/src/test/java/google/registry/tools/CompareReservedListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CompareReservedListCommandTest.java
@@ -1,0 +1,146 @@
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.tools;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.ofyTm;
+
+import com.google.common.collect.ImmutableMap;
+import google.registry.model.registry.label.ReservationType;
+import google.registry.model.registry.label.ReservedList;
+import google.registry.model.registry.label.ReservedList.ReservedListEntry;
+import google.registry.model.registry.label.ReservedListDatastoreDao;
+import google.registry.model.registry.label.ReservedListDualDatabaseDao;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link CompareReservedListsCommand}. */
+public class CompareReservedListCommandTest extends CommandTestCase<CompareReservedListsCommand> {
+
+  private ImmutableMap<String, ReservedListEntry> reservations;
+  private ImmutableMap<String, ReservedListEntry> reservations2;
+
+  private ReservedList reservedList;
+  private ReservedList reservedList2;
+
+  @BeforeEach
+  void setUp() {
+    reservations =
+        ImmutableMap.of(
+            "food",
+            ReservedListEntry.create("food", ReservationType.RESERVED_FOR_SPECIFIC_USE, null),
+            "music",
+            ReservedListEntry.create("music", ReservationType.FULLY_BLOCKED, "fully blocked"));
+
+    reservations2 =
+        ImmutableMap.of(
+            "candy", ReservedListEntry.create("candy", ReservationType.ALLOWED_IN_SUNRISE, null));
+
+    reservedList =
+        new ReservedList.Builder()
+            .setName("testlist")
+            .setLastUpdateTime(fakeClock.nowUtc())
+            .setShouldPublish(false)
+            .setReservedListMap(reservations)
+            .build();
+
+    reservedList2 =
+        new ReservedList.Builder()
+            .setName("testlist2")
+            .setLastUpdateTime(fakeClock.nowUtc())
+            .setShouldPublish(false)
+            .setReservedListMap(reservations2)
+            .build();
+
+    ReservedListDualDatabaseDao.save(reservedList);
+    ReservedListDualDatabaseDao.save(reservedList2);
+  }
+
+  @Test
+  void test_success() throws Exception {
+    runCommand();
+    String stdout = getStdoutAsString();
+    assertThat(stdout).isEqualTo("Found 0 unequal lists.\n");
+  }
+
+  @Test
+  void test_listMissingFromCloudSql() throws Exception {
+    jpaTm().transact(() -> jpaTm().delete(reservedList));
+    runCommand();
+    String stdout = getStdoutAsString();
+    assertThat(stdout)
+        .isEqualTo(
+            "ReservedList with name testlist is present in Datastore, but not in Cloud SQL\n"
+                + "Found 1 unequal lists.\n");
+  }
+
+  @Test
+  void test_listMissingFromDatastore() throws Exception {
+    ofyTm().transact(() -> ofyTm().delete(reservedList));
+    runCommand();
+    String stdout = getStdoutAsString();
+    assertThat(stdout)
+        .isEqualTo(
+            "ReservedList with name testlist is present in Cloud SQL, but not in Datastore\n"
+                + "Found 1 unequal lists.\n");
+  }
+
+  @Test
+  void test_listsDiffer() throws Exception {
+    ImmutableMap<String, ReservedListEntry> newReservations =
+        ImmutableMap.of(
+            "food",
+            ReservedListEntry.create("food", ReservationType.RESERVED_FOR_SPECIFIC_USE, null));
+    ReservedList secondList =
+        new ReservedList.Builder()
+            .setName("testlist")
+            .setLastUpdateTime(fakeClock.nowUtc())
+            .setShouldPublish(false)
+            .setReservedListMap(newReservations)
+            .build();
+    ReservedListDatastoreDao.save(secondList);
+    runCommand();
+    String stdout = getStdoutAsString();
+    assertThat(stdout)
+        .isEqualTo(
+            "ReservedList with name testlist has different entries in each database\n"
+                + "Found 1 unequal lists.\n");
+  }
+
+  @Test
+  void test_listsDifferAndMissing() throws Exception {
+    ofyTm().transact(() -> ofyTm().delete(reservedList2));
+    ImmutableMap<String, ReservedListEntry> newReservations =
+        ImmutableMap.of(
+            "food",
+            ReservedListEntry.create("food", ReservationType.RESERVED_FOR_SPECIFIC_USE, null));
+    ReservedList secondList =
+        new ReservedList.Builder()
+            .setName("testlist")
+            .setLastUpdateTime(fakeClock.nowUtc())
+            .setShouldPublish(false)
+            .setReservedListMap(newReservations)
+            .build();
+    ReservedListDatastoreDao.save(secondList);
+    runCommand();
+    String stdout = getStdoutAsString();
+    assertThat(stdout)
+        .isEqualTo(
+            "ReservedList with name testlist has different entries in each database\n"
+                + "ReservedList with name testlist2 is present in Cloud SQL, but not in Datastore\n"
+                + "Found 2 unequal lists.\n");
+  }
+}


### PR DESCRIPTION
This command loads the list of all ReservedLists in Datastore and Cloud SQL and returns the name of any list that is either missing from one of the DBs or that has differing content. The output of this command does not indicate what the actual diff between the lists are, so GetReservedListCommand should be used to actually view the contents of the offending lists. 

I already ran this comparison test on Sandbox and Production and fixed all the issues it found. (One list I missed in Sandbox when resaving, and 7 lists that were only in Cloud SQL in production.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1054)
<!-- Reviewable:end -->
