### PR TITLE
Upload latest version of RDE report to icann

### DIFF
--- a/core/src/main/java/google/registry/model/rde/RdeRevision.java
+++ b/core/src/main/java/google/registry/model/rde/RdeRevision.java
@@ -103,6 +103,15 @@ public final class RdeRevision extends BackupGroupRoot implements NonReplicatedE
     return revisionOptional.map(rdeRevision -> rdeRevision.revision + 1).orElse(0);
   }
 
+  /** Returns the latest revision of the report already generated for the given triplet. */
+  public static Optional<Integer> getCurrentRevision(String tld, DateTime date, RdeMode mode) {
+    int nextRevision = getNextRevision(tld, date, mode);
+    if (nextRevision == 0) {
+      return Optional.empty();
+    }
+    return Optional.of(nextRevision - 1);
+  }
+
   /**
    * Sets the revision ID for a given triplet.
    *

--- a/core/src/main/java/google/registry/rde/RdeReportAction.java
+++ b/core/src/main/java/google/registry/rde/RdeReportAction.java
@@ -24,6 +24,7 @@ import static google.registry.request.Action.Method.POST;
 import static google.registry.util.DateTimeUtils.isBeforeOrAt;
 
 import com.google.appengine.tools.cloudstorage.GcsFilename;
+import com.google.common.flogger.FluentLogger;
 import com.google.common.io.ByteStreams;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.gcs.GcsUtils;
@@ -31,6 +32,7 @@ import google.registry.keyring.api.KeyModule.Key;
 import google.registry.model.common.Cursor;
 import google.registry.model.common.Cursor.CursorType;
 import google.registry.model.rde.RdeNamingUtils;
+import google.registry.model.rde.RdeRevision;
 import google.registry.model.registry.Registry;
 import google.registry.rde.EscrowTaskRunner.EscrowTask;
 import google.registry.request.Action;
@@ -56,6 +58,8 @@ import org.joda.time.Duration;
     method = POST,
     auth = Auth.AUTH_INTERNAL_OR_ADMIN)
 public final class RdeReportAction implements Runnable, EscrowTask {
+
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   static final String PATH = "/_dr/task/rdeReport";
 
@@ -88,12 +92,15 @@ public final class RdeReportAction implements Runnable, EscrowTask {
                   + "last upload completion was at %s",
               tld, watermark, cursorTime));
     }
-    String prefix = RdeNamingUtils.makeRydeFilename(tld, watermark, FULL, 1, 0);
+    int revision = RdeRevision.getNextRevision(tld, watermark, FULL) - 1;
+    verify(revision >= 0, "RdeRevision was not set on generated deposit");
+    String prefix = RdeNamingUtils.makeRydeFilename(tld, watermark, FULL, 1, revision);
     GcsFilename reportFilename = new GcsFilename(bucket, prefix + "-report.xml.ghostryde");
     verify(gcsUtils.existsAndNotEmpty(reportFilename), "Missing file: %s", reportFilename);
     reporter.send(readReportFromGcs(reportFilename));
     response.setContentType(PLAIN_TEXT_UTF_8);
     response.setPayload(String.format("OK %s %s\n", tld, watermark));
+    logger.atInfo().log("Successfully sent %s", reportFilename);
   }
 
   /** Reads and decrypts the XML file from cloud storage. */

--- a/core/src/main/java/google/registry/rde/RdeUploadAction.java
+++ b/core/src/main/java/google/registry/rde/RdeUploadAction.java
@@ -160,8 +160,10 @@ public final class RdeUploadAction implements Runnable, EscrowTask {
               sftpCursorTime,
               timeSinceLastSftp.getStandardMinutes()));
     }
-    int revision = RdeRevision.getNextRevision(tld, watermark, FULL) - 1;
-    verify(revision >= 0, "RdeRevision was not set on generated deposit");
+    int revision =
+        RdeRevision.getCurrentRevision(tld, watermark, FULL)
+            .orElseThrow(
+                () -> new IllegalStateException("RdeRevision was not set on generated deposit"));
     final String name = RdeNamingUtils.makeRydeFilename(tld, watermark, FULL, 1, revision);
     final GcsFilename xmlFilename = new GcsFilename(bucket, name + ".xml.ghostryde");
     final GcsFilename xmlLengthFilename = new GcsFilename(bucket, name + ".xml.length");

--- a/core/src/test/java/google/registry/testing/GcsTestingUtils.java
+++ b/core/src/test/java/google/registry/testing/GcsTestingUtils.java
@@ -40,5 +40,9 @@ public final class GcsTestingUtils {
     gcsService.createOrReplace(file, GcsFileOptions.getDefaultInstance(), ByteBuffer.wrap(data));
   }
 
+  public static void deleteGcsFile(GcsService gcsService, GcsFilename file) throws IOException {
+    gcsService.delete(file);
+  }
+
   private GcsTestingUtils() {}
 }


### PR DESCRIPTION
Currently the RdeReportAction is hard coded to load the initial version
of a report. This is wrong when reports have been regenerated.

Changed lines are copied from RdeUploadAction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1089)
<!-- Reviewable:end -->
