### PR TITLE
Re-enable tests in RC build

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,4 +1,5 @@
 python/
+node_modules/
 **/build/
 **/out/
 .*/

--- a/release/builder/build.sh
+++ b/release/builder/build.sh
@@ -48,6 +48,8 @@ apt-get install docker.io -y
 apt-get install wget -y
 wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 apt install ./google-chrome-stable_current_amd64.deb -y
+# Install libxss1 (needed by Karma)
+apt install libxss1
 apt-get remove apt-utils locales -y
 apt-get autoclean -y
 apt-get autoremove -y

--- a/release/cloudbuild-deploy.yaml
+++ b/release/cloudbuild-deploy.yaml
@@ -96,4 +96,4 @@ steps:
 
 timeout: 3600s
 options:
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_32'

--- a/release/cloudbuild-dev-resource.yaml
+++ b/release/cloudbuild-dev-resource.yaml
@@ -35,4 +35,4 @@ steps:
          'gs://${PROJECT_ID}-er-diagram']
 timeout: 3600s
 options:
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_32'

--- a/release/cloudbuild-kythe.yaml
+++ b/release/cloudbuild-kythe.yaml
@@ -58,4 +58,4 @@ artifacts:
 
 timeout: 3600s
 options:
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_32'

--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -20,16 +20,16 @@ steps:
 - name: 'gcr.io/${PROJECT_ID}/builder:latest'
   args: ['mkdir', 'nomulus']
 # Run tests
-#- name: 'gcr.io/${PROJECT_ID}/builder:latest'
-#  # Set home for Gradle caches. Must be consistent with last step below
-#  # and ./build_nomulus_for_env.sh
-#  env: [ 'GRADLE_USER_HOME=./cloudbuild-caches' ]
-#  args: ['./gradlew',
-#         'test',
-#         '-PskipDockerIncompatibleTests=true',
-#         '-PmavenUrl=gcs://domain-registry-maven-repository/maven',
-#         '-PpluginsUrl=gcs://domain-registry-maven-repository/plugins'
-#        ]
+- name: 'gcr.io/${PROJECT_ID}/builder:latest'
+  # Set home for Gradle caches. Must be consistent with last step below
+  # and ./build_nomulus_for_env.sh
+  env: [ 'GRADLE_USER_HOME=./cloudbuild-caches' ]
+  args: ['./gradlew',
+         'test',
+         '-PskipDockerIncompatibleTests=true',
+         '-PmavenUrl=gcs://domain-registry-maven-repository/maven',
+         '-PpluginsUrl=gcs://domain-registry-maven-repository/plugins'
+        ]
 # Build the tool binary and image.
 - name: 'gcr.io/${PROJECT_ID}/builder:latest'
   args: ['release/build_nomulus_for_env.sh', 'tool', 'output']
@@ -138,4 +138,4 @@ artifacts:
 
 timeout: 3600s
 options:
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_32'

--- a/release/cloudbuild-proxy.yaml
+++ b/release/cloudbuild-proxy.yaml
@@ -64,4 +64,4 @@ artifacts:
     - 'release/cloudbuild-tag.yaml'
 timeout: 3600s
 options:
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_32'

--- a/release/cloudbuild-release.yaml
+++ b/release/cloudbuild-release.yaml
@@ -182,4 +182,4 @@ steps:
     git push origin ${TAG_NAME}
 timeout: 3600s
 options:
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_32'

--- a/release/cloudbuild-schema-deploy.yaml
+++ b/release/cloudbuild-schema-deploy.yaml
@@ -94,4 +94,4 @@ steps:
       gsutil cp - gs://$PROJECT_ID-deployed-tags/sql.${_ENV}.tag\
 timeout: 3600s
 options:
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_32'

--- a/release/cloudbuild-sync.yaml
+++ b/release/cloudbuild-sync.yaml
@@ -29,4 +29,4 @@ steps:
   - gs://$PROJECT_ID-deploy/live
 timeout: 3600s
 options:
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_32'

--- a/release/cloudbuild-tag.yaml
+++ b/release/cloudbuild-tag.yaml
@@ -29,4 +29,4 @@ steps:
   - gcr.io/$PROJECT_ID/${_IMAGE}:live
 timeout: 3600s
 options:
-  machineType: 'N1_HIGHCPU_8'
+  machineType: 'E2_HIGHCPU_32'


### PR DESCRIPTION
There has been a case where the CI was broken on Friday and no one
noticied or fixed it and a RC build was built with broken tests.
The tests were disabled due to unknown test failures that have since
been fixed.

Also update the machine type used by GCB to be more powerful. This is
necessary for the tests to past because N1_HIGHCPU_8 is RAM constraint
and the tests crashes. I updated all jobs to use the new type which
hopefully will make the build faster as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1130)
<!-- Reviewable:end -->
