### PR TITLE
Partially convert EppResourceUtils to SQL

### DIFF
--- a/core/src/main/java/google/registry/model/EppResourceUtils.java
+++ b/core/src/main/java/google/registry/model/EppResourceUtils.java
@@ -195,30 +195,6 @@ public final class EppResourceUtils {
   }
 
   /**
-   * Loads resources that match some filter and that have {@link EppResource#deletionTime} that is
-   * not before "now".
-   *
-   * <p>This is an eventually consistent query.
-   *
-   * @param clazz the resource type to load
-   * @param now the logical time of the check
-   * @param filterDefinition the filter to apply when loading resources
-   * @param filterValue the acceptable value for the filter
-   */
-  public static <T extends EppResource> Iterable<T> queryNotDeleted(
-      Class<T> clazz, DateTime now, String filterDefinition, Object filterValue) {
-    return ofy()
-        .load()
-        .type(clazz)
-        .filter(filterDefinition, filterValue)
-        .filter("deletionTime >", now.toDate())
-        .list()
-        .stream()
-        .map(EppResourceUtils.transformAtTime(now))
-        .collect(toImmutableSet());
-  }
-
-  /**
    * Returns a Function that transforms an EppResource to the given DateTime, suitable for use with
    * Iterables.transform() over a collection of EppResources.
    */

--- a/core/src/test/java/google/registry/testing/FullFieldsTestEntityHelper.java
+++ b/core/src/test/java/google/registry/testing/FullFieldsTestEntityHelper.java
@@ -218,27 +218,20 @@ public final class FullFieldsTestEntityHelper {
             .setCountryCode("US")
             .build());
     }
-    ContactResource.Builder builder = new ContactResource.Builder()
-        .setContactId(id)
-        .setRepoId(generateNewContactHostRoid())
-        .setCreationTimeForTest(DateTime.parse("2000-10-08T00:45:00Z"))
-        .setInternationalizedPostalInfo(postalBuilder.build())
-        .setVoiceNumber(
-            new ContactPhoneNumber.Builder()
-            .setPhoneNumber("+1.2126660420")
-            .build())
-        .setFaxNumber(
-            new ContactPhoneNumber.Builder()
-            .setPhoneNumber("+1.2126660420")
-            .build());
+    ContactResource.Builder builder =
+        new ContactResource.Builder()
+            .setContactId(id)
+            .setRepoId(generateNewContactHostRoid())
+            .setCreationTimeForTest(DateTime.parse("2000-10-08T00:45:00Z"))
+            .setInternationalizedPostalInfo(postalBuilder.build())
+            .setVoiceNumber(
+                new ContactPhoneNumber.Builder().setPhoneNumber("+1.2126660420").build())
+            .setFaxNumber(new ContactPhoneNumber.Builder().setPhoneNumber("+1.2126660420").build());
     if (email != null) {
       builder.setEmailAddress(email);
     }
-    if (registrar != null) {
-      builder
-          .setCreationClientId(registrar.getClientId())
-          .setPersistedCurrentSponsorClientId(registrar.getClientId());
-    }
+    String registrarId = registrar == null ? "TheRegistrar" : registrar.getClientId();
+    builder.setCreationClientId(registrarId).setPersistedCurrentSponsorClientId(registrarId);
     if (deletionTime != null) {
       builder.setDeletionTime(deletionTime);
     }

--- a/core/src/test/java/google/registry/whois/WhoisCommandFactoryTest.java
+++ b/core/src/test/java/google/registry/whois/WhoisCommandFactoryTest.java
@@ -29,15 +29,17 @@ import google.registry.model.domain.DomainBase;
 import google.registry.model.host.HostResource;
 import google.registry.model.registrar.Registrar;
 import google.registry.testing.AppEngineExtension;
+import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.FakeClock;
 import google.registry.testing.TestCacheExtension;
+import google.registry.testing.TestOfyAndSql;
 import java.net.InetAddress;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+@DualDatabaseTest
 class WhoisCommandFactoryTest {
 
   FakeClock clock = new FakeClock();
@@ -90,7 +92,7 @@ class WhoisCommandFactoryTest {
     RegistryConfig.CONFIG_SETTINGS.get().caching.singletonCacheRefreshSeconds = 0;
   }
 
-  @Test
+  @TestOfyAndSql
   void testNonCached_NameserverLookupByHostCommand() throws Exception {
     WhoisResponse response =
         noncachedFactory
@@ -114,7 +116,7 @@ class WhoisCommandFactoryTest {
         .contains("Registrar: OtherRegistrar name");
   }
 
-  @Test
+  @TestOfyAndSql
   void testCached_NameserverLookupByHostCommand() throws Exception {
     WhoisResponse response =
         cachedFactory
@@ -137,7 +139,7 @@ class WhoisCommandFactoryTest {
         .contains("Registrar: The Registrar");
   }
 
-  @Test
+  @TestOfyAndSql
   void testNonCached_DomainLookupCommand() throws Exception {
     WhoisResponse response =
         noncachedFactory
@@ -161,7 +163,7 @@ class WhoisCommandFactoryTest {
         .contains("Registrar: OtherRegistrar name");
   }
 
-  @Test
+  @TestOfyAndSql
   void testCached_DomainLookupCommand() throws Exception {
     WhoisResponse response =
         cachedFactory
@@ -185,7 +187,7 @@ class WhoisCommandFactoryTest {
         .contains("Registrar: The Registrar");
   }
 
-  @Test
+  @TestOfyAndSql
   void testNonCached_RegistrarLookupCommand() throws Exception {
     WhoisResponse response =
         noncachedFactory.registrarLookup("OtherRegistrar").executeQuery(clock.nowUtc());
@@ -199,7 +201,7 @@ class WhoisCommandFactoryTest {
         .contains("Phone Number: +1.2345677890");
   }
 
-  @Test
+  @TestOfyAndSql
   void testCached_RegistrarLookupCommand() throws Exception {
     WhoisResponse response =
         cachedFactory.registrarLookup("OtherRegistrar").executeQuery(clock.nowUtc());
@@ -213,7 +215,7 @@ class WhoisCommandFactoryTest {
         .contains("Phone Number: +1.2223334444");
   }
 
-  @Test
+  @TestOfyAndSql
   void testNonCached_NameserverLookupByIpCommand() throws Exception {
     // Note that this lookup currently doesn't cache the hosts, so there's no point in testing the
     // "cached" case.  This test is here so that it will fail if anyone adds caching.

--- a/core/src/test/java/google/registry/whois/WhoisReaderTest.java
+++ b/core/src/test/java/google/registry/whois/WhoisReaderTest.java
@@ -22,14 +22,16 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.google.common.flogger.LoggerConfig;
 import com.google.common.testing.TestLogHandler;
 import google.registry.testing.AppEngineExtension;
+import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.FakeClock;
+import google.registry.testing.TestOfyAndSql;
 import java.io.StringReader;
 import java.util.logging.Level;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link WhoisReader}. */
+@DualDatabaseTest
 class WhoisReaderTest {
 
   @RegisterExtension
@@ -83,245 +85,245 @@ class WhoisReaderTest {
         .isEqualTo("Example Registrar, Inc.");
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrarLookupWithOneToken() throws Exception {
     assertThat(this.<RegistrarLookupCommand>readCommand("Example").registrarName)
         .isEqualTo("Example");
   }
 
-  @Test
+  @TestOfyAndSql
   void testDomainLookupWithoutCRLF() throws Exception {
     assertLoadsExampleTld("example.tld");
   }
 
-  @Test
+  @TestOfyAndSql
   void testWhitespaceOnDomainLookupWithCommand() throws Exception {
     assertLoadsExampleTld(" \t domain \t \t   example.tld    \r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testDomainLookup() throws Exception {
     assertLoadsExampleTld("example.tld\r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testDomainLookupWithCommand() throws Exception {
     assertLoadsExampleTld("domain example.tld\r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testCaseInsensitiveDomainLookup() throws Exception {
     assertLoadsExampleTld("EXAMPLE.TLD\r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testCaseInsensitiveDomainLookupWithCommand() throws Exception {
     assertLoadsExampleTld("DOMAIN EXAMPLE.TLD\r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testIDNULabelDomainLookup() throws Exception {
     assertLoadsIDN("مثال.إختبار\r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testIDNULabelDomainLookupWithCommand() throws Exception {
     assertLoadsIDN("domain مثال.إختبار\r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testIDNALabelDomainLookupWithCommand() throws Exception {
     assertLoadsIDN("domain xn--mgbh0fb.xn--kgbechtv\r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testIDNALabelDomainLookup() throws Exception {
     assertLoadsIDN("xn--mgbh0fb.xn--kgbechtv\r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testTooManyArgsDomainLookup() {
     assertThrows(WhoisException.class, () -> readCommand("domain example.tld foo.bar"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testTooFewArgsDomainLookup() {
     assertThrows(WhoisException.class, () -> readCommand("domain"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testIllegalArgDomainLookup() {
     assertThrows(WhoisException.class, () -> readCommand("domain 1.1"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testNameserverLookupWithoutCRLF() throws Exception {
     assertLoadsExampleNs("ns.example.tld");
   }
 
-  @Test
+  @TestOfyAndSql
   void testWhitespaceOnNameserverLookupWithCommand() throws Exception {
     assertLoadsExampleNs(" \t nameserver \t \t   ns.example.tld    \r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testNameserverLookup() throws Exception {
     assertLoadsExampleNs("ns.example.tld\r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testDeepNameserverLookup() throws Exception {
     NameserverLookupByHostCommand command = readCommand("ns.foo.bar.baz.example.tld\r\n");
     assertThat(command.domainOrHostName.toString()).isEqualTo("ns.foo.bar.baz.example.tld");
     assertThat(command.domainOrHostName.toString()).isEqualTo("ns.foo.bar.baz.example.tld");
   }
 
-  @Test
+  @TestOfyAndSql
   void testNameserverLookupWithCommand() throws Exception {
     assertLoadsExampleNs("nameserver ns.example.tld\r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testCaseInsensitiveNameserverLookup() throws Exception {
     assertLoadsExampleNs("NS.EXAMPLE.TLD\r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testCaseInsensitiveNameserverLookupWithCommand() throws Exception {
     assertLoadsExampleNs("NAMESERVER NS.EXAMPLE.TLD\r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testIDNULabelNameserverLookup() throws Exception {
     assertLoadsIDNNs("ns.مثال.إختبار\r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testIDNULabelNameserverLookupWithCommand() throws Exception {
     assertLoadsIDNNs("nameserver ns.مثال.إختبار\r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testIDNALabelNameserverLookupWithCommand() throws Exception {
     assertLoadsIDNNs("nameserver ns.xn--mgbh0fb.xn--kgbechtv\r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testIDNALabelNameserverLookup() throws Exception {
     assertLoadsIDNNs("ns.xn--mgbh0fb.xn--kgbechtv\r\n");
   }
 
-  @Test
+  @TestOfyAndSql
   void testTooManyArgsNameserverLookup() {
     assertThrows(WhoisException.class, () -> readCommand("nameserver ns.example.tld foo.bar"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testTooFewArgsNameserverLookup() {
     assertThrows(WhoisException.class, () -> readCommand("nameserver"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testIllegalArgNameserverLookup() {
     assertThrows(WhoisException.class, () -> readCommand("nameserver 1.1"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrarLookup() throws Exception {
     assertLoadsRegistrar("registrar Example Registrar, Inc.");
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrarLookupCaseInsensitive() throws Exception {
     assertLoadsRegistrar("REGISTRAR Example Registrar, Inc.");
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrarLookupWhitespace() throws Exception {
     assertLoadsRegistrar("  \t registrar \t  \tExample    Registrar,   Inc.  ");
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrarLookupByDefault() throws Exception {
     assertLoadsRegistrar("Example Registrar, Inc.");
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrarLookupOnTLD() throws Exception {
     assertThat(this.<RegistrarLookupCommand>readCommand("com").registrarName).isEqualTo("com");
   }
 
-  @Test
+  @TestOfyAndSql
   void testRegistrarLookupNoArgs() {
     assertThrows(WhoisException.class, () -> readCommand("registrar"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testNameserverLookupByIp() throws Exception {
     assertNsLookup("43.34.12.213", "43.34.12.213");
   }
 
-  @Test
+  @TestOfyAndSql
   void testNameserverLookupByIpv6() throws Exception {
     assertNsLookup("1080:0:0:0:8:800:200c:417a", "1080:0:0:0:8:800:200c:417a");
   }
 
-  @Test
+  @TestOfyAndSql
   void testNameserverLookupByCompressedIpv6() throws Exception {
     assertNsLookup("1080::8:800:200c:417a", "1080:0:0:0:8:800:200c:417a");
   }
 
-  @Test
+  @TestOfyAndSql
   void testNameserverLookupByNoncanonicalIpv6() throws Exception {
     assertNsLookup("1080:0:0:0:8:800:200C:417A", "1080:0:0:0:8:800:200c:417a");
   }
 
-  @Test
+  @TestOfyAndSql
   void testNameserverLookupByBackwardsCompatibleIpv6() throws Exception {
     assertNsLookup("::FFFF:129.144.52.38", "129.144.52.38");
   }
 
-  @Test
+  @TestOfyAndSql
   void testNameserverLookupByIpWithCommand() throws Exception {
     assertNsLookup("nameserver 43.34.12.213", "43.34.12.213");
   }
 
-  @Test
+  @TestOfyAndSql
   void testNameserverLookupByIpv6WithCommand() throws Exception {
     assertNsLookup("nameserver 1080:0:0:0:8:800:200C:417a", "1080:0:0:0:8:800:200c:417a");
   }
 
-  @Test
+  @TestOfyAndSql
   void testNameserverLookupByIpCaseInsenstive() throws Exception {
     assertNsLookup("NAMESERVER 43.34.12.213", "43.34.12.213");
   }
 
-  @Test
+  @TestOfyAndSql
   void testNameserverLookupByIpWhitespace() throws Exception {
     assertNsLookup("  \t\t NAMESERVER   \t 43.34.12.213    \r\n", "43.34.12.213");
   }
 
-  @Test
+  @TestOfyAndSql
   void testNameserverLookupByIpTooManyArgs() {
     assertThrows(WhoisException.class, () -> readCommand("nameserver 43.34.12.213 43.34.12.213"));
   }
 
-  @Test
+  @TestOfyAndSql
   void testMultilevelDomainLookup() throws Exception {
     this.<DomainLookupCommand>readCommand("example.1.test");
   }
 
-  @Test
+  @TestOfyAndSql
   void testMultilevelNameserverLookup() throws Exception {
     this.<NameserverLookupByHostCommand>readCommand("ns.example.1.test");
   }
 
-  @Test
+  @TestOfyAndSql
   void testDeepMultilevelNameserverLookup() throws Exception {
     this.<NameserverLookupByHostCommand>readCommand("ns.corp.example.1.test");
   }
 
-  @Test
+  @TestOfyAndSql
   void testUnconfiguredTld() throws Exception {
     this.<RegistrarLookupCommand>readCommand("example.test");
     this.<RegistrarLookupCommand>readCommand("1.example.test");
@@ -330,12 +332,12 @@ class WhoisReaderTest {
     this.<RegistrarLookupCommand>readCommand("tld");
   }
 
-  @Test
+  @TestOfyAndSql
   void testNoArgs() {
     assertThrows(WhoisException.class, () -> readCommand(""));
   }
 
-  @Test
+  @TestOfyAndSql
   void testLogsDomainLookupCommand() throws Exception {
     readCommand("domain example.tld");
     assertAboutLogs()
@@ -344,7 +346,7 @@ class WhoisReaderTest {
             Level.INFO, "Attempting domain lookup command using domain name example.tld");
   }
 
-  @Test
+  @TestOfyAndSql
   void testLogsNameserverLookupCommandWithIpAddress() throws Exception {
     readCommand("nameserver 43.34.12.213");
     assertAboutLogs()
@@ -353,7 +355,7 @@ class WhoisReaderTest {
             Level.INFO, "Attempting nameserver lookup command using 43.34.12.213 as an IP address");
   }
 
-  @Test
+  @TestOfyAndSql
   void testLogsNameserverLookupCommandWithHostname() throws Exception {
     readCommand("nameserver ns.example.tld");
     assertAboutLogs()
@@ -362,7 +364,7 @@ class WhoisReaderTest {
             Level.INFO, "Attempting nameserver lookup command using ns.example.tld as a hostname");
   }
 
-  @Test
+  @TestOfyAndSql
   void testLogsRegistrarLookupCommand() throws Exception {
     readCommand("registrar Example Registrar, Inc.");
     assertAboutLogs()
@@ -372,7 +374,7 @@ class WhoisReaderTest {
             "Attempting registrar lookup command using registrar Example Registrar, Inc.");
   }
 
-  @Test
+  @TestOfyAndSql
   void testLogsSingleArgumentNameserverLookupUsingIpAddress() throws Exception {
     readCommand("43.34.12.213");
     assertAboutLogs()
@@ -381,7 +383,7 @@ class WhoisReaderTest {
             Level.INFO, "Attempting nameserver lookup using 43.34.12.213 as an IP address");
   }
 
-  @Test
+  @TestOfyAndSql
   void testLogsSingleArgumentRegistrarLookup() throws Exception {
     readCommand("test");
     assertAboutLogs()
@@ -390,7 +392,7 @@ class WhoisReaderTest {
             Level.INFO, "Attempting registrar lookup using test as a registrar");
   }
 
-  @Test
+  @TestOfyAndSql
   void testLogsSingleArgumentDomainLookup() throws Exception {
     readCommand("example.tld");
     assertAboutLogs()
@@ -399,7 +401,7 @@ class WhoisReaderTest {
             Level.INFO, "Attempting domain lookup using example.tld as a domain name");
   }
 
-  @Test
+  @TestOfyAndSql
   void testLogsSingleArgumentNameserverLookupUsingHostname() throws Exception {
     readCommand("ns.example.tld");
     assertAboutLogs()
@@ -408,7 +410,7 @@ class WhoisReaderTest {
             Level.INFO, "Attempting nameserver lookup using ns.example.tld as a hostname");
   }
 
-  @Test
+  @TestOfyAndSql
   void testLogsMultipleArgumentsButNoParticularCommand() throws Exception {
     readCommand("Example Registrar, Inc.");
     assertAboutLogs()


### PR DESCRIPTION
Some of the rest will depend on b/184578521.

The primary conversion in this PR is the change in
NameserverLookupByIpCommand as that is the only place where the removed
EppResourceUtils method was called. We also convert to DualDatabaseTest
the tests of the callers of NLBIC. and use a CriteriaQueryBuilder in the
foreign key index SQL lookup (allowing us to avoid the String.format
call).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1060)
<!-- Reviewable:end -->
