### PR TITLE
Make RefreshDnsForAllDomains SQL-aware

### DIFF
--- a/core/src/main/java/google/registry/backup/DeleteOldCommitLogsAction.java
+++ b/core/src/main/java/google/registry/backup/DeleteOldCommitLogsAction.java
@@ -66,6 +66,8 @@ import org.joda.time.Duration;
     service = Action.Service.BACKEND,
     path = "/_dr/task/deleteOldCommitLogs",
     auth = Auth.AUTH_INTERNAL_OR_ADMIN)
+// No longer needed in SQL. Subject to future removal.
+@Deprecated
 public final class DeleteOldCommitLogsAction implements Runnable {
 
   private static final int NUM_MAP_SHARDS = 20;

--- a/core/src/main/java/google/registry/batch/ResaveAllEppResourcesAction.java
+++ b/core/src/main/java/google/registry/batch/ResaveAllEppResourcesAction.java
@@ -54,6 +54,7 @@ import javax.inject.Inject;
     service = Action.Service.BACKEND,
     path = "/_dr/task/resaveAllEppResources",
     auth = Auth.AUTH_INTERNAL_OR_ADMIN)
+// No longer needed in SQL. Subject to future removal.
 @Deprecated
 public class ResaveAllEppResourcesAction implements Runnable {
 

--- a/core/src/main/java/google/registry/batch/ResaveAllEppResourcesAction.java
+++ b/core/src/main/java/google/registry/batch/ResaveAllEppResourcesAction.java
@@ -54,6 +54,7 @@ import javax.inject.Inject;
     service = Action.Service.BACKEND,
     path = "/_dr/task/resaveAllEppResources",
     auth = Auth.AUTH_INTERNAL_OR_ADMIN)
+@Deprecated
 public class ResaveAllEppResourcesAction implements Runnable {
 
   @Inject MapreduceRunner mrRunner;

--- a/core/src/main/java/google/registry/tools/server/KillAllCommitLogsAction.java
+++ b/core/src/main/java/google/registry/tools/server/KillAllCommitLogsAction.java
@@ -49,6 +49,7 @@ import javax.inject.Inject;
     path = "/_dr/task/killAllCommitLogs",
     method = POST,
     auth = Auth.AUTH_INTERNAL_OR_ADMIN)
+@Deprecated
 public class KillAllCommitLogsAction implements Runnable {
 
   @Inject MapreduceRunner mrRunner;

--- a/core/src/main/java/google/registry/tools/server/KillAllCommitLogsAction.java
+++ b/core/src/main/java/google/registry/tools/server/KillAllCommitLogsAction.java
@@ -49,6 +49,7 @@ import javax.inject.Inject;
     path = "/_dr/task/killAllCommitLogs",
     method = POST,
     auth = Auth.AUTH_INTERNAL_OR_ADMIN)
+// No longer needed in SQL. Subject to future removal.
 @Deprecated
 public class KillAllCommitLogsAction implements Runnable {
 

--- a/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
+++ b/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
@@ -104,8 +104,7 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
                       .query(
                           "SELECT fullyQualifiedDomainName FROM Domain "
                               + "WHERE tld IN (:tlds) "
-                              + "AND deletionTime > :now "
-                              + "AND creationTime <= :now",
+                              + "AND deletionTime > :now",
                           String.class)
                       .setParameter("tlds", tlds)
                       .setParameter("now", clock.nowUtc())
@@ -119,13 +118,9 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
                                   Duration.standardMinutes(random.nextInt(smearMinutes)));
                               logger.atInfo().log("active domain %s refreshed.", domainName);
                             } catch (Throwable t) {
-                              String message =
-                                  String.format(
-                                      "Error while refreshing DNS for domain %s", domainName);
-                              logger.atSevere().withCause(t).log(message);
-                              response.setPayload(message);
+                              logger.atSevere().withCause(t).log(
+                                  "Error while refreshing DNS for domain %s", domainName);
                               response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-                              throw t;
                             }
                           }));
     }

--- a/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
+++ b/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
@@ -18,6 +18,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.mapreduce.inputs.EppResourceInputs.createEntityInput;
 import static google.registry.model.EppResourceUtils.isActive;
 import static google.registry.model.registry.Registries.assertTldsExist;
+import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.RequestParameters.PARAM_TLDS;
 
 import com.google.appengine.tools.mapreduce.Mapper;
@@ -32,11 +34,11 @@ import google.registry.request.Action;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
+import google.registry.util.Clock;
 import google.registry.util.NonFinalForTesting;
 import java.util.Random;
 import javax.inject.Inject;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.joda.time.Duration;
 
 /**
@@ -74,6 +76,8 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
   @Parameter("smearMinutes")
   int smearMinutes;
 
+  @Inject DnsQueue dnsQueue;
+  @Inject Clock clock;
   @Inject Random random;
 
   @Inject
@@ -83,14 +87,44 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
   public void run() {
     assertTldsExist(tlds);
     checkArgument(smearMinutes > 0, "Must specify a positive number of smear minutes");
-    mrRunner
-        .setJobName("Refresh DNS for all domains")
-        .setModuleName("tools")
-        .setDefaultMapShards(10)
-        .runMapOnly(
-            new RefreshDnsForAllDomainsActionMapper(tlds, smearMinutes, random),
-            ImmutableList.of(createEntityInput(DomainBase.class)))
-        .sendLinkToMapreduceConsole(response);
+    if (tm().isOfy()) {
+      mrRunner
+          .setJobName("Refresh DNS for all domains")
+          .setModuleName("tools")
+          .setDefaultMapShards(10)
+          .runMapOnly(
+              new RefreshDnsForAllDomainsActionMapper(tlds, smearMinutes, random, clock.nowUtc()),
+              ImmutableList.of(createEntityInput(DomainBase.class)))
+          .sendLinkToMapreduceConsole(response);
+    } else {
+      tm().transact(
+              () ->
+                  jpaTm()
+                      .getEntityManager()
+                      .createNativeQuery(
+                          "SELECT domain_name FROM \"Domain\" "
+                              + "WHERE tld IN (:tlds) "
+                              + "AND creation_time <= :now "
+                              + "AND deletion_time > :now")
+                      .setParameter("tlds", tlds)
+                      .setParameter("now", clock.nowUtc().toDate())
+                      .getResultStream()
+                      .forEach(
+                          row -> {
+                            @SuppressWarnings("unchecked")
+                            String domainName = (String) row;
+                            try {
+                              // Smear the task execution time over the next N minutes.
+                              dnsQueue.addDomainRefreshTask(
+                                  domainName,
+                                  Duration.standardMinutes(random.nextInt(smearMinutes)));
+                              logger.atInfo().log("active domain %s refreshed.", domainName);
+                            } catch (Throwable t) {
+                              logger.atSevere().withCause(t).log(
+                                  "Error while refreshing DNS for domain %s", domainName);
+                            }
+                          }));
+    }
   }
 
   /** Mapper to refresh DNS for all active domain resources. */
@@ -104,19 +138,21 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
     private final ImmutableSet<String> tlds;
     private final int smearMinutes;
     private final Random random;
+    private final DateTime now;
 
     RefreshDnsForAllDomainsActionMapper(
-        ImmutableSet<String> tlds, int smearMinutes, Random random) {
+        ImmutableSet<String> tlds, int smearMinutes, Random random, DateTime now) {
       this.tlds = tlds;
       this.smearMinutes = smearMinutes;
       this.random = random;
+      this.now = now;
     }
 
     @Override
     public void map(final DomainBase domain) {
       String domainName = domain.getDomainName();
       if (tlds.contains(domain.getTld())) {
-        if (isActive(domain, DateTime.now(DateTimeZone.UTC))) {
+        if (isActive(domain, now)) {
           try {
             // Smear the task execution time over the next N minutes.
             dnsQueue.addDomainRefreshTask(

--- a/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
+++ b/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
@@ -116,10 +116,9 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
                               dnsQueue.addDomainRefreshTask(
                                   domainName,
                                   Duration.standardMinutes(random.nextInt(smearMinutes)));
-                              logger.atInfo().log("active domain %s refreshed.", domainName);
                             } catch (Throwable t) {
                               logger.atSevere().withCause(t).log(
-                                  "Error while refreshing DNS for domain %s", domainName);
+                                  "Error while enqueuing DNS refresh for domain %s", domainName);
                               response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
                             }
                           }));
@@ -159,7 +158,7 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
             getContext().incrementCounter("active domains refreshed");
           } catch (Throwable t) {
             logger.atSevere().withCause(t).log(
-                "Error while refreshing DNS for domain %s", domainName);
+                "Error while enqueuing DNS refresh for domain %s", domainName);
             getContext().incrementCounter("active domains errored");
           }
         } else {

--- a/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
+++ b/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
@@ -38,6 +38,7 @@ import google.registry.util.Clock;
 import google.registry.util.NonFinalForTesting;
 import java.util.Random;
 import javax.inject.Inject;
+import org.apache.http.HttpStatus;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
@@ -120,8 +121,13 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
                                   Duration.standardMinutes(random.nextInt(smearMinutes)));
                               logger.atInfo().log("active domain %s refreshed.", domainName);
                             } catch (Throwable t) {
-                              logger.atSevere().withCause(t).log(
-                                  "Error while refreshing DNS for domain %s", domainName);
+                              String message =
+                                  String.format(
+                                      "Error while refreshing DNS for domain %s", domainName);
+                              logger.atSevere().withCause(t).log(message);
+                              response.setPayload(message);
+                              response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+                              throw t;
                             }
                           }));
     }

--- a/core/src/main/java/google/registry/tools/server/ResaveAllHistoryEntriesAction.java
+++ b/core/src/main/java/google/registry/tools/server/ResaveAllHistoryEntriesAction.java
@@ -42,6 +42,7 @@ import javax.inject.Inject;
     service = Action.Service.TOOLS,
     path = "/_dr/task/resaveAllHistoryEntries",
     auth = Auth.AUTH_INTERNAL_OR_ADMIN)
+@Deprecated
 public class ResaveAllHistoryEntriesAction implements Runnable {
 
   @Inject MapreduceRunner mrRunner;

--- a/core/src/main/java/google/registry/tools/server/ResaveAllHistoryEntriesAction.java
+++ b/core/src/main/java/google/registry/tools/server/ResaveAllHistoryEntriesAction.java
@@ -42,6 +42,7 @@ import javax.inject.Inject;
     service = Action.Service.TOOLS,
     path = "/_dr/task/resaveAllHistoryEntries",
     auth = Auth.AUTH_INTERNAL_OR_ADMIN)
+// No longer needed in SQL. Subject to future removal.
 @Deprecated
 public class ResaveAllHistoryEntriesAction implements Runnable {
 

--- a/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
+++ b/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
@@ -18,7 +18,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistDeletedDomain;
-import static org.joda.time.DateTimeZone.UTC;
 import static org.joda.time.Duration.standardMinutes;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
@@ -28,8 +27,12 @@ import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.ImmutableSet;
 import google.registry.dns.DnsQueue;
+import google.registry.model.ofy.Ofy;
+import google.registry.testing.DualDatabaseTest;
+import google.registry.testing.FakeClock;
 import google.registry.testing.FakeResponse;
 import google.registry.testing.InjectExtension;
+import google.registry.testing.TestOfyAndSql;
 import google.registry.testing.mapreduce.MapreduceTestCase;
 import google.registry.tools.server.RefreshDnsForAllDomainsAction.RefreshDnsForAllDomainsActionMapper;
 import java.util.Random;
@@ -37,18 +40,23 @@ import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 
 /** Unit tests for {@link RefreshDnsForAllDomainsAction}. */
+@DualDatabaseTest
 public class RefreshDnsForAllDomainsActionTest
     extends MapreduceTestCase<RefreshDnsForAllDomainsAction> {
 
-  @RegisterExtension public final InjectExtension inject = new InjectExtension();
-
+  private final FakeClock clock = new FakeClock(DateTime.parse("2020-02-02T02:02:02Z"));
   private final DnsQueue dnsQueue = mock(DnsQueue.class);
   private DnsQueue origDnsQueue;
+
+  @Order(Order.DEFAULT - 1)
+  @RegisterExtension
+  public final InjectExtension inject =
+      new InjectExtension().withStaticFieldOverride(Ofy.class, "clock", clock);
 
   @BeforeEach
   void beforeEach() {
@@ -60,6 +68,8 @@ public class RefreshDnsForAllDomainsActionTest
     action.random.setSeed(123L);
     action.mrRunner = makeDefaultRunner();
     action.response = new FakeResponse();
+    action.clock = clock;
+    action.dnsQueue = dnsQueue;
 
     createTld("bar");
   }
@@ -70,58 +80,58 @@ public class RefreshDnsForAllDomainsActionTest
         .isEqualTo(dnsQueue);
   }
 
-  private void runMapreduce() throws Exception {
+  private void runAction() throws Exception {
     action.run();
     executeTasksUntilEmpty("mapreduce");
   }
 
-  @Test
+  @TestOfyAndSql
   void test_runAction_successfullyEnqueuesDnsRefreshes() throws Exception {
     persistActiveDomain("foo.bar");
     persistActiveDomain("low.bar");
     action.tlds = ImmutableSet.of("bar");
-    runMapreduce();
+    runAction();
     verify(dnsQueue).addDomainRefreshTask("foo.bar", Duration.ZERO);
     verify(dnsQueue).addDomainRefreshTask("low.bar", Duration.ZERO);
   }
 
-  @Test
+  @TestOfyAndSql
   void test_runAction_smearsOutDnsRefreshes() throws Exception {
     persistActiveDomain("foo.bar");
     persistActiveDomain("low.bar");
     action.tlds = ImmutableSet.of("bar");
     action.smearMinutes = 1000;
-    runMapreduce();
+    runAction();
     ArgumentCaptor<Duration> captor = ArgumentCaptor.forClass(Duration.class);
     verify(dnsQueue).addDomainRefreshTask(eq("foo.bar"), captor.capture());
     verify(dnsQueue).addDomainRefreshTask(eq("low.bar"), captor.capture());
     assertThat(captor.getAllValues()).containsExactly(standardMinutes(450), standardMinutes(782));
   }
 
-  @Test
+  @TestOfyAndSql
   void test_runAction_doesntRefreshDeletedDomain() throws Exception {
     persistActiveDomain("foo.bar");
-    persistDeletedDomain("deleted.bar", DateTime.now(UTC).minusYears(1));
+    persistDeletedDomain("deleted.bar", clock.nowUtc().minusYears(1));
     action.tlds = ImmutableSet.of("bar");
-    runMapreduce();
+    runAction();
     verify(dnsQueue).addDomainRefreshTask("foo.bar", Duration.ZERO);
     verify(dnsQueue, never()).addDomainRefreshTask("deleted.bar", Duration.ZERO);
   }
 
-  @Test
+  @TestOfyAndSql
   void test_runAction_ignoresDomainsOnOtherTlds() throws Exception {
     createTld("baz");
     persistActiveDomain("foo.bar");
     persistActiveDomain("low.bar");
     persistActiveDomain("ignore.baz");
     action.tlds = ImmutableSet.of("bar");
-    runMapreduce();
+    runAction();
     verify(dnsQueue).addDomainRefreshTask("foo.bar", Duration.ZERO);
     verify(dnsQueue).addDomainRefreshTask("low.bar", Duration.ZERO);
     verify(dnsQueue, never()).addDomainRefreshTask("ignore.baz", Duration.ZERO);
   }
 
-  @Test
+  @TestOfyAndSql
   void test_smearMinutesMustBeSpecified() {
     action.tlds = ImmutableSet.of("bar");
     action.smearMinutes = 0;

--- a/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
+++ b/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
@@ -102,7 +102,7 @@ public class RefreshDnsForAllDomainsActionTest
     when(faultyQueue.addDomainRefreshTask(anyString(), any(Duration.class)))
         .thenThrow(new RuntimeException("Error enqueuing task."));
     action.dnsQueue = faultyQueue;
-    assertThrows(RuntimeException.class, () -> runAction());
+    runAction();
     assertNoDnsTasksEnqueued();
     assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_INTERNAL_SERVER_ERROR);
   }


### PR DESCRIPTION
Also marks a few mapreduce actions as @Deprecated as they are no longer
needed in SQL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1197)
<!-- Reviewable:end -->
