### PR TITLE
Make Numulus compile on macOS

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -423,7 +423,7 @@ task jaxbToJava {
       }
     }
     execInBash(
-        'find . -name *.java -exec sed -i /\\*\\ \\<p\\>\\$/d {} +',
+        'find . -name *.java -exec sed -i -e /\\*\\ \\<p\\>\\$/d {} +',
         generatedDir)
   }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -423,7 +423,7 @@ task jaxbToJava {
       }
     }
     execInBash(
-        'find . -name *.java -exec sed -i -e /\\*\\ \\<p\\>\\$/d {} +',
+        "find . -name *.java -exec sed -i -e '/" + /\* <p>$/ + "/d' {} +",
         generatedDir)
   }
 }


### PR DESCRIPTION
BSD sed behaves differently than Linux sed. By adding a "-e" flag the
comand works in both systems.

See: https://unix.stackexchange.com/questions/101059/sed-behaves-different-on-freebsd-and-on-linux

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1070)
<!-- Reviewable:end -->
