### PR TITLE
Always detach entities during load

### DIFF
--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -36,7 +36,9 @@ import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.OneToMany;
+import javax.persistence.PostLoad;
 import javax.persistence.Table;
+import org.hibernate.Hibernate;
 import org.joda.time.DateTime;
 
 /**
@@ -74,6 +76,8 @@ public class DomainBase extends DomainContent
     return super.getRepoId();
   }
 
+  // It seems like this should be FetchType.EAGER, but for some reason when we do that we get a lazy
+  // load error during the load of a domain.
   @ElementCollection
   @JoinTable(
       name = "DomainHost",
@@ -133,6 +137,19 @@ public class DomainBase extends DomainContent
   @SuppressWarnings("UnusedMethod")
   private Set<DelegationSignerData> getInternalDelegationSignerData() {
     return dsData;
+  }
+
+  /**
+   * Post-load method to eager load the collections.
+   *
+   * <p>We've named this "postLoad2" because there's already a "postLoad" in DomainContent and our
+   * code to invoke all post-loads doesn't seem to call both if they have the same name.
+   */
+  @PostLoad
+  @SuppressWarnings("UnusedMethod")
+  private void postLoad2() {
+    Hibernate.initialize(getInternalDelegationSignerData());
+    Hibernate.initialize(getInternalGracePeriods());
   }
 
   @Override

--- a/core/src/main/java/google/registry/model/domain/DomainHistory.java
+++ b/core/src/main/java/google/registry/model/domain/DomainHistory.java
@@ -54,6 +54,7 @@ import javax.persistence.JoinTable;
 import javax.persistence.OneToMany;
 import javax.persistence.PostLoad;
 import javax.persistence.Table;
+import org.hibernate.Hibernate;
 
 /**
  * A persisted history entry representing an EPP modification to a domain.
@@ -256,6 +257,12 @@ public class DomainHistory extends HistoryEntry implements SqlEntity {
         }
       }
     }
+
+    // Eager fetch doesn't seem to work for this, so we do it explicitly.
+    Hibernate.initialize(getDomainTransactionRecords());
+    Hibernate.initialize(getNsHosts());
+    Hibernate.initialize(dsDataHistories);
+    Hibernate.initialize(gracePeriodHistories);
   }
 
   // In Datastore, save as a HistoryEntry object regardless of this object's type

--- a/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
+++ b/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
@@ -285,8 +285,9 @@ public class DatastoreTransactionManager implements TransactionManager {
   }
 
   @Override
-  public void delete(Object entity) {
+  public <T> T delete(T entity) {
     syncIfTransactionless(getOfy().delete().entity(entity));
+    return entity;
   }
 
   @Override

--- a/core/src/main/java/google/registry/model/registry/label/PremiumList.java
+++ b/core/src/main/java/google/registry/model/registry/label/PremiumList.java
@@ -55,6 +55,7 @@ import javax.persistence.PostLoad;
 import javax.persistence.PrePersist;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+import org.hibernate.Hibernate;
 import org.hibernate.LazyInitializationException;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
@@ -319,5 +320,6 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
   @PostLoad
   void postLoad() {
     creationTime = lastUpdateTime;
+    Hibernate.initialize(labelsToPrices);
   }
 }

--- a/core/src/main/java/google/registry/model/registry/label/ReservedList.java
+++ b/core/src/main/java/google/registry/model/registry/label/ReservedList.java
@@ -52,7 +52,9 @@ import javax.persistence.Embeddable;
 import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.MapKeyColumn;
+import javax.persistence.PostLoad;
 import javax.persistence.Table;
+import org.hibernate.Hibernate;
 import org.joda.time.DateTime;
 
 /**
@@ -81,6 +83,11 @@ public final class ReservedList
 
   @Column(nullable = false)
   boolean shouldPublish = true;
+
+  @PostLoad
+  void postLoad() {
+    Hibernate.initialize(reservedListMap);
+  }
 
   /**
    * A reserved list entry entity, persisted to Datastore, that represents a single label and its

--- a/core/src/main/java/google/registry/model/tmch/ClaimsListShard.java
+++ b/core/src/main/java/google/registry/model/tmch/ClaimsListShard.java
@@ -58,8 +58,10 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.JoinColumn;
 import javax.persistence.MapKeyColumn;
+import javax.persistence.PostLoad;
 import javax.persistence.Table;
 import javax.persistence.Transient;
+import org.hibernate.Hibernate;
 import org.joda.time.DateTime;
 
 /**
@@ -136,6 +138,12 @@ public class ClaimsListShard extends ImmutableObject implements NonReplicatedEnt
   @Ignore @Transient boolean isShard = false;
 
   private static final Retrier LOADER_RETRIER = new Retrier(new SystemSleeper(), 2);
+
+  @PostLoad
+  @SuppressWarnings("UnusedMethod")
+  private void postLoad() {
+    Hibernate.initialize(labelsToKeys);
+  }
 
   private static Optional<ClaimsListShard> loadClaimsListShard() {
     // Find the most recent revision.

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -51,6 +51,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+import javax.annotation.Nullable;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.EntityTransaction;
@@ -392,7 +393,8 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   public <T> Optional<T> loadByKeyIfPresent(VKey<T> key) {
     checkArgumentNotNull(key, "key must be specified");
     assertInTransaction();
-    return Optional.ofNullable(getEntityManager().find(key.getKind(), key.getSqlKey()));
+    return Optional.ofNullable(getEntityManager().find(key.getKind(), key.getSqlKey()))
+        .map(this::detach);
   }
 
   @Override
@@ -406,7 +408,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
         .map(
             key ->
                 new SimpleEntry<VKey<? extends T>, T>(
-                    key, getEntityManager().find(key.getKind(), key.getSqlKey())))
+                    key, detach(getEntityManager().find(key.getKind(), key.getSqlKey()))))
         .filter(entry -> entry.getValue() != null)
         .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
   }
@@ -428,7 +430,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
     if (result == null) {
       throw new NoSuchElementException(key.toString());
     }
-    return result;
+    return detach(result);
   }
 
   @Override
@@ -468,12 +470,12 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   public <T> ImmutableList<T> loadAllOf(Class<T> clazz) {
     checkArgumentNotNull(clazz, "clazz must be specified");
     assertInTransaction();
-    return ImmutableList.copyOf(
-        getEntityManager()
-            .createQuery(
-                String.format("SELECT entity FROM %s entity", getEntityType(clazz).getName()),
-                clazz)
-            .getResultList());
+    return getEntityManager()
+        .createQuery(
+            String.format("SELECT entity FROM %s entity", getEntityType(clazz).getName()), clazz)
+        .getResultStream()
+        .map(this::detach)
+        .collect(toImmutableList());
   }
 
   private int internalDelete(VKey<?> key) {
@@ -505,18 +507,19 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   }
 
   @Override
-  public void delete(Object entity) {
+  public <T> T delete(T entity) {
     checkArgumentNotNull(entity, "entity must be specified");
     if (isEntityOfIgnoredClass(entity)) {
-      return;
+      return entity;
     }
     assertInTransaction();
     entity = toChildHistoryEntryIfPossible(entity);
-    Object managedEntity = entity;
+    T managedEntity = entity;
     if (!getEntityManager().contains(entity)) {
       managedEntity = getEntityManager().merge(entity);
     }
     getEntityManager().remove(managedEntity);
+    return managedEntity;
   }
 
   @Override
@@ -536,7 +539,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
 
   @Override
   public <T> QueryComposer<T> createQueryComposer(Class<T> entity) {
-    return new JpaQueryComposerImpl<T>(entity, getEntityManager());
+    return new JpaQueryComposerImpl<T>(entity);
   }
 
   @Override
@@ -639,6 +642,15 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
     }
   }
 
+  /** Detach the entity, suitable for use in Optional.map(). */
+  @Nullable
+  private <T> T detach(@Nullable T entity) {
+    if (entity != null) {
+      getEntityManager().detach(entity);
+    }
+    return entity;
+  }
+
   private static class TransactionInfo {
     EntityManager entityManager;
     boolean inTransaction = false;
@@ -691,17 +703,15 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
     }
   }
 
-  private static class JpaQueryComposerImpl<T> extends QueryComposer<T> {
+  private class JpaQueryComposerImpl<T> extends QueryComposer<T> {
 
-    EntityManager em;
-
-    JpaQueryComposerImpl(Class<T> entityClass, EntityManager em) {
+    JpaQueryComposerImpl(Class<T> entityClass) {
       super(entityClass);
-      this.em = em;
     }
 
     private TypedQuery<T> buildQuery() {
-      CriteriaQueryBuilder<T> queryBuilder = CriteriaQueryBuilder.create(em, entityClass);
+      CriteriaQueryBuilder<T> queryBuilder =
+          CriteriaQueryBuilder.create(getEntityManager(), entityClass);
       return addCriteria(queryBuilder);
     }
 
@@ -714,28 +724,29 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
         queryBuilder.orderByAsc(orderBy);
       }
 
-      return em.createQuery(queryBuilder.build());
+      return getEntityManager().createQuery(queryBuilder.build());
     }
 
     @Override
     public Optional<T> first() {
       List<T> results = buildQuery().setMaxResults(1).getResultList();
-      return results.size() > 0 ? Optional.of(results.get(0)) : Optional.empty();
+      return results.size() > 0 ? Optional.of(detach(results.get(0))) : Optional.empty();
     }
 
     @Override
     public T getSingleResult() {
-      return buildQuery().getSingleResult();
+      return detach(buildQuery().getSingleResult());
     }
 
     @Override
     public Stream<T> stream() {
-      return buildQuery().getResultStream();
+      return buildQuery().getResultStream().map(JpaTransactionManagerImpl.this::detach);
     }
 
     @Override
     public long count() {
-      CriteriaQueryBuilder<Long> queryBuilder = CriteriaQueryBuilder.createCount(em, entityClass);
+      CriteriaQueryBuilder<Long> queryBuilder =
+          CriteriaQueryBuilder.createCount(getEntityManager(), entityClass);
       return addCriteria(queryBuilder).getSingleResult();
     }
   }

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
@@ -252,8 +252,13 @@ public interface TransactionManager {
   /** Deletes the set of entities by their key id. */
   void delete(Iterable<? extends VKey<?>> keys);
 
-  /** Deletes the given entity from the database. */
-  void delete(Object entity);
+  /**
+   * Deletes the given entity from the database.
+   *
+   * <p>This returns the deleted entity, which may not necessarily be the same as the original
+   * entity passed in.
+   */
+  <T> T delete(T entity);
 
   /**
    * Deletes the entity by its id without writing commit logs if the underlying database is

--- a/core/src/test/java/google/registry/persistence/transaction/QueryComposerTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/QueryComposerTest.java
@@ -27,6 +27,7 @@ import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Index;
 import google.registry.model.ImmutableObject;
 import google.registry.testing.AppEngineExtension;
+import google.registry.testing.DatabaseHelper;
 import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.FakeClock;
 import google.registry.testing.TestOfyAndSql;
@@ -73,16 +74,9 @@ public class QueryComposerTest {
             transactIfJpaTm(
                 () ->
                     tm().createQueryComposer(TestEntity.class)
-                        .where("name", Comparator.EQ, "bravo")
-                        .first()
-                        .get()))
-        .isEqualTo(bravo);
-    assertThat(
-            transactIfJpaTm(
-                () ->
-                    tm().createQueryComposer(TestEntity.class)
                         .where("name", Comparator.GT, "bravo")
                         .first()
+                        .map(DatabaseHelper::assertDetached)
                         .get()))
         .isEqualTo(charlie);
     assertThat(
@@ -91,6 +85,7 @@ public class QueryComposerTest {
                     tm().createQueryComposer(TestEntity.class)
                         .where("name", Comparator.GTE, "charlie")
                         .first()
+                        .map(DatabaseHelper::assertDetached)
                         .get()))
         .isEqualTo(charlie);
     assertThat(
@@ -99,6 +94,7 @@ public class QueryComposerTest {
                     tm().createQueryComposer(TestEntity.class)
                         .where("name", Comparator.LT, "bravo")
                         .first()
+                        .map(DatabaseHelper::assertDetached)
                         .get()))
         .isEqualTo(alpha);
     assertThat(
@@ -107,6 +103,7 @@ public class QueryComposerTest {
                     tm().createQueryComposer(TestEntity.class)
                         .where("name", Comparator.LTE, "alpha")
                         .first()
+                        .map(DatabaseHelper::assertDetached)
                         .get()))
         .isEqualTo(alpha);
   }
@@ -127,9 +124,10 @@ public class QueryComposerTest {
     assertThat(
             transactIfJpaTm(
                 () ->
-                    tm().createQueryComposer(TestEntity.class)
-                        .where("name", Comparator.EQ, "alpha")
-                        .getSingleResult()))
+                    DatabaseHelper.assertDetached(
+                        tm().createQueryComposer(TestEntity.class)
+                            .where("name", Comparator.EQ, "alpha")
+                            .getSingleResult())))
         .isEqualTo(alpha);
   }
 
@@ -164,17 +162,9 @@ public class QueryComposerTest {
                 () ->
                     tm()
                         .createQueryComposer(TestEntity.class)
-                        .where("name", Comparator.EQ, "alpha")
-                        .stream()
-                        .collect(toImmutableList())))
-        .isEqualTo(ImmutableList.of(alpha));
-    assertThat(
-            transactIfJpaTm(
-                () ->
-                    tm()
-                        .createQueryComposer(TestEntity.class)
                         .where("name", Comparator.GT, "alpha")
                         .stream()
+                        .map(DatabaseHelper::assertDetached)
                         .collect(toImmutableList())))
         .isEqualTo(ImmutableList.of(bravo, charlie));
     assertThat(
@@ -184,6 +174,7 @@ public class QueryComposerTest {
                         .createQueryComposer(TestEntity.class)
                         .where("name", Comparator.GTE, "bravo")
                         .stream()
+                        .map(DatabaseHelper::assertDetached)
                         .collect(toImmutableList())))
         .isEqualTo(ImmutableList.of(bravo, charlie));
     assertThat(
@@ -193,6 +184,7 @@ public class QueryComposerTest {
                         .createQueryComposer(TestEntity.class)
                         .where("name", Comparator.LT, "charlie")
                         .stream()
+                        .map(DatabaseHelper::assertDetached)
                         .collect(toImmutableList())))
         .isEqualTo(ImmutableList.of(alpha, bravo));
     assertThat(
@@ -202,6 +194,7 @@ public class QueryComposerTest {
                         .createQueryComposer(TestEntity.class)
                         .where("name", Comparator.LTE, "bravo")
                         .stream()
+                        .map(DatabaseHelper::assertDetached)
                         .collect(toImmutableList())))
         .isEqualTo(ImmutableList.of(alpha, bravo));
   }
@@ -214,6 +207,7 @@ public class QueryComposerTest {
                     tm().createQueryComposer(TestEntity.class)
                         .where("val", Comparator.EQ, 2)
                         .first()
+                        .map(DatabaseHelper::assertDetached)
                         .get()))
         .isEqualTo(bravo);
   }
@@ -228,6 +222,7 @@ public class QueryComposerTest {
                         .where("val", Comparator.GT, 1)
                         .orderBy("val")
                         .stream()
+                        .map(DatabaseHelper::assertDetached)
                         .collect(toImmutableList())))
         .isEqualTo(ImmutableList.of(bravo, alpha));
   }

--- a/core/src/test/java/google/registry/persistence/transaction/TransactionManagerTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/TransactionManagerTest.java
@@ -378,6 +378,17 @@ public class TransactionManagerTest {
         () -> tm().transact(() -> tm().loadAllOf(TestEntity.class)));
   }
 
+  @TestOfyAndSql
+  void mutatedObjectNotPersisted() {
+    tm().transact(() -> tm().insert(theEntity));
+    tm().transact(
+            () -> {
+              TestEntity e = tm().loadByKey(theEntity.key());
+              e.data = "some other data!";
+            });
+    assertThat(tm().transact(() -> tm().loadByKey(theEntity.key())).data).isEqualTo("foo");
+  }
+
   private static void assertEntityExists(TestEntity entity) {
     assertThat(tm().transact(() -> tm().exists(entity))).isTrue();
   }

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -117,7 +117,6 @@ import google.registry.model.transfer.TransferData;
 import google.registry.model.transfer.TransferStatus;
 import google.registry.persistence.VKey;
 import google.registry.tmch.LordnTaskUtils;
-import java.lang.reflect.Field;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -126,7 +125,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Nullable;
-import org.hibernate.Hibernate;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
@@ -1302,28 +1300,11 @@ public class DatabaseHelper {
                 ImmutableList.Builder<Object> result = new ImmutableList.Builder<>();
                 for (Class<?> entityClass : entityClasses) {
                   for (Object object : jpaTm().loadAllOf(entityClass)) {
-                    // Initialize and detach the objects so they can be used for comparison later
-                    initializeHibernateObject(object);
-                    jpaTm().getEntityManager().detach(object);
                     result.add(object);
                   }
                 }
                 return result.build();
               });
-    }
-  }
-
-  /**
-   * Initializes all fields in a Hibernate proxy object so it can be used outside of a transaction.
-   */
-  private static void initializeHibernateObject(Object object) {
-    for (Field field : object.getClass().getDeclaredFields()) {
-      field.setAccessible(true);
-      try {
-        Hibernate.initialize(field.get(object));
-      } catch (IllegalAccessException e) {
-        // shouldn't happen since we set the field to be accessible
-      }
     }
   }
 
@@ -1389,6 +1370,18 @@ public class DatabaseHelper {
   public static <T> ImmutableMap<VKey<? extends T>, T> loadByKeysIfPresent(
       Iterable<? extends VKey<? extends T>> keys) {
     return transactIfJpaTm(() -> tm().loadByKeysIfPresent(keys));
+  }
+
+  /**
+   * In JPA mode, assert that the given entity is detached from the current entity manager.
+   *
+   * <p>Returns the original entity object.
+   */
+  public static <T> T assertDetached(T entity) {
+    if (!tm().isOfy()) {
+      assertThat(jpaTm().getEntityManager().contains(entity)).isFalse();
+    }
+    return entity;
   }
 
   private DatabaseHelper() {}


### PR DESCRIPTION
The mutations on non-transient fields that we do in some of the PostLoad
methods have been causing the objects to be marked as "dirty", and hibernate
has been quietly persisting them during transaction commit.

By detaching the entities on load, we avoid any possibility of this, which
works in our case because we treat all of our model objects as immutable
during normal use.

There is another mixed blessing to this: lazy loading won't work on these
objects once they are detached from a session, meaning that all fields must be
initialized up front.  This is unfortunate in that we don't always need those
lazy-loaded fields and there is a performance cost to loading them, but it is
also useful in that objects will now be complete when used outside of the
transaction that loaded them (prior to this, an attempt to access a
lazy-loaded field after its transaction closed would have caused an error at
runtime).