### PR TITLE
Fix GCS bucket/subdir handling in IcannReportingStager

### DIFF
--- a/core/src/main/java/google/registry/reporting/icann/IcannReportingStager.java
+++ b/core/src/main/java/google/registry/reporting/icann/IcannReportingStager.java
@@ -259,8 +259,8 @@ public class IcannReportingStager {
             tld,
             Ascii.toLowerCase(reportType.toString()),
             DateTimeFormat.forPattern("yyyyMM").print(yearMonth));
-    String reportBucketname = String.format("%s/%s", reportingBucket, subdir);
-    final BlobId gcsFilename = BlobId.of(reportBucketname, reportFilename);
+    final BlobId gcsFilename =
+        BlobId.of(reportingBucket, String.format("%s/%s", subdir, reportFilename));
     gcsUtils.createFromBytes(gcsFilename, reportBytes);
     logger.atInfo().log("Wrote %d bytes to file location %s", reportBytes.length, gcsFilename);
     return reportFilename;
@@ -268,8 +268,8 @@ public class IcannReportingStager {
 
   /** Creates and stores a manifest file on GCS, indicating which reports were generated. */
   void createAndUploadManifest(String subdir, ImmutableList<String> filenames) throws IOException {
-    String reportBucketname = String.format("%s/%s", reportingBucket, subdir);
-    final BlobId gcsFilename = BlobId.of(reportBucketname, MANIFEST_FILE_NAME);
+    final BlobId gcsFilename =
+        BlobId.of(reportingBucket, String.format("%s/%s", subdir, MANIFEST_FILE_NAME));
     StringBuilder manifestString = new StringBuilder();
     filenames.forEach((filename) -> manifestString.append(filename).append("\n"));
     gcsUtils.createFromBytes(gcsFilename, manifestString.toString().getBytes(UTF_8));

--- a/core/src/main/java/google/registry/reporting/icann/IcannReportingUploadAction.java
+++ b/core/src/main/java/google/registry/reporting/icann/IcannReportingUploadAction.java
@@ -145,8 +145,9 @@ public final class IcannReportingUploadAction implements Runnable {
         String.format(
             "icann/monthly/%d-%02d",
             cursorTimeMinusMonth.getYear(), cursorTimeMinusMonth.getMonthOfYear());
-    String filename = getFileName(cursorType, cursorTime, tldStr, reportSubdir);
-    final BlobId gcsFilename = BlobId.of(reportingBucket, filename);
+    String filename = getFileName(cursorType, cursorTime, tldStr);
+    final BlobId gcsFilename =
+        BlobId.of(reportingBucket, String.format("%s/%s", reportSubdir, filename));
     logger.atInfo().log("Reading ICANN report %s from bucket %s", filename, reportingBucket);
     // Check that the report exists
     try {
@@ -191,12 +192,10 @@ public final class IcannReportingUploadAction implements Runnable {
     }
   }
 
-  private String getFileName(
-      CursorType cursorType, DateTime cursorTime, String tld, String subdir) {
+  private String getFileName(CursorType cursorType, DateTime cursorTime, String tld) {
     DateTime cursorTimeMinusMonth = cursorTime.withDayOfMonth(1).minusMonths(1);
     return String.format(
-        "%s/%s%s%d%02d.csv",
-        subdir,
+        "%s%s%d%02d.csv",
         tld,
         (cursorType.equals(CursorType.ICANN_UPLOAD_ACTIVITY) ? "-activity-" : "-transactions-"),
         cursorTimeMinusMonth.year().get(),

--- a/core/src/main/java/google/registry/reporting/icann/IcannReportingUploadAction.java
+++ b/core/src/main/java/google/registry/reporting/icann/IcannReportingUploadAction.java
@@ -145,10 +145,9 @@ public final class IcannReportingUploadAction implements Runnable {
         String.format(
             "icann/monthly/%d-%02d",
             cursorTimeMinusMonth.getYear(), cursorTimeMinusMonth.getMonthOfYear());
-    String reportBucketname = String.format("%s/%s", reportingBucket, reportSubdir);
-    String filename = getFileName(cursorType, cursorTime, tldStr);
-    final BlobId gcsFilename = BlobId.of(reportBucketname, filename);
-    logger.atInfo().log("Reading ICANN report %s from bucket %s", filename, reportBucketname);
+    String filename = getFileName(cursorType, cursorTime, tldStr, reportSubdir);
+    final BlobId gcsFilename = BlobId.of(reportingBucket, filename);
+    logger.atInfo().log("Reading ICANN report %s from bucket %s", filename, reportingBucket);
     // Check that the report exists
     try {
       verifyFileExists(gcsFilename);
@@ -192,10 +191,12 @@ public final class IcannReportingUploadAction implements Runnable {
     }
   }
 
-  private String getFileName(CursorType cursorType, DateTime cursorTime, String tld) {
+  private String getFileName(
+      CursorType cursorType, DateTime cursorTime, String tld, String subdir) {
     DateTime cursorTimeMinusMonth = cursorTime.withDayOfMonth(1).minusMonths(1);
     return String.format(
-        "%s%s%d%02d.csv",
+        "%s/%s%s%d%02d.csv",
+        subdir,
         tld,
         (cursorType.equals(CursorType.ICANN_UPLOAD_ACTIVITY) ? "-activity-" : "-transactions-"),
         cursorTimeMinusMonth.year().get(),


### PR DESCRIPTION
After the migration to the new GCS API it becomes apparent that the
BlobId.of() method needs to take the bucket name (without any trailing
directories) as the first argument. I did a search on all occurrences of
"BlobId.of" in the code base and verified that it is only in the ICANN
reporting job that the API was misused.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1265)
<!-- Reviewable:end -->
