### PR TITLE
Fix BigDecimal precision of PremiumList.getLabelsToPrices()

### DIFF
--- a/core/src/main/java/google/registry/schema/tld/PremiumListDao.java
+++ b/core/src/main/java/google/registry/schema/tld/PremiumListDao.java
@@ -143,12 +143,7 @@ public class PremiumListDao {
     RevisionIdAndLabel revisionIdAndLabel =
         RevisionIdAndLabel.create(loadedList.getRevisionId(), label);
     try {
-      Optional<BigDecimal> price = premiumEntryCache.get(revisionIdAndLabel);
-      return price.map(
-          p ->
-              Money.of(
-                  loadedList.getCurrency(),
-                  p.setScale(loadedList.getCurrency().getDecimalPlaces())));
+      return premiumEntryCache.get(revisionIdAndLabel).map(loadedList::convertAmountToMoney);
     } catch (InvalidCacheLoadException | ExecutionException e) {
       throw new RuntimeException(
           String.format(

--- a/core/src/test/java/google/registry/model/registry/label/PremiumListTest.java
+++ b/core/src/test/java/google/registry/model/registry/label/PremiumListTest.java
@@ -20,6 +20,8 @@ import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistPremiumList;
 import static google.registry.testing.DatabaseHelper.persistReservedList;
 import static google.registry.testing.DatabaseHelper.persistResource;
+import static org.joda.money.CurrencyUnit.JPY;
+import static org.joda.money.CurrencyUnit.USD;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
@@ -28,6 +30,7 @@ import google.registry.model.registry.Registry;
 import google.registry.model.registry.label.PremiumList.PremiumListEntry;
 import google.registry.schema.tld.PremiumListDao;
 import google.registry.testing.AppEngineExtension;
+import java.math.BigDecimal;
 import org.joda.money.Money;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -124,5 +127,31 @@ public class PremiumListTest {
                     .setLabel("lower.みんな")
                     .build());
     assertThat(e).hasMessageThat().contains("must be in puny-coded, lower-case form");
+  }
+
+  @Test
+  void testConvertAmountToMoney_USD() {
+    PremiumList premiumList = new PremiumList.Builder().setName("foo").setCurrency(USD).build();
+    assertThat(premiumList.convertAmountToMoney(new BigDecimal("20.000")))
+        .isEqualTo(Money.of(USD, new BigDecimal("20.00")));
+    assertThat(premiumList.convertAmountToMoney(new BigDecimal("37")))
+        .isEqualTo(Money.of(USD, new BigDecimal("37.00")));
+    assertThat(premiumList.convertAmountToMoney(new BigDecimal("42.5")))
+        .isEqualTo(Money.of(USD, new BigDecimal("42.50")));
+    assertThat(premiumList.convertAmountToMoney(new BigDecimal("15.678")))
+        .isEqualTo(Money.of(USD, new BigDecimal("15.68")));
+  }
+
+  @Test
+  void testConvertAmountToMoney_JPY() {
+    PremiumList premiumList = new PremiumList.Builder().setName("foo").setCurrency(JPY).build();
+    assertThat(premiumList.convertAmountToMoney(new BigDecimal("20.000")))
+        .isEqualTo(Money.of(JPY, new BigDecimal("20")));
+    assertThat(premiumList.convertAmountToMoney(new BigDecimal("37")))
+        .isEqualTo(Money.of(JPY, new BigDecimal("37")));
+    assertThat(premiumList.convertAmountToMoney(new BigDecimal("42.5")))
+        .isEqualTo(Money.of(JPY, new BigDecimal("42")));
+    assertThat(premiumList.convertAmountToMoney(new BigDecimal("15.678")))
+        .isEqualTo(Money.of(JPY, new BigDecimal("16")));
   }
 }


### PR DESCRIPTION
Different currencies have different numbers of decimal places (e.g. USD has 2,
JPY has 0, and some even have 3). Thus, when loading the contents of a premium
list, we need to set the precision correctly on all of the BigDecimal prices.

This issue was introduced as part of the Registry 3.0 database migration when we
changed each PremiumEntry to being a Money to a BigDecimal (to remove the
redundancy of storing the same currency value over and over).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1221)
<!-- Reviewable:end -->
