### PR TITLE
Update cron jobs in crash

### DIFF
--- a/core/src/main/java/google/registry/env/crash/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/crash/default/WEB-INF/cron.xml
@@ -147,9 +147,6 @@
     <target>backend</target>
   </cron>
 
-  <!--
-    Removed for the duration of load testing
-    TODO(b/71607184): Restore after loadtesting is done
   <cron>
     <url><![CDATA[/_dr/cron/fanout?queue=retryable-cron-tasks&endpoint=/_dr/task/deleteProberData&runInEmpty]]></url>
     <description>
@@ -159,7 +156,6 @@
     <timezone>UTC</timezone>
     <target>backend</target>
   </cron>
-  -->
 
   <!-- TODO: Add borgmon job to check that these files are created and updated successfully. -->
   <cron>
@@ -200,12 +196,24 @@
     <target>backend</target>
   </cron>
 
+  <!--
+    The next two wipeout jobs are required when crash has production data.
+   -->
   <cron>
-    <url><![CDATA[/_dr/cron/fanout?queue=replay-commit-logs-to-sql&endpoint=/_dr/task/replayCommitLogsToSql&runInEmpty]]></url>
+    <url><![CDATA[/_dr/task/wipeOutCloudSql]]></url>
     <description>
-      Replays recent commit logs from Datastore to the SQL secondary backend.
+      This job runs an action that deletes all data in Cloud SQL.
     </description>
-    <schedule>every 3 minutes</schedule>
+    <schedule>every saturday 03:07</schedule>
+    <target>backend</target>
+  </cron>
+
+  <cron>
+    <url><![CDATA[/_dr/task/wipeOutDatastore]]></url>
+    <description>
+      This job runs an action that deletes all data in Cloud Datastore.
+    </description>
+    <schedule>every saturday 03:07</schedule>
     <target>backend</target>
   </cron>
 </cronentries>

--- a/core/src/main/java/google/registry/env/crash/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/crash/default/WEB-INF/cron.xml
@@ -102,6 +102,7 @@
     <target>backend</target>
   </cron>
 
+  <!-- Disabled for sql-only tests.
   <cron>
     <url><![CDATA[/_dr/cron/commitLogCheckpoint]]></url>
     <description>
@@ -110,6 +111,7 @@
     <schedule>every 3 minutes synchronized</schedule>
     <target>backend</target>
   </cron>
+  -->
 
   <cron>
     <url><![CDATA[/_dr/task/deleteContactsAndHosts]]></url>
@@ -133,6 +135,7 @@
     <target>backend</target>
   </cron>
 
+  <!-- Disabled for sql-only tests
   <cron>
     <url><![CDATA[/_dr/cron/fanout?queue=export-snapshot&endpoint=/_dr/task/backupDatastore&runInEmpty]]></url>
     <description>
@@ -142,10 +145,11 @@
     </description>
     <!--
       Keep google.registry.export.CheckBackupAction.MAXIMUM_BACKUP_RUNNING_TIME less than
-      this interval. -->
+      this interval. - ->
     <schedule>every day 06:00</schedule>
     <target>backend</target>
   </cron>
+  -->
 
   <cron>
     <url><![CDATA[/_dr/cron/fanout?queue=retryable-cron-tasks&endpoint=/_dr/task/deleteProberData&runInEmpty]]></url>

--- a/core/src/main/java/google/registry/env/crash/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/crash/default/WEB-INF/cron.xml
@@ -200,6 +200,17 @@
     <target>backend</target>
   </cron>
 
+  <!-- Disabled for sql-only tests.
+  <cron>
+    <url><![CDATA[/_dr/cron/fanout?queue=replay-commit-logs-to-sql&endpoint=/_dr/task/replayCommitLogsToSql&runInEmpty]]></url>
+    <description>
+      Replays recent commit logs from Datastore to the SQL secondary backend.
+    </description>
+    <schedule>every 3 minutes</schedule>
+    <target>backend</target>
+  </cron>
+  -->
+
   <!--
     The next two wipeout jobs are required when crash has production data.
    -->


### PR DESCRIPTION
Add wipeout cron jobs for the duration of migration testing with
production data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1284)
<!-- Reviewable:end -->
