### PR TITLE
Remove labels from output of list_premium_lists

### DIFF
--- a/core/src/main/java/google/registry/tools/server/ListPremiumListsAction.java
+++ b/core/src/main/java/google/registry/tools/server/ListPremiumListsAction.java
@@ -19,7 +19,6 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.request.Action.Method.GET;
 import static google.registry.request.Action.Method.POST;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import google.registry.model.registry.label.PremiumList;
 import google.registry.request.Action;
@@ -58,16 +57,6 @@ public final class ListPremiumListsAction extends ListObjectsAction<PremiumList>
                     .map(PremiumListDao::getLatestRevision)
                     .filter(Optional::isPresent)
                     .map(Optional::get)
-                    .peek(list -> list.getLabelsToPrices())
                     .collect(toImmutableSortedSet(Comparator.comparing(PremiumList::getName))));
-  }
-
-  /**
-   * Provide a field override for labelsToPrices, since it is an {@code Insignificant} field and
-   * doesn't get returned from {@link google.registry.model.ImmutableObject#toDiffableFieldMap}.
-   */
-  @Override
-  public ImmutableMap<String, String> getFieldOverrides(PremiumList list) {
-    return ImmutableMap.of("labelsToPrices", list.getLabelsToPrices().toString());
   }
 }

--- a/core/src/test/java/google/registry/tools/server/ListPremiumListsActionTest.java
+++ b/core/src/test/java/google/registry/tools/server/ListPremiumListsActionTest.java
@@ -44,19 +44,6 @@ class ListPremiumListsActionTest extends ListActionTestCase {
   }
 
   @Test
-  void testRun_withLabelsToPrices() {
-    testRunSuccess(
-        action,
-        Optional.of("labelsToPrices"),
-        Optional.empty(),
-        Optional.empty(),
-        "^name\\s+labelsToPrices\\s*$",
-        "^-+\\s+-+\\s*$",
-        "^how\\s+\\{richer=5000.00\\}$",
-        "^xn--q9jyb4c\\s+\\{rich=100\\.00\\}\\s+$");
-  }
-
-  @Test
   void testRun_withBadField_returnsError() {
     testRunError(
         action,


### PR DESCRIPTION
Remove the ability to show all of the labels associated with a premium list in
the list_premium_lists command.  Supporting this requires loading the entire
contents of all premium lists from the database as opposed to just the list
records, and the information can be obtained using get_premium_list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1182)
<!-- Reviewable:end -->
