### PR TITLE
Load DatabaseMigrationStateSchedule in a more performant way

### DIFF
--- a/core/src/main/java/google/registry/model/ofy/Ofy.java
+++ b/core/src/main/java/google/registry/model/ofy/Ofy.java
@@ -325,7 +325,7 @@ public class Ofy {
   }
 
   /** Execute some work in a transactionless context. */
-  <R> R doTransactionless(Supplier<R> work) {
+  public <R> R doTransactionless(Supplier<R> work) {
     try {
       com.googlecode.objectify.ObjectifyService.push(
           com.googlecode.objectify.ObjectifyService.ofy().transactionless());


### PR DESCRIPTION
This performs a direct load-by-key (the most efficient Datastore operation),
rather than attempting to load all entities by type using an ancestor query. The
existing implementation is possibly more error-prone as well, and might be
responsible for the "cross-group transaction need to be explicitly specified"
error we're seeing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1273)
<!-- Reviewable:end -->
