### PR TITLE
Clean up some SqlEntity classes

### DIFF
--- a/core/src/main/java/google/registry/model/domain/secdns/DomainDsDataHistory.java
+++ b/core/src/main/java/google/registry/model/domain/secdns/DomainDsDataHistory.java
@@ -16,9 +16,7 @@ package google.registry.model.domain.secdns;
 
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.ofy.ObjectifyService;
-import google.registry.schema.replay.DatastoreEntity;
-import google.registry.schema.replay.SqlEntity;
-import java.util.Optional;
+import google.registry.schema.replay.SqlOnlyEntity;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
 import javax.persistence.Column;
@@ -27,7 +25,7 @@ import javax.persistence.Id;
 
 /** Entity class to represent a historic {@link DelegationSignerData}. */
 @Entity
-public class DomainDsDataHistory extends DomainDsDataBase implements SqlEntity {
+public class DomainDsDataHistory extends DomainDsDataBase implements SqlOnlyEntity {
 
   @Id Long dsDataHistoryRevisionId;
 
@@ -83,10 +81,5 @@ public class DomainDsDataHistory extends DomainDsDataBase implements SqlEntity {
   @Column(nullable = false)
   public byte[] getDigest() {
     return super.getDigest();
-  }
-
-  @Override
-  public Optional<DatastoreEntity> toDatastoreEntity() {
-    return Optional.empty(); // Not persisted in Datastore
   }
 }

--- a/core/src/main/java/google/registry/model/reporting/Spec11ThreatMatch.java
+++ b/core/src/main/java/google/registry/model/reporting/Spec11ThreatMatch.java
@@ -21,10 +21,8 @@ import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 import com.google.common.collect.ImmutableSet;
 import google.registry.model.Buildable;
 import google.registry.model.ImmutableObject;
-import google.registry.schema.replay.DatastoreEntity;
-import google.registry.schema.replay.SqlEntity;
+import google.registry.schema.replay.SqlOnlyEntity;
 import google.registry.util.DomainNameUtils;
-import java.util.Optional;
 import java.util.Set;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -42,7 +40,7 @@ import org.joda.time.LocalDate;
       @Index(name = "spec11threatmatch_tld_idx", columnList = "tld"),
       @Index(name = "spec11threatmatch_check_date_idx", columnList = "checkDate")
     })
-public class Spec11ThreatMatch extends ImmutableObject implements Buildable, SqlEntity {
+public class Spec11ThreatMatch extends ImmutableObject implements Buildable, SqlOnlyEntity {
 
   /** The type of threat detected. */
   public enum ThreatType {
@@ -108,11 +106,6 @@ public class Spec11ThreatMatch extends ImmutableObject implements Buildable, Sql
 
   public String getTld() {
     return tld;
-  }
-
-  @Override
-  public Optional<DatastoreEntity> toDatastoreEntity() {
-    return Optional.empty(); // Not persisted in Datastore
   }
 
   @Override

--- a/core/src/main/java/google/registry/model/smd/SignedMarkRevocationList.java
+++ b/core/src/main/java/google/registry/model/smd/SignedMarkRevocationList.java
@@ -21,10 +21,8 @@ import static google.registry.util.DateTimeUtils.isBeforeOrAt;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.ImmutableObject;
-import google.registry.schema.replay.DatastoreEntity;
-import google.registry.schema.replay.SqlEntity;
+import google.registry.schema.replay.SqlOnlyEntity;
 import java.util.Map;
-import java.util.Optional;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -48,7 +46,7 @@ import org.joda.time.DateTime;
  *     functional specifications - SMD Revocation List</a>
  */
 @Entity
-public class SignedMarkRevocationList extends ImmutableObject implements SqlEntity {
+public class SignedMarkRevocationList extends ImmutableObject implements SqlOnlyEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -103,10 +101,5 @@ public class SignedMarkRevocationList extends ImmutableObject implements SqlEnti
   public SignedMarkRevocationList save() {
     SignedMarkRevocationListDao.save(this);
     return this;
-  }
-
-  @Override
-  public Optional<DatastoreEntity> toDatastoreEntity() {
-    return Optional.empty(); // Not persisted in Datastore
   }
 }

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionEntity.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionEntity.java
@@ -14,9 +14,7 @@
 
 package google.registry.persistence.transaction;
 
-import google.registry.schema.replay.DatastoreEntity;
-import google.registry.schema.replay.SqlEntity;
-import java.util.Optional;
+import google.registry.schema.replay.SqlOnlyEntity;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -30,7 +28,7 @@ import javax.persistence.Table;
  */
 @Entity
 @Table(name = "Transaction")
-public class TransactionEntity implements SqlEntity {
+public class TransactionEntity implements SqlOnlyEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,11 +40,6 @@ public class TransactionEntity implements SqlEntity {
 
   TransactionEntity(byte[] contents) {
     this.contents = contents;
-  }
-
-  @Override
-  public Optional<DatastoreEntity> toDatastoreEntity() {
-    return Optional.empty(); // Not persisted in Datastore per se
   }
 
   public long getId() {

--- a/core/src/main/java/google/registry/schema/domain/RegistryLock.java
+++ b/core/src/main/java/google/registry/schema/domain/RegistryLock.java
@@ -23,8 +23,7 @@ import google.registry.model.Buildable;
 import google.registry.model.CreateAutoTimestamp;
 import google.registry.model.ImmutableObject;
 import google.registry.model.UpdateAutoTimestamp;
-import google.registry.schema.replay.DatastoreEntity;
-import google.registry.schema.replay.SqlEntity;
+import google.registry.schema.replay.SqlOnlyEntity;
 import google.registry.util.DateTimeUtils;
 import java.time.ZonedDateTime;
 import java.util.Optional;
@@ -75,7 +74,7 @@ import org.joda.time.Duration;
       @Index(name = "idx_registry_lock_verification_code", columnList = "verificationCode"),
       @Index(name = "idx_registry_lock_registrar_id", columnList = "registrarId")
     })
-public final class RegistryLock extends ImmutableObject implements Buildable, SqlEntity {
+public final class RegistryLock extends ImmutableObject implements Buildable, SqlOnlyEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -231,11 +230,6 @@ public final class RegistryLock extends ImmutableObject implements Buildable, Sq
   @Override
   public Builder asBuilder() {
     return new Builder(clone(this));
-  }
-
-  @Override
-  public Optional<DatastoreEntity> toDatastoreEntity() {
-    return Optional.empty(); // Not persisted in Datastore
   }
 
   /** Builder for {@link google.registry.schema.domain.RegistryLock}. */

--- a/core/src/main/java/google/registry/schema/replay/SqlOnlyEntity.java
+++ b/core/src/main/java/google/registry/schema/replay/SqlOnlyEntity.java
@@ -1,0 +1,25 @@
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.schema.replay;
+
+import java.util.Optional;
+
+/** An entity that is only stored in SQL, that should not be replayed to Datastore. */
+public interface SqlOnlyEntity extends SqlEntity {
+  @Override
+  default Optional<DatastoreEntity> toDatastoreEntity() {
+    return Optional.empty();
+  }
+}

--- a/core/src/main/java/google/registry/schema/replay/SqlReplayCheckpoint.java
+++ b/core/src/main/java/google/registry/schema/replay/SqlReplayCheckpoint.java
@@ -18,30 +18,21 @@ import static google.registry.model.common.CrossTldSingleton.SINGLETON_ID;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
-import java.util.Optional;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import org.joda.time.DateTime;
 
 @Entity
-public class SqlReplayCheckpoint implements SqlEntity {
+public class SqlReplayCheckpoint implements SqlOnlyEntity {
 
   // Hibernate doesn't allow us to have a converted DateTime as our primary key so we need this
   @Id private long revisionId = SINGLETON_ID;
 
   private DateTime lastReplayTime;
 
-  @Override
-  public Optional<DatastoreEntity> toDatastoreEntity() {
-    return Optional.empty(); // Not necessary to persist in Datastore
-  }
-
   public static DateTime get() {
     jpaTm().assertInTransaction();
-    return jpaTm()
-        .query("FROM SqlReplayCheckpoint", SqlReplayCheckpoint.class)
-        .setMaxResults(1)
-        .getResultStream()
+    return jpaTm().loadAllOf(SqlReplayCheckpoint.class).stream()
         .findFirst()
         .map(checkpoint -> checkpoint.lastReplayTime)
         .orElse(START_OF_TIME);

--- a/core/src/main/java/google/registry/schema/tld/PremiumEntry.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumEntry.java
@@ -16,11 +16,9 @@ package google.registry.schema.tld;
 
 import google.registry.model.ImmutableObject;
 import google.registry.model.registry.label.PremiumList;
-import google.registry.schema.replay.DatastoreEntity;
-import google.registry.schema.replay.SqlEntity;
+import google.registry.schema.replay.SqlOnlyEntity;
 import java.io.Serializable;
 import java.math.BigDecimal;
-import java.util.Optional;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -31,7 +29,7 @@ import javax.persistence.Id;
  * <p>These are not persisted directly, but rather, using {@link PremiumList#getLabelsToPrices()}.
  */
 @Entity
-public class PremiumEntry extends ImmutableObject implements Serializable, SqlEntity {
+public class PremiumEntry extends ImmutableObject implements Serializable, SqlOnlyEntity {
 
   @Id
   @Column(nullable = false)
@@ -45,11 +43,6 @@ public class PremiumEntry extends ImmutableObject implements Serializable, SqlEn
   String domainLabel;
 
   private PremiumEntry() {}
-
-  @Override
-  public Optional<DatastoreEntity> toDatastoreEntity() {
-    return Optional.empty(); // PremiumList is dually-written
-  }
 
   public BigDecimal getPrice() {
     return price;


### PR DESCRIPTION
This started as having a better check for when to run the
ReplayCommitLogsToSqlAction but that'll require a bit more thought, and
this is a fairly simple PR that can be split out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1158)
<!-- Reviewable:end -->
