### PR TITLE
Implement query abstraction

### DIFF
--- a/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
+++ b/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
@@ -379,7 +379,7 @@ public class DatastoreTransactionManager implements TransactionManager {
 
     Query<T> buildQuery() {
       Query<T> result = ofy().load().type(entityClass);
-      for (WhereCondition pred : predicates) {
+      for (WhereClause pred : predicates) {
         result = result.filter(pred.fieldName + pred.comparator.getDatastoreString(), pred.value);
       }
 

--- a/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
+++ b/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
@@ -307,7 +307,7 @@ public class DatastoreTransactionManager implements TransactionManager {
 
   @Override
   public <T> QueryComposer<T> createQueryComposer(Class<T> entity) {
-    return new QueryComposerImpl(entity);
+    return new DatastoreQueryComposerImpl(entity);
   }
 
   @Override
@@ -372,13 +372,13 @@ public class DatastoreTransactionManager implements TransactionManager {
     return obj;
   }
 
-  private static class QueryComposerImpl<T> extends QueryComposer<T> {
-    QueryComposerImpl(Class<T> entity) {
-      super(entity);
+  private static class DatastoreQueryComposerImpl<T> extends QueryComposer<T> {
+    DatastoreQueryComposerImpl(Class<T> entityClass) {
+      super(entityClass);
     }
 
     Query<T> buildQuery() {
-      Query<T> result = ofy().load().type(entity);
+      Query<T> result = ofy().load().type(entityClass);
       for (WhereCondition pred : predicates) {
         result = result.filter(pred.fieldName + pred.comparator.getDatastoreString(), pred.value);
       }

--- a/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
+++ b/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
@@ -411,7 +411,6 @@ public class DatastoreTransactionManager implements TransactionManager {
 
     @Override
     public Stream<T> stream() {
-      // TODO: there should be a better way to do this.
       return Streams.stream(buildQuery());
     }
   }

--- a/core/src/main/java/google/registry/persistence/transaction/CriteriaQueryBuilder.java
+++ b/core/src/main/java/google/registry/persistence/transaction/CriteriaQueryBuilder.java
@@ -18,6 +18,7 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 
 import com.google.common.collect.ImmutableList;
 import java.util.Collection;
+import javax.persistence.EntityManager;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Expression;
@@ -94,7 +95,12 @@ public class CriteriaQueryBuilder<T> {
 
   /** Creates a query builder that will SELECT from the given class. */
   public static <T> CriteriaQueryBuilder<T> create(Class<T> clazz) {
-    CriteriaQuery<T> query = jpaTm().getEntityManager().getCriteriaBuilder().createQuery(clazz);
+    return create(jpaTm().getEntityManager(), clazz);
+  }
+
+  /** Creates a query builder for the given entity manager. */
+  public static <T> CriteriaQueryBuilder<T> create(EntityManager em, Class<T> clazz) {
+    CriteriaQuery<T> query = em.getCriteriaBuilder().createQuery(clazz);
     Root<T> root = query.from(clazz);
     query = query.select(root);
     return new CriteriaQueryBuilder<>(query, root);

--- a/core/src/main/java/google/registry/persistence/transaction/CriteriaQueryBuilder.java
+++ b/core/src/main/java/google/registry/persistence/transaction/CriteriaQueryBuilder.java
@@ -36,7 +36,7 @@ import javax.persistence.criteria.Root;
 public class CriteriaQueryBuilder<T> {
 
   /** Functional interface that defines the 'where' operator, e.g. {@link CriteriaBuilder#equal}. */
-  public interface WhereClause<U> {
+  public interface WhereOperator<U> {
     Predicate predicate(Expression<U> expression, U object);
   }
 
@@ -51,7 +51,8 @@ public class CriteriaQueryBuilder<T> {
   }
 
   /** Adds a WHERE clause to the query, given the specified operation, field, and value. */
-  public <V> CriteriaQueryBuilder<T> where(String fieldName, WhereClause<V> whereClause, V value) {
+  public <V> CriteriaQueryBuilder<T> where(
+      String fieldName, WhereOperator<V> whereClause, V value) {
     Expression<V> expression = root.get(fieldName);
     return where(whereClause.predicate(expression, value));
   }

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -43,6 +43,7 @@ import google.registry.util.Clock;
 import google.registry.util.Retrier;
 import google.registry.util.SystemSleeper;
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -712,7 +713,13 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
     }
 
     @Override
-    public T first() {
+    public Optional<T> first() {
+      List<T> results = buildQuery().setMaxResults(1).getResultList();
+      return results.size() > 0 ? Optional.of(results.get(0)) : Optional.empty();
+    }
+
+    @Override
+    public T getSingleResult() {
       return buildQuery().getSingleResult();
     }
 

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -55,7 +55,6 @@ import javax.persistence.EntityTransaction;
 import javax.persistence.PersistenceException;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
-import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.metamodel.EntityType;
 import javax.persistence.metamodel.SingularAttribute;
 import org.joda.time.DateTime;
@@ -699,11 +698,10 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
     }
 
     private TypedQuery<T> buildQuery() {
-      CriteriaBuilder criteriaBuilder = em.getCriteriaBuilder();
       CriteriaQueryBuilder<T> queryBuilder = CriteriaQueryBuilder.create(em, entityClass);
 
-      for (WhereCondition<?> pred : predicates) {
-        pred.addToCriteriaQueryBuilder(queryBuilder, criteriaBuilder);
+      for (WhereClause<?> pred : predicates) {
+        pred.addToCriteriaQueryBuilder(queryBuilder);
       }
 
       if (orderBy != null) {

--- a/core/src/main/java/google/registry/persistence/transaction/QueryComposer.java
+++ b/core/src/main/java/google/registry/persistence/transaction/QueryComposer.java
@@ -1,0 +1,166 @@
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.persistence.transaction;
+
+import google.registry.persistence.transaction.CriteriaQueryBuilder.WhereClause;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import javax.persistence.criteria.CriteriaBuilder;
+
+/**
+ * Creates queries that can be used both for objectify and JPA.
+ *
+ * <p>Example usage:
+ *
+ * <p>tm().createQueryComposer(EntityType.class) .where("fieldName", Comparator.EQ, "value"
+ * .orderBy("fieldName") .stream()
+ */
+public abstract class QueryComposer<T> {
+
+  // The class whose entities we're querying.  Note that this limits us to single table queries in
+  // SQL.  In datastore, there's really no other kind of query.
+  protected Class<T> entity;
+
+  // Field to order by, if any.  Null if we don't care about order.
+  @Nullable protected String orderBy;
+
+  protected List<WhereCondition<?>> predicates = new ArrayList<WhereCondition<?>>();
+
+  protected QueryComposer(Class<T> entity) {
+    this.entity = entity;
+  }
+
+  /**
+   * Introduce a "where" clause to the query.
+   *
+   * <p>Causes the query to return only results where the field and value have the relationship
+   * specified by the comparator. For example, "field EQ value", "field GT value" etc.
+   */
+  public <U extends Comparable<? super U>> QueryComposer<T> where(
+      String fieldName, Comparator comparator, U value) {
+    predicates.add(new WhereCondition(fieldName, comparator, value));
+    return this;
+  }
+
+  /** Order the query results by the value of the specified field. */
+  public QueryComposer<T> orderBy(String fieldName) {
+    orderBy = fieldName;
+    return this;
+  }
+
+  /**
+   * Returns the first result of the query.
+   *
+   * <p>Throws javax.persistence.NoResultException if not found.
+   */
+  public abstract T first();
+
+  /** Returns the results of the query as a stream. */
+  public abstract Stream<T> stream();
+
+  // We have to wrap the CriteriaQueryBuilder predicate factories in our own functions because at
+  // the point where we pass them to the Comparator constructor, the compiler can't determine which
+  // of the overloads to use since there is no "value" object for context.
+  // The only place where this context exists is in the call to the "where" method, which is why we
+  // wrap the entire "where" method instead of just the original predicate factory.
+
+  @com.google.errorprone.annotations.Immutable
+  private interface ConditionAppender {
+    <U extends Comparable<? super U>> void add(
+        CriteriaQueryBuilder queryBuilder,
+        CriteriaBuilder criteriaBuilder,
+        String fieldName,
+        U value);
+  }
+
+  private static <U extends Comparable<? super U>> void addEqualCond(
+      CriteriaQueryBuilder queryBuilder,
+      CriteriaBuilder criteriaBuilder,
+      String fieldName,
+      U value) {
+    queryBuilder.where(fieldName, criteriaBuilder::equal, value);
+  }
+
+  private static <U extends Comparable<? super U>> void addLessThanCond(
+      CriteriaQueryBuilder queryBuilder,
+      CriteriaBuilder criteriaBuilder,
+      String fieldName,
+      U value) {
+    queryBuilder.where(fieldName, (WhereClause<U>) criteriaBuilder::lessThan, value);
+  }
+
+  private static <U extends Comparable<? super U>> void addLessThanOrEqualToCond(
+      CriteriaQueryBuilder queryBuilder,
+      CriteriaBuilder criteriaBuilder,
+      String fieldName,
+      U value) {
+    queryBuilder.where(fieldName, (WhereClause<U>) criteriaBuilder::lessThanOrEqualTo, value);
+  }
+
+  private static <U extends Comparable<? super U>> void addGreaterThanOrEqualToCond(
+      CriteriaQueryBuilder queryBuilder,
+      CriteriaBuilder criteriaBuilder,
+      String fieldName,
+      U value) {
+    queryBuilder.where(fieldName, (WhereClause<U>) criteriaBuilder::greaterThanOrEqualTo, value);
+  }
+
+  private static <U extends Comparable<? super U>> void addGreaterThanCond(
+      CriteriaQueryBuilder queryBuilder,
+      CriteriaBuilder criteriaBuilder,
+      String fieldName,
+      U value) {
+    queryBuilder.where(fieldName, (WhereClause<U>) criteriaBuilder::greaterThan, value);
+  }
+
+  public enum Comparator {
+    EQ("", QueryComposer::addEqualCond),
+    LT(" <", QueryComposer::addLessThanCond),
+    LTE(" <=", QueryComposer::addLessThanOrEqualToCond),
+    GTE(" >=", QueryComposer::addGreaterThanOrEqualToCond),
+    GT(" >", QueryComposer::addGreaterThanCond);
+
+    private final String datastoreString;
+    private final ConditionAppender conditionAppender;
+
+    Comparator(String datastoreString, ConditionAppender conditionAppender) {
+      this.datastoreString = datastoreString;
+      this.conditionAppender = conditionAppender;
+    }
+
+    public String getDatastoreString() {
+      return datastoreString;
+    }
+  };
+
+  protected static class WhereCondition<U extends Comparable<? super U>> {
+    public String fieldName;
+    public Comparator comparator;
+    public U value;
+
+    WhereCondition(String fieldName, Comparator comparator, U value) {
+      this.fieldName = fieldName;
+      this.comparator = comparator;
+      this.value = value;
+    }
+
+    public void addToCriteriaQueryBuilder(
+        CriteriaQueryBuilder queryBuilder, CriteriaBuilder criteriaBuilder) {
+      comparator.conditionAppender.add(queryBuilder, criteriaBuilder, fieldName, (U) value);
+    }
+  }
+}

--- a/core/src/main/java/google/registry/persistence/transaction/QueryComposer.java
+++ b/core/src/main/java/google/registry/persistence/transaction/QueryComposer.java
@@ -80,8 +80,8 @@ public abstract class QueryComposer<T> {
   /**
    * Returns the one and only result of a query.
    *
-   * <p>Throws a {@link NonUniqueResultException} if there is more than one result, throws {@link
-   * NoResultException} if no results are found.
+   * <p>Throws a {@link javax.persistence.NonUniqueResultException} if there is more than one
+   * result, throws {@link javax.persistence.NoResultException} if no results are found.
    */
   public abstract T getSingleResult();
 
@@ -151,6 +151,8 @@ public abstract class QueryComposer<T> {
     GT(" >", QueryComposer::greaterThan);
 
     private final String datastoreString;
+
+    @SuppressWarnings("ImmutableEnumChecker") // Functions are immutable.
     private final Function<CriteriaBuilder, WhereOperator<?>> operatorFactory;
 
     Comparator(

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
@@ -273,6 +273,11 @@ public interface TransactionManager {
    */
   void deleteWithoutBackup(Object entity);
 
+  /**
+   * Returns a QueryComposer which can be used to construct portable queries for the given entity.
+   */
+  <T> QueryComposer<T> createQueryComposer(Class<T> entity);
+
   /** Clears the session cache if the underlying database is Datastore, otherwise it is a no-op. */
   void clearSessionCache();
 

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
@@ -273,9 +273,7 @@ public interface TransactionManager {
    */
   void deleteWithoutBackup(Object entity);
 
-  /**
-   * Returns a QueryComposer which can be used to construct portable queries for the given entity.
-   */
+  /** Returns a QueryComposer which can be used to perform queries against the current database. */
   <T> QueryComposer<T> createQueryComposer(Class<T> entity);
 
   /** Clears the session cache if the underlying database is Datastore, otherwise it is a no-op. */

--- a/core/src/main/java/google/registry/reporting/spec11/Spec11EmailUtils.java
+++ b/core/src/main/java/google/registry/reporting/spec11/Spec11EmailUtils.java
@@ -141,7 +141,7 @@ public class Spec11EmailUtils {
                                   "fullyQualifiedDomainName",
                                   Comparator.EQ,
                                   threatMatch.fullyQualifiedDomainName())
-                              .first()
+                              .getSingleResult()
                               .shouldPublishToDns())
                   .collect(toImmutableList());
             });

--- a/core/src/main/java/google/registry/reporting/spec11/Spec11EmailUtils.java
+++ b/core/src/main/java/google/registry/reporting/spec11/Spec11EmailUtils.java
@@ -17,7 +17,9 @@ package google.registry.reporting.spec11;
 import static com.google.common.base.Throwables.getRootCause;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.io.Resources.getResource;
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.persistence.transaction.QueryComposer.Comparator;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.persistence.transaction.TransactionManagerUtil.transactIfJpaTm;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -129,17 +131,20 @@ public class Spec11EmailUtils {
   private RegistrarThreatMatches filterOutNonPublishedMatches(
       RegistrarThreatMatches registrarThreatMatches) {
     ImmutableList<ThreatMatch> filteredMatches =
-        registrarThreatMatches.threatMatches().stream()
-            .filter(
-                threatMatch ->
-                    ofy()
-                        .load()
-                        .type(DomainBase.class)
-                        .filter("fullyQualifiedDomainName", threatMatch.fullyQualifiedDomainName())
-                        .first()
-                        .now()
-                        .shouldPublishToDns())
-            .collect(toImmutableList());
+        transactIfJpaTm(
+            () -> {
+              return registrarThreatMatches.threatMatches().stream()
+                  .filter(
+                      threatMatch ->
+                          tm().createQueryComposer(DomainBase.class)
+                              .where(
+                                  "fullyQualifiedDomainName",
+                                  Comparator.EQ,
+                                  threatMatch.fullyQualifiedDomainName())
+                              .first()
+                              .shouldPublishToDns())
+                  .collect(toImmutableList());
+            });
     return RegistrarThreatMatches.create(registrarThreatMatches.clientId(), filteredMatches);
   }
 

--- a/core/src/test/java/google/registry/persistence/transaction/QueryComposerTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/QueryComposerTest.java
@@ -1,0 +1,227 @@
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.persistence.transaction;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.persistence.transaction.QueryComposer.Comparator;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.persistence.transaction.TransactionManagerUtil.transactIfJpaTm;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableList;
+import com.googlecode.objectify.annotation.Entity;
+import com.googlecode.objectify.annotation.Id;
+import com.googlecode.objectify.annotation.Index;
+import google.registry.model.ImmutableObject;
+import google.registry.testing.AppEngineExtension;
+import google.registry.testing.DualDatabaseTest;
+import google.registry.testing.FakeClock;
+import google.registry.testing.TestOfyAndSql;
+import javax.persistence.Column;
+import javax.persistence.NoResultException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@DualDatabaseTest
+public class QueryComposerTest {
+
+  private final FakeClock fakeClock = new FakeClock();
+
+  TestEntity alpha = new TestEntity("alpha", 3);
+  TestEntity bravo = new TestEntity("bravo", 2);
+  TestEntity charlie = new TestEntity("charlie", 1);
+
+  @RegisterExtension
+  public final AppEngineExtension appEngine =
+      AppEngineExtension.builder()
+          .withClock(fakeClock)
+          .withDatastoreAndCloudSql()
+          .withOfyTestEntities(TestEntity.class)
+          .withJpaUnitTestEntities(TestEntity.class)
+          .build();
+
+  public QueryComposerTest() {}
+
+  @BeforeEach
+  void setUp() {
+    tm().transact(
+            () -> {
+              tm().insert(alpha);
+              tm().insert(bravo);
+              tm().insert(charlie);
+            });
+  }
+
+  @TestOfyAndSql
+  public void testFirstQueries() {
+    assertThat(
+            transactIfJpaTm(
+                () ->
+                    tm().createQueryComposer(TestEntity.class)
+                        .where("name", Comparator.EQ, "bravo")
+                        .first()))
+        .isEqualTo(bravo);
+    assertThat(
+            transactIfJpaTm(
+                () ->
+                    tm().createQueryComposer(TestEntity.class)
+                        .where("name", Comparator.GT, "bravo")
+                        .first()))
+        .isEqualTo(charlie);
+    assertThat(
+            transactIfJpaTm(
+                () ->
+                    tm().createQueryComposer(TestEntity.class)
+                        .where("name", Comparator.GTE, "charlie")
+                        .first()))
+        .isEqualTo(charlie);
+    assertThat(
+            transactIfJpaTm(
+                () ->
+                    tm().createQueryComposer(TestEntity.class)
+                        .where("name", Comparator.LT, "bravo")
+                        .first()))
+        .isEqualTo(alpha);
+    assertThat(
+            transactIfJpaTm(
+                () ->
+                    tm().createQueryComposer(TestEntity.class)
+                        .where("name", Comparator.LTE, "alpha")
+                        .first()))
+        .isEqualTo(alpha);
+  }
+
+  @TestOfyAndSql
+  public void testStreamQueries() {
+    assertThat(
+            transactIfJpaTm(
+                () ->
+                    tm()
+                        .createQueryComposer(TestEntity.class)
+                        .where("name", Comparator.EQ, "alpha")
+                        .stream()
+                        .collect(toImmutableList())))
+        .isEqualTo(ImmutableList.of(alpha));
+    assertThat(
+            transactIfJpaTm(
+                () ->
+                    tm()
+                        .createQueryComposer(TestEntity.class)
+                        .where("name", Comparator.GT, "alpha")
+                        .stream()
+                        .collect(toImmutableList())))
+        .isEqualTo(ImmutableList.of(bravo, charlie));
+    assertThat(
+            transactIfJpaTm(
+                () ->
+                    tm()
+                        .createQueryComposer(TestEntity.class)
+                        .where("name", Comparator.GTE, "bravo")
+                        .stream()
+                        .collect(toImmutableList())))
+        .isEqualTo(ImmutableList.of(bravo, charlie));
+    assertThat(
+            transactIfJpaTm(
+                () ->
+                    tm()
+                        .createQueryComposer(TestEntity.class)
+                        .where("name", Comparator.LT, "charlie")
+                        .stream()
+                        .collect(toImmutableList())))
+        .isEqualTo(ImmutableList.of(alpha, bravo));
+    assertThat(
+            transactIfJpaTm(
+                () ->
+                    tm()
+                        .createQueryComposer(TestEntity.class)
+                        .where("name", Comparator.LTE, "bravo")
+                        .stream()
+                        .collect(toImmutableList())))
+        .isEqualTo(ImmutableList.of(alpha, bravo));
+  }
+
+  @TestOfyAndSql
+  public void testNonPrimaryKey() {
+    assertThat(
+            transactIfJpaTm(
+                () ->
+                    tm().createQueryComposer(TestEntity.class)
+                        .where("val", Comparator.EQ, 2)
+                        .first()))
+        .isEqualTo(bravo);
+  }
+
+  @TestOfyAndSql
+  public void testOrderBy() {
+    assertThat(
+            transactIfJpaTm(
+                () ->
+                    tm()
+                        .createQueryComposer(TestEntity.class)
+                        .where("val", Comparator.GT, 1)
+                        .orderBy("val")
+                        .stream()
+                        .collect(toImmutableList())))
+        .isEqualTo(ImmutableList.of(bravo, alpha));
+  }
+
+  @TestOfyAndSql
+  public void testEmptyQueries() {
+    assertThrows(
+        NoResultException.class,
+        () ->
+            transactIfJpaTm(
+                () ->
+                    tm().createQueryComposer(TestEntity.class)
+                        .where("name", Comparator.GT, "foxtrot")
+                        .first()));
+    assertThat(
+            transactIfJpaTm(
+                () ->
+                    tm()
+                        .createQueryComposer(TestEntity.class)
+                        .where("name", Comparator.GT, "foxtrot")
+                        .stream()
+                        .collect(toImmutableList())))
+        .isEqualTo(ImmutableList.of());
+  }
+
+  @javax.persistence.Entity
+  @Entity
+  private static class TestEntity extends ImmutableObject {
+    @javax.persistence.Id @Id private String name;
+
+    @Index
+    // Renaming this implicitly verifies that property names work for hibernate queries.
+    @Column(name = "some_value")
+    private int val;
+
+    public TestEntity() {}
+
+    public TestEntity(String name, int val) {
+      this.name = name;
+      this.val = val;
+    }
+
+    public int getVal() {
+      return val;
+    }
+
+    public String getName() {
+      return name;
+    }
+  }
+}

--- a/core/src/test/java/google/registry/persistence/transaction/QueryComposerTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/QueryComposerTest.java
@@ -200,7 +200,7 @@ public class QueryComposerTest {
   }
 
   @javax.persistence.Entity
-  @Entity
+  @Entity(name = "QueryComposerTestEntity")
   private static class TestEntity extends ImmutableObject {
     @javax.persistence.Id @Id private String name;
 


### PR DESCRIPTION
Implement a query abstraction layer ("QueryComposer") that allows us to
construct fluent-style queries that work across both Objectify and JPA.

As a demonstration of the concept, convert Spec11EmailUtils and its test to
use the new API.

Limitations:
-  The primary limitations of this system are imposed by datastore, for
   example all queryable fields must be indexed, orderBy must coincide with
   the order of any inequality queries, inequality filters are limited to one
   property...
-  JPA queries are limited to a set of where clauses (all of which must match)
   and an "order by" clause.  Joins, functions, complex where logic and
   multi-table queries are simply not allowed.
-  Descending sort order is currently unsupported (this is simple enough to
   add).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1069)
<!-- Reviewable:end -->
