### PR TITLE
Update xmlhttprequest-ssl version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -404,6 +404,12 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "xmlhttprequest-ssl": {
+          "version": "1.5.5",
+          "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+          "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+          "dev": true
         }
       }
     },
@@ -1505,9 +1511,9 @@
       "dev": true
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.2.tgz",
+      "integrity": "sha512-tYOaldF/0BLfKuoA39QMwD4j2m8lq4DIncqj1yuNELX4vz9+z/ieG/vwmctjJce+boFHXstqhWnHSxc4W8f4qg==",
       "dev": true
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "karma-chrome-launcher": "3.1.0",
     "karma-closure": "0.1.3",
     "karma-jasmine": "2.0.1",
-    "puppeteer": "2.0.0"
+    "puppeteer": "2.0.0",
+    "xmlhttprequest-ssl": ">=1.6.2"
   }
 }


### PR DESCRIPTION
We are using a version with known vulnerability per https://github.com/google/nomulus/security/dependabot/package-lock.json/xmlhttprequest-ssl/open

The `package-lock.json` file is autogenerated. Not sure if it is correct given that it still has v1.5.5 in it...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1131)
<!-- Reviewable:end -->
