### PR TITLE
Fix runtime issues with commit-log-to-SQL replay

### DIFF
--- a/core/src/test/java/google/registry/backup/RestoreCommitLogsActionTest.java
+++ b/core/src/test/java/google/registry/backup/RestoreCommitLogsActionTest.java
@@ -88,7 +88,7 @@ public class RestoreCommitLogsActionTest {
     action.gcsBucketOverride = Optional.empty();
     action.diffLister = new GcsDiffFileLister();
     action.diffLister.gcsUtils = gcsUtils;
-    action.diffLister.lazyExecutor = MoreExecutors::newDirectExecutorService;
+    action.diffLister.executorProvider = MoreExecutors::newDirectExecutorService;
     action.diffLister.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
   }
 


### PR DESCRIPTION
- We now use a more intelligent prefix to narrow the listObjects search
space in GCS. Otherwise, we're returning >30k objects which can take
roughly 50 seconds. This results in a listObjects time of 1-3 seconds.

- We now search hour by hour to efficiently make use of the prefixing.
Basically, we keep searching for new files until we hit the current time
or until we hit the overall replay timeout.

- Dry-run only prints out the first hour's worth of files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1240)
<!-- Reviewable:end -->
