### PR TITLE
Convert more ofy() to auditedOfy() calls

### DIFF
--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -69,7 +69,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
 
   // The entity of classes in this set will be simply ignored when passed to modification
   // operations, i.e. insert, put, update and delete. This is to help maintain a single code path
-  // when we switch from ofy() to tm() for the database migration as we don't need have a condition
+  // when we switch from ofy to tm() for the database migration as we don't need have a condition
   // to exclude the Datastore specific entities when the underlying tm() is jpaTm().
   // TODO(b/176108270): Remove this property after database migration.
   private static final ImmutableSet<Class<? extends ImmutableObject>> IGNORED_ENTITY_CLASSES =

--- a/core/src/main/java/google/registry/tools/AckPollMessagesCommand.java
+++ b/core/src/main/java/google/registry/tools/AckPollMessagesCommand.java
@@ -17,7 +17,7 @@ package google.registry.tools;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static google.registry.flows.poll.PollFlowUtils.SQL_POLL_MESSAGE_QUERY;
 import static google.registry.flows.poll.PollFlowUtils.datastorePollMessageQuery;
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.model.ofy.ObjectifyService.auditedOfy;
 import static google.registry.model.poll.PollMessageExternalKeyConverter.makePollMessageExternalId;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
@@ -107,7 +107,7 @@ final class AckPollMessagesCommand implements CommandWithRemoteApi {
       tm().transact(
               () ->
                   // Load poll messages and filter to just those of interest.
-                  ofy().load().keys(keys).values().stream()
+                  auditedOfy().load().keys(keys).values().stream()
                       .filter(pm -> isNullOrEmpty(message) || pm.getMsg().contains(message))
                       .forEach(this::actOnPollMessage));
     }

--- a/core/src/main/java/google/registry/tools/CompareReservedListsCommand.java
+++ b/core/src/main/java/google/registry/tools/CompareReservedListsCommand.java
@@ -16,7 +16,7 @@ package google.registry.tools;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static google.registry.model.common.EntityGroupRoot.getCrossTldKey;
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.model.ofy.ObjectifyService.auditedOfy;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 
 import com.beust.jcommander.Parameters;
@@ -37,7 +37,7 @@ final class CompareReservedListsCommand implements CommandWithRemoteApi {
   @Override
   public void run() {
     ImmutableSet<String> datastoreLists =
-        ofy().load().type(ReservedList.class).ancestor(getCrossTldKey()).list().stream()
+        auditedOfy().load().type(ReservedList.class).ancestor(getCrossTldKey()).list().stream()
             .map(ReservedList::getName)
             .collect(toImmutableSet());
 

--- a/core/src/main/java/google/registry/tools/DedupeRecurringBillingEventIdsCommand.java
+++ b/core/src/main/java/google/registry/tools/DedupeRecurringBillingEventIdsCommand.java
@@ -15,7 +15,7 @@
 package google.registry.tools;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.model.ofy.ObjectifyService.auditedOfy;
 
 import com.beust.jcommander.Parameters;
 import com.google.common.collect.ImmutableSet;
@@ -61,9 +61,9 @@ public class DedupeRecurringBillingEventIdsCommand extends ReadEntityFromKeyPath
     // Loads the associated DomainBase and BillingEvent.OneTime entities that
     // may have reference to this BillingEvent.Recurring entity.
     Key<DomainBase> domainKey = getGrandParentAsDomain(Key.create(recurring));
-    DomainBase domain = ofy().load().key(domainKey).now();
+    DomainBase domain = auditedOfy().load().key(domainKey).now();
     List<BillingEvent.OneTime> oneTimes =
-        ofy().load().type(BillingEvent.OneTime.class).ancestor(domainKey).list();
+        auditedOfy().load().type(BillingEvent.OneTime.class).ancestor(domainKey).list();
 
     VKey<Recurring> oldRecurringVKey = recurring.createVKey();
     // By setting id to 0L, Buildable.build() will assign an application wide unique id to it.

--- a/core/src/main/java/google/registry/tools/GetResourceByKeyCommand.java
+++ b/core/src/main/java/google/registry/tools/GetResourceByKeyCommand.java
@@ -15,7 +15,7 @@
 package google.registry.tools;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.model.ofy.ObjectifyService.auditedOfy;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
@@ -47,7 +47,7 @@ final class GetResourceByKeyCommand implements CommandWithRemoteApi {
           checkNotNull(Key.create(keyString), "Could not parse key string: " + keyString);
       EppResource resource =
           checkNotNull(
-              ofy().load().key(resourceKey).now(),
+              auditedOfy().load().key(resourceKey).now(),
               "Could not load resource for key: " + resourceKey);
       System.out.println(expand ? resource.toHydratedString() : resource.toString());
     }

--- a/core/src/main/java/google/registry/tools/ReadEntityFromKeyPathCommand.java
+++ b/core/src/main/java/google/registry/tools/ReadEntityFromKeyPathCommand.java
@@ -15,7 +15,7 @@
 package google.registry.tools;
 
 import static com.google.common.base.Preconditions.checkState;
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.model.ofy.ObjectifyService.auditedOfy;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.beust.jcommander.Parameter;
@@ -64,7 +64,7 @@ abstract class ReadEntityFromKeyPathCommand<T> extends MutatingCommand {
             : Files.readLines(keyPathsFile, UTF_8);
     for (String keyPath : keyPaths) {
       Key<?> untypedKey = parseKeyPath(keyPath);
-      Object entity = ofy().load().key(untypedKey).now();
+      Object entity = auditedOfy().load().key(untypedKey).now();
       if (entity == null) {
         System.err.printf(
             "Entity %s read from %s doesn't exist in Datastore! Skipping.%n",

--- a/core/src/main/java/google/registry/tools/RegistryCli.java
+++ b/core/src/main/java/google/registry/tools/RegistryCli.java
@@ -15,7 +15,7 @@
 package google.registry.tools;
 
 import static com.google.common.base.Preconditions.checkState;
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.tools.Injector.injectReflectively;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -244,7 +244,7 @@ final class RegistryCli implements AutoCloseable, CommandRunner {
       ObjectifyService.initOfy();
       // Make sure we start the command with a clean cache, so that any previous command won't
       // interfere with this one.
-      ofy().clearSessionCache();
+      tm().clearSessionCache();
 
       // Enable Cloud SQL for command that needs remote API as they will very likely use
       // Cloud SQL after the database migration. Note that the DB password is stored in Datastore

--- a/core/src/main/java/google/registry/tools/ResaveEntitiesCommand.java
+++ b/core/src/main/java/google/registry/tools/ResaveEntitiesCommand.java
@@ -15,7 +15,7 @@
 package google.registry.tools;
 
 import static com.google.common.collect.Lists.partition;
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.model.ofy.ObjectifyService.auditedOfy;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
@@ -44,7 +44,8 @@ public final class ResaveEntitiesCommand extends MutatingCommand {
   protected void init() {
     for (List<String> batch : partition(mainParameters, BATCH_SIZE)) {
       for (String websafeKey : batch) {
-        ImmutableObject entity = ofy().load().key(Key.<ImmutableObject>create(websafeKey)).now();
+        ImmutableObject entity =
+            auditedOfy().load().key(Key.<ImmutableObject>create(websafeKey)).now();
         stageEntityChange(entity, entity);
       }
       flushTransaction();

--- a/core/src/main/java/google/registry/tools/ResaveEnvironmentEntitiesCommand.java
+++ b/core/src/main/java/google/registry/tools/ResaveEnvironmentEntitiesCommand.java
@@ -16,7 +16,7 @@ package google.registry.tools;
 
 import static com.google.common.collect.Lists.partition;
 import static google.registry.model.common.EntityGroupRoot.getCrossTldKey;
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.model.ofy.ObjectifyService.auditedOfy;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.beust.jcommander.Parameters;
@@ -46,8 +46,9 @@ final class ResaveEnvironmentEntitiesCommand implements CommandWithRemoteApi {
   private static <T> void batchSave(Class<T> clazz) {
     System.out.printf("Re-saving %s entities.\n", clazz.getSimpleName());
     for (final Iterable<Key<T>> batch :
-        partition(ofy().load().type(clazz).ancestor(getCrossTldKey()).keys().list(), BATCH_SIZE)) {
-      tm().transact(() -> ofy().save().entities(ofy().load().keys(batch).values()));
+        partition(
+            auditedOfy().load().type(clazz).ancestor(getCrossTldKey()).keys().list(), BATCH_SIZE)) {
+      tm().transact(() -> auditedOfy().save().entities(auditedOfy().load().keys(batch).values()));
       System.out.printf("Re-saved entities batch: %s.\n", batch);
     }
   }

--- a/core/src/main/java/google/registry/tools/server/KillAllEntitiesReducer.java
+++ b/core/src/main/java/google/registry/tools/server/KillAllEntitiesReducer.java
@@ -15,7 +15,7 @@
 package google.registry.tools.server;
 
 import static com.google.common.collect.Iterators.partition;
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.model.ofy.ObjectifyService.auditedOfy;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.google.appengine.tools.mapreduce.Reducer;
@@ -37,7 +37,7 @@ public class KillAllEntitiesReducer extends Reducer<Key<?>, Key<?>, Void> {
     while (batches.hasNext()) {
       final List<Key<?>> batch = batches.next();
       // Use a transaction to get retrying for free.
-      tm().transact(() -> ofy().deleteWithoutBackup().keys(batch));
+      tm().transact(() -> auditedOfy().deleteWithoutBackup().keys(batch));
       getContext().incrementCounter("entities deleted", batch.size());
       for (Key<?> key : batch) {
         getContext().incrementCounter(String.format("%s deleted", key.getKind()));

--- a/core/src/main/java/google/registry/tools/server/KillAllEppResourcesAction.java
+++ b/core/src/main/java/google/registry/tools/server/KillAllEppResourcesAction.java
@@ -15,7 +15,7 @@
 package google.registry.tools.server;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.model.ofy.ObjectifyService.auditedOfy;
 import static google.registry.request.Action.Method.POST;
 
 import com.google.appengine.tools.mapreduce.Mapper;
@@ -90,10 +90,10 @@ public class KillAllEppResourcesAction implements Runnable {
       Key<EppResourceIndex> eriKey = Key.create(eri);
       emitAndIncrementCounter(eriKey, eriKey);
       Key<?> resourceKey = eri.getKey();
-      for (Key<Object> key : ofy().load().ancestor(resourceKey).keys()) {
+      for (Key<Object> key : auditedOfy().load().ancestor(resourceKey).keys()) {
         emitAndIncrementCounter(resourceKey, key);
       }
-      EppResource resource = ofy().load().key(eri.getKey()).now();
+      EppResource resource = auditedOfy().load().key(eri.getKey()).now();
       // TODO(b/28247733): What about FKI's for renamed hosts?
       Key<?> indexKey = ForeignKeyIndex.createKey(resource);
       emitAndIncrementCounter(indexKey, indexKey);

--- a/core/src/main/java/google/registry/tools/server/ListDomainsAction.java
+++ b/core/src/main/java/google/registry/tools/server/ListDomainsAction.java
@@ -16,7 +16,7 @@ package google.registry.tools.server;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.model.ofy.ObjectifyService.auditedOfy;
 import static google.registry.model.registry.Registries.assertTldsExist;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
@@ -86,7 +86,7 @@ public final class ListDomainsAction extends ListObjectsAction<DomainBase> {
     // Combine the batches together by sorting all domains together with newest first, applying the
     // limit, and then reversing for display order.
     for (List<String> tldsBatch : Lists.partition(tlds.asList(), maxNumSubqueries)) {
-      ofy()
+      auditedOfy()
           .load()
           .type(DomainBase.class)
           .filter("tld in", tldsBatch)

--- a/core/src/main/java/google/registry/tools/server/ResaveAllHistoryEntriesAction.java
+++ b/core/src/main/java/google/registry/tools/server/ResaveAllHistoryEntriesAction.java
@@ -14,7 +14,7 @@
 
 package google.registry.tools.server;
 
-import static google.registry.model.ofy.ObjectifyService.ofy;
+import static google.registry.model.ofy.ObjectifyService.auditedOfy;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.google.appengine.tools.mapreduce.Mapper;
@@ -69,7 +69,9 @@ public class ResaveAllHistoryEntriesAction implements Runnable {
 
     @Override
     public final void map(final HistoryEntry historyEntry) {
-      tm().transact(() -> ofy().save().entity(ofy().load().entity(historyEntry).now()).now());
+      tm().transact(
+              () ->
+                  auditedOfy().save().entity(auditedOfy().load().entity(historyEntry).now()).now());
       getContext().incrementCounter(
           String.format(
               "HistoryEntries parented under %s re-saved", historyEntry.getParent().getKind()));


### PR DESCRIPTION
A couple of these use the QueryComposer interface to avoid branching.

In addition, we enforce the Datastore restriction that there can be at
most 1 field with an inequality query, see https://cloud.google.com/appengine/docs/standard/go111/datastore/query-restrictions#inequality_filters_are_limited_to_at_most_one_property

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1152)
<!-- Reviewable:end -->
