### PR TITLE
Convert more tests to use @DualDatabaseTest and SQL in general

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainDeleteFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainDeleteFlow.java
@@ -262,7 +262,6 @@ public final class DomainDeleteFlow implements TransactionalFlow {
             .setHistoryEntry(historyEntry)
             .setEntityChanges(EntityChanges.newBuilder().setSaves(entitiesToSave.build()).build())
             .build());
-    persistEntityChanges(entityChanges);
     BeforeResponseReturnData responseData =
         flowCustomLogic.beforeResponse(
             BeforeResponseParameters.newBuilder()
@@ -272,6 +271,7 @@ public final class DomainDeleteFlow implements TransactionalFlow {
                         : SUCCESS)
                 .setResponseExtensions(getResponseExtensions(existingDomain, now))
                 .build());
+    persistEntityChanges(entityChanges);
     return responseBuilder
         .setResultFromCode(responseData.resultCode())
         .setExtensions(responseData.responseExtensions())

--- a/core/src/main/java/google/registry/flows/host/HostInfoFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostInfoFlow.java
@@ -19,6 +19,7 @@ import static google.registry.flows.ResourceFlowUtils.loadAndVerifyExistence;
 import static google.registry.flows.host.HostFlowUtils.validateHostName;
 import static google.registry.model.EppResourceUtils.isLinked;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.persistence.transaction.TransactionManagerUtil.transactIfJpaTm;
 
 import com.google.common.collect.ImmutableSet;
 import google.registry.flows.EppException;
@@ -76,7 +77,8 @@ public final class HostInfoFlow implements Flow {
     // there is no superordinate domain, the host's own values for these fields will be correct.
     if (host.isSubordinate()) {
       DomainBase superordinateDomain =
-          tm().loadByKey(host.getSuperordinateDomain()).cloneProjectedAtTime(now);
+          transactIfJpaTm(
+              () -> tm().loadByKey(host.getSuperordinateDomain()).cloneProjectedAtTime(now));
       hostInfoDataBuilder
           .setCurrentSponsorClientId(superordinateDomain.getCurrentSponsorClientId())
           .setLastTransferTime(host.computeLastTransferTime(superordinateDomain));

--- a/core/src/test/java/google/registry/flows/EppLifecycleContactTest.java
+++ b/core/src/test/java/google/registry/flows/EppLifecycleContactTest.java
@@ -22,17 +22,23 @@ import static google.registry.testing.EppMetricSubject.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import google.registry.testing.AppEngineExtension;
-import org.junit.jupiter.api.Test;
+import google.registry.testing.DualDatabaseTest;
+import google.registry.testing.TestOfyAndSql;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Tests for contact lifecycle. */
+@DualDatabaseTest
 class EppLifecycleContactTest extends EppTestCase {
 
   @RegisterExtension
   final AppEngineExtension appEngine =
-      AppEngineExtension.builder().withDatastoreAndCloudSql().withTaskQueue().build();
+      AppEngineExtension.builder()
+          .withDatastoreAndCloudSql()
+          .withClock(clock)
+          .withTaskQueue()
+          .build();
 
-  @Test
+  @TestOfyAndSql
   void testContactLifecycle() throws Exception {
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
     assertThatCommand("contact_create_sh8013.xml")
@@ -68,7 +74,7 @@ class EppLifecycleContactTest extends EppTestCase {
     assertThatLogoutSucceeds();
   }
 
-  @Test
+  @TestOfyAndSql
   void testContactTransferPollMessage() throws Exception {
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
     assertThatCommand("contact_create_sh8013.xml")

--- a/core/src/test/java/google/registry/flows/EppLifecycleHostTest.java
+++ b/core/src/test/java/google/registry/flows/EppLifecycleHostTest.java
@@ -27,18 +27,24 @@ import com.google.common.collect.ImmutableMap;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.host.HostResource;
 import google.registry.testing.AppEngineExtension;
+import google.registry.testing.DualDatabaseTest;
+import google.registry.testing.TestOfyAndSql;
 import org.joda.time.DateTime;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Tests for host lifecycle. */
+@DualDatabaseTest
 class EppLifecycleHostTest extends EppTestCase {
 
   @RegisterExtension
   final AppEngineExtension appEngine =
-      AppEngineExtension.builder().withDatastoreAndCloudSql().withTaskQueue().build();
+      AppEngineExtension.builder()
+          .withDatastoreAndCloudSql()
+          .withClock(clock)
+          .withTaskQueue()
+          .build();
 
-  @Test
+  @TestOfyAndSql
   void testLifecycle() throws Exception {
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
     assertThatCommand("hello.xml")
@@ -86,7 +92,7 @@ class EppLifecycleHostTest extends EppTestCase {
     assertThatLogoutSucceeds();
   }
 
-  @Test
+  @TestOfyAndSql
   void testRenamingHostToExistingHost_fails() throws Exception {
     createTld("example");
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
@@ -136,7 +142,7 @@ class EppLifecycleHostTest extends EppTestCase {
     assertThatLogoutSucceeds();
   }
 
-  @Test
+  @TestOfyAndSql
   void testSuccess_multipartTldsWithSharedSuffixes() throws Exception {
     createTlds("bar.foo.tld", "foo.tld", "tld");
 

--- a/core/src/test/java/google/registry/flows/EppTestCase.java
+++ b/core/src/test/java/google/registry/flows/EppTestCase.java
@@ -15,9 +15,10 @@
 package google.registry.flows;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static com.google.common.truth.Truth8.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.getOnlyHistoryEntryOfType;
+import static google.registry.testing.DatabaseHelper.loadAllOf;
 import static google.registry.testing.DatabaseHelper.stripBillingEventId;
 import static google.registry.testing.TestDataHelper.loadFile;
 import static google.registry.xml.XmlTestUtils.assertXmlEqualsWithMessage;
@@ -28,7 +29,6 @@ import static org.joda.time.DateTimeZone.UTC;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.MediaType;
-import com.google.common.truth.Truth8;
 import com.googlecode.objectify.Key;
 import google.registry.flows.EppTestComponent.FakesAndMocksModule;
 import google.registry.model.billing.BillingEvent;
@@ -411,17 +411,13 @@ public class EppTestCase {
    */
   private static Key<OneTime> findKeyToActualOneTimeBillingEvent(OneTime expectedBillingEvent) {
     Optional<OneTime> actualCreateBillingEvent =
-        ofy()
-            .load()
-            .type(BillingEvent.OneTime.class)
-            .list()
-            .stream()
+        loadAllOf(BillingEvent.OneTime.class).stream()
             .filter(
                 b ->
                     Objects.equals(
                         stripBillingEventId(b), stripBillingEventId(expectedBillingEvent)))
             .findFirst();
-    Truth8.assertThat(actualCreateBillingEvent).isPresent();
+    assertThat(actualCreateBillingEvent).isPresent();
     return Key.create(actualCreateBillingEvent.get());
   }
 }

--- a/core/src/test/java/google/registry/model/server/KmsSecretRevisionTest.java
+++ b/core/src/test/java/google/registry/model/server/KmsSecretRevisionTest.java
@@ -15,7 +15,7 @@
 package google.registry.model.server;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.persistence.transaction.TransactionManagerFactory.ofyTm;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -63,6 +63,6 @@ public class KmsSecretRevisionTest {
 
   @Test
   void testPersistence() {
-    assertThat(ofy().load().entity(secretRevision).now()).isEqualTo(secretRevision);
+    assertThat(ofyTm().loadByEntity(secretRevision)).isEqualTo(secretRevision);
   }
 }

--- a/core/src/test/java/google/registry/model/server/KmsSecretTest.java
+++ b/core/src/test/java/google/registry/model/server/KmsSecretTest.java
@@ -15,7 +15,7 @@
 package google.registry.model.server;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.persistence.transaction.TransactionManagerFactory.ofyTm;
 import static google.registry.testing.DatabaseHelper.persistResource;
 
 import google.registry.testing.AppEngineExtension;
@@ -47,6 +47,6 @@ public class KmsSecretTest {
 
   @Test
   void testPersistence() {
-    assertThat(ofy().load().entity(secret).now()).isEqualTo(secret);
+    assertThat(ofyTm().loadByEntity(secret)).isEqualTo(secret);
   }
 }

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistryLockVerifyActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistryLockVerifyActionTest.java
@@ -15,9 +15,9 @@
 package google.registry.ui.server.registrar;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.testing.DatabaseHelper.createTlds;
 import static google.registry.testing.DatabaseHelper.getOnlyHistoryEntryOfType;
+import static google.registry.testing.DatabaseHelper.loadByEntity;
 import static google.registry.testing.DatabaseHelper.newDomainBase;
 import static google.registry.testing.DatabaseHelper.persistActiveHost;
 import static google.registry.testing.DatabaseHelper.persistResource;
@@ -301,7 +301,7 @@ final class RegistryLockVerifyActionTest {
   }
 
   private DomainBase reloadDomain() {
-    return ofy().load().entity(domain).now();
+    return loadByEntity(domain);
   }
 
   private void assertNoDomainChanges() {

--- a/db/src/main/resources/sql/er_diagram/brief_er_diagram.html
+++ b/db/src/main/resources/sql/er_diagram/brief_er_diagram.html
@@ -261,7 +261,7 @@ td.section {
     </tr> 
     <tr> 
      <td class="property_name">generated on</td> 
-     <td class="property_value">2021-04-19 23:14:22.344615</td> 
+     <td class="property_value">2021-04-21 21:56:39.575987</td> 
     </tr> 
     <tr>
      <td class="property_name">last flyway file</td>
@@ -284,7 +284,7 @@ td.section {
      generated on
     </text> 
     <text text-anchor="start" x="4027.94" y="-10.8" font-family="Helvetica,sans-Serif" font-size="14.00">
-     2021-04-19 23:14:22.344615
+     2021-04-21 21:56:39.575987
     </text> 
     <polygon fill="none" stroke="#888888" points="3940.44,-4 3940.44,-44 4205.44,-44 4205.44,-4 3940.44,-4" /> <!-- allocationtoken_a08ccbef --> 
     <g id="node1" class="node"> 

--- a/db/src/main/resources/sql/er_diagram/full_er_diagram.html
+++ b/db/src/main/resources/sql/er_diagram/full_er_diagram.html
@@ -261,7 +261,7 @@ td.section {
     </tr> 
     <tr> 
      <td class="property_name">generated on</td> 
-     <td class="property_value">2021-04-19 23:14:20.274596</td> 
+     <td class="property_value">2021-04-21 21:56:37.513728</td> 
     </tr> 
     <tr>
      <td class="property_name">last flyway file</td>
@@ -284,7 +284,7 @@ td.section {
      generated on
     </text> 
     <text text-anchor="start" x="4656.52" y="-10.8" font-family="Helvetica,sans-Serif" font-size="14.00">
-     2021-04-19 23:14:20.274596
+     2021-04-21 21:56:37.513728
     </text> 
     <polygon fill="none" stroke="#888888" points="4569.02,-4 4569.02,-44 4834.02,-44 4834.02,-4 4569.02,-4" /> <!-- allocationtoken_a08ccbef --> 
     <g id="node1" class="node"> 


### PR DESCRIPTION
Nothing super crazy here other than persisting the entity changes in
DomainDeleteFlow at the end of the flow rather than almost at the end.
This means that when we return the results we give the results as they
were originally present, rather than the subsequently-changed values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1101)
<!-- Reviewable:end -->
