### PR TITLE
Detach result objects obtained through jpaTm().query()

### DIFF
--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManager.java
@@ -40,8 +40,8 @@ public interface JpaTransactionManager extends TransactionManager {
    * <p>This is a convenience method for the longer <code>
    * jpaTm().getEntityManager().createQuery(...)</code>.
    *
-   * <p>Note that while this method can legally be used for queries that return results, <ul>it
-   * should not be</ul>, as it does not correctly detach entities as must be done for nomulus model
+   * <p>Note that while this method can legally be used for queries that return results, <u>it
+   * should not be</u>, as it does not correctly detach entities as must be done for nomulus model
    * objects.
    */
   Query query(String sqlString);

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManager.java
@@ -35,10 +35,14 @@ public interface JpaTransactionManager extends TransactionManager {
   <T> TypedQuery<T> query(String sqlString, Class<T> resultClass);
 
   /**
-   * Creates a JPA SQL query for the given query string (which does not return results).
+   * Creates a JPA SQL query for the given query string.
    *
    * <p>This is a convenience method for the longer <code>
    * jpaTm().getEntityManager().createQuery(...)</code>.
+   *
+   * <p>Note that while this method can legally be used for queries that return results, <ul>it
+   * should not be</ul>, as it does not correctly detach entities as must be done for nomulus model
+   * objects.
    */
   Query query(String sqlString);
 

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerImplTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerImplTest.java
@@ -22,9 +22,11 @@ import static google.registry.testing.TestDataHelper.fileClassPath;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -44,6 +46,7 @@ import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.OptimisticLockException;
 import javax.persistence.RollbackException;
+import javax.persistence.TypedQuery;
 import org.hibernate.exception.JDBCConnectionException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -586,6 +589,15 @@ class JpaTransactionManagerImplTest {
                             })))
         .hasMessageThat()
         .contains("Inserted/updated object reloaded: ");
+  }
+
+  @Test
+  void transformingTypedQuery() {
+    TypedQuery<Integer> mockRep = mock(TypedQuery.class);
+    when(mockRep.getResultStream()).thenReturn(ImmutableList.of(100, 200).stream());
+    TypedQuery<Integer> ttq =
+        new JpaTransactionManagerImpl.TransformingTypedQuery<>(mockRep, x -> x + 1);
+    assertThat(ttq.getResultList()).containsExactly(101, 201);
   }
 
   private void insertPerson(int age) {

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerImplTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerImplTest.java
@@ -22,11 +22,9 @@ import static google.registry.testing.TestDataHelper.fileClassPath;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -46,7 +44,6 @@ import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.OptimisticLockException;
 import javax.persistence.RollbackException;
-import javax.persistence.TypedQuery;
 import org.hibernate.exception.JDBCConnectionException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -589,15 +586,6 @@ class JpaTransactionManagerImplTest {
                             })))
         .hasMessageThat()
         .contains("Inserted/updated object reloaded: ");
-  }
-
-  @Test
-  void transformingTypedQuery() {
-    TypedQuery<Integer> mockRep = mock(TypedQuery.class);
-    when(mockRep.getResultStream()).thenReturn(ImmutableList.of(100, 200).stream());
-    TypedQuery<Integer> ttq =
-        new JpaTransactionManagerImpl.TransformingTypedQuery<>(mockRep, x -> x + 1);
-    assertThat(ttq.getResultList()).containsExactly(101, 201);
   }
 
   @Test

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerImplTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerImplTest.java
@@ -600,6 +600,36 @@ class JpaTransactionManagerImplTest {
     assertThat(ttq.getResultList()).containsExactly(101, 201);
   }
 
+  @Test
+  void query_detachesResults() {
+    jpaTm().transact(() -> jpaTm().insertAll(moreEntities));
+    jpaTm()
+        .transact(
+            () ->
+                jpaTm().query("FROM TestEntity", TestEntity.class).getResultList().stream()
+                    .forEach(e -> assertThat(jpaTm().getEntityManager().contains(e)).isFalse()));
+    jpaTm()
+        .transact(
+            () ->
+                jpaTm()
+                    .query("FROM TestEntity", TestEntity.class)
+                    .getResultStream()
+                    .forEach(e -> assertThat(jpaTm().getEntityManager().contains(e)).isFalse()));
+
+    jpaTm()
+        .transact(
+            () ->
+                assertThat(
+                        jpaTm()
+                            .getEntityManager()
+                            .contains(
+                                jpaTm()
+                                    .query(
+                                        "FROM TestEntity WHERE name = 'entity1'", TestEntity.class)
+                                    .getSingleResult()))
+                    .isFalse());
+  }
+
   private void insertPerson(int age) {
     jpaTm()
         .getEntityManager()


### PR DESCRIPTION
Detach all entity result objects obtained through `TypedQuery`s returned by the `jpaTm().query()` method.

This is in line with the general practice of always detaching objects on load, which prevents issues with implicit saves and immutability violations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1183)
<!-- Reviewable:end -->
