### PR TITLE
Delete hosts synchronously when using SQL

### DIFF
--- a/core/src/main/java/google/registry/flows/FlowModule.java
+++ b/core/src/main/java/google/registry/flows/FlowModule.java
@@ -32,6 +32,7 @@ import google.registry.model.eppinput.ResourceCommand;
 import google.registry.model.eppinput.ResourceCommand.SingleResourceCommand;
 import google.registry.model.eppoutput.EppResponse;
 import google.registry.model.eppoutput.Result;
+import google.registry.model.host.HostHistory;
 import google.registry.model.reporting.HistoryEntry;
 import java.lang.annotation.Documented;
 import java.util.Optional;
@@ -233,11 +234,11 @@ public class FlowModule {
             .setClientId(clientId);
     Optional<MetadataExtension> metadataExtension =
         eppInput.getSingleExtension(MetadataExtension.class);
-    if (metadataExtension.isPresent()) {
-      historyBuilder
-          .setReason(metadataExtension.get().getReason())
-          .setRequestedByRegistrar(metadataExtension.get().getRequestedByRegistrar());
-    }
+    metadataExtension.ifPresent(
+        extension ->
+            historyBuilder
+                .setReason(extension.getReason())
+                .setRequestedByRegistrar(extension.getRequestedByRegistrar()));
     return historyBuilder;
   }
 
@@ -253,6 +254,11 @@ public class FlowModule {
     return new DomainHistory.Builder().copyFrom(historyEntryBuilder);
   }
 
+  @Provides
+  static HostHistory.Builder provideHostHistoryBuilder(HistoryEntry.Builder historyEntryBuilder) {
+    return new HostHistory.Builder().copyFrom(historyEntryBuilder);
+  }
+
   /**
    * Provides a partially filled in {@link EppResponse} builder.
    *
@@ -263,7 +269,7 @@ public class FlowModule {
   static EppResponse.Builder provideEppResponseBuilder(Trid trid) {
     return new EppResponse.Builder()
         .setTrid(trid)
-        .setResultFromCode(Result.Code.SUCCESS);  // Default to success.
+        .setResultFromCode(Result.Code.SUCCESS); // Default to success.
   }
 
   @Provides

--- a/core/src/test/java/google/registry/flows/EppLifecycleContactTest.java
+++ b/core/src/test/java/google/registry/flows/EppLifecycleContactTest.java
@@ -65,22 +65,22 @@ class EppLifecycleContactTest extends EppTestCase {
         .hasCommandName("ContactInfo")
         .and()
         .hasStatus(SUCCESS);
-    Result.Code resultCode;
+    Result.Code deleteResultCode;
     if (tm().isOfy()) {
       assertThatCommand("contact_delete_sh8013.xml")
           .hasResponse("contact_delete_response_sh8013_pending.xml");
-      resultCode = SUCCESS_WITH_ACTION_PENDING;
+      deleteResultCode = SUCCESS_WITH_ACTION_PENDING;
     } else {
       assertThatCommand("contact_delete_sh8013.xml")
           .hasResponse("contact_delete_response_sh8013.xml");
-      resultCode = SUCCESS;
+      deleteResultCode = SUCCESS;
     }
     assertThat(getRecordedEppMetric())
         .hasClientId("NewRegistrar")
         .and()
         .hasCommandName("ContactDelete")
         .and()
-        .hasStatus(resultCode);
+        .hasStatus(deleteResultCode);
     assertThatLogoutSucceeds();
   }
 

--- a/core/src/test/resources/google/registry/flows/host/host_delete_response.xml
+++ b/core/src/test/resources/google/registry/flows/host/host_delete_response.xml
@@ -1,7 +1,7 @@
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
   <response>
-    <result code="1001">
-      <msg>Command completed successfully; action pending</msg>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
     </result>
     <trID>
       <clTRID>ABC-12345</clTRID>

--- a/core/src/test/resources/google/registry/flows/host/host_delete_response_no_cltrid_pending.xml
+++ b/core/src/test/resources/google/registry/flows/host/host_delete_response_no_cltrid_pending.xml
@@ -1,7 +1,7 @@
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
   <response>
-    <result code="1000">
-      <msg>Command completed successfully</msg>
+    <result code="1001">
+      <msg>Command completed successfully; action pending</msg>
     </result>
     <trID>
       <svTRID>server-trid</svTRID>

--- a/core/src/test/resources/google/registry/flows/host/host_delete_response_pending.xml
+++ b/core/src/test/resources/google/registry/flows/host/host_delete_response_pending.xml
@@ -1,9 +1,10 @@
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
   <response>
-    <result code="1000">
-      <msg>Command completed successfully</msg>
+    <result code="1001">
+      <msg>Command completed successfully; action pending</msg>
     </result>
     <trID>
+      <clTRID>ABC-12345</clTRID>
       <svTRID>server-trid</svTRID>
     </trID>
   </response>


### PR DESCRIPTION
Also put some common logic in helper funcions in ContactDeleteFlowTest
to reduce clutter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1141)
<!-- Reviewable:end -->
