### PR TITLE
Update references to RDAP RFCs

### DIFF
--- a/core/src/main/java/google/registry/rdap/AbstractJsonableObject.java
+++ b/core/src/main/java/google/registry/rdap/AbstractJsonableObject.java
@@ -339,7 +339,7 @@ abstract class AbstractJsonableObject implements Jsonable {
       return new JsonPrimitive((Boolean) object);
     }
     if (object instanceof DateTime) {
-      // According to RFC7483 section 3, the syntax of dates and times is defined in RFC3339.
+      // According to RFC 9083 section 3, the syntax of dates and times is defined in RFC3339.
       //
       // According to RFC3339, we should use ISO8601, which is what DateTime.toString does!
       return new JsonPrimitive(((DateTime) object).toString());

--- a/core/src/main/java/google/registry/rdap/RdapActionBase.java
+++ b/core/src/main/java/google/registry/rdap/RdapActionBase.java
@@ -50,8 +50,8 @@ import org.joda.time.DateTime;
 /**
  * Base RDAP (new WHOIS) action for all requests.
  *
- * @see <a href="https://tools.ietf.org/html/rfc7482">
- *        RFC 7482: Registration Data Access Protocol (RDAP) Query Format</a>
+ * @see <a href="https://tools.ietf.org/html/rfc9082">RFC 9082: Registration Data Access Protocol
+ *     (RDAP) Query Format</a>
  */
 public abstract class RdapActionBase implements Runnable {
 

--- a/core/src/main/java/google/registry/rdap/RdapDataStructures.java
+++ b/core/src/main/java/google/registry/rdap/RdapDataStructures.java
@@ -22,16 +22,12 @@ import google.registry.rdap.AbstractJsonableObject.RestrictJsonNames;
 import java.util.Optional;
 import org.joda.time.DateTime;
 
-/**
- * Data Structures defined in RFC7483 section 4.
- */
+/** Data Structures defined in RFC 9083 section 4. */
 final class RdapDataStructures {
 
   private RdapDataStructures() {}
 
-  /**
-   * RDAP conformance defined in 4.1 of RFC7483.
-   */
+  /** RDAP conformance defined in 4.1 of RFC 9083. */
   @RestrictJsonNames("rdapConformance")
   static final class RdapConformance implements Jsonable {
 
@@ -42,7 +38,7 @@ final class RdapDataStructures {
     @Override
     public JsonArray toJson() {
       JsonArray jsonArray = new JsonArray();
-      // Conformance to RFC7483
+      // Conformance to RFC 9083
       jsonArray.add("rdap_level_0");
 
       // Conformance to the RDAP Response Profile V2.1
@@ -57,9 +53,7 @@ final class RdapDataStructures {
     }
   }
 
-  /**
-   * Links defined in 4.2 of RFC7483.
-   */
+  /** Links defined in 4.2 of RFC 9083. */
   @RestrictJsonNames("links[]")
   @AutoValue
   abstract static class Link extends AbstractJsonableObject {
@@ -91,7 +85,7 @@ final class RdapDataStructures {
   }
 
   /**
-   * Notices and Remarks defined in 4.3 of RFC7483.
+   * Notices and Remarks defined in 4.3 of RFC 9083.
    *
    * <p>Each has an optional "type" denoting a registered type string defined in 10.2.1. The type is
    * defined as common to both Notices and Remarks, but each item is only appropriate to one of
@@ -118,7 +112,7 @@ final class RdapDataStructures {
   }
 
   /**
-   * Notices defined in 4.3 of RFC7483.
+   * Notices defined in 4.3 of RFC 9083.
    *
    * <p>A notice denotes information about the service itself or the entire response, and hence will
    * only be in the top-most object.
@@ -128,7 +122,7 @@ final class RdapDataStructures {
   abstract static class Notice extends NoticeOrRemark {
 
     /**
-     * Notice and Remark Type are defined in 10.2.1 of RFC7483.
+     * Notice and Remark Type are defined in 10.2.1 of RFC 9083.
      *
      * <p>We only keep the "service or entire response" values for Notice.Type.
      */
@@ -138,16 +132,15 @@ final class RdapDataStructures {
       RESULT_TRUNCATED_LOAD("result set truncated due to excessive load"),
       RESULT_TRUNCATED_UNEXPLAINABLE("result set truncated due to unexplainable reasons");
 
+      private final String rfc9083String;
 
-      private final String rfc7483String;
-
-      Type(String rfc7483String) {
-        this.rfc7483String = rfc7483String;
+      Type(String rfc9083String) {
+        this.rfc9083String = rfc9083String;
       }
 
       @Override
       public JsonPrimitive toJson() {
-        return new JsonPrimitive(rfc7483String);
+        return new JsonPrimitive(rfc9083String);
       }
     }
 
@@ -167,7 +160,7 @@ final class RdapDataStructures {
   }
 
   /**
-   * Remarks defined in 4.3 of RFC7483.
+   * Remarks defined in 4.3 of RFC 9083.
    *
    * <p>A remark denotes information about the specific object, and hence each object has its own
    * "remarks" array.
@@ -177,7 +170,7 @@ final class RdapDataStructures {
   abstract static class Remark extends NoticeOrRemark {
 
     /**
-     * Notice and Remark Type are defined in 10.2.1 of RFC7483.
+     * Notice and Remark Type are defined in 10.2.1 of RFC 9083.
      *
      * <p>We only keep the "specific object" values for Remark.Type.
      */
@@ -190,15 +183,15 @@ final class RdapDataStructures {
       // so I'm adding it here, but we have to ask them about it...
       OBJECT_REDACTED_AUTHORIZATION("object redacted due to authorization");
 
-      private final String rfc7483String;
+      private final String rfc9083String;
 
-      Type(String rfc7483String) {
-        this.rfc7483String = rfc7483String;
+      Type(String rfc9083String) {
+        this.rfc9083String = rfc9083String;
       }
 
       @Override
       public JsonPrimitive toJson() {
-        return new JsonPrimitive(rfc7483String);
+        return new JsonPrimitive(rfc9083String);
       }
     }
 
@@ -218,9 +211,9 @@ final class RdapDataStructures {
   }
 
   /**
-   * Language Identifier defined in 4.4 of RFC7483.
+   * Language Identifier defined in 4.4 of RFC 9083.
    *
-   * The allowed values are described in RFC5646.
+   * <p>The allowed values are described in RFC5646.
    */
   @RestrictJsonNames("lang")
   enum LanguageIdentifier implements Jsonable {
@@ -239,7 +232,7 @@ final class RdapDataStructures {
   }
 
   /**
-   * Events defined in 4.5 of RFC7483.
+   * Events defined in 4.5 of RFC 9083.
    *
    * <p>There's a type of Event that must not have the "eventActor" (see 5.1), so we create 2
    * versions - one with and one without.
@@ -263,7 +256,7 @@ final class RdapDataStructures {
     }
   }
 
-  /** Status values for events specified in RFC 7483 § 10.2.3. */
+  /** Status values for events specified in RFC 9083 § 10.2.3. */
   enum EventAction implements Jsonable {
     REGISTRATION("registration"),
     REREGISTRATION("reregistration"),
@@ -277,25 +270,24 @@ final class RdapDataStructures {
     LAST_UPDATE_OF_RDAP_DATABASE("last update of RDAP database");
 
     /** Value as it appears in RDAP messages. */
-    private final String rfc7483String;
+    private final String rfc9083String;
 
-    EventAction(String rfc7483String) {
-      this.rfc7483String = rfc7483String;
+    EventAction(String rfc9083String) {
+      this.rfc9083String = rfc9083String;
     }
 
     String getDisplayName() {
-      return rfc7483String;
+      return rfc9083String;
     }
 
     @Override
     public JsonPrimitive toJson() {
-      return new JsonPrimitive(rfc7483String);
+      return new JsonPrimitive(rfc9083String);
     }
   }
 
-
   /**
-   * Events defined in 4.5 of RFC7483.
+   * Events defined in 4.5 of RFC 9083.
    *
    * <p>There's a type of Event that MUST NOT have the "eventActor" (see 5.1), so we have this
    * object to enforce that.
@@ -315,9 +307,7 @@ final class RdapDataStructures {
     }
   }
 
-  /**
-   * Events defined in 4.5 of RFC7483.
-   */
+  /** Events defined in 4.5 of RFC 9083. */
   @RestrictJsonNames("events[]")
   @AutoValue
   abstract static class Event extends EventBase {
@@ -336,7 +326,7 @@ final class RdapDataStructures {
   }
 
   /**
-   * Status defined in 4.6 of RFC7483.
+   * Status defined in 4.6 of RFC 9083.
    *
    * <p>This indicates the state of the registered object.
    *
@@ -345,7 +335,7 @@ final class RdapDataStructures {
   @RestrictJsonNames("status[]")
   enum RdapStatus implements Jsonable {
 
-    // Status values specified in RFC 7483 § 10.2.2.
+    // Status values specified in RFC 9083 § 10.2.2.
     VALIDATED("validated"),
     RENEW_PROHIBITED("renew prohibited"),
     UPDATE_PROHIBITED("update prohibited"),
@@ -385,24 +375,24 @@ final class RdapDataStructures {
     TRANSFER_PERIOD("transfer period");
 
     /** Value as it appears in RDAP messages. */
-    private final String rfc7483String;
+    private final String rfc9083String;
 
-    RdapStatus(String rfc7483String) {
-      this.rfc7483String = rfc7483String;
+    RdapStatus(String rfc9083String) {
+      this.rfc9083String = rfc9083String;
     }
 
     String getDisplayName() {
-      return rfc7483String;
+      return rfc9083String;
     }
 
     @Override
     public JsonPrimitive toJson() {
-      return new JsonPrimitive(rfc7483String);
+      return new JsonPrimitive(rfc9083String);
     }
   }
 
   /**
-   * Port 43 WHOIS Server defined in 4.7 of RFC7483.
+   * Port 43 WHOIS Server defined in 4.7 of RFC 9083.
    *
    * <p>This contains the fully qualifies host name of IP address of the WHOIS RFC3912 server where
    * the containing object instance may be found.
@@ -423,7 +413,7 @@ final class RdapDataStructures {
   }
 
   /**
-   * Public IDs defined in 4.8 of RFC7483.
+   * Public IDs defined in 4.8 of RFC 9083.
    *
    * <p>Maps a public identifier to an object class.
    */
@@ -434,15 +424,15 @@ final class RdapDataStructures {
     enum Type implements Jsonable {
       IANA_REGISTRAR_ID("IANA Registrar ID");
 
-      private final String rfc7483String;
+      private final String rfc9083String;
 
-      Type(String rfc7483String) {
-        this.rfc7483String = rfc7483String;
+      Type(String rfc9083String) {
+        this.rfc9083String = rfc9083String;
       }
 
       @Override
       public JsonPrimitive toJson() {
-        return new JsonPrimitive(rfc7483String);
+        return new JsonPrimitive(rfc9083String);
       }
     }
 
@@ -457,7 +447,7 @@ final class RdapDataStructures {
   }
 
   /**
-   * Object Class Name defined in 4.7 of RFC7483.
+   * Object Class Name defined in 4.7 of RFC 9083.
    *
    * <p>Identifies the type of the object being processed. Is REQUIRED in all RDAP response objects,
    * but not so for internal objects whose type can be inferred by their key name in the enclosing
@@ -465,15 +455,15 @@ final class RdapDataStructures {
    */
   @RestrictJsonNames("objectClassName")
   enum ObjectClassName implements Jsonable {
-    /** Defined in 5.1 of RFC7483. */
+    /** Defined in 5.1 of RFC 9083. */
     ENTITY("entity"),
-    /** Defined in 5.2 of RFC7483. */
+    /** Defined in 5.2 of RFC 9083. */
     NAMESERVER("nameserver"),
-    /** Defined in 5.3 of RFC7483. */
+    /** Defined in 5.3 of RFC 9083. */
     DOMAIN("domain"),
-    /** Defined in 5.4 of RFC7483. Only relevant for Registrars, so isn't implemented here. */
+    /** Defined in 5.4 of RFC 9083. Only relevant for Registrars, so isn't implemented here. */
     IP_NETWORK("ip network"),
-    /** Defined in 5.5 of RFC7483. Only relevant for Registrars, so isn't implemented here. */
+    /** Defined in 5.5 of RFC 9083. Only relevant for Registrars, so isn't implemented here. */
     AUTONOMUS_SYSTEM("autnum");
 
     private final String className;

--- a/core/src/main/java/google/registry/rdap/RdapDomainSearchAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapDomainSearchAction.java
@@ -68,9 +68,9 @@ import org.hibernate.Hibernate;
  *
  * <p>All commands and responses conform to the RDAP spec as defined in RFCs 7480 through 7485.
  *
- * @see <a href="http://tools.ietf.org/html/rfc7482">RFC 7482: Registration Data Access Protocol
+ * @see <a href="http://tools.ietf.org/html/rfc9082">RFC 9082: Registration Data Access Protocol
  *     (RDAP) Query Format</a>
- * @see <a href="http://tools.ietf.org/html/rfc7483">RFC 7483: JSON Responses for the Registration
+ * @see <a href="http://tools.ietf.org/html/rfc9083">RFC 9083: JSON Responses for the Registration
  *     Data Access Protocol (RDAP)</a>
  */
 // TODO: This isn't required by the RDAP Technical Implementation Guide, and hence should be
@@ -119,7 +119,7 @@ public class RdapDomainSearchAction extends RdapSearchActionBase {
     } else if (nsLdhNameParam.isPresent()) {
       metricInformationBuilder.setSearchType(SearchType.BY_NAMESERVER_NAME);
       // syntax: /rdap/domains?nsLdhName=ns1.exam*.com
-      // RFC 7482 appears to say that Unicode domains must be specified using punycode when
+      // RFC 9082 appears to say that Unicode domains must be specified using punycode when
       // passed to nsLdhName, so IDN.toASCII is not called here.
       results =
           searchByNameserverLdhName(

--- a/core/src/main/java/google/registry/rdap/RdapEntityAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapEntityAction.java
@@ -41,7 +41,7 @@ import javax.inject.Inject;
  * profile dictates that the "handle" for registrars is to be the IANA registrar ID:
  *
  * <p>2.8.3. Registries MUST support lookup for entities with the registrar role within other
- * objects using the handle (as described in 3.1.5 of RFC7482). The handle of the entity with the
+ * objects using the handle (as described in 3.1.5 of RFC 9082). The handle of the entity with the
  * registrar role MUST be equal to IANA Registrar ID. The entity with the registrar role in the RDAP
  * response MUST contain a publicIDs member to identify the IANA Registrar ID from the IANA’s
  * Registrar ID registry. The type value of the publicID object MUST be equal to IANA Registrar ID.

--- a/core/src/main/java/google/registry/rdap/RdapEntitySearchAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapEntitySearchAction.java
@@ -73,9 +73,9 @@ import javax.inject.Inject;
  * that we can skip the contact search altogether (because we returned a registrar, and all
  * registrars come after all contacts).
  *
- * @see <a href="http://tools.ietf.org/html/rfc7482">RFC 7482: Registration Data Access Protocol
+ * @see <a href="http://tools.ietf.org/html/rfc9082">RFC 9082: Registration Data Access Protocol
  *     (RDAP) Query Format</a>
- * @see <a href="http://tools.ietf.org/html/rfc7483">RFC 7483: JSON Responses for the Registration
+ * @see <a href="http://tools.ietf.org/html/rfc9083">RFC 9083: JSON Responses for the Registration
  *     Data Access Protocol (RDAP)</a>
  */
 // TODO: This isn't required by the RDAP Technical Implementation Guide, and hence should be
@@ -195,7 +195,7 @@ public class RdapEntitySearchAction extends RdapSearchActionBase {
    * <p>The search is by registrar name only. The profile is supporting the functionality defined in
    * the Base Registry Agreement.
    *
-   * <p>According to RFC 7482 section 6.1, punycode is only used for domain name labels, so we can
+   * <p>According to RFC 9082 section 6.1, punycode is only used for domain name labels, so we can
    * assume that entity names are regular unicode.
    *
    * <p>The includeDeleted flag is ignored when searching for contacts, because contact names are

--- a/core/src/main/java/google/registry/rdap/RdapJsonFormatter.java
+++ b/core/src/main/java/google/registry/rdap/RdapJsonFormatter.java
@@ -91,8 +91,8 @@ import org.joda.time.DateTime;
  * of the methods, is used as the first part of the link URL. For instance, if linkBase is
  * "http://rdap.org/dir/", the link URLs will look like "http://rdap.org/dir/domain/XXXX", etc.
  *
- * @see <a href="https://tools.ietf.org/html/rfc7483">
- *        RFC 7483: JSON Responses for the Registration Data Access Protocol (RDAP)</a>
+ * @see <a href="https://tools.ietf.org/html/rfc9083">RFC 9083: JSON Responses for the Registration
+ *     Data Access Protocol (RDAP)</a>
  */
 public class RdapJsonFormatter {
 
@@ -253,9 +253,9 @@ public class RdapJsonFormatter {
   /**
    * Creates a JSON object for a {@link DomainBase}.
    *
-   * <p>NOTE that domain searches aren't in the spec yet - they're in the RFC7482 that describes the
-   * query format, but they aren't in the RDAP Technical Implementation Guide 15feb19, meaning we
-   * don't have to implement them yet and the RDAP Response Profile doesn't apply to them.
+   * <p>NOTE that domain searches aren't in the spec yet - they're in the RFC 9082 that describes
+   * the query format, but they aren't in the RDAP Technical Implementation Guide 15feb19, meaning
+   * we don't have to implement them yet and the RDAP Response Profile doesn't apply to them.
    *
    * <p>We're implementing domain searches anyway, BUT we won't have the response for searches
    * conform to the RDAP Response Profile.
@@ -811,7 +811,7 @@ public class RdapJsonFormatter {
     return Optional.of(builder.build());
   }
 
-  /** Converts a domain registry contact type into a role as defined by RFC 7483. */
+  /** Converts a domain registry contact type into a role as defined by RFC 9083. */
   private static RdapEntity.Role convertContactTypeToRdapRole(DesignatedContact.Type contactType) {
     switch (contactType) {
       case REGISTRANT:
@@ -928,7 +928,7 @@ public class RdapJsonFormatter {
     return eventsBuilder.build();
   }
 
-  /** Creates an RDAP event object as defined by RFC 7483. */
+  /** Creates an RDAP event object as defined by RFC 9083. */
   private static Event makeEvent(
       EventAction eventAction, @Nullable String eventActor, DateTime eventDate) {
     Event.Builder builder = Event.builder()
@@ -1069,7 +1069,7 @@ public class RdapJsonFormatter {
   /**
    * Creates a self link as directed by the spec.
    *
-   * @see <a href="https://tools.ietf.org/html/rfc7483">RFC 7483: JSON Responses for the
+   * @see <a href="https://tools.ietf.org/html/rfc9083">RFC 9083: JSON Responses for the
    *     Registration Data Access Protocol (RDAP)</a>
    */
   private Link makeSelfLink(String type, String name) {

--- a/core/src/main/java/google/registry/rdap/RdapNameserverSearchAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapNameserverSearchAction.java
@@ -52,9 +52,9 @@ import javax.inject.Inject;
  *
  * <p>All commands and responses conform to the RDAP spec as defined in RFCs 7480 through 7485.
  *
- * @see <a href="http://tools.ietf.org/html/rfc7482">RFC 7482: Registration Data Access Protocol
+ * @see <a href="http://tools.ietf.org/html/rfc9082">RFC 9082: Registration Data Access Protocol
  *     (RDAP) Query Format</a>
- * @see <a href="http://tools.ietf.org/html/rfc7483">RFC 7483: JSON Responses for the Registration
+ * @see <a href="http://tools.ietf.org/html/rfc9083">RFC 9083: JSON Responses for the Registration
  *     Data Access Protocol (RDAP)</a>
  */
 @Action(
@@ -91,7 +91,7 @@ public class RdapNameserverSearchAction extends RdapSearchActionBase {
     NameserverSearchResponse results;
     if (nameParam.isPresent()) {
       // RDAP Technical Implementation Guilde 2.2.3 - we MAY support nameserver search queries based
-      // on a "nameserver search pattern" as defined in RFC7482
+      // on a "nameserver search pattern" as defined in RFC 9082
       //
       // syntax: /rdap/nameservers?name=exam*.com
       metricInformationBuilder.setSearchType(SearchType.BY_NAMESERVER_NAME);
@@ -101,7 +101,7 @@ public class RdapNameserverSearchAction extends RdapSearchActionBase {
                   RdapSearchPattern.createFromLdhOrUnicodeDomainName(nameParam.get())));
     } else {
       // RDAP Technical Implementation Guide 2.2.3 - we MUST support nameserver search queries based
-      // on IP address as defined in RFC7482 3.2.2. Doesn't require pattern matching
+      // on IP address as defined in RFC 9082 3.2.2. Doesn't require pattern matching
       //
       // syntax: /rdap/nameservers?ip=1.2.3.4
       metricInformationBuilder.setSearchType(SearchType.BY_NAMESERVER_ADDRESS);

--- a/core/src/main/java/google/registry/rdap/RdapObjectClasses.java
+++ b/core/src/main/java/google/registry/rdap/RdapObjectClasses.java
@@ -41,9 +41,7 @@ import google.registry.rdap.RdapDataStructures.Remark;
 import google.registry.util.Idn;
 import java.util.Optional;
 
-/**
- * Object Classes defined in RFC7483 section 5.
- */
+/** Object Classes defined in RFC 9083 section 5. */
 final class RdapObjectClasses {
 
   /**
@@ -161,7 +159,7 @@ final class RdapObjectClasses {
   /**
    * The Top Level JSON reply, Adds the required top-level boilerplate to a ReplyPayloadBase.
    *
-   * <p>RFC 7483 specifies that the top-level object should include an entry indicating the
+   * <p>RFC 9083 specifies that the top-level object should include an entry indicating the
    * conformance level. ICANN RDAP spec for 15feb19 mandates several additional entries, in sections
    * 2.6.3, 2.11 of the Response Profile and 3.3, 3.5, of the Technical Implementation Guide.
    */
@@ -250,7 +248,7 @@ final class RdapObjectClasses {
   }
 
   /**
-   * The Entity Object Class defined in 5.1 of RFC7483.
+   * The Entity Object Class defined in 5.1 of RFC 9083.
    *
    * <p>Entities are used both for Contacts and for Registrars. We will create different subobjects
    * for each one for type safety.
@@ -260,7 +258,7 @@ final class RdapObjectClasses {
   @RestrictJsonNames({"entities[]", "entitySearchResults[]"})
   abstract static class RdapEntity extends RdapObjectBase {
 
-    /** Role values specified in RFC 7483 § 10.2.4. */
+    /** Role values specified in RFC 9083 § 10.2.4. */
     @RestrictJsonNames("roles[]")
     enum Role implements Jsonable {
       REGISTRANT("registrant"),
@@ -276,15 +274,15 @@ final class RdapObjectClasses {
       NOC("noc");
 
       /** Value as it appears in RDAP messages. */
-      final String rfc7483String;
+      final String rfc9083String;
 
-      Role(String rfc7483String) {
-        this.rfc7483String = rfc7483String;
+      Role(String rfc9083String) {
+        this.rfc9083String = rfc9083String;
       }
 
       @Override
       public JsonPrimitive toJson() {
-        return new JsonPrimitive(rfc7483String);
+        return new JsonPrimitive(rfc9083String);
       }
     }
 
@@ -306,7 +304,7 @@ final class RdapObjectClasses {
   }
 
   /**
-   * Registrar version of the Entity Object Class defined in 5.1 of RFC7483.
+   * Registrar version of the Entity Object Class defined in 5.1 of RFC 9083.
    *
    * <p>Entities are used both for Contacts and for Registrars. We will create different subobjects
    * for each one for type safety.
@@ -325,7 +323,7 @@ final class RdapObjectClasses {
   }
 
   /**
-   * Contact version of the Entity Object Class defined in 5.1 of RFC7483.
+   * Contact version of the Entity Object Class defined in 5.1 of RFC 9083.
    *
    * <p>Entities are used both for Contacts and for Registrars. We will create different subobjects
    * for each one for type safety.
@@ -385,9 +383,7 @@ final class RdapObjectClasses {
     }
   }
 
-  /**
-   * The Nameserver Object Class defined in 5.2 of RFC7483.
-   */
+  /** The Nameserver Object Class defined in 5.2 of RFC 9083. */
   @RestrictJsonNames({"nameservers[]", "nameserverSearchResults[]"})
   @AutoValue
   abstract static class RdapNameserver extends RdapNamedObjectBase {
@@ -429,7 +425,7 @@ final class RdapObjectClasses {
     }
   }
 
-  /** Object defined in RFC7483 section 5.3, only used for RdapDomain. */
+  /** Object defined in RFC 9083 section 5.3, only used for RdapDomain. */
   @RestrictJsonNames("secureDNS")
   @AutoValue
   abstract static class SecureDns extends AbstractJsonableObject {
@@ -471,7 +467,7 @@ final class RdapObjectClasses {
      * an integer representing the signature lifetime in seconds to be used when creating the RRSIG
      * DS record in the parent zone [RFC5910].
      *
-     * <p>Note that although it isn't given as optional in RFC7483, in RFC5910 it's mentioned as
+     * <p>Note that although it isn't given as optional in RFC 9083, in RFC5910 it's mentioned as
      * optional. Also, our code doesn't support it at all - so it's set to always be empty.
      */
     @JsonableElement
@@ -504,9 +500,9 @@ final class RdapObjectClasses {
   }
 
   /**
-   * The Domain Object Class defined in 5.3 of RFC7483.
+   * The Domain Object Class defined in 5.3 of RFC 9083.
    *
-   * We're missing the "variants", "secureDNS", "network" fields
+   * <p>We're missing the "variants", "secureDNS", "network" fields
    */
   @RestrictJsonNames("domainSearchResults[]")
   @AutoValue
@@ -535,9 +531,7 @@ final class RdapObjectClasses {
     }
   }
 
-  /**
-   * Error Response Body defined in 6 of RFC7483.
-   */
+  /** Error Response Body defined in 6 of RFC 9083. */
   @RestrictJsonNames({})
   @AutoValue
   abstract static class ErrorResponse extends ReplyPayloadBase {
@@ -559,7 +553,7 @@ final class RdapObjectClasses {
   }
 
   /**
-   * Help Response defined in 7 of RFC7483.
+   * Help Response defined in 7 of RFC 9083.
    *
    * <p>The helpNotice field is optional, because if the user requests the TOS - that's already
    * given by the boilerplate of TopLevelReplyObject so we don't want to give it again.

--- a/core/src/main/java/google/registry/rdap/RdapSearchActionBase.java
+++ b/core/src/main/java/google/registry/rdap/RdapSearchActionBase.java
@@ -50,8 +50,8 @@ import javax.persistence.criteria.CriteriaBuilder;
 /**
  * Base RDAP (new WHOIS) action for domain, nameserver and entity search requests.
  *
- * @see <a href="https://tools.ietf.org/html/rfc7482">
- *        RFC 7482: Registration Data Access Protocol (RDAP) Query Format</a>
+ * @see <a href="https://tools.ietf.org/html/rfc9082">RFC 9082: Registration Data Access Protocol
+ *     (RDAP) Query Format</a>
  */
 public abstract class RdapSearchActionBase extends RdapActionBase {
 

--- a/core/src/main/java/google/registry/rdap/RdapSearchPattern.java
+++ b/core/src/main/java/google/registry/rdap/RdapSearchPattern.java
@@ -29,8 +29,8 @@ import javax.annotation.Nullable;
  * must be at the end, except for a possible suffix string on the end to restrict the search to a
  * particular TLD (for domains) or domain (for nameservers).
  *
- * @see <a href="http://www.ietf.org/rfc/rfc7482.txt">
- *        RFC 7482: Registration Data Access Protocol (RDAP) Query Format</a>
+ * @see <a href="http://www.ietf.org/rfc/rfc9082.txt">RFC 9082: Registration Data Access Protocol
+ *     (RDAP) Query Format</a>
  */
 public final class RdapSearchPattern {
 
@@ -39,7 +39,7 @@ public final class RdapSearchPattern {
   /**
    * Pattern for allowed LDH searches.
    *
-   * <p>Based on RFC7482 4.1. Must contains only alphanumeric plus dots and hyphens. A single
+   * <p>Based on RFC 9082 4.1. Must contains only alphanumeric plus dots and hyphens. A single
    * whildcard asterix is allowed - but if exists must be the last character of a domain name label
    * (so exam* and exam*.com are allowed, but exam*le.com isn't allowd)
    *
@@ -57,11 +57,10 @@ public final class RdapSearchPattern {
 
   /**
    * Terminating suffix after the wildcard, or null if none was specified; for domains, it should be
-   * a TLD, for nameservers, a domain. RFC 7482 requires only that it be a sequence of domain
+   * a TLD, for nameservers, a domain. RFC 9082 requires only that it be a sequence of domain
    * labels, but this definition is stricter for efficiency purposes.
    */
-  @Nullable
-  private final String suffix;
+  @Nullable private final String suffix;
 
   private RdapSearchPattern(
       final String initialString, final boolean hasWildcard, @Nullable final String suffix) {
@@ -153,7 +152,7 @@ public final class RdapSearchPattern {
    * <p>The domain search pattern can have a single wildcard asterix that can match 0 or more
    * charecters. If such an asterix exists - it must be at the end of a domain label.
    *
-   * <p>In theory, according to RFC7482 4.1 - we should make some checks about partial matching in
+   * <p>In theory, according to RFC 9082 4.1 - we should make some checks about partial matching in
    * unicode queries. We don't, but we might want to just disable partial matches for unicode inputs
    * (meaning if it doesn't match LDH_PATTERN, then don't allow wildcard at all).
    *

--- a/core/src/main/java/google/registry/rdap/RdapSearchResults.java
+++ b/core/src/main/java/google/registry/rdap/RdapSearchResults.java
@@ -39,9 +39,7 @@ import java.util.Optional;
 @AutoValue
 abstract class RdapSearchResults {
 
-  /**
-   * Responding To Searches defined in 8 of RFC7483.
-   */
+  /** Responding To Searches defined in 8 of RFC 9083. */
   abstract static class BaseSearchResponse extends ReplyPayloadBase {
     abstract IncompletenessWarningType incompletenessWarningType();
     abstract ImmutableMap<String, URI> navigationLinks();


### PR DESCRIPTION
There were minor changes to the RDAP RFCs used -- we don't need to
change anything since we already comply with all of the changes, but we
should refer to the newer RFCs in the code.

https://docs.google.com/document/d/1Y89mJm_5VRp890LhrLajx5-5hmi07N4jAK9ZZS31xLQ/edit#heading=h.uyb2kr1ik95h for a bit more context but it's probably not necessary 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1313)
<!-- Reviewable:end -->
