### PR TITLE
Use raw EntityManager to load during beforeSqlSave

### DIFF
--- a/core/src/main/java/google/registry/backup/ReplayCommitLogsToSqlAction.java
+++ b/core/src/main/java/google/registry/backup/ReplayCommitLogsToSqlAction.java
@@ -223,7 +223,7 @@ public class ReplayCommitLogsToSqlAction implements Runnable {
           .toSqlEntity()
           .ifPresent(
               sqlEntity -> {
-                ReplaySpecializer.beforeSqlSave(sqlEntity);
+                sqlEntity.beforeSqlSaveOnReplay();
                 jpaTm().put(sqlEntity);
               });
     } else {

--- a/core/src/main/java/google/registry/model/contact/ContactHistory.java
+++ b/core/src/main/java/google/registry/model/contact/ContactHistory.java
@@ -136,9 +136,11 @@ public class ContactHistory extends HistoryEntry implements SqlEntity {
   }
 
   // Used to fill out the contactBase field during asynchronous replay
-  public static void beforeSqlSave(ContactHistory contactHistory) {
-    contactHistory.contactBase =
-        jpaTm().loadByKey(VKey.createSql(ContactResource.class, contactHistory.getContactRepoId()));
+  @Override
+  public void beforeSqlSaveOnReplay() {
+    if (contactBase == null) {
+      contactBase = jpaTm().getEntityManager().find(ContactResource.class, getContactRepoId());
+    }
   }
 
   /** Class to represent the composite primary key of {@link ContactHistory} entity. */

--- a/core/src/main/java/google/registry/model/host/HostHistory.java
+++ b/core/src/main/java/google/registry/model/host/HostHistory.java
@@ -136,9 +136,11 @@ public class HostHistory extends HistoryEntry implements SqlEntity {
   }
 
   // Used to fill out the hostBase field during asynchronous replay
-  public static void beforeSqlSave(HostHistory hostHistory) {
-    hostHistory.hostBase =
-        jpaTm().loadByKey(VKey.createSql(HostResource.class, hostHistory.getHostRepoId()));
+  @Override
+  public void beforeSqlSaveOnReplay() {
+    if (hostBase == null) {
+      hostBase = jpaTm().getEntityManager().find(HostResource.class, getHostRepoId());
+    }
   }
 
   /** Class to represent the composite primary key of {@link HostHistory} entity. */

--- a/core/src/main/java/google/registry/schema/replay/ReplaySpecializer.java
+++ b/core/src/main/java/google/registry/schema/replay/ReplaySpecializer.java
@@ -28,17 +28,11 @@ import java.lang.reflect.Method;
 public class ReplaySpecializer {
 
   public static void beforeSqlDelete(VKey<?> key) {
-    invokeMethod(key.getKind(), "beforeSqlDelete", key);
-  }
-
-  public static void beforeSqlSave(SqlEntity sqlEntity) {
-    invokeMethod(sqlEntity.getClass(), "beforeSqlSave", sqlEntity);
-  }
-
-  private static <T> void invokeMethod(Class<T> clazz, String methodName, Object argument) {
+    String methodName = "beforeSqlDelete";
+    Class<?> clazz = key.getKind();
     try {
-      Method method = clazz.getMethod(methodName, argument.getClass());
-      method.invoke(null, argument);
+      Method method = clazz.getMethod(methodName, VKey.class);
+      method.invoke(null, key);
     } catch (NoSuchMethodException e) {
       // Ignore, this just means that the class doesn't need this hook.
     } catch (IllegalAccessException e) {

--- a/core/src/main/java/google/registry/schema/replay/SqlEntity.java
+++ b/core/src/main/java/google/registry/schema/replay/SqlEntity.java
@@ -26,4 +26,7 @@ import java.util.Optional;
 public interface SqlEntity {
 
   Optional<DatastoreEntity> toDatastoreEntity();
+
+  /** A method that will ber called before the object is saved to SQL in asynchronous replay. */
+  default void beforeSqlSaveOnReplay() {}
 }

--- a/core/src/main/java/google/registry/tools/javascrap/CreateSyntheticHistoryEntriesAction.java
+++ b/core/src/main/java/google/registry/tools/javascrap/CreateSyntheticHistoryEntriesAction.java
@@ -53,7 +53,7 @@ import javax.inject.Inject;
  * However, since this is meant to be run during the Datastore-primary, SQL-secondary stage of the
  * migration, we want to make sure that we are using the most up-to-date version of the data. The
  * resource field of the history objects will be populated during asynchronous migration, e.g. in
- * {@link DomainHistory#beforeSqlSave(DomainHistory)}.
+ * {@link DomainHistory#beforeSqlSaveOnReplay}.
  */
 @Action(
     service = Action.Service.BACKEND,

--- a/core/src/test/java/google/registry/model/history/LegacyHistoryObjectTest.java
+++ b/core/src/test/java/google/registry/model/history/LegacyHistoryObjectTest.java
@@ -74,7 +74,7 @@ public class LegacyHistoryObjectTest extends EntityTestCase {
     assertAboutImmutableObjects()
         .that(legacyHistoryEntry)
         .isEqualExceptFields(fromObjectify, "contactBase", "contactRepoId");
-    assertThat(fromObjectify instanceof ContactHistory).isTrue();
+    assertThat(fromObjectify).isInstanceOf(ContactHistory.class);
     ContactHistory legacyContactHistory = (ContactHistory) fromObjectify;
 
     // Next, save that from-Datastore object in SQL and verify we can load it back in
@@ -124,7 +124,7 @@ public class LegacyHistoryObjectTest extends EntityTestCase {
             "nsHosts",
             "dsDataHistories",
             "gracePeriodHistories");
-    assertThat(fromObjectify instanceof DomainHistory).isTrue();
+    assertThat(fromObjectify).isInstanceOf(DomainHistory.class);
     DomainHistory legacyDomainHistory = (DomainHistory) fromObjectify;
 
     // Next, save that from-Datastore object in SQL and verify we can load it back in
@@ -137,15 +137,7 @@ public class LegacyHistoryObjectTest extends EntityTestCase {
               // Don't compare nsHosts directly because one is null and the other is empty
               assertAboutImmutableObjects()
                   .that(legacyDomainHistory)
-                  .isEqualExceptFields(
-                      // NB: period, transaction records, and other client ID are added in #794
-                      legacyHistoryFromSql,
-                      "period",
-                      "domainTransactionRecords",
-                      "otherClientId",
-                      "nsHosts",
-                      "dsDataHistories",
-                      "gracePeriodHistories");
+                  .isEqualExceptFields(legacyHistoryFromSql, "nsHosts");
               assertThat(nullToEmpty(legacyDomainHistory.getNsHosts()))
                   .isEqualTo(nullToEmpty(legacyHistoryFromSql.getNsHosts()));
             });
@@ -174,7 +166,7 @@ public class LegacyHistoryObjectTest extends EntityTestCase {
     assertAboutImmutableObjects()
         .that(legacyHistoryEntry)
         .isEqualExceptFields(fromObjectify, "hostBase", "hostRepoId");
-    assertThat(fromObjectify instanceof HostHistory).isTrue();
+    assertThat(fromObjectify).isInstanceOf(HostHistory.class);
     HostHistory legacyHostHistory = (HostHistory) fromObjectify;
 
     // Next, save that from-Datastore object in SQL and verify we can load it back in

--- a/core/src/test/java/google/registry/testing/TestObject.java
+++ b/core/src/test/java/google/registry/testing/TestObject.java
@@ -75,7 +75,8 @@ public class TestObject extends ImmutableObject implements DatastoreAndSqlEntity
     beforeSqlDeleteCallCount++;
   }
 
-  public static void beforeSqlSave(TestObject testObject) {
+  @Override
+  public void beforeSqlSaveOnReplay() {
     beforeSqlSaveCallCount++;
   }
 


### PR DESCRIPTION
If we use the transaction manager methods, JpaTransactionManagerImpl
will attempt to detach the EppResource in question that we're loading --
this fails because that entity has been saved in the same transaction
already. We don't need detaching during these methods (it's just for
resource population) so we can use the raw loads to get around it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1253)
<!-- Reviewable:end -->
