### PR TITLE
Change DomainLists on Registry objects to Strings

### DIFF
--- a/core/src/main/java/google/registry/export/ExportPremiumTermsAction.java
+++ b/core/src/main/java/google/registry/export/ExportPremiumTermsAction.java
@@ -138,7 +138,7 @@ public class ExportPremiumTermsAction implements Runnable {
 
   private String getFormattedPremiumTerms(Registry registry) {
     checkState(registry.getPremiumList().isPresent(), "%s does not have a premium list", tld);
-    String premiumListName = registry.getPremiumList().get().getName();
+    String premiumListName = registry.getPremiumList().get();
     checkState(
         PremiumListDao.getLatestRevision(premiumListName).isPresent(),
         "Could not load premium list for " + tld);

--- a/core/src/main/java/google/registry/model/pricing/StaticPremiumListPricingEngine.java
+++ b/core/src/main/java/google/registry/model/pricing/StaticPremiumListPricingEngine.java
@@ -41,7 +41,7 @@ public final class StaticPremiumListPricingEngine implements PremiumPricingEngin
     Optional<Money> premiumPrice =
         registry
             .getPremiumList()
-            .flatMap(listKey -> PremiumListDao.getPremiumPrice(listKey.getName(), label));
+            .flatMap(listKey -> PremiumListDao.getPremiumPrice(listKey, label));
     return DomainPrices.create(
         premiumPrice.isPresent(),
         premiumPrice.orElse(registry.getStandardCreateCost()),

--- a/core/src/main/java/google/registry/model/registry/Registry.java
+++ b/core/src/main/java/google/registry/model/registry/Registry.java
@@ -389,16 +389,16 @@ public class Registry extends ImmutableObject implements Buildable, DatastoreAnd
 
   /** The set of reserved lists that are applicable to this registry. */
   @Column(name = "reserved_list_names")
-  Set<Key<ReservedList>> reservedLists;
+  Set<String> reservedLists;
 
   /** Retrieves an ImmutableSet of all ReservedLists associated with this tld. */
-  public ImmutableSet<Key<ReservedList>> getReservedLists() {
+  public ImmutableSet<String> getReservedLists() {
     return nullToEmptyImmutableCopy(reservedLists);
   }
 
   /** The static {@link PremiumList} for this TLD, if there is one. */
   @Column(name = "premium_list_name", nullable = true)
-  Key<PremiumList> premiumList;
+  String premiumList;
 
   /** Should RDE upload a nightly escrow deposit for this TLD? */
   @Column(nullable = false)
@@ -606,7 +606,7 @@ public class Registry extends ImmutableObject implements Buildable, DatastoreAnd
     return anchorTenantAddGracePeriodLength;
   }
 
-  public Optional<Key<PremiumList>> getPremiumList() {
+  public Optional<String> getPremiumList() {
     return Optional.ofNullable(premiumList);
   }
 
@@ -878,22 +878,16 @@ public class Registry extends ImmutableObject implements Buildable, DatastoreAnd
 
     public Builder setReservedLists(Set<ReservedList> reservedLists) {
       checkArgumentNotNull(reservedLists, "reservedLists must not be null");
-      ImmutableSet.Builder<Key<ReservedList>> builder = new ImmutableSet.Builder<>();
+      ImmutableSet.Builder<String> builder = new ImmutableSet.Builder<>();
       for (ReservedList reservedList : reservedLists) {
-        builder.add(Key.create(reservedList));
+        builder.add(reservedList.getName());
       }
       getInstance().reservedLists = builder.build();
       return this;
     }
 
     public Builder setPremiumList(PremiumList premiumList) {
-      getInstance().premiumList = (premiumList == null) ? null : Key.create(premiumList);
-      return this;
-    }
-
-    @VisibleForTesting
-    public Builder setPremiumListKey(@Nullable Key<PremiumList> premiumList) {
-      getInstance().premiumList = premiumList;
+      getInstance().premiumList = (premiumList == null) ? null : premiumList.getName();
       return this;
     }
 

--- a/core/src/main/java/google/registry/model/registry/label/PremiumList.java
+++ b/core/src/main/java/google/registry/model/registry/label/PremiumList.java
@@ -270,7 +270,7 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
 
   @Override
   public boolean refersToKey(Registry registry, Key<? extends BaseDomainLabelList<?, ?>> key) {
-    return Objects.equals(registry.getPremiumList().orElse(null), key);
+    return Objects.equals(registry.getPremiumList().orElse(null), key.getName());
   }
 
   @Override

--- a/core/src/main/java/google/registry/model/registry/label/ReservedList.java
+++ b/core/src/main/java/google/registry/model/registry/label/ReservedList.java
@@ -187,7 +187,7 @@ public final class ReservedList
 
   @Override
   protected boolean refersToKey(Registry registry, Key<? extends BaseDomainLabelList<?, ?>> key) {
-    return registry.getReservedLists().contains(key);
+    return registry.getReservedLists().contains(key.getName());
   }
 
   /** Determines whether the ReservedList is in use on any Registry */
@@ -285,18 +285,15 @@ public final class ReservedList
   }
 
   private static ImmutableSet<ReservedList> loadReservedLists(
-      ImmutableSet<Key<ReservedList>> reservedListKeys) {
-    return reservedListKeys
-        .stream()
+      ImmutableSet<String> reservedListNames) {
+    return reservedListNames.stream()
         .map(
-            (listKey) -> {
+            (name) -> {
               try {
-                return cache.get(listKey.getName());
+                return cache.get(name);
               } catch (ExecutionException e) {
                 throw new UncheckedExecutionException(
-                    String.format(
-                        "Could not load the reserved list '%s' from the cache", listKey.getName()),
-                    e);
+                    String.format("Could not load the reserved list '%s' from the cache", name), e);
               }
             })
         .collect(toImmutableSet());

--- a/core/src/main/java/google/registry/tools/UpdateTldCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdateTldCommand.java
@@ -26,7 +26,6 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import com.googlecode.objectify.Key;
 import google.registry.config.RegistryEnvironment;
 import google.registry.model.registry.Registry;
 import google.registry.model.registry.Registry.TldState;
@@ -113,7 +112,7 @@ class UpdateTldCommand extends CreateOrUpdateTldCommand {
   ImmutableSet<String> getReservedLists(Registry oldRegistry) {
     return formUpdatedList(
         "reserved lists",
-        oldRegistry.getReservedLists().stream().map(Key::getName).collect(toImmutableSet()),
+        oldRegistry.getReservedLists().stream().collect(toImmutableSet()),
         reservedListNames,
         reservedListsAdd,
         reservedListsRemove);

--- a/core/src/test/java/google/registry/model/OteAccountBuilderTest.java
+++ b/core/src/test/java/google/registry/model/OteAccountBuilderTest.java
@@ -71,7 +71,7 @@ public final class OteAccountBuilderTest {
     Registry registry = Registry.get(tld);
     assertThat(registry).isNotNull();
     assertThat(registry.getPremiumList()).isPresent();
-    assertThat(registry.getPremiumList().get().getName()).isEqualTo("default_sandbox_list");
+    assertThat(registry.getPremiumList().get()).isEqualTo("default_sandbox_list");
     assertThat(registry.getTldStateTransitions()).containsExactly(START_OF_TIME, tldState);
     assertThat(registry.getDnsWriters()).containsExactly("VoidDnsWriter");
     assertThat(registry.getAddGracePeriodLength()).isEqualTo(Duration.standardHours(1));

--- a/core/src/test/java/google/registry/model/registry/RegistryTest.java
+++ b/core/src/test/java/google/registry/model/registry/RegistryTest.java
@@ -36,7 +36,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
-import com.googlecode.objectify.Key;
 import google.registry.dns.writer.VoidDnsWriter;
 import google.registry.model.EntityTestCase;
 import google.registry.model.registry.Registry.RegistryNotFoundException;
@@ -61,7 +60,6 @@ public final class RegistryTest extends EntityTestCase {
   RegistryTest() {
     super(JpaEntityCoverageCheck.ENABLED);
   }
-
   @BeforeEach
   void beforeEach() {
     // Auto-increment fakeClock in DatabaseHelper.
@@ -211,8 +209,7 @@ public final class RegistryTest extends EntityTestCase {
                 .build());
     Registry r =
         Registry.get("tld").asBuilder().setReservedLists(ImmutableSet.of(rl5, rl6)).build();
-    assertThat(r.getReservedLists().stream().map(Key::getName))
-        .containsExactly("tld-reserved5", "tld-reserved6");
+    assertThat(r.getReservedLists()).containsExactly("tld-reserved5", "tld-reserved6");
     r = Registry.get("tld").asBuilder().setReservedLists(ImmutableSet.of()).build();
     assertThat(r.getReservedLists()).isEmpty();
   }
@@ -240,8 +237,7 @@ public final class RegistryTest extends EntityTestCase {
             .asBuilder()
             .setReservedListsByName(ImmutableSet.of("tld-reserved15", "tld-reserved16"))
             .build();
-    assertThat(r.getReservedLists().stream().map(Key::getName))
-        .containsExactly("tld-reserved15", "tld-reserved16");
+    assertThat(r.getReservedLists()).containsExactly("tld-reserved15", "tld-reserved16");
     r = Registry.get("tld").asBuilder().setReservedListsByName(ImmutableSet.of()).build();
     assertThat(r.getReservedLists()).isEmpty();
   }
@@ -250,9 +246,9 @@ public final class RegistryTest extends EntityTestCase {
   void testSetPremiumList() {
     PremiumList pl2 = persistPremiumList("tld2", "lol,USD 50", "cat,USD 700");
     Registry registry = Registry.get("tld").asBuilder().setPremiumList(pl2).build();
-    Optional<Key<PremiumList>> plKey = registry.getPremiumList();
-    assertThat(plKey).isPresent();
-    PremiumList stored = PremiumListDao.getLatestRevision(plKey.get().getName()).get();
+    Optional<String> premiumList = registry.getPremiumList();
+    assertThat(premiumList).isPresent();
+    PremiumList stored = PremiumListDao.getLatestRevision(premiumList.get()).get();
     assertThat(stored.getName()).isEqualTo("tld2");
   }
 

--- a/core/src/test/java/google/registry/schema/tld/PremiumListDaoTest.java
+++ b/core/src/test/java/google/registry/schema/tld/PremiumListDaoTest.java
@@ -16,7 +16,6 @@ package google.registry.schema.tld;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
-import static google.registry.model.common.EntityGroupRoot.getCrossTldKey;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerUtil.transactIfJpaTm;
 import static google.registry.testing.DatabaseHelper.newRegistry;
@@ -27,7 +26,6 @@ import static org.joda.time.Duration.standardDays;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.googlecode.objectify.Key;
 import google.registry.model.registry.label.PremiumList;
 import google.registry.testing.AppEngineExtension;
 import google.registry.testing.FakeClock;
@@ -180,15 +178,7 @@ public class PremiumListDaoTest {
 
   @Test
   void getPremiumPrice_worksSuccessfully() {
-    persistResource(
-        newRegistry("foobar", "FOOBAR")
-            .asBuilder()
-            .setPremiumListKey(
-                Key.create(
-                    getCrossTldKey(),
-                    google.registry.model.registry.label.PremiumList.class,
-                    "premlist"))
-            .build());
+    persistResource(newRegistry("foobar", "FOOBAR"));
     PremiumListDao.save(
         new PremiumList.Builder()
             .setName("premlist")
@@ -203,15 +193,7 @@ public class PremiumListDaoTest {
 
   @Test
   void testGetPremiumPrice_worksForJPY() {
-    persistResource(
-        newRegistry("foobar", "FOOBAR")
-            .asBuilder()
-            .setPremiumListKey(
-                Key.create(
-                    getCrossTldKey(),
-                    google.registry.model.registry.label.PremiumList.class,
-                    "premlist"))
-            .build());
+    persistResource(newRegistry("foobar", "FOOBAR"));
     PremiumListDao.save(
         new PremiumList.Builder()
             .setName("premlist")

--- a/core/src/test/java/google/registry/tools/CreateTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateTldCommandTest.java
@@ -32,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.beust.jcommander.ParameterException;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Range;
-import com.googlecode.objectify.Key;
 import google.registry.model.registry.Registry;
 import java.math.BigDecimal;
 import org.joda.money.Money;
@@ -279,7 +278,7 @@ class CreateTldCommandTest extends CommandTestCase<CreateTldCommand> {
         "--roid_suffix=Q9JYB4C",
         "--dns_writers=VoidDnsWriter",
         "xn--q9jyb4c");
-    assertThat(Registry.get("xn--q9jyb4c").getReservedLists().stream().map(Key::getName))
+    assertThat(Registry.get("xn--q9jyb4c").getReservedLists())
         .containsExactly("xn--q9jyb4c_abuse", "common_abuse");
   }
 
@@ -520,8 +519,7 @@ class CreateTldCommandTest extends CommandTestCase<CreateTldCommand> {
         "--dns_writers=FooDnsWriter",
         "xn--q9jyb4c");
     assertThat(Registry.get("xn--q9jyb4c").getPremiumList()).isPresent();
-    assertThat(Registry.get("xn--q9jyb4c").getPremiumList().get().getName())
-        .isEqualTo("xn--q9jyb4c");
+    assertThat(Registry.get("xn--q9jyb4c").getPremiumList().get()).isEqualTo("xn--q9jyb4c");
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/SetupOteCommandTest.java
+++ b/core/src/test/java/google/registry/tools/SetupOteCommandTest.java
@@ -73,7 +73,7 @@ class SetupOteCommandTest extends CommandTestCase<SetupOteCommand> {
     assertThat(registry.getTldState(DateTime.now(UTC))).isEqualTo(tldState);
     assertThat(registry.getDnsWriters()).containsExactly("VoidDnsWriter");
     assertThat(registry.getPremiumList()).isNotNull();
-    assertThat(registry.getPremiumList().get().getName()).isEqualTo("default_sandbox_list");
+    assertThat(registry.getPremiumList().get()).isEqualTo("default_sandbox_list");
     assertThat(registry.getAddGracePeriodLength()).isEqualTo(Duration.standardMinutes(60));
     assertThat(registry.getRedemptionGracePeriodLength()).isEqualTo(Duration.standardMinutes(10));
     assertThat(registry.getPendingDeleteLength()).isEqualTo(Duration.standardMinutes(5));

--- a/core/src/test/java/google/registry/tools/UpdateTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateTldCommandTest.java
@@ -35,9 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.beust.jcommander.ParameterException;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
-import com.googlecode.objectify.Key;
 import google.registry.model.registry.Registry;
-import google.registry.model.registry.label.PremiumList;
 import java.util.Optional;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
@@ -254,7 +252,7 @@ class UpdateTldCommandTest extends CommandTestCase<UpdateTldCommand> {
   void testSuccess_setReservedLists() throws Exception {
     runCommandForced("--reserved_lists=xn--q9jyb4c_r1,xn--q9jyb4c_r2", "xn--q9jyb4c");
 
-    assertThat(Registry.get("xn--q9jyb4c").getReservedLists().stream().map(Key::getName))
+    assertThat(Registry.get("xn--q9jyb4c").getReservedLists())
         .containsExactly("xn--q9jyb4c_r1", "xn--q9jyb4c_r2");
   }
 
@@ -264,8 +262,7 @@ class UpdateTldCommandTest extends CommandTestCase<UpdateTldCommand> {
         .setReservedListsByName(ImmutableSet.of("xn--q9jyb4c_r1", "xn--q9jyb4c_r2"))
         .build());
     runCommandForced("--reserved_lists=xn--q9jyb4c_r2", "xn--q9jyb4c");
-    assertThat(Registry.get("xn--q9jyb4c").getReservedLists().stream().map(Key::getName))
-        .containsExactly("xn--q9jyb4c_r2");
+    assertThat(Registry.get("xn--q9jyb4c").getReservedLists()).containsExactly("xn--q9jyb4c_r2");
   }
 
   @Test
@@ -274,7 +271,7 @@ class UpdateTldCommandTest extends CommandTestCase<UpdateTldCommand> {
         .setReservedListsByName(ImmutableSet.of("xn--q9jyb4c_r1"))
         .build());
     runCommandForced("--add_reserved_lists=xn--q9jyb4c_r2", "xn--q9jyb4c");
-    assertThat(Registry.get("xn--q9jyb4c").getReservedLists().stream().map(Key::getName))
+    assertThat(Registry.get("xn--q9jyb4c").getReservedLists())
         .containsExactly("xn--q9jyb4c_r1", "xn--q9jyb4c_r2");
   }
 
@@ -293,8 +290,7 @@ class UpdateTldCommandTest extends CommandTestCase<UpdateTldCommand> {
         .setReservedListsByName(ImmutableSet.of("xn--q9jyb4c_r1", "xn--q9jyb4c_r2"))
         .build());
     runCommandForced("--remove_reserved_lists=xn--q9jyb4c_r1", "xn--q9jyb4c");
-    assertThat(Registry.get("xn--q9jyb4c").getReservedLists().stream().map(Key::getName))
-        .containsExactly("xn--q9jyb4c_r2");
+    assertThat(Registry.get("xn--q9jyb4c").getReservedLists()).containsExactly("xn--q9jyb4c_r2");
   }
 
   @Test
@@ -851,9 +847,9 @@ class UpdateTldCommandTest extends CommandTestCase<UpdateTldCommand> {
   @Test
   void testSuccess_premiumListNotRemovedWhenNotSpecified() throws Exception {
     runCommandForced("--add_reserved_lists=xn--q9jyb4c_r1,xn--q9jyb4c_r2", "xn--q9jyb4c");
-    Optional<Key<PremiumList>> premiumListKey = Registry.get("xn--q9jyb4c").getPremiumList();
-    assertThat(premiumListKey).isPresent();
-    assertThat(premiumListKey.get().getName()).isEqualTo("xn--q9jyb4c");
+    Optional<String> premiumList = Registry.get("xn--q9jyb4c").getPremiumList();
+    assertThat(premiumList).isPresent();
+    assertThat(premiumList.get()).isEqualTo("xn--q9jyb4c");
   }
 
   @Test
@@ -922,8 +918,7 @@ class UpdateTldCommandTest extends CommandTestCase<UpdateTldCommand> {
   void testSuccess_setPremiumList() throws Exception {
     runCommandForced("--premium_list=xn--q9jyb4c", "xn--q9jyb4c");
     assertThat(Registry.get("xn--q9jyb4c").getPremiumList()).isPresent();
-    assertThat(Registry.get("xn--q9jyb4c").getPremiumList().get().getName())
-        .isEqualTo("xn--q9jyb4c");
+    assertThat(Registry.get("xn--q9jyb4c").getPremiumList().get()).isEqualTo("xn--q9jyb4c");
   }
 
   @Test

--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -658,7 +658,6 @@ class google.registry.model.registry.Registry {
   boolean dnsPaused;
   boolean escrowEnabled;
   boolean invoicingEnabled;
-  com.googlecode.objectify.Key<google.registry.model.registry.label.PremiumList> premiumList;
   google.registry.model.CreateAutoTimestamp creationTime;
   google.registry.model.common.TimedTransitionProperty<google.registry.model.registry.Registry$TldState, google.registry.model.registry.Registry$TldStateTransition> tldStateTransitions;
   google.registry.model.common.TimedTransitionProperty<org.joda.money.Money, google.registry.model.registry.Registry$BillingCostTransition> eapFeeSchedule;
@@ -667,14 +666,15 @@ class google.registry.model.registry.Registry {
   int numDnsPublishLocks;
   java.lang.String driveFolderId;
   java.lang.String lordnUsername;
+  java.lang.String premiumList;
   java.lang.String pricingEngineClassName;
   java.lang.String roidSuffix;
   java.lang.String tldStr;
   java.lang.String tldUnicode;
-  java.util.Set<com.googlecode.objectify.Key<google.registry.model.registry.label.ReservedList>> reservedLists;
   java.util.Set<java.lang.String> allowedFullyQualifiedHostNames;
   java.util.Set<java.lang.String> allowedRegistrantContactIds;
   java.util.Set<java.lang.String> dnsWriters;
+  java.util.Set<java.lang.String> reservedLists;
   org.joda.money.CurrencyUnit currency;
   org.joda.money.Money createBillingCost;
   org.joda.money.Money registryLockOrUnlockBillingCost;


### PR DESCRIPTION
Reserved and premium lists were stored as keys on Registry objects in Datastore. For Cloud SQL, they are stored simply as a string representation of the list name. Since Premium and Reserved lists are no longer saved to Datastore, we can change the datatype of these lists in the Registry object.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1206)
<!-- Reviewable:end -->
