### PR TITLE
Fix flaky tests in PollAckFlow

### DIFF
--- a/core/src/test/java/google/registry/flows/poll/PollAckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/poll/PollAckFlowTest.java
@@ -32,6 +32,7 @@ import google.registry.flows.poll.PollAckFlow.NotAuthorizedToAckMessageException
 import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.poll.PollMessage;
+import google.registry.testing.AppEngineExtension;
 import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.ReplayExtension;
 import google.registry.testing.TestOfyAndSql;
@@ -54,11 +55,18 @@ class PollAckFlowTest extends FlowTestCase<PollAckFlow> {
   private DomainBase domain;
   private ContactResource contact;
 
+  PollAckFlowTest() {
+    // Delay canned test data creation until clock is initialized in setUp().
+    super(false);
+  }
+
   @BeforeEach
   void setUp() {
     setEppInput("poll_ack.xml", ImmutableMap.of("MSGID", "1-3-EXAMPLE-4-3-2011"));
     setClientIdForFlow("NewRegistrar");
     clock.setTo(DateTime.parse("2011-01-02T01:01:01Z"));
+    AppEngineExtension.loadInitialData();
+    clock.advanceOneMilli();
     createTld("example");
     clock.advanceOneMilli();
     contact = persistActiveContact("jd1234");

--- a/core/src/test/java/google/registry/testing/AppEngineExtension.java
+++ b/core/src/test/java/google/registry/testing/AppEngineExtension.java
@@ -652,7 +652,7 @@ public final class AppEngineExtension implements BeforeEachCallback, AfterEachCa
   }
 
   /** Create some fake registrars. */
-  private static void loadInitialData() {
+  public static void loadInitialData() {
     persistSimpleResources(
         ImmutableList.of(
             makeRegistrar1(),


### PR DESCRIPTION
With PollAckFlowTest, the canned data is loaded into datastore before
the clock is set to a time in the past. This cause timestamp inversion
if commit logs of subsequent writes hit the same bucket as that of the
canned data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1142)
<!-- Reviewable:end -->
