### PR TITLE
Create key based on the change type

### DIFF
--- a/core/src/main/java/google/registry/tools/MutatingCommand.java
+++ b/core/src/main/java/google/registry/tools/MutatingCommand.java
@@ -105,20 +105,20 @@ public abstract class MutatingCommand extends ConfirmingCommand implements Comma
      */
     private EntityChange(ImmutableObject oldEntity, ImmutableObject newEntity, VKey<?> vkey) {
       type = ChangeType.get(oldEntity != null, newEntity != null);
-      Key<?> oldKey = Key.create(oldEntity), newKey = Key.create(newEntity);
       if (type == ChangeType.UPDATE) {
         checkArgument(
-            oldKey.equals(newKey), "Both entity versions in an update must have the same Key.");
+            Key.create(oldEntity).equals(Key.create(newEntity)),
+            "Both entity versions in an update must have the same Key.");
         checkArgument(
-            oldKey.equals(vkey.getOfyKey()),
+            Key.create(oldEntity).equals(vkey.getOfyKey()),
             "The Key of the entity must be the same as the OfyKey of the vkey");
       } else if (type == ChangeType.CREATE) {
         checkArgument(
-            newKey.equals(vkey.getOfyKey()),
+            Key.create(newEntity).equals(vkey.getOfyKey()),
             "Both entity versions in an update must have the same Key.");
       } else if (type == ChangeType.DELETE) {
         checkArgument(
-            oldKey.equals(vkey.getOfyKey()),
+            Key.create(oldEntity).equals(vkey.getOfyKey()),
             "The Key of the entity must be the same as the OfyKey of the vkey");
       }
       this.oldEntity = oldEntity;


### PR DESCRIPTION
Currently, both old key and new key are created before type check; this only works with update since both old and new entity are not null.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1147)
<!-- Reviewable:end -->
