### PR TITLE
Fix Spec11 domain check

### DIFF
--- a/core/src/main/java/google/registry/reporting/spec11/Spec11EmailUtils.java
+++ b/core/src/main/java/google/registry/reporting/spec11/Spec11EmailUtils.java
@@ -141,8 +141,9 @@ public class Spec11EmailUtils {
                                   "fullyQualifiedDomainName",
                                   Comparator.EQ,
                                   threatMatch.fullyQualifiedDomainName())
-                              .getSingleResult()
-                              .shouldPublishToDns())
+                              .stream()
+                              .filter(domain -> domain.shouldPublishToDns())
+                              .count() > 0)
                   .collect(toImmutableList());
             });
     return RegistrarThreatMatches.create(registrarThreatMatches.clientId(), filteredMatches);

--- a/core/src/main/java/google/registry/reporting/spec11/Spec11EmailUtils.java
+++ b/core/src/main/java/google/registry/reporting/spec11/Spec11EmailUtils.java
@@ -136,14 +136,14 @@ public class Spec11EmailUtils {
               return registrarThreatMatches.threatMatches().stream()
                   .filter(
                       threatMatch ->
-                          tm().createQueryComposer(DomainBase.class)
+                          tm()
+                              .createQueryComposer(DomainBase.class)
                               .where(
                                   "fullyQualifiedDomainName",
                                   Comparator.EQ,
                                   threatMatch.fullyQualifiedDomainName())
                               .stream()
-                              .filter(domain -> domain.shouldPublishToDns())
-                              .count() > 0)
+                              .anyMatch(DomainBase::shouldPublishToDns))
                   .collect(toImmutableList());
             });
     return RegistrarThreatMatches.create(registrarThreatMatches.clientId(), filteredMatches);

--- a/core/src/test/java/google/registry/reporting/spec11/Spec11EmailUtilsTest.java
+++ b/core/src/test/java/google/registry/reporting/spec11/Spec11EmailUtilsTest.java
@@ -280,7 +280,6 @@ class Spec11EmailUtilsTest {
         Optional.empty());
   }
 
-
   @TestOfyAndSql
   void testOneFailure_sendsAlert() throws Exception {
     // If there is one failure, we should still send the other message and then an alert email

--- a/core/src/test/java/google/registry/reporting/spec11/Spec11EmailUtilsTest.java
+++ b/core/src/test/java/google/registry/reporting/spec11/Spec11EmailUtilsTest.java
@@ -238,6 +238,50 @@ class Spec11EmailUtilsTest {
   }
 
   @TestOfyAndSql
+  void testSuccess_dealsWithDeletedDomains() throws Exception {
+    // Create an inactive domain and an active domain with the same name.
+    persistResource(loadByEntity(aDomain).asBuilder().addStatusValue(SERVER_HOLD).build());
+    HostResource host = persistActiveHost("ns1.example.com");
+    aDomain = persistDomainWithHost("a.com", host);
+
+    emailUtils.emailSpec11Reports(
+        date,
+        Spec11EmailSoyInfo.MONTHLY_SPEC_11_EMAIL,
+        "Super Cool Registry Monthly Threat Detector [2018-07-15]",
+        sampleThreatMatches());
+    // We inspect individual parameters because Message doesn't implement equals().
+    verify(emailService, times(3)).sendEmail(contentCaptor.capture());
+    List<EmailMessage> capturedContents = contentCaptor.getAllValues();
+    validateMessage(
+        capturedContents.get(0),
+        "abuse@test.com",
+        "the.registrar@example.com",
+        ImmutableList.of("abuse@test.com", "bcc@test.com"),
+        "Super Cool Registry Monthly Threat Detector [2018-07-15]",
+        String.format(MONTHLY_EMAIL_FORMAT, "<tr><td>a.com</td><td>MALWARE</td></tr>"),
+        Optional.of(MediaType.HTML_UTF_8));
+    validateMessage(
+        capturedContents.get(1),
+        "abuse@test.com",
+        "new.registrar@example.com",
+        ImmutableList.of("abuse@test.com", "bcc@test.com"),
+        "Super Cool Registry Monthly Threat Detector [2018-07-15]",
+        String.format(
+            MONTHLY_EMAIL_FORMAT,
+            "<tr><td>b.com</td><td>MALWARE</td></tr><tr><td>c.com</td><td>MALWARE</td></tr>"),
+        Optional.of(MediaType.HTML_UTF_8));
+    validateMessage(
+        capturedContents.get(2),
+        "abuse@test.com",
+        "my-receiver@test.com",
+        ImmutableList.of(),
+        "Spec11 Pipeline Success 2018-07-15",
+        "Spec11 reporting completed successfully.",
+        Optional.empty());
+  }
+
+
+  @TestOfyAndSql
   void testOneFailure_sendsAlert() throws Exception {
     // If there is one failure, we should still send the other message and then an alert email
     LinkedHashSet<RegistrarThreatMatches> matches = new LinkedHashSet<>();


### PR DESCRIPTION
We should be checking to see if there are _any_ active domains for a given
reported domain, not to see if _the_ domain for the name is active.

The last change caused an exception for domains with soft-deleted past domains
of the same name.  The original code only checked the first domain returned
from the query, which may have been soft-deleted.  This version checks all
domain records to see if any are active.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1105)
<!-- Reviewable:end -->
