### PR TITLE
Fix timestamp inversion bug

### DIFF
--- a/common/src/testing/java/google/registry/testing/FakeClock.java
+++ b/common/src/testing/java/google/registry/testing/FakeClock.java
@@ -22,6 +22,7 @@ import google.registry.util.Clock;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.concurrent.ThreadSafe;
 import org.joda.time.DateTime;
+import org.joda.time.Duration;
 import org.joda.time.ReadableDuration;
 import org.joda.time.ReadableInstant;
 
@@ -80,5 +81,15 @@ public final class FakeClock implements Clock {
   /** Sets the time to the specified instant. */
   public void setTo(ReadableInstant time) {
     currentTimeMillis.set(time.getMillis());
+  }
+
+  /** Invokes {@link #setAutoIncrementStep} with one millisecond-step. */
+  public FakeClock setAutoIncrementByOneMilli() {
+    return setAutoIncrementStep(Duration.millis(1));
+  }
+
+  /** Disables the auto-increment mode. */
+  public FakeClock disableAutoIncrement() {
+    return setAutoIncrementStep(Duration.ZERO);
   }
 }

--- a/core/src/test/java/google/registry/flows/poll/PollAckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/poll/PollAckFlowTest.java
@@ -54,17 +54,20 @@ class PollAckFlowTest extends FlowTestCase<PollAckFlow> {
   private DomainBase domain;
   private ContactResource contact;
 
+  PollAckFlowTest() {
+    // Setting the fake clock in constructor fixes the timestamp inversion problem when
+    // ReplayExtension is in effect. If done in setup, the canned data in AppEngineExtension
+    // will be saved with the time chosen by the parent class.
+    clock.setTo(DateTime.parse("2011-01-02T01:01:01Z"));
+  }
+
   @BeforeEach
   void setUp() {
     setEppInput("poll_ack.xml", ImmutableMap.of("MSGID", "1-3-EXAMPLE-4-3-2011"));
     setClientIdForFlow("NewRegistrar");
-    clock.setTo(DateTime.parse("2011-01-02T01:01:01Z"));
     createTld("example");
-    clock.advanceOneMilli();
     contact = persistActiveContact("jd1234");
-    clock.advanceOneMilli();
     domain = persistResource(newDomainBase("test.example", contact));
-    clock.advanceOneMilli();
   }
 
   private void persistOneTimePollMessage(long messageId) {

--- a/core/src/test/java/google/registry/flows/poll/PollAckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/poll/PollAckFlowTest.java
@@ -34,6 +34,7 @@ import google.registry.model.domain.DomainBase;
 import google.registry.model.poll.PollMessage;
 import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.ReplayExtension;
+import google.registry.testing.SetClockExtension;
 import google.registry.testing.TestOfyAndSql;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +45,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 @DualDatabaseTest
 class PollAckFlowTest extends FlowTestCase<PollAckFlow> {
 
+  @Order(value = Order.DEFAULT - 3)
+  @RegisterExtension
+  final SetClockExtension setClockExtension = new SetClockExtension(clock, "2011-01-02T01:01:01Z");
+
   @Order(value = Order.DEFAULT - 2)
   @RegisterExtension
   final ReplayExtension replayExtension = ReplayExtension.createWithCompare(clock);
@@ -53,13 +58,6 @@ class PollAckFlowTest extends FlowTestCase<PollAckFlow> {
 
   private DomainBase domain;
   private ContactResource contact;
-
-  PollAckFlowTest() {
-    // Setting the fake clock in constructor fixes the timestamp inversion problem when
-    // ReplayExtension is in effect. If done in setup, the canned data in AppEngineExtension
-    // will be saved with the time chosen by the parent class.
-    clock.setTo(DateTime.parse("2011-01-02T01:01:01Z"));
-  }
 
   @BeforeEach
   void setUp() {

--- a/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
@@ -53,6 +53,7 @@ import google.registry.testing.DatabaseHelper;
 import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.TestOfyOnly;
 import google.registry.testing.TestSqlOnly;
+import org.junit.jupiter.api.BeforeEach;
 
 /** Tests for {@link DomainHistory}. */
 @DualDatabaseTest
@@ -60,6 +61,11 @@ public class DomainHistoryTest extends EntityTestCase {
 
   DomainHistoryTest() {
     super(JpaEntityCoverageCheck.ENABLED);
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    fakeClock.setAutoIncrementByOneMilli();
   }
 
   @TestSqlOnly
@@ -105,7 +111,6 @@ public class DomainHistoryTest extends EntityTestCase {
               tm().insert(host);
               tm().insert(contact);
             });
-    fakeClock.advanceOneMilli();
 
     DomainBase domain =
         newDomainBase("example.tld", "domainRepoId", contact)
@@ -114,7 +119,6 @@ public class DomainHistoryTest extends EntityTestCase {
             .build();
     tm().transact(() -> tm().insert(domain));
 
-    fakeClock.advanceOneMilli();
     DomainHistory domainHistory = createDomainHistory(domain);
     tm().transact(() -> tm().insert(domainHistory));
 
@@ -164,7 +168,6 @@ public class DomainHistoryTest extends EntityTestCase {
               jpaTm().insert(host);
               jpaTm().insert(contact);
             });
-    fakeClock.advanceOneMilli();
     DomainBase domain =
         newDomainBase("example.tld", "domainRepoId", contact)
             .asBuilder()
@@ -172,7 +175,6 @@ public class DomainHistoryTest extends EntityTestCase {
             .build();
     tm().transact(() -> tm().insert(domain));
     jpaTm().transact(() -> jpaTm().insert(domain));
-    fakeClock.advanceOneMilli();
 
     DomainHistory domainHistory = createDomainHistory(domain);
     tm().transact(() -> tm().insert(domainHistory));

--- a/core/src/test/java/google/registry/model/registry/RegistryTest.java
+++ b/core/src/test/java/google/registry/model/registry/RegistryTest.java
@@ -44,6 +44,7 @@ import google.registry.model.registry.Registry.TldState;
 import google.registry.model.registry.label.PremiumList;
 import google.registry.model.registry.label.PremiumListDualDao;
 import google.registry.model.registry.label.ReservedList;
+import google.registry.testing.DatabaseHelper;
 import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.TestOfyAndSql;
 import google.registry.testing.TestOfyOnly;
@@ -62,6 +63,8 @@ public final class RegistryTest extends EntityTestCase {
 
   @BeforeEach
   void beforeEach() {
+    // Auto-increment fakeClock in DatabaseHelper.
+    inject.setStaticField(DatabaseHelper.class, "clock", fakeClock);
     createTld("tld");
   }
 

--- a/core/src/test/java/google/registry/model/registry/label/PremiumListDualDaoTest.java
+++ b/core/src/test/java/google/registry/model/registry/label/PremiumListDualDaoTest.java
@@ -29,7 +29,6 @@ import google.registry.model.EntityTestCase;
 import google.registry.model.pricing.StaticPremiumListPricingEngine;
 import google.registry.model.registry.Registry;
 import google.registry.testing.TestCacheExtension;
-import org.joda.time.Duration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,12 +48,12 @@ public class PremiumListDualDaoTest extends EntityTestCase {
   @BeforeEach
   void before() {
     createTld("tld");
-    fakeClock.setAutoIncrementStep(Duration.millis(1));
+    fakeClock.setAutoIncrementByOneMilli();
   }
 
   @AfterEach
   void after() {
-    fakeClock.setAutoIncrementStep(Duration.ZERO);
+    fakeClock.disableAutoIncrement();
   }
 
   @Test

--- a/core/src/test/java/google/registry/model/registry/label/ReservedListDualDatabaseDaoTest.java
+++ b/core/src/test/java/google/registry/model/registry/label/ReservedListDualDatabaseDaoTest.java
@@ -32,6 +32,7 @@ public class ReservedListDualDatabaseDaoTest extends EntityTestCase {
 
   @BeforeEach
   void setUp() {
+    fakeClock.setAutoIncrementByOneMilli();
     reservations =
         ImmutableMap.of(
             "food",

--- a/core/src/test/java/google/registry/model/registry/label/ReservedListTest.java
+++ b/core/src/test/java/google/registry/model/registry/label/ReservedListTest.java
@@ -36,6 +36,7 @@ import google.registry.model.ofy.Ofy;
 import google.registry.model.registry.Registry;
 import google.registry.model.registry.label.ReservedList.ReservedListEntry;
 import google.registry.testing.AppEngineExtension;
+import google.registry.testing.DatabaseHelper;
 import google.registry.testing.FakeClock;
 import google.registry.testing.InjectExtension;
 import org.joda.time.DateTime;
@@ -57,6 +58,8 @@ class ReservedListTest {
   @BeforeEach
   void beforeEach() {
     inject.setStaticField(Ofy.class, "clock", clock);
+    // Auto-increment clock in DatabaseHelper.
+    inject.setStaticField(DatabaseHelper.class, "clock", clock);
     createTld("tld");
     reservedListChecks.reset();
     reservedListProcessingTime.reset();

--- a/core/src/test/java/google/registry/rde/PendingDepositCheckerTest.java
+++ b/core/src/test/java/google/registry/rde/PendingDepositCheckerTest.java
@@ -86,7 +86,7 @@ public class PendingDepositCheckerTest {
   void testMethod_firstDepositOnBrdaDay_depositsBothRdeAndBrda() {
     clock.setTo(DateTime.parse("2000-01-04T08:00Z"));  // Tuesday
     createTldWithEscrowEnabled("lol");
-    clock.advanceOneMilli();
+    clock.setAutoIncrementByOneMilli();
     assertThat(checker.getTldsAndWatermarksPendingDepositForRdeAndBrda()).isEqualTo(
         ImmutableSetMultimap.of(
             "lol", PendingDeposit.create(
@@ -153,7 +153,7 @@ public class PendingDepositCheckerTest {
     createTldWithEscrowEnabled("pal");
     clock.advanceOneMilli();
     createTldWithEscrowEnabled("fun");
-    clock.advanceOneMilli();
+    clock.setAutoIncrementByOneMilli();
     assertThat(checker.getTldsAndWatermarksPendingDepositForRdeAndBrda())
         .isEqualTo(
             ImmutableSetMultimap.of(

--- a/core/src/test/java/google/registry/rde/RdeStagingActionTest.java
+++ b/core/src/test/java/google/registry/rde/RdeStagingActionTest.java
@@ -592,7 +592,9 @@ public class RdeStagingActionTest extends MapreduceTestCase<RdeStagingAction> {
     makeDomainBase(clock, "lol");
 
     clock.setTo(DateTime.parse("2000-01-01TZ"));
+    clock.setAutoIncrementByOneMilli();
     action.run();
+    clock.disableAutoIncrement();
     executeTasksUntilEmpty("mapreduce", clock);
 
     String boggleDeposit = readXml("boggle_2000-01-01_full_S1_R0.xml.ghostryde");
@@ -613,7 +615,9 @@ public class RdeStagingActionTest extends MapreduceTestCase<RdeStagingAction> {
     makeHostResource(clock, "ns1.kuss.lol", "face::feed");
 
     clock.setTo(DateTime.parse("2000-01-01TZ"));
+    clock.setAutoIncrementByOneMilli();
     action.run();
+    clock.disableAutoIncrement();
     executeTasksUntilEmpty("mapreduce", clock);
 
     String fopDeposit = readXml("fop_2000-01-01_full_S1_R0.xml.ghostryde");

--- a/core/src/test/java/google/registry/tools/GetDatabaseTransitionScheduleCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetDatabaseTransitionScheduleCommandTest.java
@@ -28,8 +28,10 @@ import google.registry.model.common.DatabaseTransitionSchedule.TransitionId;
 import google.registry.model.common.TimedTransitionProperty;
 import google.registry.model.ofy.Ofy;
 import google.registry.testing.InjectExtension;
+import google.registry.testing.SetClockExtension;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -37,11 +39,12 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 public class GetDatabaseTransitionScheduleCommandTest
     extends CommandTestCase<GetDatabaseTransitionScheduleCommand> {
 
-  @RegisterExtension public final InjectExtension inject = new InjectExtension();
+  @Order(value = Order.DEFAULT - 3)
+  @RegisterExtension
+  final SetClockExtension setClockExtension =
+      new SetClockExtension(fakeClock, "1984-12-21T06:07:08.789Z");
 
-  GetDatabaseTransitionScheduleCommandTest() {
-    fakeClock.setTo(DateTime.parse("1984-12-21T06:07:08.789Z"));
-  }
+  @RegisterExtension public final InjectExtension inject = new InjectExtension();
 
   @BeforeEach
   void beforeEach() {

--- a/core/src/test/java/google/registry/tools/UnrenewDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UnrenewDomainCommandTest.java
@@ -85,9 +85,9 @@ public class UnrenewDomainCommandTest extends CommandTestCase<UnrenewDomainComma
         fakeClock.nowUtc(),
         fakeClock.nowUtc(),
         fakeClock.nowUtc().plusYears(4));
-    fakeClock.advanceOneMilli();
+    fakeClock.setAutoIncrementByOneMilli();
     runCommandForced("-p", "2", "foo.tld", "bar.tld");
-    fakeClock.advanceOneMilli();
+    fakeClock.disableAutoIncrement();
     assertThat(
             loadByForeignKey(DomainBase.class, "foo.tld", fakeClock.nowUtc())
                 .get()

--- a/core/src/test/java/google/registry/ui/server/registrar/ContactSettingsTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/ContactSettingsTest.java
@@ -213,6 +213,7 @@ class ContactSettingsTest extends RegistrarSettingsActionTestCase {
             AppEngineExtension.makeRegistrarContact1().toJsonMap(),
             newContactMap,
             AppEngineExtension.makeRegistrarContact3().toJsonMap()));
+    clock.advanceOneMilli();
     Map<String, Object> response =
         action.handleJsonRequest(ImmutableMap.of("op", "update", "id", CLIENT_ID, "args", reqJson));
     assertThat(response).containsAtLeastEntriesIn(ImmutableMap.of("status", "SUCCESS"));


### PR DESCRIPTION
Set the number of commitLog buckets to 1 in CommitLog replay tests to
expose all timestamp inversion problem.

Fixed PollAckFlowTest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1144)
<!-- Reviewable:end -->
