### PR TITLE
Add RetryingTest annotation to flaky RDE test

### DIFF
--- a/core/src/test/java/google/registry/beam/rde/RdePipelineTest.java
+++ b/core/src/test/java/google/registry/beam/rde/RdePipelineTest.java
@@ -91,6 +91,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junitpioneer.jupiter.RetryingTest;
 
 /** Unit tests for {@link RdePipeline}. */
 public class RdePipelineTest {
@@ -288,7 +289,8 @@ public class RdePipelineTest {
     pipeline.run().waitUntilFinish();
   }
 
-  @Test
+  // The GCS folder listing can be a bit flaky, so retry if necessary
+  @RetryingTest(4)
   void testSuccess_persistData() throws Exception {
     PendingDeposit brdaKey =
         PendingDeposit.create("soy", now, THIN, CursorType.BRDA, Duration.standardDays(1));
@@ -314,7 +316,8 @@ public class RdePipelineTest {
     assertThat(loadRevision(now, FULL)).isEqualTo(1);
   }
 
-  @Test
+  // The GCS folder listing can be a bit flaky, so retry if necessary
+  @RetryingTest(4)
   void testSuccess_persistData_manual() throws Exception {
     PendingDeposit brdaKey = PendingDeposit.createInManualOperation("soy", now, THIN, "test/", 0);
     PendingDeposit rdeKey = PendingDeposit.createInManualOperation("soy", now, FULL, "test/", 0);


### PR DESCRIPTION
I'm not sure why this test is failing. It's failing saying that the
listObjects call is failing to include
"soy_2000-01-01_thin_S1_R1.xml.ghostryde" in the results, however the
verifyFiles method that we call right beforehand verifies that file and
its contents

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1306)
<!-- Reviewable:end -->
