### PR TITLE
Clean up ReplicateToDatastoreAction and tests

### DIFF
--- a/core/src/test/java/google/registry/testing/LogsSubject.java
+++ b/core/src/test/java/google/registry/testing/LogsSubject.java
@@ -14,6 +14,7 @@
 
 package google.registry.testing;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertAbout;
 import static com.google.common.truth.Truth.assertWithMessage;
 
@@ -26,6 +27,7 @@ import com.google.common.truth.StringSubject;
 import com.google.common.truth.Subject;
 import google.registry.testing.TruthChainer.Which;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -41,7 +43,13 @@ public class LogsSubject extends Subject {
   }
 
   private static final Correspondence<String, String> CONTAINS_CORRESPONDENCE =
-      Correspondence.from((actual, expected) -> actual.contains(expected), "contains");
+      Correspondence.from(String::contains, "contains");
+
+  private static final Correspondence<Throwable, Throwable> THROWABLE_CORRESPONDENCE =
+      Correspondence.from(
+          (t1, t2) ->
+              t1.getClass().equals(t2.getClass()) && t1.getMessage().equals(t2.getMessage()),
+          "throwableEquivalent");
 
   private List<String> getMessagesAtLevel(Level level) {
     ImmutableList.Builder<String> builder = new ImmutableList.Builder<>();
@@ -55,6 +63,18 @@ public class LogsSubject extends Subject {
 
   public void hasNoLogsAtLevel(Level level) {
     check("atLevel(%s)", level).that(getMessagesAtLevel(level)).isEmpty();
+  }
+
+  public void hasSevereLogWithCause(Throwable throwable) {
+    ImmutableList<Throwable> actualThrowables =
+        actual.getStoredLogRecords().stream()
+            .map(LogRecord::getThrown)
+            .filter(Objects::nonNull)
+            .collect(toImmutableList());
+    check("atSevere")
+        .that(actualThrowables)
+        .comparingElementsUsing(THROWABLE_CORRESPONDENCE)
+        .contains(throwable);
   }
 
   public Which<StringSubject> hasLogAtLevelWithMessage(Level level, String message) {

--- a/core/src/test/java/google/registry/testing/ReplayExtension.java
+++ b/core/src/test/java/google/registry/testing/ReplayExtension.java
@@ -81,7 +81,8 @@ public class ReplayExtension implements BeforeEachCallback, AfterEachCallback {
    * Create a replay extension that replays from SQL to cloud datastore when running in SQL mode.
    */
   public static ReplayExtension createWithDoubleReplay(FakeClock clock) {
-    return new ReplayExtension(clock, true, new ReplicateToDatastoreAction(clock));
+    return new ReplayExtension(
+        clock, true, new ReplicateToDatastoreAction(clock, new FakeResponse()));
   }
 
   @Override
@@ -199,10 +200,7 @@ public class ReplayExtension implements BeforeEachCallback, AfterEachCallback {
     do {
       transactionBatch = sqlToDsReplicator.getTransactionBatch();
       for (TransactionEntity txn : transactionBatch) {
-        if (sqlToDsReplicator.applyTransaction(txn)) {
-          throw new RuntimeException(
-              "Error when replaying to Datastore in tests; see logs for more details");
-        }
+        sqlToDsReplicator.applyTransaction(txn);
         if (compare) {
           ofyTm().transact(() -> compareSqlTransaction(txn));
         }


### PR DESCRIPTION
1. applyTransaction should throw an error if it fails; this allows us to
have more information in the caller (and it shouldn't usually happen)
2. Set a response code + payload now, since this is an action that is
called by cron
3. Add a method to the test log subject that allows us to check if a
severe log with a particular Throwable cause was logged (since the cause
isn't contained in the log message itself directly)