### PR TITLE
Skip undefined secrets in keyring migration

### DIFF
--- a/core/src/main/java/google/registry/keyring/kms/KmsKeyring.java
+++ b/core/src/main/java/google/registry/keyring/kms/KmsKeyring.java
@@ -266,7 +266,13 @@ public class KmsKeyring implements Keyring {
             .collect(ImmutableList.toImmutableList());
 
     for (String keyName : labels) {
-      byte[] dsData = getDecryptedDataFromDatastore(keyName);
+      byte[] dsData;
+      try {
+        dsData = getDecryptedDataFromDatastore(keyName);
+      } catch (IllegalStateException e) {
+        logger.atWarning().log("Cannot load %s from Datastore. Skipping...", keyName);
+        continue;
+      }
       byte[] secretStoreData = getDataFromSecretStore(keyName);
       if (Arrays.equals(dsData, secretStoreData)) {
         logger.atInfo().log("%s is already up to date.\n", keyName);


### PR DESCRIPTION
If a secret does not exist in datastore, log and skip it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1098)
<!-- Reviewable:end -->
