### PR TITLE
Remove -- from crash cron comment

### DIFF
--- a/core/src/main/java/google/registry/env/crash/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/crash/default/WEB-INF/cron.xml
@@ -143,7 +143,7 @@
       It also enqueues a new task to wait on the completion of that job and then load the resulting
       snapshot into bigquery.
     </description>
-    <!--
+    <!- -
       Keep google.registry.export.CheckBackupAction.MAXIMUM_BACKUP_RUNNING_TIME less than
       this interval. - ->
     <schedule>every day 06:00</schedule>

--- a/core/src/test/java/google/registry/reporting/spec11/GenerateSpec11ReportActionTest.java
+++ b/core/src/test/java/google/registry/reporting/spec11/GenerateSpec11ReportActionTest.java
@@ -35,7 +35,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 class GenerateSpec11ReportActionTest extends BeamActionTestBase {
 
   @RegisterExtension
-  final AppEngineExtension appEngine = AppEngineExtension.builder().withTaskQueue().build();
+  final AppEngineExtension appEngine =
+      AppEngineExtension.builder().withDatastoreAndCloudSql().withTaskQueue().build();
 
   private final FakeClock clock = new FakeClock(DateTime.parse("2018-06-11T12:23:56Z"));
   private GenerateSpec11ReportAction action;


### PR DESCRIPTION
This is causing the release build to fail, see https://pantheon.corp.google.com/cloud-build/builds;region=global/22ec980b-c2b6-43fe-994a-aa98c0dbc9d4?project=domain-registry-dev

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1289)
<!-- Reviewable:end -->
