### PR TITLE
Begin saving the EppResource parent in *History objects

### DIFF
--- a/core/src/main/java/google/registry/flows/FlowModule.java
+++ b/core/src/main/java/google/registry/flows/FlowModule.java
@@ -20,6 +20,7 @@ import com.google.common.base.Strings;
 import dagger.Module;
 import dagger.Provides;
 import google.registry.flows.picker.FlowPicker;
+import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.metadata.MetadataExtension;
 import google.registry.model.eppcommon.AuthInfo;
 import google.registry.model.eppcommon.Trid;
@@ -237,6 +238,12 @@ public class FlowModule {
           .setRequestedByRegistrar(metadataExtension.get().getRequestedByRegistrar());
     }
     return historyBuilder;
+  }
+
+  @Provides
+  static DomainHistory.Builder provideDomainHistoryBuilder(
+      HistoryEntry.Builder historyEntryBuilder) {
+    return new DomainHistory.Builder().copyFrom(historyEntryBuilder.build());
   }
 
   /**

--- a/core/src/main/java/google/registry/model/contact/ContactHistory.java
+++ b/core/src/main/java/google/registry/model/contact/ContactHistory.java
@@ -56,6 +56,7 @@ import javax.persistence.PostLoad;
 public class ContactHistory extends HistoryEntry implements SqlEntity {
 
   // Store ContactBase instead of ContactResource so we don't pick up its @Id
+  // Nullable for the sake of pre-Registry-3.0 history objects
   @Nullable ContactBase contactBase;
 
   @Id
@@ -193,9 +194,13 @@ public class ContactHistory extends HistoryEntry implements SqlEntity {
       super(instance);
     }
 
-    public Builder setContactBase(ContactBase contactBase) {
+    public Builder setContactBase(@Nullable ContactBase contactBase) {
+      // Nullable for the sake of pre-Registry-3.0 history objects
+      if (contactBase == null) {
+        return this;
+      }
       getInstance().contactBase = contactBase;
-      return this;
+      return super.setParent(contactBase);
     }
 
     public Builder setContactRepoId(String contactRepoId) {

--- a/core/src/main/java/google/registry/model/domain/GracePeriodBase.java
+++ b/core/src/main/java/google/registry/model/domain/GracePeriodBase.java
@@ -38,7 +38,7 @@ import org.joda.time.DateTime;
 public class GracePeriodBase extends ImmutableObject {
 
   /** Unique id required for hibernate representation. */
-  @Transient Long gracePeriodId;
+  @Transient long gracePeriodId;
 
   /** Repository id for the domain which this grace period belongs to. */
   @Ignore

--- a/core/src/main/java/google/registry/model/host/HostHistory.java
+++ b/core/src/main/java/google/registry/model/host/HostHistory.java
@@ -57,6 +57,7 @@ import javax.persistence.PostLoad;
 public class HostHistory extends HistoryEntry implements SqlEntity {
 
   // Store HostBase instead of HostResource so we don't pick up its @Id
+  // Nullable for the sake of pre-Registry-3.0 history objects
   @Nullable HostBase hostBase;
 
   @Id
@@ -194,9 +195,13 @@ public class HostHistory extends HistoryEntry implements SqlEntity {
       super(instance);
     }
 
-    public Builder setHostBase(HostBase hostBase) {
+    public Builder setHostBase(@Nullable HostBase hostBase) {
+      // Nullable for the sake of pre-Registry-3.0 history objects
+      if (hostBase == null) {
+        return this;
+      }
       getInstance().hostBase = hostBase;
-      return this;
+      return super.setParent(hostBase);
     }
 
     public Builder setHostRepoId(String hostRepoId) {

--- a/core/src/main/java/google/registry/model/reporting/HistoryEntryDao.java
+++ b/core/src/main/java/google/registry/model/reporting/HistoryEntryDao.java
@@ -51,12 +51,15 @@ public class HistoryEntryDao {
   public static Iterable<? extends HistoryEntry> loadAllHistoryObjects(
       DateTime afterTime, DateTime beforeTime) {
     if (tm().isOfy()) {
-      return ofy()
-          .load()
-          .type(HistoryEntry.class)
-          .order("modificationTime")
-          .filter("modificationTime >=", afterTime)
-          .filter("modificationTime <=", beforeTime);
+      return Streams.stream(
+              ofy()
+                  .load()
+                  .type(HistoryEntry.class)
+                  .order("modificationTime")
+                  .filter("modificationTime >=", afterTime)
+                  .filter("modificationTime <=", beforeTime))
+          .map(HistoryEntry::toChildHistoryEntity)
+          .collect(toImmutableList());
     } else {
       return jpaTm()
           .transact(
@@ -78,13 +81,16 @@ public class HistoryEntryDao {
   public static Iterable<? extends HistoryEntry> loadHistoryObjectsForResource(
       VKey<? extends EppResource> parentKey, DateTime afterTime, DateTime beforeTime) {
     if (tm().isOfy()) {
-      return ofy()
-          .load()
-          .type(HistoryEntry.class)
-          .ancestor(parentKey.getOfyKey())
-          .order("modificationTime")
-          .filter("modificationTime >=", afterTime)
-          .filter("modificationTime <=", beforeTime);
+      return Streams.stream(
+              ofy()
+                  .load()
+                  .type(HistoryEntry.class)
+                  .ancestor(parentKey.getOfyKey())
+                  .order("modificationTime")
+                  .filter("modificationTime >=", afterTime)
+                  .filter("modificationTime <=", beforeTime))
+          .map(HistoryEntry::toChildHistoryEntity)
+          .collect(toImmutableList());
     } else {
       return jpaTm()
           .transact(() -> loadHistoryObjectsForResourceFromSql(parentKey, afterTime, beforeTime));

--- a/core/src/test/java/google/registry/flows/EppLifecycleDomainTest.java
+++ b/core/src/test/java/google/registry/flows/EppLifecycleDomainTest.java
@@ -751,11 +751,11 @@ class EppLifecycleDomainTest extends EppTestCase {
         .hasResponse(
             "poll_response_autorenew.xml",
             ImmutableMap.of(
-                "ID", "1-C-EXAMPLE-13-16-2002",
+                "ID", "1-D-EXAMPLE-11-16-2002",
                 "QDATE", "2002-06-01T00:04:00Z",
                 "DOMAIN", "fakesite.example",
                 "EXDATE", "2003-06-01T00:04:00Z"));
-    assertThatCommand("poll_ack.xml", ImmutableMap.of("ID", "1-C-EXAMPLE-13-16-2002"))
+    assertThatCommand("poll_ack.xml", ImmutableMap.of("ID", "1-D-EXAMPLE-11-16-2002"))
         .atTime("2002-07-01T00:02:00Z")
         .hasResponse("poll_ack_response_empty.xml");
 
@@ -769,13 +769,13 @@ class EppLifecycleDomainTest extends EppTestCase {
         .hasResponse(
             "poll_response_autorenew.xml",
             ImmutableMap.of(
-                "ID", "1-C-EXAMPLE-13-16-2003", // Note -- Year is different from previous ID.
+                "ID", "1-D-EXAMPLE-11-16-2003", // Note -- Year is different from previous ID.
                 "QDATE", "2003-06-01T00:04:00Z",
                 "DOMAIN", "fakesite.example",
                 "EXDATE", "2004-06-01T00:04:00Z"));
 
     // Ack the second poll message and verify that none remain.
-    assertThatCommand("poll_ack.xml", ImmutableMap.of("ID", "1-C-EXAMPLE-13-16-2003"))
+    assertThatCommand("poll_ack.xml", ImmutableMap.of("ID", "1-D-EXAMPLE-11-16-2003"))
         .atTime("2003-07-01T00:05:05Z")
         .hasResponse("poll_ack_response_empty.xml");
     assertThatCommand("poll.xml")
@@ -805,7 +805,7 @@ class EppLifecycleDomainTest extends EppTestCase {
 
     // As the losing registrar, read the request poll message, and then ack it.
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
-    String messageId = "1-C-EXAMPLE-18-24-2001";
+    String messageId = "1-D-EXAMPLE-19-25-2001";
     assertThatCommand("poll.xml")
         .atTime("2001-01-01T00:01:00Z")
         .hasResponse("poll_response_domain_transfer_request.xml", ImmutableMap.of("ID", messageId));
@@ -814,7 +814,7 @@ class EppLifecycleDomainTest extends EppTestCase {
         .hasResponse("poll_ack_response_empty.xml");
 
     // Five days in the future, expect a server approval poll message to the loser, and ack it.
-    messageId = "1-C-EXAMPLE-18-23-2001";
+    messageId = "1-D-EXAMPLE-19-24-2001";
     assertThatCommand("poll.xml")
         .atTime("2001-01-06T00:01:00Z")
         .hasResponse(
@@ -826,7 +826,7 @@ class EppLifecycleDomainTest extends EppTestCase {
     assertThatLogoutSucceeds();
 
     // Also expect a server approval poll message to the winner, with the transfer request trid.
-    messageId = "1-C-EXAMPLE-18-22-2001";
+    messageId = "1-D-EXAMPLE-19-23-2001";
     assertThatLoginSucceeds("TheRegistrar", "password2");
     assertThatCommand("poll.xml")
         .atTime("2001-01-06T00:02:00Z")

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferCancelFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferCancelFlowTest.java
@@ -403,7 +403,7 @@ class DomainTransferCancelFlowTest
     persistResource(
         new DomainHistory.Builder()
             .setType(DOMAIN_TRANSFER_REQUEST)
-            .setParent(domain)
+            .setDomainContent(domain)
             .setModificationTime(clock.nowUtc().minusDays(4))
             .setDomainTransactionRecords(
                 ImmutableSet.of(previousSuccessRecord, notCancellableRecord))

--- a/core/src/test/java/google/registry/model/poll/PollMessageExternalKeyConverterTest.java
+++ b/core/src/test/java/google/registry/model/poll/PollMessageExternalKeyConverterTest.java
@@ -62,7 +62,7 @@ public class PollMessageExternalKeyConverterTest {
     historyEntry =
         persistResource(
             new DomainHistory.Builder()
-                .setParent(persistActiveDomain("foo.foobar"))
+                .setDomainContent(persistActiveDomain("foo.foobar"))
                 .setType(HistoryEntry.Type.DOMAIN_CREATE)
                 .setPeriod(Period.create(1, Period.Unit.YEARS))
                 .setXmlBytes("<xml></xml>".getBytes(UTF_8))

--- a/core/src/test/java/google/registry/model/reporting/HistoryEntryDaoTest.java
+++ b/core/src/test/java/google/registry/model/reporting/HistoryEntryDaoTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.BeforeEach;
 class HistoryEntryDaoTest extends EntityTestCase {
 
   private DomainBase domain;
-  private HistoryEntry historyEntry;
+  private HistoryEntry domainHistory;
 
   @BeforeEach
   void beforeEach() {
@@ -55,10 +55,10 @@ class HistoryEntryDaoTest extends EntityTestCase {
             .setReportField(TransactionReportField.NET_ADDS_1_YR)
             .setReportAmount(1)
             .build();
-    // Set up a new persisted HistoryEntry entity.
-    historyEntry =
+    // Set up a new persisted DomainHistory entity.
+    domainHistory =
         new DomainHistory.Builder()
-            .setParent(domain)
+            .setDomainContent(domain)
             .setType(HistoryEntry.Type.DOMAIN_CREATE)
             .setPeriod(Period.create(1, Period.Unit.YEARS))
             .setXmlBytes("<xml></xml>".getBytes(UTF_8))
@@ -71,14 +71,14 @@ class HistoryEntryDaoTest extends EntityTestCase {
             .setRequestedByRegistrar(false)
             .setDomainTransactionRecords(ImmutableSet.of(transactionRecord))
             .build();
-    persistResource(historyEntry);
+    persistResource(domainHistory);
   }
 
   @TestOfyAndSql
   void testSimpleLoadAll() {
     assertThat(HistoryEntryDao.loadAllHistoryObjects(START_OF_TIME, END_OF_TIME))
-        .comparingElementsUsing(immutableObjectCorrespondence("nsHosts"))
-        .containsExactly(historyEntry);
+        .comparingElementsUsing(immutableObjectCorrespondence("nsHosts", "domainContent"))
+        .containsExactly(domainHistory);
   }
 
   @TestOfyAndSql
@@ -99,8 +99,8 @@ class HistoryEntryDaoTest extends EntityTestCase {
     transactIfJpaTm(
         () ->
             assertThat(HistoryEntryDao.loadHistoryObjectsForResource(domain.createVKey()))
-                .comparingElementsUsing(immutableObjectCorrespondence("nsHosts"))
-                .containsExactly(historyEntry));
+                .comparingElementsUsing(immutableObjectCorrespondence("nsHosts", "domainContent"))
+                .containsExactly(domainHistory));
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/model/reporting/HistoryEntryTest.java
+++ b/core/src/test/java/google/registry/model/reporting/HistoryEntryTest.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.BeforeEach;
 @DualDatabaseTest
 class HistoryEntryTest extends EntityTestCase {
 
-  private HistoryEntry historyEntry;
+  private DomainHistory domainHistory;
 
   @BeforeEach
   void setUp() {
@@ -53,9 +53,9 @@ class HistoryEntryTest extends EntityTestCase {
             .setReportAmount(1)
             .build();
     // Set up a new persisted HistoryEntry entity.
-    historyEntry =
+    domainHistory =
         new DomainHistory.Builder()
-            .setParent(domain)
+            .setDomainContent(domain)
             .setType(HistoryEntry.Type.DOMAIN_CREATE)
             .setPeriod(Period.create(1, Period.Unit.YEARS))
             .setXmlBytes("<xml></xml>".getBytes(UTF_8))
@@ -68,26 +68,27 @@ class HistoryEntryTest extends EntityTestCase {
             .setRequestedByRegistrar(false)
             .setDomainTransactionRecords(ImmutableSet.of(transactionRecord))
             .build();
-    persistResource(historyEntry);
+    persistResource(domainHistory);
   }
 
   @TestOfyAndSql
   void testPersistence() {
     transactIfJpaTm(
         () -> {
-          HistoryEntry fromDatabase = tm().loadByEntity(historyEntry);
+          HistoryEntry fromDatabase = tm().loadByEntity(domainHistory);
           assertAboutImmutableObjects()
               .that(fromDatabase)
-              .isEqualExceptFields(historyEntry, "nsHosts", "domainTransactionRecords");
+              .isEqualExceptFields(
+                  domainHistory, "nsHosts", "domainTransactionRecords", "domainContent");
           assertAboutImmutableObjects()
               .that(Iterables.getOnlyElement(fromDatabase.getDomainTransactionRecords()))
               .isEqualExceptFields(
-                  Iterables.getOnlyElement(historyEntry.getDomainTransactionRecords()), "id");
+                  Iterables.getOnlyElement(domainHistory.getDomainTransactionRecords()), "id");
         });
   }
 
   @TestOfyOnly
   void testIndexing() throws Exception {
-    verifyIndexing(historyEntry.asHistoryEntry(), "modificationTime", "clientId");
+    verifyIndexing(domainHistory.asHistoryEntry(), "modificationTime", "clientId");
   }
 }

--- a/core/src/test/java/google/registry/rde/DomainBaseToXjcConverterTest.java
+++ b/core/src/test/java/google/registry/rde/DomainBaseToXjcConverterTest.java
@@ -224,7 +224,7 @@ public class DomainBaseToXjcConverterTest {
             new DomainHistory.Builder()
                 .setModificationTime(clock.nowUtc())
                 .setType(HistoryEntry.Type.DOMAIN_CREATE)
-                .setParent(domain)
+                .setDomainContent(domain)
                 .build());
     BillingEvent.OneTime billingEvent =
         persistResource(

--- a/core/src/test/java/google/registry/tools/DedupeRecurringBillingEventIdsCommandTest.java
+++ b/core/src/test/java/google/registry/tools/DedupeRecurringBillingEventIdsCommandTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
 import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.testing.DatabaseHelper.createTld;
+import static google.registry.testing.DatabaseHelper.loadByEntity;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
@@ -225,7 +226,7 @@ class DedupeRecurringBillingEventIdsCommandTest
   private static void assertNotChangeExceptUpdateTime(ImmutableObject... entities) {
     for (ImmutableObject entity : entities) {
       assertAboutImmutableObjects()
-          .that(ofy().load().entity(entity).now())
+          .that(loadByEntity(entity))
           .isEqualExceptFields(entity, "updateTimestamp", "revisions");
     }
   }

--- a/core/src/test/java/google/registry/tools/EppLifecycleToolsTest.java
+++ b/core/src/test/java/google/registry/tools/EppLifecycleToolsTest.java
@@ -108,7 +108,7 @@ class EppLifecycleToolsTest extends EppTestCase {
         .atTime("2001-06-08T00:00:00Z")
         .hasResponse("poll_response_unrenew.xml");
 
-    assertThatCommand("poll_ack.xml", ImmutableMap.of("ID", "1-8-TLD-19-20-2001"))
+    assertThatCommand("poll_ack.xml", ImmutableMap.of("ID", "1-9-TLD-20-21-2001"))
         .atTime("2001-06-08T00:00:01Z")
         .hasResponse("poll_ack_response_empty.xml");
 
@@ -129,7 +129,7 @@ class EppLifecycleToolsTest extends EppTestCase {
         .hasResponse(
             "poll_response_autorenew.xml",
             ImmutableMap.of(
-                "ID", "1-8-TLD-19-22-2003",
+                "ID", "1-9-TLD-20-23-2003",
                 "QDATE", "2003-06-01T00:02:00Z",
                 "DOMAIN", "example.tld",
                 "EXDATE", "2004-06-01T00:02:00Z"));

--- a/core/src/test/java/google/registry/tools/UpdateDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateDomainCommandTest.java
@@ -298,7 +298,7 @@ class UpdateDomainCommandTest extends EppToolCommandTestCase<UpdateDomainCommand
             new DomainHistory.Builder()
                 .setModificationTime(fakeClock.nowUtc())
                 .setType(DOMAIN_CREATE)
-                .setParent(domain)
+                .setDomainContent(domain)
                 .build());
     BillingEvent.Recurring autorenewBillingEvent =
         persistResource(

--- a/core/src/test/resources/google/registry/flows/poll_response_unrenew.xml
+++ b/core/src/test/resources/google/registry/flows/poll_response_unrenew.xml
@@ -3,7 +3,7 @@
     <result code="1301">
       <msg>Command completed successfully; ack to dequeue</msg>
     </result>
-    <msgQ count="1" id="1-8-TLD-19-20-2001">
+    <msgQ count="1" id="1-9-TLD-20-21-2001">
       <qDate>2001-06-07T00:00:00Z</qDate>
       <msg>Domain example.tld was unrenewed by 3 years; now expires at 2003-06-01T00:02:00.000Z.</msg>
     </msgQ>

--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -294,8 +294,8 @@ class google.registry.model.domain.GracePeriod {
   google.registry.model.domain.rgp.GracePeriodStatus type;
   google.registry.persistence.BillingVKey$BillingEventVKey billingEventOneTime;
   google.registry.persistence.BillingVKey$BillingRecurrenceVKey billingEventRecurring;
-  java.lang.Long gracePeriodId;
   java.lang.String clientId;
+  long gracePeriodId;
   org.joda.time.DateTime expirationTime;
 }
 class google.registry.model.domain.Period {


### PR DESCRIPTION
We use DomainCreateFlow as an example here of how this will work. There
were a few changes necessary:

- various changes around GracePeriod / GracePeriodHistory so that we can
actually store them without throwing NPEs
- Creating one injectable *History.Builder field and using in place of
the HistoryEntry.Builder injected field in DomainCreateFlow
- Saving the EppResource as the parent in the *History.Builder setParent
calls
- Converting to/from HistoryEntry/*History classes in
DatastoreTransactionManager. Basically, we'll want to return the
*History subclasses (and similar in the ofy portions of HistoryEntryDao)
- Converting a few HistoryEntry.Builder usages to DomainHistory.Builder
usages. Eventually we should convert all of them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1090)
<!-- Reviewable:end -->
