### PR TITLE
Remove VKeyTranslatorFactory.createVKey(String)

### DIFF
--- a/core/src/main/java/google/registry/model/translators/VKeyTranslatorFactory.java
+++ b/core/src/main/java/google/registry/model/translators/VKeyTranslatorFactory.java
@@ -92,11 +92,6 @@ public class VKeyTranslatorFactory extends AbstractSimpleTranslatorFactory<VKey,
     }
   }
 
-  /** Create a VKey from a URL-safe string representation. */
-  public static VKey<?> createVKey(String urlSafe) {
-    return createVKey(com.googlecode.objectify.Key.create(urlSafe));
-  }
-
   @VisibleForTesting
   public static void addTestEntityClass(Class<?> clazz) {
     CLASS_REGISTRY.put(com.googlecode.objectify.Key.getKind(clazz), clazz);

--- a/core/src/test/java/google/registry/model/translators/VKeyTranslatorFactoryTest.java
+++ b/core/src/test/java/google/registry/model/translators/VKeyTranslatorFactoryTest.java
@@ -89,18 +89,6 @@ public class VKeyTranslatorFactoryTest {
   }
 
   @Test
-  void testUrlSafeKey() {
-    // Creating an objectify key instead of a datastore key as this should get a correctly formatted
-    // key path.
-    DomainBase domain = newDomainBase("example.com", "ROID-1", persistActiveContact("contact-1"));
-    Key<DomainBase> key = Key.create(domain);
-    VKey<DomainBase> vkey = (VKey<DomainBase>) VKeyTranslatorFactory.createVKey(key.getString());
-    assertThat(vkey.getKind()).isEqualTo(DomainBase.class);
-    assertThat(vkey.getOfyKey()).isEqualTo(key);
-    assertThat(vkey.getSqlKey()).isEqualTo("ROID-1");
-  }
-
-  @Test
   void testExtraEntityClass() {
     TestObject testObject = TestObject.create("id", "field");
     Key<TestObject> key = Key.create(testObject);

--- a/core/src/test/java/google/registry/persistence/VKeyTest.java
+++ b/core/src/test/java/google/registry/persistence/VKeyTest.java
@@ -15,11 +15,14 @@ package google.registry.persistence;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
+import static google.registry.testing.DatabaseHelper.newDomainBase;
+import static google.registry.testing.DatabaseHelper.persistActiveContact;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.annotation.Entity;
 import google.registry.model.billing.BillingEvent.OneTime;
+import google.registry.model.domain.DomainBase;
 import google.registry.model.registrar.RegistrarContact;
 import google.registry.testing.AppEngineExtension;
 import google.registry.testing.TestObject;
@@ -112,6 +115,19 @@ class VKeyTest {
     assertThat(thrown)
         .hasMessageThat()
         .contains("Missing value for last key of type class google.registry.testing.TestObject");
+  }
+
+  @Test
+  void testFromWebsafeKey() {
+    // Creating an objectify key instead of a datastore key as this should get a correctly formatted
+    // key path.  We have to one of our actual model object classes for this, TestObject can not be
+    // reconstructed by the VKeyTranslatorFactory.
+    DomainBase domain = newDomainBase("example.com", "ROID-1", persistActiveContact("contact-1"));
+    Key<DomainBase> key = Key.create(domain);
+    VKey<DomainBase> vkey = VKey.fromWebsafeKey(key.getString());
+    assertThat(vkey.getKind()).isEqualTo(DomainBase.class);
+    assertThat(vkey.getOfyKey()).isEqualTo(key);
+    assertThat(vkey.getSqlKey()).isEqualTo("ROID-1");
   }
 
   @Entity


### PR DESCRIPTION
This method serves the same function as VKey.fromWebsafeKey(), and isn't used
anywhere.  Move the test for it into VKeyTest and use it to instead test
fromWebsafeKey() (which didn't previously have a test).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1312)
<!-- Reviewable:end -->
