### PR TITLE
Fix Datastore "count" queries

### DIFF
--- a/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
+++ b/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
@@ -481,8 +481,11 @@ public class DatastoreTransactionManager implements TransactionManager {
     @Override
     public long count() {
       // Objectify provides a count() function, but unfortunately that doesn't work if there are
-      // more than 1000 (the default response page size?) entries in the database.  We use
+      // more than 1000 (the default response page size?) entries in the result set.  We also use
       // chunkAll() here as it provides a nice performance boost.
+      //
+      // There is some information on this issue on SO, see:
+      // https://stackoverflow.com/questions/751124/how-does-one-get-a-count-of-rows-in-a-datastore-model-in-google-app-engine
       return Iterables.size(buildQuery().chunkAll().keys());
     }
 

--- a/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
+++ b/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
@@ -480,7 +480,10 @@ public class DatastoreTransactionManager implements TransactionManager {
 
     @Override
     public long count() {
-      return buildQuery().count();
+      // Objectify provides a count() function, but unfortunately that doesn't work if there are
+      // more than 1000 (the default response page size?) entries in the database.  We use
+      // chunkAll() here as it provides a nice performance boost.
+      return Iterables.size(buildQuery().chunkAll().keys());
     }
 
     @Override


### PR DESCRIPTION
The objectify "count()" method doesn't work for result sets larger than 1000
elements, use the original trick from "count domains" that fetches the keys
and counts them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1201)
<!-- Reviewable:end -->
