### PR TITLE
Enable cross referencing for generated sources

### DIFF
--- a/vnames.json
+++ b/vnames.json
@@ -1,6 +1,6 @@
 [
   {
-    "pattern": "(build/[^/]+)/(.*)",
+    "pattern": "([^/]+/build/[^/]+)/(.*)",
     "vname": {
       "corpus": "github.com/google/nomulus",
       "path": "@2@",


### PR DESCRIPTION
This change should allow generated classes like AutoValue or Dagger
classes to be cross-referencable on cs.nomulus.foo

See b/184284124 for context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1057)
<!-- Reviewable:end -->
