### PR TITLE
Create a ReadOnlyTransactionManager for SQL migration

### DIFF
--- a/core/src/main/java/google/registry/persistence/transaction/ReadOnlyTransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/ReadOnlyTransactionManager.java
@@ -1,0 +1,268 @@
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.persistence.transaction;
+
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import google.registry.persistence.VKey;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.joda.time.DateTime;
+
+/**
+ * A transaction manager that only supports read operations.
+ *
+ * <p>This is used during the Registry 3.0 Datastore-to-SQL migration during the read-only phases so
+ * that we can prevent any new writes from occurring -- the only changes during the read-only phases
+ * should be the asynchronous transaction replay. See {@link
+ * google.registry.model.common.DatabaseMigrationStateSchedule} for more information.
+ */
+public class ReadOnlyTransactionManager implements TransactionManager {
+
+  private final TransactionManager delegate;
+
+  public ReadOnlyTransactionManager(TransactionManager delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public boolean inTransaction() {
+    return delegate.inTransaction();
+  }
+
+  @Override
+  public void assertInTransaction() {
+    delegate.assertInTransaction();
+  }
+
+  @Override
+  public <T> T transact(Supplier<T> work) {
+    return delegate.transact(work);
+  }
+
+  @Override
+  public void transact(Runnable work) {
+    delegate.transact(work);
+  }
+
+  @Override
+  public <T> T transactNew(Supplier<T> work) {
+    return delegate.transactNew(work);
+  }
+
+  @Override
+  public void transactNew(Runnable work) {
+    delegate.transactNew(work);
+  }
+
+  @Override
+  public <R> R transactNewReadOnly(Supplier<R> work) {
+    return delegate.transactNewReadOnly(work);
+  }
+
+  @Override
+  public void transactNewReadOnly(Runnable work) {
+    delegate.transactNewReadOnly(work);
+  }
+
+  @Override
+  public <R> R doTransactionless(Supplier<R> work) {
+    return delegate.doTransactionless(work);
+  }
+
+  @Override
+  public DateTime getTransactionTime() {
+    return delegate.getTransactionTime();
+  }
+
+  @Override
+  public void insert(Object entity) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public void insertAll(ImmutableCollection<?> entities) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public void insertWithoutBackup(Object entity) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public void insertAllWithoutBackup(ImmutableCollection<?> entities) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public void put(Object entity) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public void putAll(Object... entities) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public void putAll(ImmutableCollection<?> entities) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public void putWithoutBackup(Object entity) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public void putAllWithoutBackup(ImmutableCollection<?> entities) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public void update(Object entity) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public void updateAll(ImmutableCollection<?> entities) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public void updateAll(Object... entities) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public void updateWithoutBackup(Object entity) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public void updateAllWithoutBackup(ImmutableCollection<?> entities) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public boolean exists(Object entity) {
+    return delegate.exists(entity);
+  }
+
+  @Override
+  public <T> boolean exists(VKey<T> key) {
+    return delegate.exists(key);
+  }
+
+  @Override
+  public <T> Optional<T> loadByKeyIfPresent(VKey<T> key) {
+    return delegate.loadByKeyIfPresent(key);
+  }
+
+  @Override
+  public <T> ImmutableMap<VKey<? extends T>, T> loadByKeysIfPresent(
+      Iterable<? extends VKey<? extends T>> vKeys) {
+    return delegate.loadByKeysIfPresent(vKeys);
+  }
+
+  @Override
+  public <T> ImmutableList<T> loadByEntitiesIfPresent(Iterable<T> entities) {
+    return delegate.loadByEntitiesIfPresent(entities);
+  }
+
+  @Override
+  public <T> T loadByKey(VKey<T> key) {
+    return delegate.loadByKey(key);
+  }
+
+  @Override
+  public <T> ImmutableMap<VKey<? extends T>, T> loadByKeys(
+      Iterable<? extends VKey<? extends T>> vKeys) {
+    return delegate.loadByKeys(vKeys);
+  }
+
+  @Override
+  public <T> T loadByEntity(T entity) {
+    return delegate.loadByEntity(entity);
+  }
+
+  @Override
+  public <T> ImmutableList<T> loadByEntities(Iterable<T> entities) {
+    return delegate.loadByEntities(entities);
+  }
+
+  @Override
+  public <T> ImmutableList<T> loadAllOf(Class<T> clazz) {
+    return delegate.loadAllOf(clazz);
+  }
+
+  @Override
+  public <T> Stream<T> loadAllOfStream(Class<T> clazz) {
+    return delegate.loadAllOfStream(clazz);
+  }
+
+  @Override
+  public <T> Optional<T> loadSingleton(Class<T> clazz) {
+    return delegate.loadSingleton(clazz);
+  }
+
+  @Override
+  public void delete(VKey<?> key) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public void delete(Iterable<? extends VKey<?>> keys) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public <T> T delete(T entity) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public void deleteWithoutBackup(VKey<?> key) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public void deleteWithoutBackup(Iterable<? extends VKey<?>> keys) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public void deleteWithoutBackup(Object entity) {
+    throw new UnsupportedOperationException("Transaction manager currently in read-only mode");
+  }
+
+  @Override
+  public <T> QueryComposer<T> createQueryComposer(Class<T> entity) {
+    return delegate.createQueryComposer(entity);
+  }
+
+  @Override
+  public void clearSessionCache() {
+    delegate.clearSessionCache();
+  }
+
+  @Override
+  public boolean isOfy() {
+    return delegate.isOfy();
+  }
+}

--- a/core/src/test/java/google/registry/persistence/transaction/ReadOnlyTransactionManagerTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/ReadOnlyTransactionManagerTest.java
@@ -1,0 +1,64 @@
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.persistence.transaction;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static org.junit.Assert.assertThrows;
+
+import google.registry.model.registrar.Registrar;
+import google.registry.persistence.VKey;
+import google.registry.testing.AppEngineExtension;
+import google.registry.testing.DualDatabaseTest;
+import google.registry.testing.TestOfyAndSql;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Unit tests for {@link ReadOnlyTransactionManager}. */
+@DualDatabaseTest
+public class ReadOnlyTransactionManagerTest {
+
+  @RegisterExtension
+  final AppEngineExtension appEngine =
+      AppEngineExtension.builder().withDatastoreAndCloudSql().build();
+
+  private TransactionManager readOnlyTm;
+  private VKey<Registrar> registrarKey;
+
+  @BeforeEach
+  void beforeEach() {
+    readOnlyTm = new ReadOnlyTransactionManager(tm());
+    registrarKey = AppEngineExtension.makeRegistrar2().createVKey();
+  }
+
+  @TestOfyAndSql
+  void testRead_succeeds() {
+    assertThat(readOnlyTm.transact(() -> readOnlyTm.loadByKey(registrarKey).getEmailAddress()))
+        .isEqualTo("the.registrar@example.com");
+  }
+
+  @TestOfyAndSql
+  void testWrite_fails() {
+    readOnlyTm.transact(
+        () -> {
+          Registrar registrar = readOnlyTm.loadByKey(registrarKey);
+          Registrar modified = registrar.asBuilder().setEmailAddress("foo@bar.com").build();
+          assertThat(
+                  assertThrows(UnsupportedOperationException.class, () -> readOnlyTm.put(modified)))
+              .hasMessageThat()
+              .isEqualTo("Transaction manager currently in read-only mode");
+        });
+  }
+}


### PR DESCRIPTION
We don't use it yet, but in the future we will have tm() return a
ReadOnlyTransactionManager wrapping a Datastore/SQL delegate (as
appropriate) when we are in the read-only segments of the migration.
That way, tm() calls will still be read-only but the asynchronous
migration's jpaTm() or ofyTm() calls will still always function.