### PR TITLE
Make PremiumList.labelsToPrices "insignificant"

### DIFF
--- a/core/src/main/java/google/registry/model/registry/label/PremiumList.java
+++ b/core/src/main/java/google/registry/model/registry/label/PremiumList.java
@@ -177,7 +177,6 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
    * using this anyway as it's inefficient to load all of the PremiumEntry rows if you don't need
    * them. To check prices, use {@link PremiumListDao#getPremiumPrice} instead.
    */
-  @Nullable
   public synchronized ImmutableMap<String, BigDecimal> getLabelsToPrices() {
     if (labelsToPrices == null) {
       labelsToPrices =
@@ -332,7 +331,7 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
   }
 
   @PreRemove
-  void preDelete() {
+  void preRemove() {
     jpaTm()
         .query("DELETE FROM PremiumEntry WHERE revision_id = :revisionId")
         .setParameter("revisionId", revisionId)

--- a/core/src/main/java/google/registry/model/registry/label/PremiumList.java
+++ b/core/src/main/java/google/registry/model/registry/label/PremiumList.java
@@ -57,7 +57,6 @@ import javax.persistence.PrePersist;
 import javax.persistence.PreRemove;
 import javax.persistence.Table;
 import javax.persistence.Transient;
-import org.hibernate.LazyInitializationException;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
 
@@ -86,7 +85,7 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
   /**
    * Mapping from unqualified domain names to their prices.
    *
-   * <p>This field requires special treatment since we want to lazy load it.  We have to remove it
+   * <p>This field requires special treatment since we want to lazy load it. We have to remove it
    * from the immutability contract so we can modify it after construction and we have to handle the
    * database processing on our own so we can detach it after load.
    */
@@ -173,8 +172,8 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
    * Returns a {@link Map} of domain labels to prices.
    *
    * <p>Note that this is lazily loaded and thus must be called inside a transaction. You generally
-   * should not be using this anyway as it's inefficient to load all of the PremiumEntry rows if
-   * you don't need them. To check prices, use {@link PremiumListDao#getPremiumPrice} instead.
+   * should not be using this anyway as it's inefficient to load all of the PremiumEntry rows if you
+   * don't need them. To check prices, use {@link PremiumListDao#getPremiumPrice} instead.
    */
   public synchronized ImmutableMap<String, BigDecimal> getLabelsToPrices() {
     if (labelsToPrices == null) {
@@ -338,8 +337,8 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
   }
 
   /**
-   * Hibernate hook called on the insert of a new PremiumList.  Stores the associated
-   * {@link PremiumEntry}'s.
+   * Hibernate hook called on the insert of a new PremiumList. Stores the associated {@link
+   * PremiumEntry}'s.
    *
    * <p>We need to persist the list entries, but only on the initial insert (not on update) since
    * the entries themselves never get changed, so we only annotate it with {@link PostPersist}, not

--- a/core/src/main/java/google/registry/model/registry/label/PremiumList.java
+++ b/core/src/main/java/google/registry/model/registry/label/PremiumList.java
@@ -83,9 +83,13 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
   @Column(nullable = false)
   CurrencyUnit currency;
 
-  // This field requires special treatment since we want to lazy load it.  We have to remove it from
-  // the immutability contract so we can modify it after construction and we have to handle the
-  // database processing on our own so we can detach it after load.
+  /**
+   * Mapping from unqualified domain names to their prices.
+   *
+   * <p>This field requires special treatment since we want to lazy load it.  We have to remove it
+   * from the immutability contract so we can modify it after construction and we have to handle the
+   * database processing on our own so we can detach it after load.
+   */
   @Ignore @ImmutableObject.Insignificant @Transient ImmutableMap<String, BigDecimal> labelsToPrices;
 
   @Ignore
@@ -335,8 +339,14 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
         .executeUpdate();
   }
 
-  // We need to persist the list entries, but only on the initial insert (not on update) since the
-  // entries themselves never get changed.
+  /**
+   * Hibernate hook called on the insert of a new PremiumList.  Stores the associated
+   * {@link PremiumEntry}'s.
+   *
+   * <p>We need to persist the list entries, but only on the initial insert (not on update) since
+   * the entries themselves never get changed, so we only annotate it with {@link PostPersist}, not
+   * {@link PostUpdate}.
+   */
   @PostPersist
   void postPersist() {
     // If the price map is loaded, persist it too.

--- a/core/src/main/java/google/registry/model/registry/label/PremiumList.java
+++ b/core/src/main/java/google/registry/model/registry/label/PremiumList.java
@@ -54,6 +54,7 @@ import javax.persistence.Index;
 import javax.persistence.PostLoad;
 import javax.persistence.PostPersist;
 import javax.persistence.PrePersist;
+import javax.persistence.PreRemove;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import org.hibernate.LazyInitializationException;
@@ -324,6 +325,13 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
   @PostLoad
   void postLoad() {
     creationTime = lastUpdateTime;
+  }
+
+  @PreRemove
+  void preDelete() {
+    jpaTm().query("DELETE FROM PremiumEntry WHERE revision_id = :revisionId")
+        .setParameter("revisionId", revisionId)
+        .executeUpdate();
   }
 
   // We need to persist the list entries, but only on the initial insert (not on update) since the

--- a/core/src/main/java/google/registry/model/registry/label/PremiumList.java
+++ b/core/src/main/java/google/registry/model/registry/label/PremiumList.java
@@ -172,10 +172,9 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
   /**
    * Returns a {@link Map} of domain labels to prices.
    *
-   * <p>Note that this is lazily loaded and thus will throw a {@link LazyInitializationException} if
-   * used outside the transaction in which the given entity was loaded. You generally should not be
-   * using this anyway as it's inefficient to load all of the PremiumEntry rows if you don't need
-   * them. To check prices, use {@link PremiumListDao#getPremiumPrice} instead.
+   * <p>Note that this is lazily loaded and thus must be called inside a transaction. You generally
+   * should not be using this anyway as it's inefficient to load all of the PremiumEntry rows if
+   * you don't need them. To check prices, use {@link PremiumListDao#getPremiumPrice} instead.
    */
   public synchronized ImmutableMap<String, BigDecimal> getLabelsToPrices() {
     if (labelsToPrices == null) {

--- a/core/src/main/java/google/registry/model/registry/label/PremiumList.java
+++ b/core/src/main/java/google/registry/model/registry/label/PremiumList.java
@@ -329,7 +329,8 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
 
   @PreRemove
   void preDelete() {
-    jpaTm().query("DELETE FROM PremiumEntry WHERE revision_id = :revisionId")
+    jpaTm()
+        .query("DELETE FROM PremiumEntry WHERE revision_id = :revisionId")
         .setParameter("revisionId", revisionId)
         .executeUpdate();
   }

--- a/core/src/main/java/google/registry/schema/tld/PremiumEntry.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumEntry.java
@@ -52,8 +52,9 @@ public class PremiumEntry extends ImmutableObject implements Serializable, SqlOn
     return domainLabel;
   }
 
-  public static PremiumEntry create(BigDecimal price, String domainLabel) {
+  public static PremiumEntry create(long revisionId, BigDecimal price, String domainLabel) {
     PremiumEntry result = new PremiumEntry();
+    result.revisionId = revisionId;
     result.price = price;
     result.domainLabel = domainLabel;
     return result;

--- a/core/src/main/java/google/registry/schema/tld/PremiumEntry.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumEntry.java
@@ -16,7 +16,7 @@ package google.registry.schema.tld;
 
 import google.registry.model.ImmutableObject;
 import google.registry.model.registry.label.PremiumList;
-import google.registry.schema.replay.SqlOnlyEntity;
+import google.registry.schema.replay.NonReplicatedEntity;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import javax.persistence.Column;
@@ -29,7 +29,7 @@ import javax.persistence.Id;
  * <p>These are not persisted directly, but rather, using {@link PremiumList#getLabelsToPrices()}.
  */
 @Entity
-public class PremiumEntry extends ImmutableObject implements Serializable, SqlOnlyEntity {
+public class PremiumEntry extends ImmutableObject implements NonReplicatedEntity, Serializable {
 
   @Id
   @Column(nullable = false)

--- a/core/src/main/java/google/registry/schema/tld/PremiumEntry.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumEntry.java
@@ -16,7 +16,7 @@ package google.registry.schema.tld;
 
 import google.registry.model.ImmutableObject;
 import google.registry.model.registry.label.PremiumList;
-import google.registry.schema.replay.NonReplicatedEntity;
+import google.registry.schema.replay.SqlOnlyEntity;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import javax.persistence.Column;
@@ -29,7 +29,7 @@ import javax.persistence.Id;
  * <p>These are not persisted directly, but rather, using {@link PremiumList#getLabelsToPrices()}.
  */
 @Entity
-public class PremiumEntry extends ImmutableObject implements NonReplicatedEntity, Serializable {
+public class PremiumEntry extends ImmutableObject implements Serializable, SqlOnlyEntity {
 
   @Id
   @Column(nullable = false)

--- a/core/src/main/java/google/registry/tools/server/ListPremiumListsAction.java
+++ b/core/src/main/java/google/registry/tools/server/ListPremiumListsAction.java
@@ -64,7 +64,7 @@ public final class ListPremiumListsAction extends ListObjectsAction<PremiumList>
 
   /**
    * Provide a field override for labelsToPrices, since it is an {@code Insignificant} field and
-   * doesn't get returned from {@link google.registry.model.ImmutableObject.toDiffableFieldMap()}.
+   * doesn't get returned from {@link google.registry.model.ImmutableObject#toDiffableFieldMap}.
    */
   @Override
   public ImmutableMap<String, String> getFieldOverrides(PremiumList list) {

--- a/core/src/main/java/google/registry/tools/server/ListPremiumListsAction.java
+++ b/core/src/main/java/google/registry/tools/server/ListPremiumListsAction.java
@@ -19,6 +19,7 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.request.Action.Method.GET;
 import static google.registry.request.Action.Method.POST;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import google.registry.model.registry.label.PremiumList;
 import google.registry.request.Action;
@@ -27,7 +28,6 @@ import google.registry.schema.tld.PremiumListDao;
 import java.util.Comparator;
 import java.util.Optional;
 import javax.inject.Inject;
-import org.hibernate.Hibernate;
 
 /**
  * An action that lists premium lists, for use by the {@code nomulus list_premium_lists} command.
@@ -58,7 +58,16 @@ public final class ListPremiumListsAction extends ListObjectsAction<PremiumList>
                     .map(PremiumListDao::getLatestRevision)
                     .filter(Optional::isPresent)
                     .map(Optional::get)
-                    .peek(list -> Hibernate.initialize(list.getLabelsToPrices()))
+                    .peek(list -> list.getLabelsToPrices())
                     .collect(toImmutableSortedSet(Comparator.comparing(PremiumList::getName))));
+  }
+
+  /**
+   * Provide a field override for labelsToPrices, since it is an {@code Insignificant} field and
+   * doesn't get returned from {@link google.registry.model.ImmutableObject.toDiffableFieldMap()}.
+   */
+  @Override
+  public ImmutableMap<String, String> getFieldOverrides(PremiumList list) {
+    return ImmutableMap.of("labelsToPrices", list.getLabelsToPrices().toString());
   }
 }

--- a/core/src/test/java/google/registry/backup/ReplayCommitLogsToSqlActionTest.java
+++ b/core/src/test/java/google/registry/backup/ReplayCommitLogsToSqlActionTest.java
@@ -61,6 +61,7 @@ import google.registry.persistence.VKey;
 import google.registry.persistence.transaction.JpaTransactionManager;
 import google.registry.persistence.transaction.TransactionManagerFactory;
 import google.registry.schema.replay.SqlReplayCheckpoint;
+import google.registry.schema.tld.PremiumEntry;
 import google.registry.testing.AppEngineExtension;
 import google.registry.testing.FakeClock;
 import google.registry.testing.FakeResponse;
@@ -98,6 +99,7 @@ public class ReplayCommitLogsToSqlActionTest {
               DomainBase.class,
               GracePeriod.class,
               PremiumList.class,
+              PremiumEntry.class,
               RegistrarContact.class,
               SqlReplayCheckpoint.class,
               TestObject.class)

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -862,11 +862,6 @@ create index spec11threatmatch_check_date_idx on "Spec11ThreatMatch" (check_date
        foreign key (domain_repo_id, domain_history_revision_id) 
        references "DomainHistory";
 
-    alter table if exists "PremiumEntry" 
-       add constraint FKo0gw90lpo1tuee56l0nb6y6g5 
-       foreign key (revision_id) 
-       references "PremiumList";
-
     alter table if exists "RegistryLock" 
        add constraint FK2lhcwpxlnqijr96irylrh1707 
        foreign key (relock_revision_id) 


### PR DESCRIPTION
Add the ImmutableObject.Insignificant annotation to labelsToPrices and also
mark it as Transient.  In order to do lazy-loads on this field, we need to do
so explicitly: doing otherwise breaks the immutability contract and prevents
detaching the object upon load.

Note that this is an expedient solution to this problem, but not the optimal
one.  Ideally, the disassociation between PremiumList and its PremiumEntry's
would be more explicit.  However, breaking labelsToPrices out would at minimum
require reworking the Create/UpdatePremiumList commands, which currently rely
on passing around a self-contained PremiumList object, both from the parser
interfaces and to the database.

If this approach is acceptable, we can apply it to ReservedList and ClaimsList
as well (though it may be easier to break the association in those cases).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1167)
<!-- Reviewable:end -->
