### PR TITLE
Remove isNearingExpiration() after shouldReceiveExpiringNotification() being added to code base

### DIFF
--- a/core/src/main/java/google/registry/flows/certs/CertificateChecker.java
+++ b/core/src/main/java/google/registry/flows/certs/CertificateChecker.java
@@ -201,22 +201,6 @@ public class CertificateChecker {
     return checkCertificate(getCertificate(certificateString));
   }
 
-  /**
-   * Returns whether the certificate is nearing expiration.
-   *
-   * <p>Note that this is <i>all</i> that it checks. The certificate itself may well be expired or
-   * not yet valid and this message will still return false. So you definitely want to pair a call
-   * to this method with a call to {@link #checkCertificate} to determine other issues with the
-   * certificate that may be occurring.
-   */
-  public boolean isNearingExpiration(X509Certificate certificate) {
-    Date nearingExpirationDate =
-        DateTime.parse(certificate.getNotAfter().toInstant().toString())
-            .minusDays(expirationWarningDays)
-            .toDate();
-    return clock.nowUtc().toDate().after(nearingExpirationDate);
-  }
-
   /** Converts the given string to a certificate object. */
   public X509Certificate getCertificate(String certificateStr) {
     X509Certificate certificate;

--- a/core/src/test/java/google/registry/flows/certs/CertificateCheckerTest.java
+++ b/core/src/test/java/google/registry/flows/certs/CertificateCheckerTest.java
@@ -219,30 +219,6 @@ class CertificateCheckerTest {
   }
 
   @Test
-  void test_isNearingExpiration_yesItIs() throws Exception {
-    fakeClock.setTo(DateTime.parse("2021-09-20T00:00:00Z"));
-    X509Certificate certificate =
-        SelfSignedCaCertificate.create(
-                SSL_HOST,
-                DateTime.parse("2020-09-02T00:00:00Z"),
-                DateTime.parse("2021-10-01T00:00:00Z"))
-            .cert();
-    assertThat(certificateChecker.isNearingExpiration(certificate)).isTrue();
-  }
-
-  @Test
-  void test_isNearingExpiration_noItsNot() throws Exception {
-    fakeClock.setTo(DateTime.parse("2021-07-20T00:00:00Z"));
-    X509Certificate certificate =
-        SelfSignedCaCertificate.create(
-                SSL_HOST,
-                DateTime.parse("2020-09-02T00:00:00Z"),
-                DateTime.parse("2021-10-01T00:00:00Z"))
-            .cert();
-    assertThat(certificateChecker.isNearingExpiration(certificate)).isFalse();
-  }
-
-  @Test
   void test_getCertificate_throwsException_invalidCertificateString() {
     IllegalArgumentException thrown =
         assertThrows(


### PR DESCRIPTION
- isNearingExpiration() will no longer necessary once shouldReceiveExpiringNotification() is added to the code base. isNearingExpiration() was originally added to check whether the certificate is nearing expiration and shouldReceiveExpiringNotification() was based on the logic of isNearingExpiration() with additional checks. 
- isNearingExpiration() was added along with test cases but not being used in the any features at the moment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1255)
<!-- Reviewable:end -->
