### PR TITLE
Add new domain list fields to Registry objects

### DIFF
--- a/core/src/main/java/google/registry/model/registry/Registry.java
+++ b/core/src/main/java/google/registry/model/registry/Registry.java
@@ -417,7 +417,12 @@ public class Registry extends ImmutableObject implements Buildable, DatastoreAnd
   @Column(name = "reserved_list_names")
   Set<String> reservedListNames;
 
-  /** Retrieves an ImmutableSet of all ReservedLists associated with this tld. */
+  /**
+   * Retrieves an ImmutableSet of all ReservedLists associated with this tld. This set contains only
+   * the names of the list and not a reference to the lists. Updates to a reserved list in Cloud SQL
+   * are saved as a new ReservedList entity. When using the ReservedList for a registry, the
+   * database should be queried for the entity with this name that has the largest revision ID.
+   */
   public ImmutableSet<Key<ReservedList>> getReservedLists() {
     return nullToEmptyImmutableCopy(reservedLists);
   }
@@ -425,7 +430,12 @@ public class Registry extends ImmutableObject implements Buildable, DatastoreAnd
   /** The static {@link PremiumList} for this TLD, if there is one. */
   @Transient Key<PremiumList> premiumList;
 
-  /** The name of the {@link PremiumList} for this TLD, if there is one. */
+  /**
+   * The name of the {@link PremiumList} for this TLD, if there is one. This is only the name of the
+   * list and not a reference to the list. Updates to the premium list in Cloud SQL are saved as a
+   * new PremiumList entity. When using the PremiumList for a registry, the database should be
+   * queried for the entity with this name that has the largest revision ID.
+   */
   @Column(name = "premium_list_name", nullable = true)
   String premiumListName;
 

--- a/core/src/main/java/google/registry/model/registry/Registry.java
+++ b/core/src/main/java/google/registry/model/registry/Registry.java
@@ -416,7 +416,7 @@ public class Registry extends ImmutableObject implements Buildable, DatastoreAnd
   Set<String> reservedListNames;
 
   /**
-   * Retrieves an ImmutableSet of all ReservedLists associated with this tld.
+   * Retrieves an ImmutableSet of all ReservedLists associated with this TLD.
    *
    * <p>This set contains only the names of the list and not a reference to the lists. Updates to a
    * reserved list in Cloud SQL are saved as a new ReservedList entity. When using the ReservedList

--- a/core/src/main/java/google/registry/model/registry/Registry.java
+++ b/core/src/main/java/google/registry/model/registry/Registry.java
@@ -112,7 +112,7 @@ public class Registry extends ImmutableObject implements Buildable, DatastoreAnd
   @PostLoad
   void postLoad() {
     tldStr = tldStrId;
-    // TODO(sarahbot@): Remove this rest of this method after this data migration is complete
+    // TODO(sarahbot@): Remove the rest of this method after this data migration is complete
     if (premiumListName != null) {
       premiumList = Key.create(getCrossTldKey(), PremiumList.class, premiumListName);
     }

--- a/core/src/main/java/google/registry/tools/RegistryTool.java
+++ b/core/src/main/java/google/registry/tools/RegistryTool.java
@@ -20,6 +20,7 @@ import google.registry.tools.javascrap.BackfillSpec11ThreatMatchesCommand;
 import google.registry.tools.javascrap.DeleteContactByRoidCommand;
 import google.registry.tools.javascrap.PopulateNullRegistrarFieldsCommand;
 import google.registry.tools.javascrap.RemoveIpAddressCommand;
+import google.registry.tools.javascrap.ResaveAllTldsCommand;
 
 /** Container class to create and run remote commands against a Datastore instance. */
 public final class RegistryTool {
@@ -106,6 +107,7 @@ public final class RegistryTool {
           .put("remove_ip_address", RemoveIpAddressCommand.class)
           .put("remove_registry_one_key", RemoveRegistryOneKeyCommand.class)
           .put("renew_domain", RenewDomainCommand.class)
+          .put("resave_all_tlds", ResaveAllTldsCommand.class)
           .put("resave_entities", ResaveEntitiesCommand.class)
           .put("resave_environment_entities", ResaveEnvironmentEntitiesCommand.class)
           .put("resave_epp_resource", ResaveEppResourceCommand.class)

--- a/core/src/main/java/google/registry/tools/javascrap/ResaveAllTldsCommand.java
+++ b/core/src/main/java/google/registry/tools/javascrap/ResaveAllTldsCommand.java
@@ -1,0 +1,30 @@
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.tools.javascrap;
+
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+
+import com.beust.jcommander.Parameters;
+import google.registry.model.registry.Registry;
+import google.registry.tools.CommandWithRemoteApi;
+
+/** Scrap command to resave all Registry entities. */
+@Parameters(commandDescription = "Resave all TLDs")
+public class ResaveAllTldsCommand implements CommandWithRemoteApi {
+  @Override
+  public void run() throws Exception {
+    tm().transact(() -> tm().putAll(tm().loadAllOf(Registry.class)));
+  }
+}

--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -667,6 +667,7 @@ class google.registry.model.registry.Registry {
   int numDnsPublishLocks;
   java.lang.String driveFolderId;
   java.lang.String lordnUsername;
+  java.lang.String premiumListName;
   java.lang.String pricingEngineClassName;
   java.lang.String roidSuffix;
   java.lang.String tldStr;
@@ -675,6 +676,7 @@ class google.registry.model.registry.Registry {
   java.util.Set<java.lang.String> allowedFullyQualifiedHostNames;
   java.util.Set<java.lang.String> allowedRegistrantContactIds;
   java.util.Set<java.lang.String> dnsWriters;
+  java.util.Set<java.lang.String> reservedListNames;
   org.joda.money.CurrencyUnit currency;
   org.joda.money.Money createBillingCost;
   org.joda.money.Money registryLockOrUnlockBillingCost;


### PR DESCRIPTION
As part of b/186247597, this adds new fields to the Registry object that represent Premium and Reserved list. Once this code is live, all existing Registry entities should be resaved in order to populate these new fields. Then, the old premiumList and ReservedList fields can be removed to allow for the removal of Premium and Reserved list entities from the Datastore schema.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1208)
<!-- Reviewable:end -->
