### PR TITLE
Fix RegistryJpaIO.Read problem with large data

### DIFF
--- a/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
+++ b/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
@@ -449,8 +449,8 @@ public class DatastoreTransactionManager implements TransactionManager {
     }
 
     @Override
-    public List<T> list() {
-      return buildQuery().list();
+    public ImmutableList<T> list() {
+      return ImmutableList.copyOf(buildQuery().list());
     }
 
     private void checkOnlyOneInequalityField() {

--- a/core/src/main/java/google/registry/persistence/transaction/QueryComposer.java
+++ b/core/src/main/java/google/registry/persistence/transaction/QueryComposer.java
@@ -17,6 +17,7 @@ package google.registry.persistence.transaction;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
 import google.registry.persistence.transaction.CriteriaQueryBuilder.WhereOperator;
 import java.util.ArrayList;
 import java.util.List;
@@ -94,7 +95,7 @@ public abstract class QueryComposer<T> {
 
   /**
    * Specifies if JPA entities should be automatically detached from the persistence context after
-   * loading.
+   * loading. The default behavior is auto-detach.
    *
    * <p>This configuration has no effect on Datastore queries.
    */
@@ -120,7 +121,7 @@ public abstract class QueryComposer<T> {
   public abstract long count();
 
   /** Returns the results of the query as a list. */
-  public abstract List<T> list();
+  public abstract ImmutableList<T> list();
 
   // We have to wrap the CriteriaQueryBuilder predicate factories in our own functions because at
   // the point where we pass them to the Comparator constructor, the compiler can't determine which

--- a/core/src/main/java/google/registry/persistence/transaction/QueryComposer.java
+++ b/core/src/main/java/google/registry/persistence/transaction/QueryComposer.java
@@ -92,6 +92,20 @@ public abstract class QueryComposer<T> {
     return this;
   }
 
+  /**
+   * Specifies if JPA entities should be automatically detached from the persistence context after
+   * loading. Set this configuration to true when loading large data sets into data processing
+   * pipelines.
+   *
+   * <p>Entity detachment may be best effort. It does not have to happen immediately for a
+   * particular entity, or to happen at all.
+   *
+   * <p>This configuration has no effect on Datastore queries.
+   */
+  public QueryComposer<T> withAutoDetachOnLoad(boolean autoDetachOnLoad) {
+    return this;
+  }
+
   /** Returns the first result of the query or an empty optional if there is none. */
   public abstract Optional<T> first();
 

--- a/core/src/main/java/google/registry/persistence/transaction/QueryComposer.java
+++ b/core/src/main/java/google/registry/persistence/transaction/QueryComposer.java
@@ -94,11 +94,7 @@ public abstract class QueryComposer<T> {
 
   /**
    * Specifies if JPA entities should be automatically detached from the persistence context after
-   * loading. Set this configuration to true when loading large data sets into data processing
-   * pipelines.
-   *
-   * <p>Entity detachment may be best effort. It does not have to happen immediately for a
-   * particular entity, or to happen at all.
+   * loading.
    *
    * <p>This configuration has no effect on Datastore queries.
    */

--- a/core/src/main/java/google/registry/tools/GenerateLordnCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateLordnCommand.java
@@ -69,6 +69,7 @@ final class GenerateLordnCommand implements CommandWithRemoteApi {
                 .createQueryComposer(DomainBase.class)
                 .where("tld", Comparator.EQ, tld)
                 .orderBy("repoId")
+                .withAutoDetachOnLoad(false)
                 .stream()
                 .forEach(domain -> processDomain(claimsCsv, sunriseCsv, domain)));
     ImmutableList<String> claimsRows = claimsCsv.build();

--- a/core/src/main/java/google/registry/tools/javascrap/BackfillSpec11ThreatMatchesCommand.java
+++ b/core/src/main/java/google/registry/tools/javascrap/BackfillSpec11ThreatMatchesCommand.java
@@ -39,7 +39,6 @@ import google.registry.tools.ConfirmingCommand;
 import google.registry.util.Clock;
 import java.io.IOException;
 import java.util.Comparator;
-import java.util.List;
 import java.util.function.Function;
 import javax.inject.Inject;
 import org.joda.time.LocalDate;
@@ -137,18 +136,18 @@ public class BackfillSpec11ThreatMatchesCommand extends ConfirmingCommand
             flatteningToImmutableListMultimap(
                 Function.identity(),
                 (domainName) -> {
-                  List<DomainBase> domains = loadDomainsForFqdn(domainName);
-                  domains.sort(Comparator.comparing(DomainBase::getCreationTime).reversed());
+                  ImmutableList<DomainBase> domains = loadDomainsForFqdn(domainName);
                   checkState(
                       !domains.isEmpty(),
                       "Domain name %s had no associated DomainBase objects.",
                       domainName);
-                  return domains.stream();
+                  return domains.stream()
+                      .sorted(Comparator.comparing(DomainBase::getCreationTime).reversed());
                 }));
   }
 
   /** Loads in all {@link DomainBase} objects for a given FQDN. */
-  private List<DomainBase> loadDomainsForFqdn(String fullyQualifiedDomainName) {
+  private ImmutableList<DomainBase> loadDomainsForFqdn(String fullyQualifiedDomainName) {
     return transactIfJpaTm(
         () ->
             tm().createQueryComposer(DomainBase.class)

--- a/core/src/test/java/google/registry/beam/common/RegistryJpaReadTest.java
+++ b/core/src/test/java/google/registry/beam/common/RegistryJpaReadTest.java
@@ -83,7 +83,7 @@ public class RegistryJpaReadTest {
   }
 
   @Test
-  void nonTransactionalQuery() {
+  void jpaRead() {
     Read<ContactResource, String> read =
         RegistryJpaIO.read(
             (JpaTransactionManager jpaTm) -> jpaTm.createQueryComposer(ContactResource.class),


### PR DESCRIPTION
The read connector needs to detach loaded entities.

Also removed the 'transaction mode' property from the Read connector.
There are no obvious use cases for non-transaction query, and
implementation is not straightforward with the current code base.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1161)
<!-- Reviewable:end -->
