### PR TITLE
Use the DatabaseMigrationSchedule to determine which TM to use

### DIFF
--- a/core/src/test/java/google/registry/backup/ReplayCommitLogsToSqlActionTest.java
+++ b/core/src/test/java/google/registry/backup/ReplayCommitLogsToSqlActionTest.java
@@ -74,6 +74,7 @@ import google.registry.util.RequestStatusChecker;
 import java.io.IOException;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -142,6 +143,11 @@ public class ReplayCommitLogsToSqlActionTest {
                         MigrationState.DATASTORE_PRIMARY)));
     TestObject.beforeSqlSaveCallCount = 0;
     TestObject.beforeSqlDeleteCallCount = 0;
+  }
+
+  @AfterEach
+  void afterEach() {
+    ofyTm().transact(() -> DatabaseMigrationStateSchedule.set(DEFAULT_TRANSITION_MAP.toValueMap()));
   }
 
   @Test

--- a/core/src/test/java/google/registry/beam/rde/RdePipelineTest.java
+++ b/core/src/test/java/google/registry/beam/rde/RdePipelineTest.java
@@ -23,7 +23,7 @@ import static google.registry.model.common.Cursor.CursorType.RDE_STAGING;
 import static google.registry.model.rde.RdeMode.FULL;
 import static google.registry.model.rde.RdeMode.THIN;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
-import static google.registry.persistence.transaction.TransactionManagerFactory.setTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.setTmForTest;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.rde.RdeResourceType.CONTACT;
 import static google.registry.rde.RdeResourceType.DOMAIN;
@@ -122,7 +122,7 @@ public class RdePipelineTest {
   @BeforeEach
   void beforeEach() throws Exception {
     originalTm = tm();
-    setTm(jpaTm());
+    setTmForTest(jpaTm());
     loadInitialData();
 
     // Two real registrars have been created by loadInitialData(), named "New Registrar" and "The
@@ -169,7 +169,7 @@ public class RdePipelineTest {
 
   @AfterEach
   void afterEach() {
-    setTm(originalTm);
+    setTmForTest(originalTm);
   }
 
   @Test

--- a/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
+++ b/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
@@ -18,7 +18,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.immutableObjectCorrespondence;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
-import static google.registry.persistence.transaction.TransactionManagerFactory.setTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.setTmForTest;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.AppEngineExtension.makeRegistrar1;
 import static google.registry.testing.DatabaseHelper.createTld;
@@ -231,7 +231,7 @@ class Spec11PipelineTest {
 
   private void setupCloudSql() {
     TransactionManager originalTm = tm();
-    setTm(jpaTm());
+    setTmForTest(jpaTm());
     persistNewRegistrar("TheRegistrar");
     persistNewRegistrar("NewRegistrar");
     Registrar registrar1 =
@@ -271,7 +271,7 @@ class Spec11PipelineTest {
     persistResource(createDomain("no-email.com", "2A4BA9BBC-COM", registrar2, contact2));
     persistResource(
         createDomain("anti-anti-anti-virus.dev", "555666888-DEV", registrar3, contact3));
-    setTm(originalTm);
+    setTmForTest(originalTm);
   }
 
   private void verifySaveToGcs() throws Exception {

--- a/core/src/test/java/google/registry/schema/replay/ReplicateToDatastoreActionTest.java
+++ b/core/src/test/java/google/registry/schema/replay/ReplicateToDatastoreActionTest.java
@@ -96,6 +96,13 @@ public class ReplicateToDatastoreActionTest {
   public void tearDown() {
     fakeClock.disableAutoIncrement();
     RegistryConfig.overrideCloudSqlReplicateTransactions(false);
+    ofyTm()
+        .transact(
+            () ->
+                ofyTm()
+                    .loadSingleton(DatabaseMigrationStateSchedule.class)
+                    .ifPresent(ofyTm()::delete));
+    DatabaseMigrationStateSchedule.CACHE.invalidateAll();
   }
 
   @RetryingTest(4)

--- a/core/src/test/java/google/registry/testing/DualDatabaseTestInvocationContextProvider.java
+++ b/core/src/test/java/google/registry/testing/DualDatabaseTestInvocationContextProvider.java
@@ -154,15 +154,13 @@ class DualDatabaseTestInvocationContextProvider implements TestTemplateInvocatio
       context.getStore(NAMESPACE).put(ORIGINAL_TM_KEY, tm());
       DatabaseType databaseType =
           (DatabaseType) context.getStore(NAMESPACE).get(INJECTED_TM_SUPPLIER_KEY);
-      TransactionManagerFactory.setTm(databaseType.getTm());
+      TransactionManagerFactory.setTmForTest(databaseType.getTm());
     }
   }
 
   static void restoreTmAfterDualDatabaseTest(ExtensionContext context) {
     if (isDualDatabaseTest(context)) {
-      TransactionManager original =
-          (TransactionManager) context.getStore(NAMESPACE).get(ORIGINAL_TM_KEY);
-      TransactionManagerFactory.setTm(original);
+      TransactionManagerFactory.removeTmOverrideForTest();
     }
   }
 

--- a/core/src/test/java/google/registry/tools/GetDatabaseMigrationStateCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetDatabaseMigrationStateCommandTest.java
@@ -24,15 +24,15 @@ import google.registry.model.common.DatabaseMigrationStateSchedule.MigrationStat
 import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.TestOfyAndSql;
 import org.joda.time.DateTime;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 
 /** Tests for {@link GetDatabaseMigrationStateCommand}. */
 @DualDatabaseTest
 public class GetDatabaseMigrationStateCommandTest
     extends CommandTestCase<GetDatabaseMigrationStateCommand> {
 
-  @BeforeEach
-  void beforeEach() {
+  @AfterEach
+  void afterEach() {
     ofyTm().transact(() -> DatabaseMigrationStateSchedule.set(DEFAULT_TRANSITION_MAP.toValueMap()));
   }
 

--- a/core/src/test/java/google/registry/tools/SetDatabaseMigrationStateCommandTest.java
+++ b/core/src/test/java/google/registry/tools/SetDatabaseMigrationStateCommandTest.java
@@ -28,6 +28,7 @@ import google.registry.model.common.DatabaseMigrationStateSchedule.MigrationStat
 import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.TestOfyAndSql;
 import org.joda.time.DateTime;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 /** Tests for {@link SetDatabaseMigrationStateCommand}. */
@@ -45,6 +46,11 @@ public class SetDatabaseMigrationStateCommandTest
                     .loadSingleton(DatabaseMigrationStateSchedule.class)
                     .ifPresent(ofyTm()::delete));
     DatabaseMigrationStateSchedule.CACHE.invalidateAll();
+  }
+
+  @AfterEach
+  void afterEach() {
+    ofyTm().transact(() -> DatabaseMigrationStateSchedule.set(DEFAULT_TRANSITION_MAP.toValueMap()));
   }
 
   @TestOfyAndSql


### PR DESCRIPTION
We still allow the "manual" specification of a particular transaction
manager, most useful in @DualDatabaseTest classes. If that isn't
specified, we examine the migration schedule to see which to return.

Notes:
- This requires that any test that sets the migration schedule clean up
after itself so that it won't affect future test runs of other classes
(because the migration schedule cache is static)
- One alternative would, instead of having a "test override" for the
transaction manager, be to examine the registry environment and only
override the transaction manager in the UNIT_TEST environment. This
doesn't work because there are many instances in which tests simulate
non-test environments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1233)
<!-- Reviewable:end -->
