### PR TITLE
Add -r when rsync a release to the live folder

### DIFF
--- a/release/cloudbuild-sync.yaml
+++ b/release/cloudbuild-sync.yaml
@@ -24,6 +24,7 @@ steps:
   - -m
   - rsync
   - -d
+  - -r
   - gs://$PROJECT_ID-deploy/${TAG_NAME}
   - gs://$PROJECT_ID-deploy/live
 timeout: 3600s


### PR DESCRIPTION
Release folders now are no longer flat. Each of them has a 'beam'
subfolder with pipeline metadata files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1063)
<!-- Reviewable:end -->
