### PR TITLE
Add a temporary fix to Hibernate detach in BEAM queries

### DIFF
--- a/core/src/main/java/google/registry/persistence/transaction/ReadOnlyCheckingTypedQuery.java
+++ b/core/src/main/java/google/registry/persistence/transaction/ReadOnlyCheckingTypedQuery.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 import javax.persistence.FlushModeType;
 import javax.persistence.LockModeType;
 import javax.persistence.Parameter;
@@ -39,6 +40,11 @@ class ReadOnlyCheckingTypedQuery<T> implements TypedQuery<T> {
   @Override
   public List<T> getResultList() {
     return delegate.getResultList();
+  }
+
+  @Override
+  public Stream<T> getResultStream() {
+    return delegate.getResultStream();
   }
 
   @Override


### PR DESCRIPTION
Make RegistryQuery (exclusively used by BEAM) use EntityManager.clear()
to detach entities. This is a temporary measure to unblock work in BEAM. We
will revert the work once JpaTransactionManager can detach entities properly
for all types of queries.

Also fixed regression bugs that broke query result streaming:
- The code that sets query fetch size was not carried over from
QueryComposer.
- The new ReadOnlyCheckingTypedQuery class did not override parent's
getResultStream() method, which calls getList().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1314)
<!-- Reviewable:end -->
