### PR TITLE
Add methods to return subtypes of HistoryEntry when querying

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -317,6 +317,7 @@ dependencies {
   testCompile deps['com.google.monitoring-client:contrib']
   testCompile deps['com.google.truth:truth']
   testCompile deps['com.google.truth.extensions:truth-java8-extension']
+  testCompile deps['org.checkerframework:checker-qual']
   testCompile deps['org.hamcrest:hamcrest']
   testCompile deps['org.hamcrest:hamcrest-core']
   testCompile deps['org.hamcrest:hamcrest-library']

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -120,6 +120,7 @@ ext {
       'jline:jline:1.0',
       'joda-time:joda-time:2.9.2',
       'junit:junit:4.13',
+      'org.checkerframework:checker-qual:3.9.1',
       'org.junit.jupiter:junit-jupiter-api:5.6.2',
       'org.junit.jupiter:junit-jupiter-engine:5.6.2',
       'org.junit.jupiter:junit-jupiter-migrationsupport:5.6.2',


### PR DESCRIPTION
This is useful when we expect a specific subtype in the return value so
that we can set the parent resource (e. g. DomainContent for
DomainHistory) on it, or when a specific subtype is needed from the call
site.

This PR also fixes some use of generic return values. It is always better to
return <HistoryEntry> than a wildcard <? extends HistoryEntry>, because for
immutable collections, <? extends HistoryEntry> is no different than
<HistoryEntry> as return value -- you can only get a HistoryEntry from it.
The wildcard return value means that even if you are indeed getting a
<DomainHistory> from the query, the call site has no compile time knowledge of
it and can only assume it is a <HistoryEntry>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1172)
<!-- Reviewable:end -->
