### PR TITLE
Populate the domain in DomainHistory objects created in Domain flows

### DIFF
--- a/core/src/main/java/google/registry/flows/FlowModule.java
+++ b/core/src/main/java/google/registry/flows/FlowModule.java
@@ -243,7 +243,7 @@ public class FlowModule {
   @Provides
   static DomainHistory.Builder provideDomainHistoryBuilder(
       HistoryEntry.Builder historyEntryBuilder) {
-    return new DomainHistory.Builder().copyFrom(historyEntryBuilder.build());
+    return new DomainHistory.Builder().copyFrom(historyEntryBuilder);
   }
 
   /**

--- a/core/src/main/java/google/registry/flows/FlowUtils.java
+++ b/core/src/main/java/google/registry/flows/FlowUtils.java
@@ -22,15 +22,19 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Throwables;
 import com.google.common.flogger.FluentLogger;
+import com.googlecode.objectify.Key;
 import google.registry.flows.EppException.CommandUseErrorException;
 import google.registry.flows.EppException.ParameterValueRangeErrorException;
 import google.registry.flows.EppException.SyntaxErrorException;
 import google.registry.flows.EppException.UnimplementedProtocolVersionException;
 import google.registry.flows.custom.EntityChanges;
+import google.registry.model.EppResource;
 import google.registry.model.eppcommon.EppXmlTransformer;
 import google.registry.model.eppinput.EppInput.WrongProtocolVersionException;
 import google.registry.model.eppoutput.EppOutput;
 import google.registry.model.host.InetAddressAdapter.IpVersionMismatchException;
+import google.registry.model.ofy.ObjectifyService;
+import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.translators.CurrencyUnitAdapter.UnknownCurrencyException;
 import google.registry.xml.XmlException;
 import java.util.List;
@@ -97,6 +101,11 @@ public final class FlowUtils {
         throw new RuntimeException(e2); // Failing to marshal at all is not recoverable.
       }
     }
+  }
+
+  public static <H extends HistoryEntry> Key<H> createHistoryKey(
+      EppResource parent, Class<H> clazz) {
+    return Key.create(Key.create(parent), clazz, ObjectifyService.allocateId());
   }
 
   /** Registrar is not logged in. */

--- a/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
@@ -14,6 +14,7 @@
 
 package google.registry.flows.domain;
 
+import static google.registry.flows.FlowUtils.createHistoryKey;
 import static google.registry.flows.FlowUtils.validateClientIsLoggedIn;
 import static google.registry.flows.ResourceFlowUtils.loadAndVerifyExistence;
 import static google.registry.flows.ResourceFlowUtils.verifyOptionalAuthInfo;
@@ -49,6 +50,7 @@ import google.registry.model.billing.BillingEvent.OneTime;
 import google.registry.model.billing.BillingEvent.Reason;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.domain.DomainCommand.Update;
+import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.fee.BaseFee.FeeType;
 import google.registry.model.domain.fee.Fee;
 import google.registry.model.domain.fee.FeeTransformResponseExtension;
@@ -117,7 +119,7 @@ public final class DomainRestoreRequestFlow implements TransactionalFlow  {
   @Inject @ClientId String clientId;
   @Inject @TargetId String targetId;
   @Inject @Superuser boolean isSuperuser;
-  @Inject HistoryEntry.Builder historyBuilder;
+  @Inject DomainHistory.Builder historyBuilder;
   @Inject DnsQueue dnsQueue;
   @Inject EppResponse.Builder responseBuilder;
   @Inject DomainPricingLogic pricingLogic;
@@ -142,7 +144,8 @@ public final class DomainRestoreRequestFlow implements TransactionalFlow  {
     Optional<FeeUpdateCommandExtension> feeUpdate =
         eppInput.getSingleExtension(FeeUpdateCommandExtension.class);
     verifyRestoreAllowed(command, existingDomain, feeUpdate, feesAndCredits, now);
-    HistoryEntry historyEntry = buildHistoryEntry(existingDomain, now);
+    Key<DomainHistory> domainHistoryKey = createHistoryKey(existingDomain, DomainHistory.class);
+    historyBuilder.setId(domainHistoryKey.getId());
     ImmutableSet.Builder<ImmutableObject> entitiesToSave = new ImmutableSet.Builder<>();
 
     DateTime newExpirationTime =
@@ -150,29 +153,31 @@ public final class DomainRestoreRequestFlow implements TransactionalFlow  {
     // Restore the expiration time on the deleted domain, except if that's already passed, then add
     // a year and bill for it immediately, with no grace period.
     if (isExpired) {
-      entitiesToSave.add(createRenewBillingEvent(historyEntry, feesAndCredits.getRenewCost(), now));
+      entitiesToSave.add(
+          createRenewBillingEvent(domainHistoryKey, feesAndCredits.getRenewCost(), now));
     }
     // Always bill for the restore itself.
     entitiesToSave.add(
-        createRestoreBillingEvent(historyEntry, feesAndCredits.getRestoreCost(), now));
+        createRestoreBillingEvent(domainHistoryKey, feesAndCredits.getRestoreCost(), now));
 
     BillingEvent.Recurring autorenewEvent =
         newAutorenewBillingEvent(existingDomain)
             .setEventTime(newExpirationTime)
             .setRecurrenceEndTime(END_OF_TIME)
-            .setParent(historyEntry)
+            .setParent(domainHistoryKey)
             .build();
     PollMessage.Autorenew autorenewPollMessage =
         newAutorenewPollMessage(existingDomain)
             .setEventTime(newExpirationTime)
             .setAutorenewEndTime(END_OF_TIME)
-            .setParent(historyEntry)
+            .setParentKey(domainHistoryKey)
             .build();
     DomainBase newDomain =
         performRestore(
             existingDomain, newExpirationTime, autorenewEvent, autorenewPollMessage, now, clientId);
     updateForeignKeyIndexDeletionTime(newDomain);
-    entitiesToSave.add(newDomain, historyEntry, autorenewEvent, autorenewPollMessage);
+    DomainHistory domainHistory = buildDomainHistory(newDomain, now);
+    entitiesToSave.add(newDomain, domainHistory, autorenewEvent, autorenewPollMessage);
     tm().putAll(entitiesToSave.build());
     tm().delete(existingDomain.getDeletePollMessage());
     dnsQueue.addDomainRefreshTask(existingDomain.getDomainName());
@@ -181,15 +186,15 @@ public final class DomainRestoreRequestFlow implements TransactionalFlow  {
         .build();
   }
 
-  private HistoryEntry buildHistoryEntry(DomainBase existingDomain, DateTime now) {
+  private DomainHistory buildDomainHistory(DomainBase newDomain, DateTime now) {
     return historyBuilder
         .setType(HistoryEntry.Type.DOMAIN_RESTORE)
         .setModificationTime(now)
-        .setParent(Key.create(existingDomain))
+        .setDomainContent(newDomain)
         .setDomainTransactionRecords(
             ImmutableSet.of(
                 DomainTransactionRecord.create(
-                    existingDomain.getTld(), now, TransactionReportField.RESTORED_DOMAINS, 1)))
+                    newDomain.getTld(), now, TransactionReportField.RESTORED_DOMAINS, 1)))
         .build();
   }
 
@@ -242,20 +247,19 @@ public final class DomainRestoreRequestFlow implements TransactionalFlow  {
   }
 
   private OneTime createRenewBillingEvent(
-      HistoryEntry historyEntry, Money renewCost, DateTime now) {
-    return prepareBillingEvent(historyEntry, renewCost, now)
-        .setReason(Reason.RENEW)
-        .build();
+      Key<DomainHistory> domainHistoryKey, Money renewCost, DateTime now) {
+    return prepareBillingEvent(domainHistoryKey, renewCost, now).setReason(Reason.RENEW).build();
   }
 
   private BillingEvent.OneTime createRestoreBillingEvent(
-      HistoryEntry historyEntry, Money restoreCost, DateTime now) {
-    return prepareBillingEvent(historyEntry, restoreCost, now)
+      Key<DomainHistory> domainHistoryKey, Money restoreCost, DateTime now) {
+    return prepareBillingEvent(domainHistoryKey, restoreCost, now)
         .setReason(Reason.RESTORE)
         .build();
   }
 
-  private OneTime.Builder prepareBillingEvent(HistoryEntry historyEntry, Money cost, DateTime now) {
+  private OneTime.Builder prepareBillingEvent(
+      Key<DomainHistory> domainHistoryKey, Money cost, DateTime now) {
     return new BillingEvent.OneTime.Builder()
         .setTargetId(targetId)
         .setClientId(clientId)
@@ -263,7 +267,7 @@ public final class DomainRestoreRequestFlow implements TransactionalFlow  {
         .setBillingTime(now)
         .setPeriodYears(1)
         .setCost(cost)
-        .setParent(historyEntry);
+        .setParent(domainHistoryKey);
   }
 
   private static ImmutableList<FeeTransformResponseExtension> createResponseExtensions(

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
@@ -14,6 +14,7 @@
 
 package google.registry.flows.domain;
 
+import static google.registry.flows.FlowUtils.createHistoryKey;
 import static google.registry.flows.FlowUtils.validateClientIsLoggedIn;
 import static google.registry.flows.ResourceFlowUtils.computeExDateForApprovalTime;
 import static google.registry.flows.ResourceFlowUtils.loadAndVerifyExistence;
@@ -51,6 +52,7 @@ import google.registry.flows.exceptions.TransferPeriodMustBeOneYearException;
 import google.registry.flows.exceptions.TransferPeriodZeroAndFeeTransferExtensionException;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.domain.DomainCommand.Transfer;
+import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.Period;
 import google.registry.model.domain.fee.FeeTransferCommandExtension;
 import google.registry.model.domain.fee.FeeTransformResponseExtension;
@@ -126,7 +128,7 @@ public final class DomainTransferRequestFlow implements TransactionalFlow {
   @Inject @ClientId String gainingClientId;
   @Inject @TargetId String targetId;
   @Inject @Superuser boolean isSuperuser;
-  @Inject HistoryEntry.Builder historyBuilder;
+  @Inject DomainHistory.Builder historyBuilder;
   @Inject Trid trid;
   @Inject AsyncTaskEnqueuer asyncTaskEnqueuer;
   @Inject EppResponse.Builder responseBuilder;
@@ -169,7 +171,10 @@ public final class DomainTransferRequestFlow implements TransactionalFlow {
     if (feesAndCredits.isPresent()) {
       validateFeeChallenge(targetId, now, feeTransfer, feesAndCredits.get());
     }
-    HistoryEntry historyEntry = buildHistoryEntry(existingDomain, registry, now, period);
+    Key<DomainHistory> domainHistoryKey = createHistoryKey(existingDomain, DomainHistory.class);
+    historyBuilder
+        .setId(domainHistoryKey.getId())
+        .setOtherClientId(existingDomain.getCurrentSponsorClientId());
     DateTime automaticTransferTime =
         superuserExtension.isPresent()
             ? now.plusDays(superuserExtension.get().getAutomaticTransferLength())
@@ -190,7 +195,7 @@ public final class DomainTransferRequestFlow implements TransactionalFlow {
         createTransferServerApproveEntities(
             automaticTransferTime,
             serverApproveNewExpirationTime,
-            historyEntry,
+            domainHistoryKey,
             existingDomain,
             trid,
             gainingClientId,
@@ -209,9 +214,12 @@ public final class DomainTransferRequestFlow implements TransactionalFlow {
             serverApproveEntities,
             period);
     // Create a poll message to notify the losing registrar that a transfer was requested.
-    PollMessage requestPollMessage = createLosingTransferPollMessage(
-        targetId, pendingTransferData, serverApproveNewExpirationTime, historyEntry)
-            .asBuilder().setEventTime(now).build();
+    PollMessage requestPollMessage =
+        createLosingTransferPollMessage(
+                targetId, pendingTransferData, serverApproveNewExpirationTime, domainHistoryKey)
+            .asBuilder()
+            .setEventTime(now)
+            .build();
     // End the old autorenew event and poll message at the implicit transfer time. This may delete
     // the poll message if it has no events left. Note that if the automatic transfer succeeds, then
     // cloneProjectedAtTime() will replace these old autorenew entities with the server approve ones
@@ -225,10 +233,12 @@ public final class DomainTransferRequestFlow implements TransactionalFlow {
             .setLastEppUpdateTime(now)
             .setLastEppUpdateClientId(gainingClientId)
             .build();
+    DomainHistory domainHistory = buildDomainHistory(newDomain, registry, now, period);
+
     asyncTaskEnqueuer.enqueueAsyncResave(newDomain, now, automaticTransferTime);
     tm().putAll(
             new ImmutableSet.Builder<>()
-                .add(newDomain, historyEntry, requestPollMessage)
+                .add(newDomain, domainHistory, requestPollMessage)
                 .addAll(serverApproveEntities)
                 .build());
     return responseBuilder
@@ -302,14 +312,13 @@ public final class DomainTransferRequestFlow implements TransactionalFlow {
     }
   }
 
-  private HistoryEntry buildHistoryEntry(
-      DomainBase existingDomain, Registry registry, DateTime now, Period period) {
+  private DomainHistory buildDomainHistory(
+      DomainBase newDomain, Registry registry, DateTime now, Period period) {
     return historyBuilder
         .setType(HistoryEntry.Type.DOMAIN_TRANSFER_REQUEST)
-        .setOtherClientId(existingDomain.getCurrentSponsorClientId())
         .setPeriod(period)
         .setModificationTime(now)
-        .setParent(Key.create(existingDomain))
+        .setDomainContent(newDomain)
         .setDomainTransactionRecords(
             ImmutableSet.of(
                 DomainTransactionRecord.create(

--- a/core/src/main/java/google/registry/model/reporting/HistoryEntry.java
+++ b/core/src/main/java/google/registry/model/reporting/HistoryEntry.java
@@ -377,12 +377,16 @@ public class HistoryEntry extends ImmutableObject implements Buildable, Datastor
       return thisCastToDerived();
     }
 
+    public B copyFrom(HistoryEntry.Builder<? extends HistoryEntry, ?> builder) {
+      return copyFrom(builder.getInstance());
+    }
+
     @Override
     public T build() {
       return super.build();
     }
 
-    public B setId(long id) {
+    public B setId(Long id) {
       getInstance().id = id;
       return thisCastToDerived();
     }

--- a/core/src/main/java/google/registry/model/transfer/DomainTransferData.java
+++ b/core/src/main/java/google/registry/model/transfer/DomainTransferData.java
@@ -164,6 +164,7 @@ public class DomainTransferData extends TransferData<DomainTransferData.Builder>
       serverApproveEntities = null;
       postLoad();
     }
+    hashCode = null; // reset the hash code since we may have changed the entities
   }
 
   /**
@@ -271,6 +272,7 @@ public class DomainTransferData extends TransferData<DomainTransferData.Builder>
       serverApproveEntitiesBuilder.add(billingCancellationId);
     }
     serverApproveEntities = forceEmptyToNull(serverApproveEntitiesBuilder.build());
+    hashCode = null; // reset the hash code since we may have changed the entities
   }
 
   @Override

--- a/core/src/test/java/google/registry/flows/EppLifecycleDomainTest.java
+++ b/core/src/test/java/google/registry/flows/EppLifecycleDomainTest.java
@@ -757,11 +757,11 @@ class EppLifecycleDomainTest extends EppTestCase {
         .hasResponse(
             "poll_response_autorenew.xml",
             ImmutableMap.of(
-                "ID", "1-D-EXAMPLE-11-16-2002",
+                "ID", "1-C-EXAMPLE-13-16-2002",
                 "QDATE", "2002-06-01T00:04:00Z",
                 "DOMAIN", "fakesite.example",
                 "EXDATE", "2003-06-01T00:04:00Z"));
-    assertThatCommand("poll_ack.xml", ImmutableMap.of("ID", "1-D-EXAMPLE-11-16-2002"))
+    assertThatCommand("poll_ack.xml", ImmutableMap.of("ID", "1-C-EXAMPLE-13-16-2002"))
         .atTime("2002-07-01T00:02:00Z")
         .hasResponse("poll_ack_response_empty.xml");
 
@@ -775,13 +775,13 @@ class EppLifecycleDomainTest extends EppTestCase {
         .hasResponse(
             "poll_response_autorenew.xml",
             ImmutableMap.of(
-                "ID", "1-D-EXAMPLE-11-16-2003", // Note -- Year is different from previous ID.
+                "ID", "1-C-EXAMPLE-13-16-2003", // Note -- Year is different from previous ID.
                 "QDATE", "2003-06-01T00:04:00Z",
                 "DOMAIN", "fakesite.example",
                 "EXDATE", "2004-06-01T00:04:00Z"));
 
     // Ack the second poll message and verify that none remain.
-    assertThatCommand("poll_ack.xml", ImmutableMap.of("ID", "1-D-EXAMPLE-11-16-2003"))
+    assertThatCommand("poll_ack.xml", ImmutableMap.of("ID", "1-C-EXAMPLE-13-16-2003"))
         .atTime("2003-07-01T00:05:05Z")
         .hasResponse("poll_ack_response_empty.xml");
     assertThatCommand("poll.xml")
@@ -811,7 +811,7 @@ class EppLifecycleDomainTest extends EppTestCase {
 
     // As the losing registrar, read the request poll message, and then ack it.
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
-    String messageId = "1-D-EXAMPLE-19-25-2001";
+    String messageId = "1-C-EXAMPLE-19-25-2001";
     assertThatCommand("poll.xml")
         .atTime("2001-01-01T00:01:00Z")
         .hasResponse("poll_response_domain_transfer_request.xml", ImmutableMap.of("ID", messageId));
@@ -820,7 +820,7 @@ class EppLifecycleDomainTest extends EppTestCase {
         .hasResponse("poll_ack_response_empty.xml");
 
     // Five days in the future, expect a server approval poll message to the loser, and ack it.
-    messageId = "1-D-EXAMPLE-19-24-2001";
+    messageId = "1-C-EXAMPLE-19-24-2001";
     assertThatCommand("poll.xml")
         .atTime("2001-01-06T00:01:00Z")
         .hasResponse(
@@ -832,7 +832,7 @@ class EppLifecycleDomainTest extends EppTestCase {
     assertThatLogoutSucceeds();
 
     // Also expect a server approval poll message to the winner, with the transfer request trid.
-    messageId = "1-D-EXAMPLE-19-23-2001";
+    messageId = "1-C-EXAMPLE-19-23-2001";
     assertThatLoginSucceeds("TheRegistrar", "password2");
     assertThatCommand("poll.xml")
         .atTime("2001-01-06T00:02:00Z")

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -265,6 +265,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         isAnchorTenant
             ? clock.nowUtc().plus(Registry.get(domainTld).getAnchorTenantAddGracePeriodLength())
             : clock.nowUtc().plus(Registry.get(domainTld).getAddGracePeriodLength());
+    assertLastHistoryContainsResource(domain);
     HistoryEntry historyEntry = getHistoryEntries(domain).get(0);
     assertAboutDomains()
         .that(domain)

--- a/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
@@ -456,6 +456,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     // where the expirationTime advances and the grace period appears, but since the delete flow
     // closed the autorenew recurrences immediately, there are no other autorenew effects.
     assertAboutDomains().that(resource).hasRegistrationExpirationTime(expectedExpirationTime);
+    assertLastHistoryContainsResource(resource);
     // All existing grace periods that were for billable actions should cause cancellations.
     assertAutorenewClosedAndCancellationCreatedFor(
         renewBillingEvent, getOnlyHistoryEntryOfType(resource, DOMAIN_DELETE));

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferCancelFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferCancelFlowTest.java
@@ -132,6 +132,7 @@ class DomainTransferCancelFlowTest
 
     // Transfer should have been cancelled. Verify correct fields were set.
     domain = reloadResourceByForeignKey();
+    assertLastHistoryContainsResource(domain);
     assertTransferFailed(domain, TransferStatus.CLIENT_CANCELLED, originalTransferData);
     assertAboutDomains()
         .that(domain)

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRejectFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRejectFlowTest.java
@@ -119,6 +119,7 @@ class DomainTransferRejectFlowTest
     final HistoryEntry historyEntryTransferRejected =
         getOnlyHistoryEntryOfType(domain, DOMAIN_TRANSFER_REJECT);
     assertAboutHistoryEntries().that(historyEntryTransferRejected).hasOtherClientId("NewRegistrar");
+    assertLastHistoryContainsResource(domain);
     // The only billing event left should be the original autorenew event, now reopened.
     assertBillingEvents(
         getLosingClientAutorenewEvent().asBuilder().setRecurrenceEndTime(END_OF_TIME).build());

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
@@ -484,6 +484,7 @@ class DomainTransferRequestFlowTest
     assertAboutDomains()
         .that(domain)
         .hasOneHistoryEntryEachOfTypes(DOMAIN_CREATE, DOMAIN_TRANSFER_REQUEST);
+    assertLastHistoryContainsResource(domain);
     final HistoryEntry historyEntryTransferRequest =
         getOnlyHistoryEntryOfType(domain, DOMAIN_TRANSFER_REQUEST);
     assertAboutHistoryEntries()

--- a/core/src/test/java/google/registry/tools/EppLifecycleToolsTest.java
+++ b/core/src/test/java/google/registry/tools/EppLifecycleToolsTest.java
@@ -108,7 +108,7 @@ class EppLifecycleToolsTest extends EppTestCase {
         .atTime("2001-06-08T00:00:00Z")
         .hasResponse("poll_response_unrenew.xml");
 
-    assertThatCommand("poll_ack.xml", ImmutableMap.of("ID", "1-9-TLD-20-21-2001"))
+    assertThatCommand("poll_ack.xml", ImmutableMap.of("ID", "1-8-TLD-21-22-2001"))
         .atTime("2001-06-08T00:00:01Z")
         .hasResponse("poll_ack_response_empty.xml");
 
@@ -129,7 +129,7 @@ class EppLifecycleToolsTest extends EppTestCase {
         .hasResponse(
             "poll_response_autorenew.xml",
             ImmutableMap.of(
-                "ID", "1-9-TLD-20-23-2003",
+                "ID", "1-8-TLD-21-24-2003",
                 "QDATE", "2003-06-01T00:02:00Z",
                 "DOMAIN", "example.tld",
                 "EXDATE", "2004-06-01T00:02:00Z"));

--- a/core/src/test/resources/google/registry/flows/poll_response_unrenew.xml
+++ b/core/src/test/resources/google/registry/flows/poll_response_unrenew.xml
@@ -3,7 +3,7 @@
     <result code="1301">
       <msg>Command completed successfully; ack to dequeue</msg>
     </result>
-    <msgQ count="1" id="1-9-TLD-20-21-2001">
+    <msgQ count="1" id="1-8-TLD-21-22-2001">
       <qDate>2001-06-07T00:00:00Z</qDate>
       <msg>Domain example.tld was unrenewed by 3 years; now expires at 2003-06-01T00:02:00.000Z.</msg>
     </msgQ>

--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -6,7 +6,7 @@ class google.registry.model.UpdateAutoTimestamp {
 }
 class google.registry.model.billing.BillingEvent$Cancellation {
   @Id java.lang.Long id;
-  @Parent com.googlecode.objectify.Key<google.registry.model.reporting.HistoryEntry> parent;
+  @Parent com.googlecode.objectify.Key<? extends google.registry.model.reporting.HistoryEntry> parent;
   google.registry.model.billing.BillingEvent$Reason reason;
   google.registry.persistence.BillingVKey$BillingEventVKey refOneTime;
   google.registry.persistence.BillingVKey$BillingRecurrenceVKey refRecurring;
@@ -27,7 +27,7 @@ enum google.registry.model.billing.BillingEvent$Flag {
 }
 class google.registry.model.billing.BillingEvent$Modification {
   @Id java.lang.Long id;
-  @Parent com.googlecode.objectify.Key<google.registry.model.reporting.HistoryEntry> parent;
+  @Parent com.googlecode.objectify.Key<? extends google.registry.model.reporting.HistoryEntry> parent;
   com.googlecode.objectify.Key<google.registry.model.billing.BillingEvent$OneTime> eventRef;
   google.registry.model.billing.BillingEvent$Reason reason;
   java.lang.String clientId;
@@ -39,7 +39,7 @@ class google.registry.model.billing.BillingEvent$Modification {
 }
 class google.registry.model.billing.BillingEvent$OneTime {
   @Id java.lang.Long id;
-  @Parent com.googlecode.objectify.Key<google.registry.model.reporting.HistoryEntry> parent;
+  @Parent com.googlecode.objectify.Key<? extends google.registry.model.reporting.HistoryEntry> parent;
   google.registry.model.billing.BillingEvent$Reason reason;
   google.registry.persistence.VKey<google.registry.model.billing.BillingEvent$Recurring> cancellationMatchingBillingEvent;
   google.registry.persistence.VKey<google.registry.model.domain.token.AllocationToken> allocationToken;
@@ -63,7 +63,7 @@ enum google.registry.model.billing.BillingEvent$Reason {
 }
 class google.registry.model.billing.BillingEvent$Recurring {
   @Id java.lang.Long id;
-  @Parent com.googlecode.objectify.Key<google.registry.model.reporting.HistoryEntry> parent;
+  @Parent com.googlecode.objectify.Key<? extends google.registry.model.reporting.HistoryEntry> parent;
   google.registry.model.billing.BillingEvent$Reason reason;
   google.registry.model.common.TimeOfYear recurrenceTimeOfYear;
   java.lang.String clientId;


### PR DESCRIPTION
Unfortunately, much of the time there's a bit of a circular dependency
in the object creation, e.g. the Domain object stores references to the
billing events which store references to the history object which
contains the Domain object. As a result, we sort of need to create the
history object twice.

In addition, we add a utility copyFrom method in HistoryEntry.Builder to
avoid unnecessary ID allocations.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1106)
<!-- Reviewable:end -->
