### PR TITLE
Remove enforcement date from the SslServerInitializer

### DIFF
--- a/networking/build.gradle
+++ b/networking/build.gradle
@@ -43,7 +43,6 @@ dependencies {
 
   annotationProcessor deps['com.google.dagger:dagger-compiler']
   testAnnotationProcessor deps['com.google.dagger:dagger-compiler']
-  compile 'joda-time:joda-time:2.9.2'
 }
 
 // Make testing artifacts available to be depended up on by other projects.

--- a/networking/src/main/java/google/registry/networking/handler/SslServerInitializer.java
+++ b/networking/src/main/java/google/registry/networking/handler/SslServerInitializer.java
@@ -19,7 +19,6 @@ import static google.registry.util.X509Utils.getCertificateHash;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.flogger.FluentLogger;
-import google.registry.util.Clock;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler.Sharable;
@@ -43,7 +42,6 @@ import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAPublicKey;
 import java.util.function.Supplier;
 import javax.net.ssl.SSLSession;
-import org.joda.time.DateTime;
 
 /**
  * Adds a server side SSL handler to the channel pipeline.
@@ -102,19 +100,13 @@ public class SslServerInitializer<C extends Channel> extends ChannelInitializer<
   private final Supplier<PrivateKey> privateKeySupplier;
   private final Supplier<ImmutableList<X509Certificate>> certificatesSupplier;
   private final ImmutableList<String> supportedSslVersions;
-  // TODO(sarahbot): Remove this variable and its check after enforcement start date has passed.
-  private final ImmutableList<String> oldSupportedSslVersions;
-  private final DateTime enforcementStartTime;
-  private final Clock clock;
 
   public SslServerInitializer(
       boolean requireClientCert,
       boolean validateClientCert,
       SslProvider sslProvider,
       Supplier<PrivateKey> privateKeySupplier,
-      Supplier<ImmutableList<X509Certificate>> certificatesSupplier,
-      DateTime enforcementStartTime,
-      Clock clock) {
+      Supplier<ImmutableList<X509Certificate>> certificatesSupplier) {
     logger.atInfo().log("Server SSL Provider: %s", sslProvider);
     checkArgument(
         requireClientCert || !validateClientCert,
@@ -130,12 +122,6 @@ public class SslServerInitializer<C extends Channel> extends ChannelInitializer<
             // JDK support for TLS 1.3 won't be available until 2021-04-20 at the earliest.
             // See: https://java.com/en/jre-jdk-cryptoroadmap.html
             : ImmutableList.of("TLSv1.2");
-    this.oldSupportedSslVersions =
-        sslProvider == SslProvider.OPENSSL
-            ? ImmutableList.of("TLSv1.3", "TLSv1.2", "TLSv1.1", "TLSv1")
-            : ImmutableList.of("TLSv1.2", "TLSv1.1", "TLSv1");
-    this.enforcementStartTime = enforcementStartTime;
-    this.clock = clock;
   }
 
   @Override
@@ -147,13 +133,8 @@ public class SslServerInitializer<C extends Channel> extends ChannelInitializer<
             .sslProvider(sslProvider)
             .trustManager(InsecureTrustManagerFactory.INSTANCE)
             .clientAuth(requireClientCert ? ClientAuth.REQUIRE : ClientAuth.NONE)
-            .protocols(
-                enforcementStartTime.isBefore(clock.nowUtc())
-                    ? supportedSslVersions
-                    : oldSupportedSslVersions)
-            .ciphers(
-                enforcementStartTime.isBefore(clock.nowUtc()) ? ALLOWED_TLS_CIPHERS : null,
-                SupportedCipherSuiteFilter.INSTANCE)
+            .protocols(supportedSslVersions)
+            .ciphers(ALLOWED_TLS_CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
             .build();
 
     logger.atInfo().log("Available Cipher Suites: %s", sslContext.cipherSuites());

--- a/networking/src/test/java/google/registry/networking/handler/SslServerInitializerTest.java
+++ b/networking/src/test/java/google/registry/networking/handler/SslServerInitializerTest.java
@@ -23,6 +23,7 @@ import static google.registry.networking.handler.SslServerInitializer.CLIENT_CER
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.flogger.FluentLogger;
 import google.registry.util.SelfSignedCaCertificate;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
@@ -280,6 +281,10 @@ class SslServerInitializerTest {
         localAddress,
         getClientHandler(
             sslProvider, serverSsc.cert(), clientSsc.key(), clientSsc.cert(), "TLSv1", null));
+
+    FluentLogger.forEnclosingClass()
+        .atInfo()
+        .log("Java version: " + System.getProperty("java.version"));
 
     verifySslException(
         nettyExtension.getServerChannel(),

--- a/networking/src/test/java/google/registry/networking/handler/SslServerInitializerTest.java
+++ b/networking/src/test/java/google/registry/networking/handler/SslServerInitializerTest.java
@@ -23,7 +23,6 @@ import static google.registry.networking.handler.SslServerInitializer.CLIENT_CER
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
-import google.registry.testing.FakeClock;
 import google.registry.util.SelfSignedCaCertificate;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
@@ -52,8 +51,6 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSession;
-import org.joda.time.DateTime;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -102,9 +99,7 @@ class SslServerInitializerTest {
         validateClientCert,
         sslProvider,
         Suppliers.ofInstance(privateKey),
-        Suppliers.ofInstance(ImmutableList.copyOf(certificates)),
-        DateTime.parse("2021-04-01T16:00:00Z"),
-        new FakeClock(DateTime.parse("2021-05-01T16:00:00Z")));
+        Suppliers.ofInstance(ImmutableList.copyOf(certificates)));
   }
 
   private ChannelHandler getClientHandler(
@@ -160,9 +155,7 @@ class SslServerInitializerTest {
             false,
             sslProvider,
             Suppliers.ofInstance(ssc.key()),
-            Suppliers.ofInstance(ImmutableList.of(ssc.cert())),
-            DateTime.parse("2021-04-01T16:00:00Z"),
-            new FakeClock(DateTime.parse("2021-05-01T16:00:00Z")));
+            Suppliers.ofInstance(ImmutableList.of(ssc.cert())));
     EmbeddedChannel channel = new EmbeddedChannel();
     ChannelPipeline pipeline = channel.pipeline();
     pipeline.addLast(sslServerInitializer);
@@ -239,9 +232,7 @@ class SslServerInitializerTest {
             true,
             sslProvider,
             Suppliers.ofInstance(serverSsc.key()),
-            Suppliers.ofInstance(ImmutableList.of(serverSsc.cert())),
-            DateTime.parse("2021-04-01T16:00:00Z"),
-            new FakeClock(DateTime.parse("2021-05-01T16:00:00Z"))));
+            Suppliers.ofInstance(ImmutableList.of(serverSsc.cert()))));
     SelfSignedCaCertificate clientSsc =
         SelfSignedCaCertificate.create(
             "CLIENT",
@@ -282,9 +273,7 @@ class SslServerInitializerTest {
             true,
             sslProvider,
             Suppliers.ofInstance(serverSsc.key()),
-            Suppliers.ofInstance(ImmutableList.of(serverSsc.cert())),
-            DateTime.parse("2021-04-01T16:00:00Z"),
-            new FakeClock(DateTime.parse("2021-03-01T16:00:00Z"))));
+            Suppliers.ofInstance(ImmutableList.of(serverSsc.cert()))));
     SelfSignedCaCertificate clientSsc =
         SelfSignedCaCertificate.create(
             "CLIENT",
@@ -311,7 +300,6 @@ class SslServerInitializerTest {
   // support TLS 1.1 anymore, and in that case it throws a ClosedChannelException instead of a
   // SSLHandShakeException. It's going to be hard to accommodate both the OpenSSL and the JDK
   // provider. Disable it for now to unblock people.
-  @Disabled
   @ParameterizedTest
   @MethodSource("provideTestCombinations")
   void testFailure_protocolNotAccepted(SslProvider sslProvider) throws Exception {
@@ -328,47 +316,12 @@ class SslServerInitializerTest {
     nettyExtension.setUpClient(
         localAddress,
         getClientHandler(
-            sslProvider, serverSsc.cert(), clientSsc.key(), clientSsc.cert(), "TLSv1.1", null));
+            sslProvider, serverSsc.cert(), clientSsc.key(), clientSsc.cert(), "TLSv1", null));
 
     verifySslException(
         nettyExtension.getServerChannel(),
         channel -> channel.attr(CLIENT_CERTIFICATE_PROMISE_KEY).get().get(),
         SSLHandshakeException.class);
-  }
-
-  @Disabled
-  @ParameterizedTest
-  @MethodSource("provideTestCombinations")
-  void testSuccess_protocolNotAccepted_beforeEnforcementDate(SslProvider sslProvider)
-      throws Exception {
-    SelfSignedCaCertificate serverSsc = SelfSignedCaCertificate.create(SSL_HOST);
-    LocalAddress localAddress = new LocalAddress("PROTOCOL_ACCEPTED_BEFORE_DATE_" + sslProvider);
-
-    nettyExtension.setUpServer(
-        localAddress,
-        new SslServerInitializer<LocalChannel>(
-            true,
-            true,
-            sslProvider,
-            Suppliers.ofInstance(serverSsc.key()),
-            Suppliers.ofInstance(ImmutableList.of(serverSsc.cert())),
-            DateTime.parse("2021-04-01T16:00:00Z"),
-            new FakeClock(DateTime.parse("2021-03-01T16:00:00Z"))));
-    SelfSignedCaCertificate clientSsc =
-        SelfSignedCaCertificate.create(
-            "CLIENT",
-            Date.from(Instant.now().minus(Duration.ofDays(2))),
-            Date.from(Instant.now().plus(Duration.ofDays(1))));
-    nettyExtension.setUpClient(
-        localAddress,
-        getClientHandler(
-            sslProvider, serverSsc.cert(), clientSsc.key(), clientSsc.cert(), "TLSv1.1", null));
-
-    SSLSession sslSession = setUpSslChannel(nettyExtension.getClientChannel(), serverSsc.cert());
-    nettyExtension.assertThatMessagesWork();
-
-    assertThat(sslSession.getLocalCertificates()).asList().containsExactly(clientSsc.cert());
-    assertThat(sslSession.getPeerCertificates()).asList().containsExactly(serverSsc.cert());
   }
 
   @ParameterizedTest

--- a/proxy/src/main/java/google/registry/proxy/EppProtocolModule.java
+++ b/proxy/src/main/java/google/registry/proxy/EppProtocolModule.java
@@ -50,7 +50,6 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Qualifier;
 import javax.inject.Singleton;
-import org.joda.time.DateTime;
 
 /** A module that provides the {@link FrontendProtocol} used for epp protocol. */
 @Module
@@ -160,19 +159,11 @@ public final class EppProtocolModule {
   @Provides
   @EppProtocol
   static SslServerInitializer<NioSocketChannel> provideSslServerInitializer(
-      ProxyConfig config,
       SslProvider sslProvider,
       Supplier<PrivateKey> privateKeySupplier,
-      Supplier<ImmutableList<X509Certificate>> certificatesSupplier,
-      Clock clock) {
+      Supplier<ImmutableList<X509Certificate>> certificatesSupplier) {
     return new SslServerInitializer<>(
-        true,
-        false,
-        sslProvider,
-        privateKeySupplier,
-        certificatesSupplier,
-        DateTime.parse(config.tlsEnforcementStartTime),
-        clock);
+        true, false, sslProvider, privateKeySupplier, certificatesSupplier);
   }
 
   @Provides

--- a/proxy/src/main/java/google/registry/proxy/ProxyConfig.java
+++ b/proxy/src/main/java/google/registry/proxy/ProxyConfig.java
@@ -48,7 +48,6 @@ public class ProxyConfig {
   public WebWhois webWhois;
   public HttpsRelay httpsRelay;
   public Metrics metrics;
-  public String tlsEnforcementStartTime;
 
   /** Configuration options that apply to GCS. */
   public static class Gcs {

--- a/proxy/src/main/java/google/registry/proxy/WebWhoisProtocolsModule.java
+++ b/proxy/src/main/java/google/registry/proxy/WebWhoisProtocolsModule.java
@@ -21,8 +21,6 @@ import dagger.multibindings.IntoSet;
 import google.registry.networking.handler.SslServerInitializer;
 import google.registry.proxy.Protocol.FrontendProtocol;
 import google.registry.proxy.handler.WebWhoisRedirectHandler;
-import google.registry.util.Clock;
-import google.registry.util.DateTimeUtils;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.HttpServerCodec;
@@ -135,15 +133,8 @@ public final class WebWhoisProtocolsModule {
   static SslServerInitializer<NioSocketChannel> provideSslServerInitializer(
       SslProvider sslProvider,
       Supplier<PrivateKey> privateKeySupplier,
-      Supplier<ImmutableList<X509Certificate>> certificatesSupplier,
-      Clock clock) {
+      Supplier<ImmutableList<X509Certificate>> certificatesSupplier) {
     return new SslServerInitializer<>(
-        false,
-        false,
-        sslProvider,
-        privateKeySupplier,
-        certificatesSupplier,
-        DateTimeUtils.END_OF_TIME,
-        clock);
+        false, false, sslProvider, privateKeySupplier, certificatesSupplier);
   }
 }

--- a/proxy/src/main/java/google/registry/proxy/config/default-config.yaml
+++ b/proxy/src/main/java/google/registry/proxy/config/default-config.yaml
@@ -8,9 +8,6 @@
 # GCP project ID
 projectId: your-gcp-project-id
 
-# Time to begin enforcement of TLS versions and cipher suites.
-tlsEnforcementStartTime: "1970-01-01T00:00:00Z"
-
 # OAuth scope that the GoogleCredential will be constructed with. This list
 # should include all service scopes that the proxy depends on.
 gcpScopes:


### PR DESCRIPTION
The enforcement data has passed and ICANN has confirmed that their web
WHOIS prober conforms to our requirements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1117)
<!-- Reviewable:end -->
