### PR TITLE
Perform synchronous contact delete in SQL

### DIFF
--- a/core/src/main/java/google/registry/batch/DeleteContactsAndHostsAction.java
+++ b/core/src/main/java/google/registry/batch/DeleteContactsAndHostsAction.java
@@ -109,6 +109,7 @@ import org.joda.time.Duration;
  * A mapreduce that processes batch asynchronous deletions of contact and host resources by mapping
  * over all domains and checking for any references to the contacts/hosts in pending deletion.
  */
+@Deprecated
 @Action(
     service = Action.Service.BACKEND,
     path = "/_dr/task/deleteContactsAndHosts",

--- a/core/src/test/resources/google/registry/flows/contact/contact_delete_response.xml
+++ b/core/src/test/resources/google/registry/flows/contact/contact_delete_response.xml
@@ -1,7 +1,7 @@
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
   <response>
-    <result code="1001">
-      <msg>Command completed successfully; action pending</msg>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
     </result>
     <trID>
       <clTRID>ABC-12345</clTRID>

--- a/core/src/test/resources/google/registry/flows/contact/contact_delete_response_no_cltrid_pending.xml
+++ b/core/src/test/resources/google/registry/flows/contact/contact_delete_response_no_cltrid_pending.xml
@@ -1,7 +1,7 @@
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
   <response>
-    <result code="1000">
-      <msg>Command completed successfully</msg>
+    <result code="1001">
+      <msg>Command completed successfully; action pending</msg>
     </result>
     <trID>
       <svTRID>server-trid</svTRID>

--- a/core/src/test/resources/google/registry/flows/contact/contact_delete_response_pending.xml
+++ b/core/src/test/resources/google/registry/flows/contact/contact_delete_response_pending.xml
@@ -1,9 +1,10 @@
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
   <response>
-    <result code="1000">
-      <msg>Command completed successfully</msg>
+    <result code="1001">
+      <msg>Command completed successfully; action pending</msg>
     </result>
     <trID>
+      <clTRID>ABC-12345</clTRID>
       <svTRID>server-trid</svTRID>
     </trID>
   </response>

--- a/core/src/test/resources/google/registry/flows/contact_delete_response_sh8013.xml
+++ b/core/src/test/resources/google/registry/flows/contact_delete_response_sh8013.xml
@@ -1,7 +1,7 @@
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
   <response>
-    <result code="1001">
-      <msg>Command completed successfully; action pending</msg>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
     </result>
     <trID>
       <clTRID>ABC-12345</clTRID>

--- a/core/src/test/resources/google/registry/flows/contact_delete_response_sh8013_pending.xml
+++ b/core/src/test/resources/google/registry/flows/contact_delete_response_sh8013_pending.xml
@@ -1,9 +1,10 @@
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
   <response>
-    <result code="1000">
-      <msg>Command completed successfully</msg>
+    <result code="1001">
+      <msg>Command completed successfully; action pending</msg>
     </result>
     <trID>
+      <clTRID>ABC-12345</clTRID>
       <svTRID>server-trid</svTRID>
     </trID>
   </response>

--- a/core/src/test/resources/google/registry/flows/session/contact_delete_response_sh8013_pending.xml
+++ b/core/src/test/resources/google/registry/flows/session/contact_delete_response_sh8013_pending.xml
@@ -1,9 +1,10 @@
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
   <response>
-    <result code="1000">
-      <msg>Command completed successfully</msg>
+    <result code="1001">
+      <msg>Command completed successfully; action pending</msg>
     </result>
     <trID>
+      <clTRID>ABC-12345</clTRID>
       <svTRID>server-trid</svTRID>
     </trID>
   </response>


### PR DESCRIPTION
In SQL the contact of a domain is an indexed field and therefore we can
find linked domains synchronously, without the need for MapReduce.

The delete logic is mostly lifted from DeleteContactsAndHostsAction, but
because everything happens in a transaction we do not need to recheck a
lot of the preconditions that were necessary to ensure that the async
delete request still meets the conditions that when the request was
enqueued.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1137)
<!-- Reviewable:end -->
