### PR TITLE
Use SecretManager for nomulus-tool-cloudbuild cred

### DIFF
--- a/release/cloudbuild-deploy.yaml
+++ b/release/cloudbuild-deploy.yaml
@@ -21,21 +21,13 @@
 steps:
 # Pull the credential for nomulus tool.
 - name: 'gcr.io/$PROJECT_ID/builder:latest'
-  args:
-  - gsutil
-  - cp
-  - gs://$PROJECT_ID-deploy/secrets/tool-credential.json.enc
-  - .
-# Decrypt the credential.
-- name: 'gcr.io/$PROJECT_ID/builder:latest'
   entrypoint: /bin/bash
   args:
   - -c
   - |
     set -e
-    cat tool-credential.json.enc | base64 -d | gcloud kms decrypt \
-      --ciphertext-file=- --plaintext-file=tool-credential.json \
-      --location=global --keyring=nomulus-tool-keyring --key=nomulus-tool-key
+    gcloud secrets versions access latest \
+      --secret nomulus-tool-cloudbuild-credential > tool-credential.json
 # Deploy the GAE config files.
 # First authorize the gcloud tool to use the credential json file, then
 # download and unzip the tarball that contains the relevant config files
@@ -53,8 +45,6 @@ steps:
     fi
     gsutil cp gs://$PROJECT_ID-deploy/${TAG_NAME}/${_ENV}.tar .
     tar -xvf ${_ENV}.tar
-    # Note that this currently does not work for google.com projects that
-    # we use due to b/137891685. External projects are likely to work.
     for filename in cron dispatch dos index queue; do
       gcloud -q --project $project_id app deploy \
         default/WEB-INF/appengine-generated/$filename.yaml

--- a/release/cloudbuild-schema-deploy.yaml
+++ b/release/cloudbuild-schema-deploy.yaml
@@ -39,12 +39,9 @@ steps:
   - -c
   - |
     set -e
-    gsutil cp gs://$PROJECT_ID-deploy/secrets/tool-credential.json.enc - \
-      | base64 -d \
-      | gcloud kms decrypt \
-        --ciphertext-file=- \
-        --plaintext-file=/secrets/cloud_sql_credential.json \
-        --location=global --keyring=nomulus-tool-keyring --key=nomulus-tool-key
+    gcloud secrets versions access latest \
+      --secret nomulus-tool-cloudbuild-credential \
+      > /secrets/cloud_sql_credential.json
 # Fetch the Cloud SQL credential for schema_deployer
 - name: 'gcr.io/$PROJECT_ID/nomulus-tool:latest'
   volumes:


### PR DESCRIPTION
Store cloudbuild's nomulus-tool credential in SecretManager and make the
deployment pipeline load it from the SecretManager.

The tool-credential.json.enc file in the
gs://domain-registry-dev-deploy/secrets folder is no longer needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1188)
<!-- Reviewable:end -->
