### PR TITLE
Remove key references from BaseDomainLabelList

### DIFF
--- a/core/src/main/java/google/registry/model/registry/label/BaseDomainLabelList.java
+++ b/core/src/main/java/google/registry/model/registry/label/BaseDomainLabelList.java
@@ -164,16 +164,12 @@ public abstract class BaseDomainLabelList<T extends Comparable<?>, R extends Dom
 
   /** Gets the names of the tlds that reference this list. */
   public final ImmutableSet<String> getReferencingTlds() {
-    Key<? extends BaseDomainLabelList<?, ?>> key = Key.create(this);
-    return getTlds()
-        .stream()
-        .filter((tld) -> refersToKey(Registry.get(tld), key))
+    return getTlds().stream()
+        .filter((tld) -> refersToList(Registry.get(tld), name))
         .collect(toImmutableSet());
   }
 
-  // TODO(b/193043636): Refactor this class to no longer use key references
-  protected abstract boolean refersToKey(
-      Registry registry, Key<? extends BaseDomainLabelList<?, ?>> key);
+  protected abstract boolean refersToList(Registry registry, String name);
 
   protected static <R> Optional<R> getFromCache(String listName, LoadingCache<String, R> cache) {
     try {

--- a/core/src/main/java/google/registry/model/registry/label/PremiumList.java
+++ b/core/src/main/java/google/registry/model/registry/label/PremiumList.java
@@ -282,8 +282,8 @@ public final class PremiumList extends BaseDomainLabelList<Money, PremiumList.Pr
   }
 
   @Override
-  public boolean refersToKey(Registry registry, Key<? extends BaseDomainLabelList<?, ?>> key) {
-    return Objects.equals(registry.getPremiumListName().orElse(null), key.getName());
+  public boolean refersToList(Registry registry, String name) {
+    return Objects.equals(registry.getPremiumListName().orElse(null), name);
   }
 
   @Override

--- a/core/src/main/java/google/registry/model/registry/label/ReservedList.java
+++ b/core/src/main/java/google/registry/model/registry/label/ReservedList.java
@@ -33,7 +33,6 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import com.googlecode.objectify.Key;
 import com.googlecode.objectify.annotation.Embed;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Mapify;
@@ -185,8 +184,8 @@ public final class ReservedList
   }
 
   @Override
-  protected boolean refersToKey(Registry registry, Key<? extends BaseDomainLabelList<?, ?>> key) {
-    return registry.getReservedListNames().contains(key.getName());
+  protected boolean refersToList(Registry registry, String name) {
+    return registry.getReservedListNames().contains(name);
   }
 
   /** Determines whether the ReservedList is in use on any Registry */


### PR DESCRIPTION
These keys are no longer necessary since Reserved and Premium list are no longer Read or written to Datastore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1239)
<!-- Reviewable:end -->
