### PR TITLE
Fix a test flake in SetDatabaseMigrationScheduleCommandTest

### DIFF
--- a/core/src/main/java/google/registry/model/common/DatabaseMigrationStateSchedule.java
+++ b/core/src/main/java/google/registry/model/common/DatabaseMigrationStateSchedule.java
@@ -111,7 +111,8 @@ public class DatabaseMigrationStateSchedule extends CrossTldSingleton
    * Cache of the current migration schedule. The key is meaningless; this is essentially a memoized
    * Supplier that can be reset for testing purposes and after writes.
    */
-  private static final LoadingCache<
+  @VisibleForTesting
+  public static final LoadingCache<
           Class<DatabaseMigrationStateSchedule>,
           TimedTransitionProperty<MigrationState, MigrationStateTransition>>
       // Each instance should cache the migration schedule for five minutes before reloading

--- a/core/src/test/java/google/registry/tools/SetDatabaseMigrationStateCommandTest.java
+++ b/core/src/test/java/google/registry/tools/SetDatabaseMigrationStateCommandTest.java
@@ -28,11 +28,24 @@ import google.registry.model.common.DatabaseMigrationStateSchedule.MigrationStat
 import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.TestOfyAndSql;
 import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
 
 /** Tests for {@link SetDatabaseMigrationStateCommand}. */
 @DualDatabaseTest
 public class SetDatabaseMigrationStateCommandTest
     extends CommandTestCase<SetDatabaseMigrationStateCommand> {
+
+  @BeforeEach
+  void beforeEach() {
+    // clear out any static state that may have been persisted
+    ofyTm()
+        .transact(
+            () ->
+                ofyTm()
+                    .loadSingleton(DatabaseMigrationStateSchedule.class)
+                    .ifPresent(ofyTm()::delete));
+    DatabaseMigrationStateSchedule.CACHE.invalidateAll();
+  }
 
   @TestOfyAndSql
   void testSuccess_setsBasicSchedule() throws Exception {


### PR DESCRIPTION
The cache is static so some odd state may stick around between tests --
we should clear it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1198)
<!-- Reviewable:end -->
