### PR TITLE
Populate the contact in ContactHistory objects created in Contact flows

### DIFF
--- a/core/src/main/java/google/registry/flows/FlowModule.java
+++ b/core/src/main/java/google/registry/flows/FlowModule.java
@@ -20,6 +20,7 @@ import com.google.common.base.Strings;
 import dagger.Module;
 import dagger.Provides;
 import google.registry.flows.picker.FlowPicker;
+import google.registry.model.contact.ContactHistory;
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.metadata.MetadataExtension;
 import google.registry.model.eppcommon.AuthInfo;
@@ -238,6 +239,12 @@ public class FlowModule {
           .setRequestedByRegistrar(metadataExtension.get().getRequestedByRegistrar());
     }
     return historyBuilder;
+  }
+
+  @Provides
+  static ContactHistory.Builder provideContactHistoryBuilder(
+      HistoryEntry.Builder historyEntryBuilder) {
+    return new ContactHistory.Builder().copyFrom(historyEntryBuilder);
   }
 
   @Provides

--- a/core/src/main/java/google/registry/flows/contact/ContactCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactCreateFlow.java
@@ -33,6 +33,7 @@ import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.exceptions.ResourceAlreadyExistsForThisClientException;
 import google.registry.flows.exceptions.ResourceCreateContentionException;
 import google.registry.model.contact.ContactCommand.Create;
+import google.registry.model.contact.ContactHistory;
 import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.metadata.MetadataExtension;
 import google.registry.model.eppinput.ResourceCommand;
@@ -61,7 +62,7 @@ public final class ContactCreateFlow implements TransactionalFlow {
   @Inject ExtensionManager extensionManager;
   @Inject @ClientId String clientId;
   @Inject @TargetId String targetId;
-  @Inject HistoryEntry.Builder historyBuilder;
+  @Inject ContactHistory.Builder historyBuilder;
   @Inject EppResponse.Builder responseBuilder;
   @Inject @Config("contactAndHostRoidSuffix") String roidSuffix;
   @Inject ContactCreateFlow() {}
@@ -93,12 +94,12 @@ public final class ContactCreateFlow implements TransactionalFlow {
     historyBuilder
         .setType(HistoryEntry.Type.CONTACT_CREATE)
         .setModificationTime(now)
-        .setXmlBytes(null)  // We don't want to store contact details in the history entry.
-        .setParent(Key.create(newContact));
+        .setXmlBytes(null) // We don't want to store contact details in the history entry.
+        .setContactBase(newContact);
     tm().insertAll(
             ImmutableSet.of(
                 newContact,
-                historyBuilder.build().toChildHistoryEntity(),
+                historyBuilder.build(),
                 ForeignKeyIndex.create(newContact, newContact.getDeletionTime()),
                 EppResourceIndex.create(Key.create(newContact))));
     return responseBuilder

--- a/core/src/main/java/google/registry/flows/contact/ContactDeleteFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactDeleteFlow.java
@@ -24,7 +24,6 @@ import static google.registry.model.eppoutput.Result.Code.SUCCESS_WITH_ACTION_PE
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.google.common.collect.ImmutableSet;
-import com.googlecode.objectify.Key;
 import google.registry.batch.AsyncTaskEnqueuer;
 import google.registry.flows.EppException;
 import google.registry.flows.ExtensionManager;
@@ -33,6 +32,7 @@ import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
 import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
+import google.registry.model.contact.ContactHistory;
 import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.domain.metadata.MetadataExtension;
@@ -74,7 +74,7 @@ public final class ContactDeleteFlow implements TransactionalFlow {
   @Inject Trid trid;
   @Inject @Superuser boolean isSuperuser;
   @Inject Optional<AuthInfo> authInfo;
-  @Inject HistoryEntry.Builder historyBuilder;
+  @Inject ContactHistory.Builder historyBuilder;
   @Inject AsyncTaskEnqueuer asyncTaskEnqueuer;
   @Inject EppResponse.Builder responseBuilder;
   @Inject ContactDeleteFlow() {}
@@ -99,8 +99,8 @@ public final class ContactDeleteFlow implements TransactionalFlow {
     historyBuilder
         .setType(HistoryEntry.Type.CONTACT_PENDING_DELETE)
         .setModificationTime(now)
-        .setParent(Key.create(existingContact));
-    tm().insert(historyBuilder.build().toChildHistoryEntity());
+        .setContactBase(newContact);
+    tm().insert(historyBuilder.build());
     tm().update(newContact);
     return responseBuilder.setResultFromCode(SUCCESS_WITH_ACTION_PENDING).build();
   }

--- a/core/src/main/java/google/registry/flows/contact/ContactTransferApproveFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactTransferApproveFlow.java
@@ -32,6 +32,7 @@ import google.registry.flows.FlowModule.ClientId;
 import google.registry.flows.FlowModule.TargetId;
 import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
+import google.registry.model.contact.ContactHistory;
 import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.metadata.MetadataExtension;
 import google.registry.model.eppcommon.AuthInfo;
@@ -66,7 +67,7 @@ public final class ContactTransferApproveFlow implements TransactionalFlow {
   @Inject @ClientId String clientId;
   @Inject @TargetId String targetId;
   @Inject Optional<AuthInfo> authInfo;
-  @Inject HistoryEntry.Builder historyBuilder;
+  @Inject ContactHistory.Builder historyBuilder;
   @Inject EppResponse.Builder responseBuilder;
   @Inject ContactTransferApproveFlow() {}
 
@@ -86,15 +87,17 @@ public final class ContactTransferApproveFlow implements TransactionalFlow {
     verifyResourceOwnership(clientId, existingContact);
     ContactResource newContact =
         approvePendingTransfer(existingContact, TransferStatus.CLIENT_APPROVED, now);
-    HistoryEntry historyEntry = historyBuilder
-        .setType(HistoryEntry.Type.CONTACT_TRANSFER_APPROVE)
-        .setModificationTime(now)
-        .setParent(Key.create(existingContact))
-        .build();
+    ContactHistory contactHistory =
+        historyBuilder
+            .setType(HistoryEntry.Type.CONTACT_TRANSFER_APPROVE)
+            .setModificationTime(now)
+            .setContactBase(newContact)
+            .build();
     // Create a poll message for the gaining client.
     PollMessage gainingPollMessage =
-        createGainingTransferPollMessage(targetId, newContact.getTransferData(), historyEntry);
-    tm().insertAll(ImmutableSet.of(historyEntry.toChildHistoryEntity(), gainingPollMessage));
+        createGainingTransferPollMessage(
+            targetId, newContact.getTransferData(), now, Key.create(contactHistory));
+    tm().insertAll(ImmutableSet.of(contactHistory, gainingPollMessage));
     tm().update(newContact);
     // Delete the billing event and poll messages that were written in case the transfer would have
     // been implicitly server approved.

--- a/core/src/main/java/google/registry/flows/contact/ContactTransferRejectFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactTransferRejectFlow.java
@@ -32,6 +32,7 @@ import google.registry.flows.FlowModule.ClientId;
 import google.registry.flows.FlowModule.TargetId;
 import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
+import google.registry.model.contact.ContactHistory;
 import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.metadata.MetadataExtension;
 import google.registry.model.eppcommon.AuthInfo;
@@ -64,7 +65,7 @@ public final class ContactTransferRejectFlow implements TransactionalFlow {
   @Inject Optional<AuthInfo> authInfo;
   @Inject @ClientId String clientId;
   @Inject @TargetId String targetId;
-  @Inject HistoryEntry.Builder historyBuilder;
+  @Inject ContactHistory.Builder historyBuilder;
   @Inject EppResponse.Builder responseBuilder;
   @Inject ContactTransferRejectFlow() {}
 
@@ -80,14 +81,16 @@ public final class ContactTransferRejectFlow implements TransactionalFlow {
     verifyResourceOwnership(clientId, existingContact);
     ContactResource newContact =
         denyPendingTransfer(existingContact, TransferStatus.CLIENT_REJECTED, now, clientId);
-    HistoryEntry historyEntry = historyBuilder
-        .setType(HistoryEntry.Type.CONTACT_TRANSFER_REJECT)
-        .setModificationTime(now)
-        .setParent(Key.create(existingContact))
-        .build();
+    ContactHistory contactHistory =
+        historyBuilder
+            .setType(HistoryEntry.Type.CONTACT_TRANSFER_REJECT)
+            .setModificationTime(now)
+            .setContactBase(newContact)
+            .build();
     PollMessage gainingPollMessage =
-        createGainingTransferPollMessage(targetId, newContact.getTransferData(), historyEntry);
-    tm().insertAll(ImmutableSet.of(historyEntry.toChildHistoryEntity(), gainingPollMessage));
+        createGainingTransferPollMessage(
+            targetId, newContact.getTransferData(), now, Key.create(contactHistory));
+    tm().insertAll(ImmutableSet.of(contactHistory, gainingPollMessage));
     tm().update(newContact);
     // Delete the billing event and poll messages that were written in case the transfer would have
     // been implicitly server approved.

--- a/core/src/main/java/google/registry/model/contact/ContactBase.java
+++ b/core/src/main/java/google/registry/model/contact/ContactBase.java
@@ -287,7 +287,7 @@ public class ContactBase extends EppResource implements ResourceWithTransferData
   }
 
   @Override
-  public Builder asBuilder() {
+  public Builder<? extends ContactBase, ?> asBuilder() {
     return new Builder<>(clone(this));
   }
 

--- a/core/src/main/java/google/registry/model/contact/ContactHistory.java
+++ b/core/src/main/java/google/registry/model/contact/ContactHistory.java
@@ -109,6 +109,9 @@ public class ContactHistory extends HistoryEntry implements SqlEntity {
     if (contactBase != null && contactBase.getContactId() == null) {
       contactBase = null;
     }
+    if (contactBase != null && contactBase.getRepoId() == null) {
+      contactBase = contactBase.asBuilder().setRepoId(parent.getName()).build();
+    }
   }
 
   // In Datastore, save as a HistoryEntry object regardless of this object's type

--- a/core/src/test/java/google/registry/flows/ResourceFlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/ResourceFlowTestCase.java
@@ -193,7 +193,10 @@ public abstract class ResourceFlowTestCase<F extends Flow, R extends EppResource
       HistoryEntry historyEntry = Iterables.getLast(DatabaseHelper.getHistoryEntries(resource));
       if (resource instanceof ContactBase) {
         ContactHistory contactHistory = (ContactHistory) historyEntry;
-        assertThat(contactHistory.getContactBase().get()).isEqualTo(resource);
+        // Don't use direct equals comparison since one might be a subclass of the other
+        assertAboutImmutableObjects()
+            .that(contactHistory.getContactBase().get())
+            .isEqualExceptFields(resource);
       } else if (resource instanceof DomainContent) {
         DomainHistory domainHistory = (DomainHistory) historyEntry;
         assertAboutImmutableObjects()

--- a/core/src/test/java/google/registry/flows/contact/ContactCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactCreateFlowTest.java
@@ -56,14 +56,13 @@ class ContactCreateFlowTest extends ResourceFlowTestCase<ContactCreateFlow, Cont
     assertTransactionalFlow(true);
     runFlowAssertResponse(loadFile("contact_create_response.xml"));
     // Check that the contact was created and persisted with a history entry.
-    assertAboutContacts()
-        .that(reloadResourceByForeignKey())
-        .hasOnlyOneHistoryEntryWhich()
-        .hasNoXml();
+    ContactResource contact = reloadResourceByForeignKey();
+    assertAboutContacts().that(contact).hasOnlyOneHistoryEntryWhich().hasNoXml();
     assertNoBillingEvents();
     if (tm().isOfy()) {
-      assertEppResourceIndexEntityFor(reloadResourceByForeignKey());
+      assertEppResourceIndexEntityFor(contact);
     }
+    assertLastHistoryContainsResource(contact);
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/contact/ContactDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactDeleteFlowTest.java
@@ -78,6 +78,7 @@ class ContactDeleteFlowTest extends ResourceFlowTestCase<ContactDeleteFlow, Cont
         .hasOnlyOneHistoryEntryWhich()
         .hasType(HistoryEntry.Type.CONTACT_PENDING_DELETE);
     assertNoBillingEvents();
+    assertLastHistoryContainsResource(deletedContact);
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferApproveFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferApproveFlowTest.java
@@ -120,6 +120,7 @@ class ContactTransferApproveFlowTest
     assertThat(panData.getTrid())
         .isEqualTo(Trid.create("transferClient-trid", "transferServer-trid"));
     assertThat(panData.getActionResult()).isTrue();
+    assertLastHistoryContainsResource(contact);
   }
 
   private void doFailingTest(String commandFilename) throws Exception {

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferCancelFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferCancelFlowTest.java
@@ -104,6 +104,7 @@ class ContactTransferCancelFlowTest
                 .collect(onlyElement())
                 .getTransferStatus())
         .isEqualTo(TransferStatus.CLIENT_CANCELLED);
+    assertLastHistoryContainsResource(contact);
   }
 
   private void doFailingTest(String commandFilename) throws Exception {

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferRejectFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferRejectFlowTest.java
@@ -119,6 +119,7 @@ class ContactTransferRejectFlowTest
         .isEqualTo(Trid.create("transferClient-trid", "transferServer-trid"));
     assertThat(panData.getActionResult()).isFalse();
     assertNoBillingEvents();
+    assertLastHistoryContainsResource(contact);
   }
 
   private void doFailingTest(String commandFilename) throws Exception {

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferRequestFlowTest.java
@@ -137,6 +137,7 @@ class ContactTransferRequestFlowTest
         Iterables.filter(
             loadByKeys(contact.getTransferData().getServerApproveEntities()), PollMessage.class),
         ImmutableList.of(gainingApproveMessage, losingApproveMessage));
+    assertLastHistoryContainsResource(contact);
   }
 
   private void doFailingTest(String commandFilename) throws Exception {

--- a/core/src/test/java/google/registry/flows/contact/ContactUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactUpdateFlowTest.java
@@ -64,12 +64,16 @@ class ContactUpdateFlowTest extends ResourceFlowTestCase<ContactUpdateFlow, Cont
     clock.advanceOneMilli();
     assertTransactionalFlow(true);
     runFlowAssertResponse(loadFile("generic_success_response.xml"));
+    ContactResource contact = reloadResourceByForeignKey();
     // Check that the contact was updated. This value came from the xml.
-    assertAboutContacts().that(reloadResourceByForeignKey())
-        .hasAuthInfoPwd("2fooBAR").and()
+    assertAboutContacts()
+        .that(contact)
+        .hasAuthInfoPwd("2fooBAR")
+        .and()
         .hasOnlyOneHistoryEntryWhich()
         .hasNoXml();
     assertNoBillingEvents();
+    assertLastHistoryContainsResource(contact);
   }
 
   @TestOfyAndSql


### PR DESCRIPTION
Minimal interesting changes here
- a bit of reconstruction in ContactHistory to get the repo ID from the
key
- making the History revision ID Long instead of long so that it can be
null in non-built intermediate entities
- adding a copyFrom(HistoryEntry.Builder) method in HistoryEntry.Builder
so that we don't need to allocate quite as many unnecessary IDs, i.e.
removing the .build() lines in provideContactHistory and
provideDomainHistory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1111)
<!-- Reviewable:end -->
