### PR TITLE
Use FakeClock to prevent Expired Certificate Violations

### DIFF
--- a/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
+++ b/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
@@ -228,7 +228,7 @@ class EppLoginTlsTest extends EppTestCase {
   void testCertificateDoesNotMeetMultipleRequirements_fails() throws Exception {
     X509Certificate certificate =
         SelfSignedCaCertificate.create(
-            "test", clock.nowUtc().minusDays(5000), clock.nowUtc().minusDays(100))
+                "test", clock.nowUtc().minusDays(5000), clock.nowUtc().minusDays(100))
             .cert();
 
     StringWriter sw = new StringWriter();

--- a/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
+++ b/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
@@ -51,7 +51,13 @@ class EppLoginTlsTest extends EppTestCase {
   @Order(value = Integer.MAX_VALUE)
   final SystemPropertyExtension systemPropertyExtension = new SystemPropertyExtension();
 
-  private CertificateChecker certificateChecker;
+  private final CertificateChecker certificateChecker =
+      new CertificateChecker(
+          ImmutableSortedMap.of(START_OF_TIME, 825, DateTime.parse("2020-09-01T00:00:00Z"), 398),
+          30,
+          2048,
+          ImmutableSet.of("secp256r1", "secp384r1"),
+          clock);
 
   void setCredentials(String clientCertificateHash) {
     setTransportCredentials(
@@ -65,13 +71,6 @@ class EppLoginTlsTest extends EppTestCase {
   @BeforeEach
   void beforeEach() {
     clock.setTo(DateTime.parse("2020-11-01T00:00:00Z"));
-    certificateChecker =
-        new CertificateChecker(
-            ImmutableSortedMap.of(START_OF_TIME, 825, DateTime.parse("2020-09-01T00:00:00Z"), 398),
-            30,
-            2048,
-            ImmutableSet.of("secp256r1", "secp384r1"),
-            clock);
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()

--- a/core/src/test/java/google/registry/flows/EppTestCase.java
+++ b/core/src/test/java/google/registry/flows/EppTestCase.java
@@ -101,7 +101,6 @@ public class EppTestCase {
         String inputFilename, @Nullable Map<String, String> inputSubstitutions) {
       this.inputFilename = inputFilename;
       this.inputSubstitutions = inputSubstitutions;
-      // this.now = DateTime.now(UTC);
       this.now = clock.nowUtc();
     }
 

--- a/core/src/test/java/google/registry/flows/EppTestCase.java
+++ b/core/src/test/java/google/registry/flows/EppTestCase.java
@@ -24,7 +24,6 @@ import static google.registry.testing.TestDataHelper.loadFile;
 import static google.registry.xml.XmlTestUtils.assertXmlEqualsWithMessage;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
-import static org.joda.time.DateTimeZone.UTC;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -102,7 +101,8 @@ public class EppTestCase {
         String inputFilename, @Nullable Map<String, String> inputSubstitutions) {
       this.inputFilename = inputFilename;
       this.inputSubstitutions = inputSubstitutions;
-      this.now = DateTime.now(UTC);
+      // this.now = DateTime.now(UTC);
+      this.now = clock.nowUtc();
     }
 
     public CommandAsserter atTime(DateTime now) {
@@ -125,7 +125,7 @@ public class EppTestCase {
     }
 
     public String hasSuccessfulLogin() throws Exception {
-      return assertLoginCommandAndResponse(inputFilename, inputSubstitutions, null, now);
+      return assertLoginCommandAndResponse(inputFilename, inputSubstitutions, null, clock.nowUtc());
     }
   }
 
@@ -139,11 +139,12 @@ public class EppTestCase {
   }
 
   CommandAsserter assertThatLogin(String clientId, String password) {
-    return assertThatCommand("login.xml", ImmutableMap.of("CLID", clientId, "PW", password));
+    return assertThatCommand("login.xml", ImmutableMap.of("CLID", clientId, "PW", password))
+        .atTime(clock.nowUtc());
   }
 
   protected void assertThatLoginSucceeds(String clientId, String password) throws Exception {
-    assertThatLogin(clientId, password).hasSuccessfulLogin();
+    assertThatLogin(clientId, password).atTime(clock.nowUtc()).hasSuccessfulLogin();
   }
 
   protected void assertThatLogoutSucceeds() throws Exception {

--- a/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
+++ b/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
@@ -64,6 +64,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
 
   @Test
   void testSuccess_withGoodCredentials() throws Exception {
+    clock.setTo(DateTime.parse("2020-11-01T00:00:00Z"));
     persistResource(getRegistrarBuilder().build());
     credentials = new TlsCredentials(true, GOOD_CERT_HASH, GOOD_IP, certificateChecker);
     doSuccessfulTest("login_valid.xml");
@@ -71,6 +72,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
 
   @Test
   void testSuccess_withGoodCredentialsIpv6() throws Exception {
+    clock.setTo(DateTime.parse("2020-11-01T00:00:00Z"));
     persistResource(
         getRegistrarBuilder()
             .setIpAddressAllowList(
@@ -82,6 +84,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
 
   @Test
   void testSuccess_withIpv6AddressInSubnet() throws Exception {
+    clock.setTo(DateTime.parse("2020-11-01T00:00:00Z"));
     persistResource(
         getRegistrarBuilder()
             .setIpAddressAllowList(
@@ -93,6 +96,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
 
   @Test
   void testSuccess_withIpv4AddressInSubnet() throws Exception {
+    clock.setTo(DateTime.parse("2020-11-01T00:00:00Z"));
     persistResource(
         getRegistrarBuilder()
             .setIpAddressAllowList(ImmutableList.of(CidrAddressBlock.create("192.168.1.255/24")))

--- a/core/src/test/java/google/registry/tools/ValidateLoginCredentialsCommandTest.java
+++ b/core/src/test/java/google/registry/tools/ValidateLoginCredentialsCommandTest.java
@@ -60,6 +60,7 @@ class ValidateLoginCredentialsCommandTest extends CommandTestCase<ValidateLoginC
             .setState(ACTIVE)
             .setAllowedTlds(ImmutableSet.of("tld"))
             .build());
+    fakeClock.setTo(DateTime.parse("2020-11-01T00:00:00Z"));
     command.certificateChecker =
         new CertificateChecker(
             ImmutableSortedMap.of(START_OF_TIME, 825, DateTime.parse("2020-09-01T00:00:00Z"), 398),


### PR DESCRIPTION
Some unit tests began failing because the test certificate expired on April 30th. In order to prevent the need to create a new test certificate once a year, this PR modifies the tests to mock the time in the CertificateChecker. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1121)
<!-- Reviewable:end -->
