### PR TITLE
Add SQL functionality to DeleteProberDataAction

### DIFF
--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -48,6 +48,8 @@ import google.registry.util.SystemSleeper;
 import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
@@ -73,7 +75,6 @@ import javax.persistence.TemporalType;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.metamodel.EntityType;
-import javax.persistence.metamodel.SingularAttribute;
 import org.joda.time.DateTime;
 
 /** Implementation of {@link JpaTransactionManager} for JPA compatible database. */
@@ -657,10 +658,22 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   private static ImmutableSet<EntityId> getEntityIdsFromIdContainer(
       EntityType<?> entityType, Object idContainer) {
     return entityType.getIdClassAttributes().stream()
-        .map(SingularAttribute::getName)
         .map(
-            idName -> {
-              Object idValue = getFieldValue(idContainer, idName);
+            attribute -> {
+              String idName = attribute.getName();
+              // The object may use either Java getters or field names to represent the ID object.
+              // Attempt the Java getter, then fall back to the field name if that fails.
+              String methodName = attribute.getJavaMember().getName();
+              Object idValue;
+              try {
+                Method method = idContainer.getClass().getDeclaredMethod(methodName);
+                method.setAccessible(true);
+                idValue = method.invoke(idContainer);
+              } catch (NoSuchMethodException
+                  | IllegalAccessException
+                  | InvocationTargetException e) {
+                idValue = getFieldValue(idContainer, idName);
+              }
               return new EntityId(idName, idValue);
             })
         .collect(toImmutableSet());

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerImplTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerImplTest.java
@@ -75,7 +75,8 @@ class JpaTransactionManagerImplTest {
       new JpaTestRules.Builder()
           .withInitScript(fileClassPath(getClass(), "test_schema.sql"))
           .withClock(fakeClock)
-          .withEntityClass(TestEntity.class, TestCompoundIdEntity.class)
+          .withEntityClass(
+              TestEntity.class, TestCompoundIdEntity.class, TestNamedCompoundIdEntity.class)
           .buildUnitTestRule();
 
   @Test
@@ -270,6 +271,24 @@ class JpaTransactionManagerImplTest {
     assertThat(jpaTm().transact(() -> jpaTm().exists(compoundIdEntity))).isTrue();
     assertThat(jpaTm().transact(() -> jpaTm().loadByKey(compoundIdEntityKey)))
         .isEqualTo(compoundIdEntity);
+  }
+
+  @Test
+  void createNamedCompoundIdEntity_succeeds() {
+    // Compound IDs should also work even if the field names don't match up exactly
+    TestNamedCompoundIdEntity entity = new TestNamedCompoundIdEntity("foo", 1);
+    jpaTm().transact(() -> jpaTm().insert(entity));
+    jpaTm()
+        .transact(
+            () -> {
+              assertThat(jpaTm().exists(entity)).isTrue();
+              assertThat(
+                      jpaTm()
+                          .loadByKey(
+                              VKey.createSql(
+                                  TestNamedCompoundIdEntity.class, new NamedCompoundId("foo", 1))))
+                  .isEqualTo(entity);
+            });
   }
 
   @Test
@@ -775,6 +794,73 @@ class JpaTransactionManagerImplTest {
     private CompoundId(String name, int age) {
       this.name = name;
       this.age = age;
+    }
+  }
+
+  // An entity should still behave properly if the name fields in the ID are different
+  @Entity(name = "TestNamedCompoundIdEntity")
+  @IdClass(NamedCompoundId.class)
+  private static class TestNamedCompoundIdEntity extends ImmutableObject {
+    private String name;
+    private int age;
+
+    private TestNamedCompoundIdEntity() {}
+
+    private TestNamedCompoundIdEntity(String name, int age) {
+      this.name = name;
+      this.age = age;
+    }
+
+    @Id
+    public String getNameField() {
+      return name;
+    }
+
+    @Id
+    public int getAgeField() {
+      return age;
+    }
+
+    @SuppressWarnings("unused")
+    private void setNameField(String name) {
+      this.name = name;
+    }
+
+    @SuppressWarnings("unused")
+    private void setAgeField(int age) {
+      this.age = age;
+    }
+  }
+
+  private static class NamedCompoundId implements Serializable {
+    String nameField;
+    int ageField;
+
+    private NamedCompoundId() {}
+
+    private NamedCompoundId(String nameField, int ageField) {
+      this.nameField = nameField;
+      this.ageField = ageField;
+    }
+
+    @SuppressWarnings("unused")
+    private String getNameField() {
+      return nameField;
+    }
+
+    @SuppressWarnings("unused")
+    private int getAgeField() {
+      return ageField;
+    }
+
+    @SuppressWarnings("unused")
+    private void setNameField(String nameField) {
+      this.nameField = nameField;
+    }
+
+    @SuppressWarnings("unused")
+    private void setAgeField(int ageField) {
+      this.ageField = ageField;
     }
   }
 }


### PR DESCRIPTION
This includes a change to how the JPA transaction manager handles
existence and load checks for entities with compound IDs. Previously, we
relied on the fields all being named the same in the ID entity and the
parent entity. This didn't work for History objects (e.g. DomainHistory)
so existence checks were broken. Now, we use the methods the same way
that Hibernate does (if possible).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1218)
<!-- Reviewable:end -->
