### PR TITLE
Change BillingEvent parent to Key<DomainHistory>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 ######################################################################
 # Java Ignores
 
+gjf.out
 *.class
 
 # Mobile Tools for Java (J2ME)

--- a/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
@@ -292,7 +292,7 @@ public final class DomainUpdateFlow implements TransactionalFlow {
   private Optional<BillingEvent.OneTime> createBillingEventForStatusUpdates(
       DomainBase existingDomain,
       DomainBase newDomain,
-      HistoryEntry historyEntry,
+      DomainHistory historyEntry,
       DateTime now) {
     Optional<MetadataExtension> metadataExtension =
         eppInput.getSingleExtension(MetadataExtension.class);

--- a/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
@@ -290,10 +290,7 @@ public final class DomainUpdateFlow implements TransactionalFlow {
 
   /** Some status updates cost money. Bill only once no matter how many of them are changed. */
   private Optional<BillingEvent.OneTime> createBillingEventForStatusUpdates(
-      DomainBase existingDomain,
-      DomainBase newDomain,
-      DomainHistory historyEntry,
-      DateTime now) {
+      DomainBase existingDomain, DomainBase newDomain, DomainHistory historyEntry, DateTime now) {
     Optional<MetadataExtension> metadataExtension =
         eppInput.getSingleExtension(MetadataExtension.class);
     if (metadataExtension.isPresent() && metadataExtension.get().getRequestedByRegistrar()) {

--- a/core/src/main/java/google/registry/model/billing/BillingEvent.java
+++ b/core/src/main/java/google/registry/model/billing/BillingEvent.java
@@ -46,7 +46,6 @@ import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.GracePeriod;
 import google.registry.model.domain.rgp.GracePeriodStatus;
 import google.registry.model.domain.token.AllocationToken;
-import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.transfer.TransferData.TransferServerApproveEntity;
 import google.registry.persistence.BillingVKey.BillingEventVKey;
 import google.registry.persistence.BillingVKey.BillingRecurrenceVKey;
@@ -115,7 +114,7 @@ public abstract class BillingEvent extends ImmutableObject
   /** Entity id. */
   @Id @javax.persistence.Id Long id;
 
-  @Parent @DoNotHydrate @Transient Key<? extends HistoryEntry> parent;
+  @Parent @DoNotHydrate @Transient Key<DomainHistory> parent;
 
   /** The registrar to bill. */
   @Index
@@ -154,7 +153,7 @@ public abstract class BillingEvent extends ImmutableObject
     parent =
         Key.create(
             Key.create(DomainBase.class, domainRepoId),
-            HistoryEntry.class,
+            DomainHistory.class,
             domainHistoryRevisionId);
   }
 
@@ -192,7 +191,7 @@ public abstract class BillingEvent extends ImmutableObject
     return targetId;
   }
 
-  public Key<? extends HistoryEntry> getParentKey() {
+  public Key<DomainHistory> getParentKey() {
     return parent;
   }
 
@@ -254,12 +253,12 @@ public abstract class BillingEvent extends ImmutableObject
       return thisCastToDerived();
     }
 
-    public B setParent(HistoryEntry parent) {
+    public B setParent(DomainHistory parent) {
       getInstance().parent = Key.create(parent);
       return thisCastToDerived();
     }
 
-    public B setParent(Key<? extends HistoryEntry> parentKey) {
+    public B setParent(Key<DomainHistory> parentKey) {
       getInstance().parent = parentKey;
       return thisCastToDerived();
     }
@@ -735,7 +734,7 @@ public abstract class BillingEvent extends ImmutableObject
      * because it is needed by one-off scrap tools that need to make billing adjustments.
      */
     public static Modification createRefundFor(
-        OneTime billingEvent, HistoryEntry historyEntry, String description) {
+        OneTime billingEvent, DomainHistory historyEntry, String description) {
       return new Builder()
           .setClientId(billingEvent.getClientId())
           .setFlags(billingEvent.getFlags())

--- a/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
+++ b/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
@@ -224,7 +224,7 @@ public class DatastoreTransactionManager implements TransactionManager {
 
   @Override
   public <T> ImmutableList<T> loadByEntitiesIfPresent(Iterable<T> entities) {
-    return ImmutableList.copyOf(getOfy().load().entities(entities).values());
+    return Streams.stream(entities).map(this::loadByEntity).collect(toImmutableList());
   }
 
   @Override
@@ -250,6 +250,7 @@ public class DatastoreTransactionManager implements TransactionManager {
     return result;
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public <T> T loadByEntity(T entity) {
     return (T) toSqlEntity(auditedOfy().load().entity(toDatastoreEntity(entity)).now());

--- a/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
+++ b/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
@@ -44,7 +44,6 @@ import google.registry.schema.replay.DatastoreEntity;
 import google.registry.schema.replay.SqlEntity;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -223,11 +222,16 @@ public class DatastoreTransactionManager implements TransactionManager {
                 entry -> keyMap.get(entry.getKey()), entry -> toSqlEntity(entry.getValue())));
   }
 
+  @SuppressWarnings("unchecked")
   @Override
   public <T> ImmutableList<T> loadByEntitiesIfPresent(Iterable<T> entities) {
-    return Streams.stream(entities)
-        .map(this::loadByEntity)
-        .filter(Objects::nonNull)
+    return getOfy()
+        .load()
+        .entities(toDatastoreEntities(ImmutableList.copyOf(entities)))
+        .values()
+        .stream()
+        .map(DatastoreTransactionManager::toSqlEntity)
+        .map(entity -> (T) entity)
         .collect(toImmutableList());
   }
 

--- a/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
+++ b/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
@@ -44,6 +44,7 @@ import google.registry.schema.replay.DatastoreEntity;
 import google.registry.schema.replay.SqlEntity;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -224,7 +225,10 @@ public class DatastoreTransactionManager implements TransactionManager {
 
   @Override
   public <T> ImmutableList<T> loadByEntitiesIfPresent(Iterable<T> entities) {
-    return Streams.stream(entities).map(this::loadByEntity).collect(toImmutableList());
+    return Streams.stream(entities)
+        .map(this::loadByEntity)
+        .filter(Objects::nonNull)
+        .collect(toImmutableList());
   }
 
   @Override

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -456,11 +456,14 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
     assertInTransaction();
     // If the caller requested a HistoryEntry, load the corresponding *History class
     T possibleChild = toSqlEntity(entity);
-    return (T)
-        loadByKey(
-            VKey.createSql(
-                possibleChild.getClass(),
-                emf.getPersistenceUnitUtil().getIdentifier(possibleChild)));
+    @SuppressWarnings("unchecked")
+    T returnValue =
+        (T)
+            loadByKey(
+                VKey.createSql(
+                    possibleChild.getClass(),
+                    emf.getPersistenceUnitUtil().getIdentifier(possibleChild)));
+    return returnValue;
   }
 
   @Override

--- a/core/src/test/java/google/registry/batch/DeleteExpiredDomainsActionTest.java
+++ b/core/src/test/java/google/registry/batch/DeleteExpiredDomainsActionTest.java
@@ -165,7 +165,7 @@ class DeleteExpiredDomainsActionTest {
 
   private DomainBase persistNonAutorenewingDomain(String domainName) {
     DomainBase pendingExpirationDomain = persistActiveDomain(domainName);
-    HistoryEntry createHistoryEntry =
+    DomainHistory createHistoryEntry =
         persistResource(
             new DomainHistory.Builder()
                 .setType(DOMAIN_CREATE)
@@ -190,7 +190,7 @@ class DeleteExpiredDomainsActionTest {
   }
 
   private BillingEvent.Recurring.Builder createAutorenewBillingEvent(
-      HistoryEntry createHistoryEntry) {
+      DomainHistory createHistoryEntry) {
     return new BillingEvent.Recurring.Builder()
         .setReason(Reason.RENEW)
         .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))

--- a/core/src/test/java/google/registry/batch/DeleteProberDataActionTest.java
+++ b/core/src/test/java/google/registry/batch/DeleteProberDataActionTest.java
@@ -290,7 +290,7 @@ class DeleteProberDataActionTest extends MapreduceTestCase<DeleteProberDataActio
                 .build());
     BillingEvent.OneTime billingEvent = persistSimpleResource(
         new BillingEvent.OneTime.Builder()
-            .setParent(historyEntry)
+            .setParent((DomainHistory) historyEntry.toChildHistoryEntity())
             .setBillingTime(DELETION_TIME.plusYears(1))
             .setCost(Money.parse("USD 10"))
             .setPeriodYears(1)

--- a/core/src/test/java/google/registry/batch/DeleteProberDataActionTest.java
+++ b/core/src/test/java/google/registry/batch/DeleteProberDataActionTest.java
@@ -280,7 +280,7 @@ class DeleteProberDataActionTest extends MapreduceTestCase<DeleteProberDataActio
    */
   private static Set<ImmutableObject> persistDomainAndDescendants(String fqdn) {
     DomainBase domain = persistDeletedDomain(fqdn, DELETION_TIME);
-    HistoryEntry historyEntry =
+    DomainHistory historyEntry =
         persistSimpleResource(
             new DomainHistory.Builder()
                 .setDomain(domain)
@@ -290,7 +290,7 @@ class DeleteProberDataActionTest extends MapreduceTestCase<DeleteProberDataActio
                 .build());
     BillingEvent.OneTime billingEvent = persistSimpleResource(
         new BillingEvent.OneTime.Builder()
-            .setParent((DomainHistory) historyEntry.toChildHistoryEntity())
+            .setParent(historyEntry)
             .setBillingTime(DELETION_TIME.plusYears(1))
             .setCost(Money.parse("USD 10"))
             .setPeriodYears(1)

--- a/core/src/test/java/google/registry/batch/ExpandRecurringBillingEventsActionTest.java
+++ b/core/src/test/java/google/registry/batch/ExpandRecurringBillingEventsActionTest.java
@@ -75,7 +75,7 @@ public class ExpandRecurringBillingEventsActionTest
   private final FakeClock clock = new FakeClock(beginningOfTest);
 
   private DomainBase domain;
-  private HistoryEntry historyEntry;
+  private DomainHistory historyEntry;
   private BillingEvent.Recurring recurring;
 
   @BeforeEach
@@ -173,7 +173,8 @@ public class ExpandRecurringBillingEventsActionTest
     persistResource(recurring);
     action.cursorTimeParam = Optional.of(START_OF_TIME);
     runMapreduce();
-    HistoryEntry persistedEntry = getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW);
+    DomainHistory persistedEntry =
+        getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW, DomainHistory.class);
     assertHistoryEntryMatches(
         domain, persistedEntry, "TheRegistrar", DateTime.parse("2000-02-19T00:00:00Z"), true);
     BillingEvent.OneTime expected = defaultOneTimeBuilder()
@@ -209,9 +210,13 @@ public class ExpandRecurringBillingEventsActionTest
                 .build());
     action.cursorTimeParam = Optional.of(START_OF_TIME);
     runMapreduce();
-    HistoryEntry persistedEntry = getOnlyHistoryEntryOfType(deletedDomain, DOMAIN_AUTORENEW);
+    DomainHistory persistedEntry =
+        getOnlyHistoryEntryOfType(deletedDomain, DOMAIN_AUTORENEW, DomainHistory.class);
     assertHistoryEntryMatches(
-        deletedDomain, persistedEntry, "TheRegistrar", DateTime.parse("2000-02-19T00:00:00Z"),
+        deletedDomain,
+        persistedEntry,
+        "TheRegistrar",
+        DateTime.parse("2000-02-19T00:00:00Z"),
         true);
     BillingEvent.OneTime expected =
         defaultOneTimeBuilder()
@@ -227,7 +232,8 @@ public class ExpandRecurringBillingEventsActionTest
     persistResource(recurring);
     action.cursorTimeParam = Optional.of(START_OF_TIME);
     runMapreduce();
-    HistoryEntry persistedEntry = getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW);
+    DomainHistory persistedEntry =
+        getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW, DomainHistory.class);
     assertHistoryEntryMatches(
         domain, persistedEntry, "TheRegistrar", DateTime.parse("2000-02-19T00:00:00Z"), true);
     BillingEvent.OneTime expected = defaultOneTimeBuilder().setParent(persistedEntry).build();
@@ -259,7 +265,8 @@ public class ExpandRecurringBillingEventsActionTest
     persistResource(recurring);
     action.cursorTimeParam = Optional.of(START_OF_TIME);
     runMapreduce();
-    HistoryEntry persistedEntry = getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW);
+    DomainHistory persistedEntry =
+        getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW, DomainHistory.class);
     assertHistoryEntryMatches(
         domain, persistedEntry, "TheRegistrar", DateTime.parse("2000-02-19T00:00:00Z"), true);
     BillingEvent.OneTime expected = defaultOneTimeBuilder().setParent(persistedEntry).build();
@@ -280,8 +287,8 @@ public class ExpandRecurringBillingEventsActionTest
         .build());
     action.cursorTimeParam = Optional.of(START_OF_TIME);
     runMapreduce();
-    List<HistoryEntry> persistedEntries =
-        getHistoryEntriesOfType(domain, DOMAIN_AUTORENEW);
+    List<DomainHistory> persistedEntries =
+        getHistoryEntriesOfType(domain, DOMAIN_AUTORENEW, DomainHistory.class);
     for (HistoryEntry persistedEntry : persistedEntries) {
       assertHistoryEntryMatches(
           domain, persistedEntry, "TheRegistrar", DateTime.parse("2000-02-19T00:00:00Z"), true);
@@ -332,7 +339,8 @@ public class ExpandRecurringBillingEventsActionTest
     persistResource(recurring);
     action.cursorTimeParam = Optional.of(DateTime.parse("2000-02-19T00:00:00Z"));
     runMapreduce();
-    HistoryEntry persistedEntry = getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW);
+    DomainHistory persistedEntry =
+        getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW, DomainHistory.class);
     assertHistoryEntryMatches(
         domain, persistedEntry, "TheRegistrar", DateTime.parse("2000-02-19T00:00:00Z"), true);
     BillingEvent.OneTime expected = defaultOneTimeBuilder().setParent(persistedEntry).build();
@@ -345,7 +353,8 @@ public class ExpandRecurringBillingEventsActionTest
     persistResource(recurring);
     action.cursorTimeParam = Optional.of(DateTime.parse("2000-01-12T00:00:00Z"));
     runMapreduce();
-    HistoryEntry persistedEntry = getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW);
+    DomainHistory persistedEntry =
+        getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW, DomainHistory.class);
     assertHistoryEntryMatches(
         domain, persistedEntry, "TheRegistrar", DateTime.parse("2000-02-19T00:00:00Z"), true);
     BillingEvent.OneTime expected = defaultOneTimeBuilder().setParent(persistedEntry).build();
@@ -379,7 +388,8 @@ public class ExpandRecurringBillingEventsActionTest
             recurring.asBuilder().setEventTime(recurring.getEventTime().plusYears(2)).build());
     clock.setTo(testTime);
     runMapreduce();
-    HistoryEntry persistedEntry = getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW);
+    DomainHistory persistedEntry =
+        getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW, DomainHistory.class);
     assertHistoryEntryMatches(
         domain, persistedEntry, "TheRegistrar", DateTime.parse("2002-02-19T00:00:00Z"), true);
     BillingEvent.OneTime expected = defaultOneTimeBuilder()
@@ -397,7 +407,8 @@ public class ExpandRecurringBillingEventsActionTest
     persistResource(recurring);
     saveCursor(START_OF_TIME);
     runMapreduce();
-    HistoryEntry persistedEntry = getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW);
+    DomainHistory persistedEntry =
+        getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW, DomainHistory.class);
     assertHistoryEntryMatches(
         domain, persistedEntry, "TheRegistrar", DateTime.parse("2000-02-19T00:00:00Z"), true);
     BillingEvent.OneTime expected = defaultOneTimeBuilder().setParent(persistedEntry).build();
@@ -451,8 +462,8 @@ public class ExpandRecurringBillingEventsActionTest
     expectedEvents.add(persistResource(recurring));
     action.cursorTimeParam = Optional.of(START_OF_TIME);
     runMapreduce();
-    List<HistoryEntry> persistedEntries =
-        getHistoryEntriesOfType(domain, DOMAIN_AUTORENEW);
+    List<DomainHistory> persistedEntries =
+        getHistoryEntriesOfType(domain, DOMAIN_AUTORENEW, DomainHistory.class);
     assertThat(persistedEntries).hasSize(6);
     DateTime eventDate = DateTime.parse("2000-01-05T00:00:00Z");
     DateTime billingDate = DateTime.parse("2000-02-19T00:00:00Z");
@@ -482,8 +493,8 @@ public class ExpandRecurringBillingEventsActionTest
     expectedEvents.add(persistResource(recurring));
     saveCursor(DateTime.parse("2003-10-02T00:00:00Z"));
     runMapreduce();
-    List<HistoryEntry> persistedEntries =
-        getHistoryEntriesOfType(domain, DOMAIN_AUTORENEW);
+    List<DomainHistory> persistedEntries =
+        getHistoryEntriesOfType(domain, DOMAIN_AUTORENEW, DomainHistory.class);
     assertThat(persistedEntries).hasSize(2);
     DateTime eventDate = DateTime.parse("2004-01-05T00:00:00Z");
     DateTime billingDate = DateTime.parse("2004-02-19T00:00:00Z");
@@ -528,7 +539,8 @@ public class ExpandRecurringBillingEventsActionTest
         .build());
     action.cursorTimeParam = Optional.of(START_OF_TIME);
     runMapreduce();
-    HistoryEntry persistedEntry = getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW);
+    DomainHistory persistedEntry =
+        getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW, DomainHistory.class);
     assertHistoryEntryMatches(
         domain, persistedEntry, "TheRegistrar", DateTime.parse("2000-02-19T00:00:00Z"), false);
     BillingEvent.OneTime expected = defaultOneTimeBuilder()
@@ -553,7 +565,8 @@ public class ExpandRecurringBillingEventsActionTest
         .build());
     action.cursorTimeParam = Optional.of(START_OF_TIME);
     runMapreduce();
-    HistoryEntry persistedEntry = getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW);
+    DomainHistory persistedEntry =
+        getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW, DomainHistory.class);
     assertHistoryEntryMatches(
         domain, persistedEntry, "TheRegistrar", DateTime.parse("2000-02-19T00:00:00Z"), true);
     BillingEvent.OneTime expected = defaultOneTimeBuilder()
@@ -572,7 +585,8 @@ public class ExpandRecurringBillingEventsActionTest
             recurring.asBuilder().setEventTime(DateTime.parse("2000-01-15T00:00:00Z")).build());
     action.cursorTimeParam = Optional.of(START_OF_TIME);
     runMapreduce();
-    HistoryEntry persistedEntry = getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW);
+    DomainHistory persistedEntry =
+        getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW, DomainHistory.class);
     assertHistoryEntryMatches(
         domain, persistedEntry, "TheRegistrar", DateTime.parse("2000-02-29T00:00:00Z"), true);
     BillingEvent.OneTime expected = defaultOneTimeBuilder()
@@ -593,7 +607,8 @@ public class ExpandRecurringBillingEventsActionTest
     action.cursorTimeParam = Optional.of(START_OF_TIME);
     clock.setTo(testTime);
     runMapreduce();
-    HistoryEntry persistedEntry = getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW);
+    DomainHistory persistedEntry =
+        getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW, DomainHistory.class);
     assertHistoryEntryMatches(
         domain, persistedEntry, "TheRegistrar", DateTime.parse("2001-03-01T00:00:00Z"), true);
     BillingEvent.OneTime expected = defaultOneTimeBuilder()
@@ -615,7 +630,8 @@ public class ExpandRecurringBillingEventsActionTest
         .build());
     action.cursorTimeParam = Optional.of(START_OF_TIME);
     runMapreduce();
-    List<HistoryEntry> persistedEntries = getHistoryEntriesOfType(domain, DOMAIN_AUTORENEW);
+    List<DomainHistory> persistedEntries =
+        getHistoryEntriesOfType(domain, DOMAIN_AUTORENEW, DomainHistory.class);
     assertThat(persistedEntries).hasSize(2);
     assertHistoryEntryMatches(
         domain, persistedEntries.get(0), "TheRegistrar", DateTime.parse("2000-02-19T00:00:00Z"),
@@ -649,7 +665,8 @@ public class ExpandRecurringBillingEventsActionTest
     persistResource(recurring);
     action.cursorTimeParam = Optional.of(START_OF_TIME);
     runMapreduce();
-    HistoryEntry persistedEntry = getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW);
+    DomainHistory persistedEntry =
+        getOnlyHistoryEntryOfType(domain, DOMAIN_AUTORENEW, DomainHistory.class);
     assertHistoryEntryMatches(
         domain, persistedEntry, "TheRegistrar", DateTime.parse("2000-02-19T00:00:00Z"), true);
     BillingEvent.OneTime expected = defaultOneTimeBuilder()
@@ -675,8 +692,8 @@ public class ExpandRecurringBillingEventsActionTest
     persistResource(recurring);
     action.cursorTimeParam = Optional.of(START_OF_TIME);
     runMapreduce();
-    List<HistoryEntry> persistedEntries =
-        getHistoryEntriesOfType(domain, DOMAIN_AUTORENEW);
+    List<DomainHistory> persistedEntries =
+        getHistoryEntriesOfType(domain, DOMAIN_AUTORENEW, DomainHistory.class);
     assertThat(persistedEntries).hasSize(2);
     DateTime eventDate = DateTime.parse("2000-01-05T00:00:00Z");
     DateTime billingDate = DateTime.parse("2000-02-19T00:00:00Z");

--- a/core/src/test/java/google/registry/beam/initsql/InitSqlPipelineTest.java
+++ b/core/src/test/java/google/registry/beam/initsql/InitSqlPipelineTest.java
@@ -129,7 +129,7 @@ class InitSqlPipelineTest {
   private transient ContactResource contact2;
   private transient HostResource hostResource;
 
-  private transient HistoryEntry historyEntry;
+  private transient DomainHistory historyEntry;
 
   @BeforeEach
   void beforeEach() throws Exception {
@@ -187,7 +187,7 @@ class InitSqlPipelineTest {
                   .build());
       persistResource(
           new AllocationToken.Builder().setToken("abc123").setTokenType(SINGLE_USE).build());
-      Key<HistoryEntry> historyEntryKey = Key.create(historyEntry);
+      Key<DomainHistory> historyEntryKey = Key.create(historyEntry);
       BillingEvent.OneTime onetimeBillEvent =
           new BillingEvent.OneTime.Builder()
               .setId(1)

--- a/core/src/test/java/google/registry/flows/EppLifecycleDomainTest.java
+++ b/core/src/test/java/google/registry/flows/EppLifecycleDomainTest.java
@@ -42,6 +42,7 @@ import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.OneTime;
 import google.registry.model.billing.BillingEvent.Reason;
 import google.registry.model.domain.DomainBase;
+import google.registry.model.domain.DomainHistory;
 import google.registry.model.registry.Registry;
 import google.registry.model.registry.Registry.TldState;
 import google.registry.model.reporting.HistoryEntry.Type;
@@ -549,7 +550,7 @@ class EppLifecycleDomainTest extends EppTestCase {
             .setCost(Money.parse("USD 100.00"))
             .setEventTime(createTime)
             .setBillingTime(createTime.plus(Registry.get("tld").getRenewGracePeriodLength()))
-            .setParent(getOnlyHistoryEntryOfType(domain, Type.DOMAIN_CREATE))
+            .setParent(getOnlyHistoryEntryOfType(domain, Type.DOMAIN_CREATE, DomainHistory.class))
             .build();
 
     // The expected one-time billing event, that should have an associated Cancellation.

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -145,6 +145,7 @@ import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Flag;
 import google.registry.model.billing.BillingEvent.Reason;
 import google.registry.model.domain.DomainBase;
+import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.GracePeriod;
 import google.registry.model.domain.launch.LaunchNotice;
 import google.registry.model.domain.rgp.GracePeriodStatus;
@@ -266,7 +267,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             ? clock.nowUtc().plus(Registry.get(domainTld).getAnchorTenantAddGracePeriodLength())
             : clock.nowUtc().plus(Registry.get(domainTld).getAddGracePeriodLength());
     assertLastHistoryContainsResource(domain);
-    HistoryEntry historyEntry = getHistoryEntries(domain).get(0);
+    DomainHistory historyEntry = getHistoryEntries(domain, DomainHistory.class).get(0);
     assertAboutDomains()
         .that(domain)
         .hasRegistrationExpirationTime(

--- a/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
@@ -229,14 +229,14 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
   }
 
   private void assertAutorenewClosedAndCancellationCreatedFor(
-      BillingEvent.OneTime graceBillingEvent, HistoryEntry historyEntryDomainDelete) {
+      BillingEvent.OneTime graceBillingEvent, DomainHistory historyEntryDomainDelete) {
     assertAutorenewClosedAndCancellationCreatedFor(
         graceBillingEvent, historyEntryDomainDelete, clock.nowUtc());
   }
 
   private void assertAutorenewClosedAndCancellationCreatedFor(
       BillingEvent.OneTime graceBillingEvent,
-      HistoryEntry historyEntryDomainDelete,
+      DomainHistory historyEntryDomainDelete,
       DateTime eventTime) {
     assertBillingEvents(
         createAutorenewBillingEvent("TheRegistrar").setRecurrenceEndTime(eventTime).build(),
@@ -360,7 +360,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     assertThat(reloadResourceByForeignKey()).isNull();
     // The add grace period is for a billable action, so it should trigger a cancellation.
     assertAutorenewClosedAndCancellationCreatedFor(
-        graceBillingEvent, getOnlyHistoryEntryOfType(domain, DOMAIN_DELETE));
+        graceBillingEvent, getOnlyHistoryEntryOfType(domain, DOMAIN_DELETE, DomainHistory.class));
     assertDnsTasksEnqueued("example.tld");
     // There should be no poll messages. The previous autorenew poll message should now be deleted.
     assertThat(getPollMessages("TheRegistrar")).isEmpty();
@@ -461,7 +461,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     assertLastHistoryContainsResource(resource);
     // All existing grace periods that were for billable actions should cause cancellations.
     assertAutorenewClosedAndCancellationCreatedFor(
-        renewBillingEvent, getOnlyHistoryEntryOfType(resource, DOMAIN_DELETE));
+        renewBillingEvent, getOnlyHistoryEntryOfType(resource, DOMAIN_DELETE, DomainHistory.class));
     // All existing grace periods should be gone, and a new REDEMPTION one should be added.
     assertThat(resource.getGracePeriods())
         .containsExactly(
@@ -755,7 +755,9 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     runFlowAssertResponse(loadFile("generic_success_response.xml"));
     assertDnsTasksEnqueued("example.tld");
     assertAutorenewClosedAndCancellationCreatedFor(
-        graceBillingEvent, getOnlyHistoryEntryOfType(domain, DOMAIN_DELETE), eventTime);
+        graceBillingEvent,
+        getOnlyHistoryEntryOfType(domain, DOMAIN_DELETE, DomainHistory.class),
+        eventTime);
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
@@ -361,7 +361,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
   @TestOfyAndSql
   void testSuccess_autoRenewGracePeriod() throws Exception {
     persistTestEntities(false);
-    HistoryEntry historyEntry =
+    DomainHistory historyEntry =
         persistResource(
             new DomainHistory.Builder()
                 .setDomain(domain)

--- a/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
@@ -201,8 +201,8 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, DomainBa
         CommitMode.LIVE, userPrivileges, loadFile(responseFilename, substitutions));
     DomainBase domain = reloadResourceByForeignKey();
     assertLastHistoryContainsResource(domain);
-    HistoryEntry historyEntryDomainRenew =
-        getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_RENEW);
+    DomainHistory historyEntryDomainRenew =
+        getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_RENEW, DomainHistory.class);
     assertThat(loadByKey(domain.getAutorenewBillingEvent()).getEventTime())
         .isEqualTo(newExpiration);
     assertAboutDomains()
@@ -238,7 +238,9 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, DomainBa
             .setClientId("TheRegistrar")
             .setEventTime(expirationTime)
             .setRecurrenceEndTime(clock.nowUtc())
-            .setParent(getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_CREATE))
+            .setParent(
+                getOnlyHistoryEntryOfType(
+                    domain, HistoryEntry.Type.DOMAIN_CREATE, DomainHistory.class))
             .build(),
         new BillingEvent.Recurring.Builder()
             .setReason(Reason.RENEW)

--- a/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
@@ -162,8 +162,8 @@ class DomainRestoreRequestFlowTest
     assertThat(getPollMessages("TheRegistrar", clock.nowUtc().plusMonths(1))).hasSize(1);
     runFlowAssertResponse(loadFile("generic_success_response.xml"));
     DomainBase domain = reloadResourceByForeignKey();
-    HistoryEntry historyEntryDomainRestore =
-        getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_RESTORE);
+    DomainHistory historyEntryDomainRestore =
+        getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_RESTORE, DomainHistory.class);
     assertLastHistoryContainsResource(domain);
     assertThat(loadByKey(domain.getAutorenewBillingEvent()).getEventTime())
         .isEqualTo(expirationTime);
@@ -231,8 +231,8 @@ class DomainRestoreRequestFlowTest
     assertThat(getPollMessages("TheRegistrar", clock.nowUtc().plusMonths(1))).hasSize(1);
     runFlowAssertResponse(loadFile("generic_success_response.xml"));
     DomainBase domain = reloadResourceByForeignKey();
-    HistoryEntry historyEntryDomainRestore =
-        getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_RESTORE);
+    DomainHistory historyEntryDomainRestore =
+        getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_RESTORE, DomainHistory.class);
     assertLastHistoryContainsResource(domain);
     assertThat(loadByKey(domain.getAutorenewBillingEvent()).getEventTime())
         .isEqualTo(newExpirationTime);

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
@@ -260,8 +260,8 @@ class DomainTransferApproveFlowTest
       throws Exception {
     Registry registry = Registry.get(tld);
     domain = reloadResourceByForeignKey();
-    final HistoryEntry historyEntryTransferApproved =
-        getOnlyHistoryEntryOfType(domain, DOMAIN_TRANSFER_APPROVE);
+    final DomainHistory historyEntryTransferApproved =
+        getOnlyHistoryEntryOfType(domain, DOMAIN_TRANSFER_APPROVE, DomainHistory.class);
     // We expect three billing events: one for the transfer, a closed autorenew for the losing
     // client and an open autorenew for the gaining client that begins at the new expiration time.
     OneTime transferBillingEvent =
@@ -308,8 +308,8 @@ class DomainTransferApproveFlowTest
   private void assertHistoryEntriesDoNotContainTransferBillingEventsOrGracePeriods(
       BillingEvent.Cancellation.Builder... expectedCancellationBillingEvents) throws Exception {
     domain = reloadResourceByForeignKey();
-    final HistoryEntry historyEntryTransferApproved =
-        getOnlyHistoryEntryOfType(domain, DOMAIN_TRANSFER_APPROVE);
+    final DomainHistory historyEntryTransferApproved =
+        getOnlyHistoryEntryOfType(domain, DOMAIN_TRANSFER_APPROVE, DomainHistory.class);
     // We expect two billing events: a closed autorenew for the losing client and an open autorenew
     // for the gaining client that begins at the new expiration time.
     assertBillingEventsForResource(

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
@@ -86,6 +86,7 @@ import google.registry.model.billing.BillingEvent.Reason;
 import google.registry.model.contact.ContactAuthInfo;
 import google.registry.model.domain.DomainAuthInfo;
 import google.registry.model.domain.DomainBase;
+import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.GracePeriod;
 import google.registry.model.domain.Period;
 import google.registry.model.domain.Period.Unit;
@@ -250,8 +251,8 @@ class DomainTransferRequestFlowTest
       boolean expectTransferBillingEvent,
       BillingEvent.Cancellation.Builder... extraExpectedBillingEvents) {
     Registry registry = Registry.get(domain.getTld());
-    final HistoryEntry historyEntryTransferRequest =
-        getOnlyHistoryEntryOfType(domain, DOMAIN_TRANSFER_REQUEST);
+    final DomainHistory historyEntryTransferRequest =
+        getOnlyHistoryEntryOfType(domain, DOMAIN_TRANSFER_REQUEST, DomainHistory.class);
 
     // Construct the billing events we expect to exist, starting with the (optional) billing
     // event for the transfer itself.

--- a/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
@@ -687,7 +687,9 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
               .setBillingTime(clock.nowUtc())
               .setParent(
                   getOnlyHistoryEntryOfType(
-                      reloadResourceByForeignKey(), HistoryEntry.Type.DOMAIN_UPDATE))
+                      reloadResourceByForeignKey(),
+                      HistoryEntry.Type.DOMAIN_UPDATE,
+                      DomainHistory.class))
               .build());
     } else {
       assertNoBillingEvents();

--- a/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
@@ -363,7 +363,7 @@ public class DomainBaseTest extends EntityTestCase {
   }
 
   private void doExpiredTransferTest(DateTime oldExpirationTime) {
-    HistoryEntry historyEntry =
+    DomainHistory historyEntry =
         new DomainHistory.Builder()
             .setDomain(domain)
             .setModificationTime(fakeClock.nowUtc())

--- a/core/src/test/java/google/registry/model/domain/GracePeriodTest.java
+++ b/core/src/test/java/google/registry/model/domain/GracePeriodTest.java
@@ -55,7 +55,7 @@ public class GracePeriodTest {
             .setClientId("TheRegistrar")
             .setCost(Money.of(CurrencyUnit.USD, 42))
             .setParent(
-                Key.create(Key.create(DomainBase.class, "domain"), HistoryEntry.class, 12345))
+                Key.create(Key.create(DomainBase.class, "domain"), DomainHistory.class, 12345))
             .setReason(Reason.CREATE)
             .setPeriodYears(1)
             .setTargetId("foo.google")

--- a/core/src/test/java/google/registry/rde/RdeFixtures.java
+++ b/core/src/test/java/google/registry/rde/RdeFixtures.java
@@ -66,7 +66,7 @@ final class RdeFixtures {
                 makeContactResource(clock, "5372808-ERL", "(◕‿◕) nevermore", "prophet@evil.みんな")
                     .createVKey())
             .build();
-    HistoryEntry historyEntry =
+    DomainHistory historyEntry =
         persistResource(
             new DomainHistory.Builder()
                 .setDomain(domain)

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -523,7 +523,7 @@ public class DatabaseHelper {
   }
 
   public static BillingEvent.OneTime createBillingEventForTransfer(
-      DomainBase domain, HistoryEntry historyEntry, DateTime costLookupTime, DateTime eventTime) {
+      DomainBase domain, DomainHistory historyEntry, DateTime costLookupTime, DateTime eventTime) {
     return new BillingEvent.OneTime.Builder()
         .setReason(Reason.TRANSFER)
         .setTargetId(domain.getDomainName())

--- a/core/src/test/java/google/registry/tools/DedupeOneTimeBillingEventIdsCommandTest.java
+++ b/core/src/test/java/google/registry/tools/DedupeOneTimeBillingEventIdsCommandTest.java
@@ -25,10 +25,10 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableSet;
 import com.googlecode.objectify.Key;
-import google.registry.model.EppResource;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Reason;
 import google.registry.model.domain.DomainBase;
+import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.Period;
 import google.registry.model.eppcommon.Trid;
 import google.registry.model.poll.PollMessage;
@@ -49,7 +49,7 @@ class DedupeOneTimeBillingEventIdsCommandTest
     extends CommandTestCase<DedupeOneTimeBillingEventIdsCommand> {
 
   DomainBase domain;
-  HistoryEntry historyEntry;
+  DomainHistory historyEntry;
   PollMessage.Autorenew autorenewToResave;
   BillingEvent.OneTime billingEventToResave;
 
@@ -111,7 +111,7 @@ class DedupeOneTimeBillingEventIdsCommandTest
             .build());
   }
 
-  private BillingEvent.OneTime persistBillingEvent(HistoryEntry historyEntry) {
+  private BillingEvent.OneTime persistBillingEvent(DomainHistory historyEntry) {
     return persistResource(
         new BillingEvent.OneTime.Builder()
             .setClientId("a registrar")
@@ -126,9 +126,10 @@ class DedupeOneTimeBillingEventIdsCommandTest
             .build());
   }
 
-  private HistoryEntry persistHistoryEntry(EppResource parent) {
+  private DomainHistory persistHistoryEntry(DomainBase parent) {
     return persistResource(
-        HistoryEntry.createBuilderForResource(parent)
+        new DomainHistory.Builder()
+            .setDomain(parent)
             .setType(HistoryEntry.Type.DOMAIN_CREATE)
             .setPeriod(Period.create(1, Period.Unit.YEARS))
             .setXmlBytes("<xml></xml>".getBytes(UTF_8))

--- a/core/src/test/java/google/registry/tools/DomainLockUtilsTest.java
+++ b/core/src/test/java/google/registry/tools/DomainLockUtilsTest.java
@@ -41,6 +41,7 @@ import google.registry.batch.RelockDomainAction;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Reason;
 import google.registry.model.domain.DomainBase;
+import google.registry.model.domain.DomainHistory;
 import google.registry.model.host.HostResource;
 import google.registry.model.registry.Registry;
 import google.registry.model.reporting.HistoryEntry;
@@ -479,7 +480,8 @@ public final class DomainLockUtilsTest {
   private void verifyProperlyLockedDomain(boolean isAdmin) {
     assertThat(loadByEntity(domain).getStatusValues())
         .containsAtLeastElementsIn(REGISTRY_LOCK_STATUSES);
-    HistoryEntry historyEntry = getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_UPDATE);
+    DomainHistory historyEntry =
+        getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_UPDATE, DomainHistory.class);
     assertThat(historyEntry.getRequestedByRegistrar()).isEqualTo(!isAdmin);
     assertThat(historyEntry.getBySuperuser()).isEqualTo(isAdmin);
     assertThat(historyEntry.getReason())
@@ -493,8 +495,8 @@ public final class DomainLockUtilsTest {
 
   private void verifyProperlyUnlockedDomain(boolean isAdmin) {
     assertThat(loadByEntity(domain).getStatusValues()).containsNoneIn(REGISTRY_LOCK_STATUSES);
-    ImmutableList<HistoryEntry> historyEntries =
-        getHistoryEntriesOfType(domain, HistoryEntry.Type.DOMAIN_UPDATE);
+    ImmutableList<DomainHistory> historyEntries =
+        getHistoryEntriesOfType(domain, HistoryEntry.Type.DOMAIN_UPDATE, DomainHistory.class);
     assertThat(historyEntries.size()).isEqualTo(2);
     historyEntries.forEach(
         entry -> {
@@ -514,11 +516,11 @@ public final class DomainLockUtilsTest {
     assertThat(loadByEntity(domain)).isEqualTo(domain);
   }
 
-  private void assertBillingEvent(HistoryEntry historyEntry) {
+  private void assertBillingEvent(DomainHistory historyEntry) {
     assertBillingEvents(ImmutableList.of(historyEntry));
   }
 
-  private void assertBillingEvents(ImmutableList<HistoryEntry> historyEntries) {
+  private void assertBillingEvents(ImmutableList<DomainHistory> historyEntries) {
     Set<BillingEvent> expectedEvents =
         historyEntries.stream()
             .map(

--- a/core/src/test/java/google/registry/tools/EppLifecycleToolsTest.java
+++ b/core/src/test/java/google/registry/tools/EppLifecycleToolsTest.java
@@ -26,6 +26,7 @@ import google.registry.flows.EppTestCase;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Reason;
 import google.registry.model.domain.DomainBase;
+import google.registry.model.domain.DomainHistory;
 import google.registry.model.reporting.HistoryEntry.Type;
 import google.registry.testing.AppEngineExtension;
 import google.registry.util.Clock;
@@ -149,7 +150,7 @@ class EppLifecycleToolsTest extends EppTestCase {
             .setPeriodYears(4)
             .setEventTime(DateTime.parse("2000-06-07T00:00:00Z"))
             .setBillingTime(DateTime.parse("2000-06-12T00:00:00Z"))
-            .setParent(getOnlyHistoryEntryOfType(domain, Type.DOMAIN_RENEW))
+            .setParent(getOnlyHistoryEntryOfType(domain, Type.DOMAIN_RENEW, DomainHistory.class))
             .build();
 
     assertBillingEventsForResource(
@@ -159,19 +160,19 @@ class EppLifecycleToolsTest extends EppTestCase {
         // The initial autorenew billing event, which was closed at the time of the explicit renew.
         makeRecurringBillingEvent(
             domain,
-            getOnlyHistoryEntryOfType(domain, Type.DOMAIN_CREATE),
+            getOnlyHistoryEntryOfType(domain, Type.DOMAIN_CREATE, DomainHistory.class),
             createTime.plusYears(2),
             DateTime.parse("2000-06-07T00:00:00.000Z")),
         // The renew's autorenew billing event, which was closed at the time of the unrenew.
         makeRecurringBillingEvent(
             domain,
-            getOnlyHistoryEntryOfType(domain, Type.DOMAIN_RENEW),
+            getOnlyHistoryEntryOfType(domain, Type.DOMAIN_RENEW, DomainHistory.class),
             DateTime.parse("2006-06-01T00:02:00.000Z"),
             DateTime.parse("2001-06-07T00:00:00.000Z")),
         // The remaining active autorenew billing event which was created by the unrenew.
         makeRecurringBillingEvent(
             domain,
-            getOnlyHistoryEntryOfType(domain, Type.SYNTHETIC),
+            getOnlyHistoryEntryOfType(domain, Type.SYNTHETIC, DomainHistory.class),
             DateTime.parse("2003-06-01T00:02:00.000Z"),
             END_OF_TIME));
 

--- a/core/src/test/java/google/registry/tools/UnrenewDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UnrenewDomainCommandTest.java
@@ -41,10 +41,10 @@ import google.registry.model.billing.BillingEvent.Flag;
 import google.registry.model.billing.BillingEvent.Reason;
 import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.DomainBase;
+import google.registry.model.domain.DomainHistory;
 import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.ofy.Ofy;
 import google.registry.model.poll.PollMessage;
-import google.registry.model.reporting.HistoryEntry;
 import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.InjectExtension;
 import google.registry.testing.TestOfyAndSql;
@@ -132,7 +132,7 @@ public class UnrenewDomainCommandTest extends CommandTestCase<UnrenewDomainComma
         .bySuperuser(true)
         .and()
         .hasMetadataRequestedByRegistrar(false);
-    HistoryEntry synthetic = getOnlyHistoryEntryOfType(domain, SYNTHETIC);
+    DomainHistory synthetic = getOnlyHistoryEntryOfType(domain, SYNTHETIC, DomainHistory.class);
 
     assertBillingEventsEqual(
         loadByKey(domain.getAutorenewBillingEvent()),

--- a/core/src/test/java/google/registry/tools/UpdateDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateDomainCommandTest.java
@@ -42,7 +42,6 @@ import google.registry.model.domain.GracePeriod;
 import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.host.HostResource;
 import google.registry.model.ofy.Ofy;
-import google.registry.model.reporting.HistoryEntry;
 import google.registry.persistence.VKey;
 import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.InjectExtension;
@@ -293,7 +292,7 @@ class UpdateDomainCommandTest extends EppToolCommandTestCase<UpdateDomainCommand
 
   @TestOfyAndSql
   void testSuccess_disableAutorenew_inAutorenewGracePeriod() throws Exception {
-    HistoryEntry createHistoryEntry =
+    DomainHistory createHistoryEntry =
         persistResource(
             new DomainHistory.Builder()
                 .setModificationTime(fakeClock.nowUtc())

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistryLockVerifyActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistryLockVerifyActionTest.java
@@ -37,6 +37,7 @@ import google.registry.batch.AsyncTaskEnqueuerTest;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Reason;
 import google.registry.model.domain.DomainBase;
+import google.registry.model.domain.DomainHistory;
 import google.registry.model.host.HostResource;
 import google.registry.model.registry.Registry;
 import google.registry.model.reporting.HistoryEntry;
@@ -102,7 +103,8 @@ final class RegistryLockVerifyActionTest {
     assertThat(response.getStatus()).isEqualTo(SC_OK);
     assertThat(reloadDomain().getStatusValues()).containsExactlyElementsIn(REGISTRY_LOCK_STATUSES);
     assertThat(response.getPayload()).contains("Success: lock has been applied to example.tld");
-    HistoryEntry historyEntry = getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_UPDATE);
+    DomainHistory historyEntry =
+        getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_UPDATE, DomainHistory.class);
     assertThat(historyEntry.getRequestedByRegistrar()).isTrue();
     assertThat(historyEntry.getBySuperuser()).isFalse();
     assertThat(historyEntry.getReason())
@@ -119,7 +121,8 @@ final class RegistryLockVerifyActionTest {
     assertThat(response.getStatus()).isEqualTo(SC_OK);
     assertThat(response.getPayload()).contains("Success: unlock has been applied to example.tld");
     assertThat(reloadDomain().getStatusValues()).containsNoneIn(REGISTRY_LOCK_STATUSES);
-    HistoryEntry historyEntry = getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_UPDATE);
+    DomainHistory historyEntry =
+        getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_UPDATE, DomainHistory.class);
     assertThat(historyEntry.getRequestedByRegistrar()).isTrue();
     assertThat(historyEntry.getBySuperuser()).isFalse();
     assertThat(historyEntry.getReason())
@@ -308,7 +311,7 @@ final class RegistryLockVerifyActionTest {
     assertThat(reloadDomain()).isEqualTo(domain);
   }
 
-  private void assertBillingEvent(HistoryEntry historyEntry) {
+  private void assertBillingEvent(DomainHistory historyEntry) {
     DatabaseHelper.assertBillingEvents(
         new BillingEvent.OneTime.Builder()
             .setReason(Reason.SERVER_STATUS)

--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -6,7 +6,7 @@ class google.registry.model.UpdateAutoTimestamp {
 }
 class google.registry.model.billing.BillingEvent$Cancellation {
   @Id java.lang.Long id;
-  @Parent com.googlecode.objectify.Key<? extends google.registry.model.reporting.HistoryEntry> parent;
+  @Parent com.googlecode.objectify.Key<google.registry.model.domain.DomainHistory> parent;
   google.registry.model.billing.BillingEvent$Reason reason;
   google.registry.persistence.BillingVKey$BillingEventVKey refOneTime;
   google.registry.persistence.BillingVKey$BillingRecurrenceVKey refRecurring;
@@ -27,7 +27,7 @@ enum google.registry.model.billing.BillingEvent$Flag {
 }
 class google.registry.model.billing.BillingEvent$Modification {
   @Id java.lang.Long id;
-  @Parent com.googlecode.objectify.Key<? extends google.registry.model.reporting.HistoryEntry> parent;
+  @Parent com.googlecode.objectify.Key<google.registry.model.domain.DomainHistory> parent;
   com.googlecode.objectify.Key<google.registry.model.billing.BillingEvent$OneTime> eventRef;
   google.registry.model.billing.BillingEvent$Reason reason;
   java.lang.String clientId;
@@ -39,7 +39,7 @@ class google.registry.model.billing.BillingEvent$Modification {
 }
 class google.registry.model.billing.BillingEvent$OneTime {
   @Id java.lang.Long id;
-  @Parent com.googlecode.objectify.Key<? extends google.registry.model.reporting.HistoryEntry> parent;
+  @Parent com.googlecode.objectify.Key<google.registry.model.domain.DomainHistory> parent;
   google.registry.model.billing.BillingEvent$Reason reason;
   google.registry.persistence.VKey<google.registry.model.billing.BillingEvent$Recurring> cancellationMatchingBillingEvent;
   google.registry.persistence.VKey<google.registry.model.domain.token.AllocationToken> allocationToken;
@@ -63,7 +63,7 @@ enum google.registry.model.billing.BillingEvent$Reason {
 }
 class google.registry.model.billing.BillingEvent$Recurring {
   @Id java.lang.Long id;
-  @Parent com.googlecode.objectify.Key<? extends google.registry.model.reporting.HistoryEntry> parent;
+  @Parent com.googlecode.objectify.Key<google.registry.model.domain.DomainHistory> parent;
   google.registry.model.billing.BillingEvent$Reason reason;
   google.registry.model.common.TimeOfYear recurrenceTimeOfYear;
   java.lang.String clientId;


### PR DESCRIPTION
Only domain related actions can result in billing. The fact that the
@PostLoad method on DomainHistory creates a Key whose parent is a Key to
DomainBase further corroborates with this statement. Therefore it makes
sense to change the parent type to be more restrictive. This also makes
it easier down the road to expand recurring billing events to onetimes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1178)
<!-- Reviewable:end -->
