### PR TITLE
Send an immediate poll message for superuser domain deletes

### DIFF
--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -43,6 +43,7 @@ import static google.registry.util.CollectionUtils.difference;
 import static google.registry.util.CollectionUtils.union;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.isBeforeOrAt;
 import static google.registry.util.DomainNameUtils.ACE_PREFIX_REGEX;
 import static google.registry.util.DomainNameUtils.getTldFromDomainName;
 import static google.registry.util.PreconditionsUtils.checkArgumentPresent;
@@ -918,15 +919,12 @@ public class DatabaseHelper {
                 .collect(toImmutableList()));
   }
 
-  public static ImmutableList<PollMessage> getPollMessages(String clientId, DateTime now) {
+  public static ImmutableList<PollMessage> getPollMessages(String clientId, DateTime beforeOrAt) {
     return transactIfJpaTm(
         () ->
             tm().loadAllOf(PollMessage.class).stream()
                 .filter(pollMessage -> pollMessage.getClientId().equals(clientId))
-                .filter(
-                    pollMessage ->
-                        pollMessage.getEventTime().isEqual(now)
-                            || pollMessage.getEventTime().isBefore(now))
+                .filter(pollMessage -> isBeforeOrAt(pollMessage.getEventTime(), beforeOrAt))
                 .collect(toImmutableList()));
   }
 


### PR DESCRIPTION
This poll message is in addition to the normal poll message that is sent when
the domain's deletion is effective (typically 35 days later). It's needed
because, in the event of a superuser deletion, the owning registrar won't
otherwise necessarily know it's happening.

Note that, in the case of a --immediate superuser deletion, the normal poll
message is already being sent immediately, so this additional poll message is
not necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1096)
<!-- Reviewable:end -->
