### PR TITLE
Fix flaky Spec11PipelineTest

### DIFF
--- a/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
+++ b/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
@@ -16,7 +16,6 @@ package google.registry.beam.spec11;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth.assertWithMessage;
 import static google.registry.model.ImmutableObjectSubject.immutableObjectCorrespondence;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 
@@ -35,7 +34,6 @@ import google.registry.testing.DatastoreEntityExtension;
 import google.registry.testing.FakeClock;
 import google.registry.util.ResourceUtils;
 import java.io.File;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.apache.beam.sdk.coders.KvCoder;
@@ -120,11 +118,6 @@ class Spec11PipelineTest {
                     KvCoder.of(
                         SerializableCoder.of(Subdomain.class),
                         SerializableCoder.of(ThreatMatch.class))));
-    assertWithMessage(
-            "Beam pipelines don't run in an App Engine environment, and thus the tests shouldn't be"
-                + " mocking one either")
-        .that(isAppEngine())
-        .isFalse();
   }
 
   @Test
@@ -193,25 +186,6 @@ class Spec11PipelineTest {
             Correspondence.from(
                 new ThreatMatchJsonPredicate(), "has fields with unordered threatTypes equal to"))
         .containsExactlyElementsIn(expectedFileContents.subList(1, expectedFileContents.size()));
-  }
-
-  // Adapted from Guava's MoreExecutors (where it is a private method)
-  private static boolean isAppEngine() {
-    if (System.getProperty("com.google.appengine.runtime.environment") == null) {
-      return false;
-    } else {
-      try {
-        return Class.forName("com.google.apphosting.api.ApiProxy")
-                .getMethod("getCurrentEnvironment")
-                .invoke(null)
-            != null;
-      } catch (ClassNotFoundException
-          | InvocationTargetException
-          | IllegalAccessException
-          | NoSuchMethodException e) {
-        return false;
-      }
-    }
   }
 
   /** Returns the text contents of a file under the beamBucket/results directory. */

--- a/core/src/test/java/google/registry/testing/DatastoreEntityExtension.java
+++ b/core/src/test/java/google/registry/testing/DatastoreEntityExtension.java
@@ -26,9 +26,10 @@ import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
  * Allows instantiation of Datastore {@code Entity entities} without the heavyweight {@code
  * AppEngineRule}.
  *
- * <p>When used together with {@code JpaIntegrationWithCoverageExtension}, this extension must be
- * registered first. For consistency's sake, it is recommended that the field for this extension be
- * annotated with {@code @org.junit.jupiter.api.Order(value = 1)}. Please refer to {@link
+ * <p>When used together with {@code JpaIntegrationWithCoverageExtension} or @{@code
+ * TestPipelineExtension}, this extension must be registered first. For consistency's sake, it is
+ * recommended that the field for this extension be annotated with
+ * {@code @org.junit.jupiter.api.Order(value = 1)}. Please refer to {@link
  * google.registry.model.domain.DomainBaseSqlTest} for example, and to <a
  * href="https://junit.org/junit5/docs/current/user-guide/#extensions-registration-programmatic">
  * JUnit 5 User Guide</a> for details of extension ordering.


### PR DESCRIPTION
It appears when the test fails the call to isAppEngine() returns true. It
is still not clear where that comes from, but it is likely due to the
DatastoreEntityExtension trying to setup an App Engine environment for
Ofy. All Ofy needs is a project ID so we explicitly clear the system
proporty for ApiProxy in the hope that isAppEngine() will now always
return false.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1133)
<!-- Reviewable:end -->
