### PR TITLE
Preserve update_time when replicating to SQL

### DIFF
--- a/core/src/main/java/google/registry/beam/common/RegistryJpaIO.java
+++ b/core/src/main/java/google/registry/beam/common/RegistryJpaIO.java
@@ -277,8 +277,8 @@ public final class RegistryJpaIO {
     public abstract SerializableFunction<T, Object> jpaConverter();
 
     /**
-     * Signal to the writer that the the {@link UpdateAutoTimestamp} property should be written as
-     * is, without pre-persist manipulation.
+     * Signal to the writer that the {@link UpdateAutoTimestamp} property should be written as is,
+     * without pre-persist manipulation.
      *
      * <p>The default value is {@code false}.
      */

--- a/core/src/main/java/google/registry/beam/common/RegistryJpaIO.java
+++ b/core/src/main/java/google/registry/beam/common/RegistryJpaIO.java
@@ -22,6 +22,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import google.registry.backup.AppEngineEnvironment;
 import google.registry.beam.common.RegistryQuery.CriteriaQuerySupplier;
+import google.registry.model.UpdateAutoTimestamp;
+import google.registry.model.UpdateAutoTimestamp.DisableAutoUpdateResource;
 import google.registry.model.ofy.ObjectifyService;
 import google.registry.model.replay.SqlEntity;
 import google.registry.persistence.transaction.JpaTransactionManager;
@@ -274,6 +276,14 @@ public final class RegistryJpaIO {
 
     public abstract SerializableFunction<T, Object> jpaConverter();
 
+    /**
+     * Signal to the writer that entities should be written as is, without data manipulation in
+     * PrePersist/PreUpdate methods.
+     *
+     * <p>The default value is {@code false}.
+     */
+    public abstract boolean writeAsRawData();
+
     public Write<T> withName(String name) {
       return toBuilder().name(name).build();
     }
@@ -294,6 +304,10 @@ public final class RegistryJpaIO {
       return toBuilder().jpaConverter(jpaConverter).build();
     }
 
+    public Write<T> withWriteAsRawData() {
+      return toBuilder().writeAsRawData(true).build();
+    }
+
     abstract Builder<T> toBuilder();
 
     @Override
@@ -310,7 +324,7 @@ public final class RegistryJpaIO {
               GroupIntoBatches.<Integer, T>ofSize(batchSize()).withShardedKey())
           .apply(
               "Write in batch for " + name(),
-              ParDo.of(new SqlBatchWriter<>(name(), jpaConverter())));
+              ParDo.of(new SqlBatchWriter<>(name(), jpaConverter(), writeAsRawData())));
     }
 
     static <T> Builder<T> builder() {
@@ -318,7 +332,8 @@ public final class RegistryJpaIO {
           .name(DEFAULT_NAME)
           .batchSize(DEFAULT_BATCH_SIZE)
           .shards(DEFAULT_SHARDS)
-          .jpaConverter(x -> x);
+          .jpaConverter(x -> x)
+          .writeAsRawData(false);
     }
 
     @AutoValue.Builder
@@ -332,6 +347,8 @@ public final class RegistryJpaIO {
 
       abstract Builder<T> jpaConverter(SerializableFunction<T, Object> jpaConverter);
 
+      abstract Builder<T> writeAsRawData(boolean writeAsRawData);
+
       abstract Write<T> build();
     }
   }
@@ -340,10 +357,13 @@ public final class RegistryJpaIO {
   private static class SqlBatchWriter<T> extends DoFn<KV<ShardedKey<Integer>, Iterable<T>>, Void> {
     private final Counter counter;
     private final SerializableFunction<T, Object> jpaConverter;
+    private final boolean writeAsRawData;
 
-    SqlBatchWriter(String type, SerializableFunction<T, Object> jpaConverter) {
+    SqlBatchWriter(
+        String type, SerializableFunction<T, Object> jpaConverter, boolean writeAsRawData) {
       counter = Metrics.counter("SQL_WRITE", type);
       this.jpaConverter = jpaConverter;
+      this.writeAsRawData = writeAsRawData;
     }
 
     @Setup
@@ -358,6 +378,16 @@ public final class RegistryJpaIO {
 
     @ProcessElement
     public void processElement(@Element KV<ShardedKey<Integer>, Iterable<T>> kv) {
+      if (writeAsRawData) {
+        try (DisableAutoUpdateResource disable = UpdateAutoTimestamp.disableAutoUpdate()) {
+          actuallyProcessElement(kv);
+        }
+        return;
+      }
+      actuallyProcessElement(kv);
+    }
+
+    private void actuallyProcessElement(@Element KV<ShardedKey<Integer>, Iterable<T>> kv) {
       try (AppEngineEnvironment env = new AppEngineEnvironment()) {
         ImmutableList<Object> entities =
             Streams.stream(kv.getValue())

--- a/core/src/main/java/google/registry/beam/common/RegistryJpaIO.java
+++ b/core/src/main/java/google/registry/beam/common/RegistryJpaIO.java
@@ -277,12 +277,12 @@ public final class RegistryJpaIO {
     public abstract SerializableFunction<T, Object> jpaConverter();
 
     /**
-     * Signal to the writer that entities should be written as is, without data manipulation in
-     * PrePersist/PreUpdate methods.
+     * Signal to the writer that the the {@link UpdateAutoTimestamp} property should be written as
+     * is, without pre-persist manipulation.
      *
      * <p>The default value is {@code false}.
      */
-    public abstract boolean writeAsRawData();
+    public abstract boolean disableUpdateAutoTimestamp();
 
     public Write<T> withName(String name) {
       return toBuilder().name(name).build();
@@ -304,8 +304,8 @@ public final class RegistryJpaIO {
       return toBuilder().jpaConverter(jpaConverter).build();
     }
 
-    public Write<T> withWriteAsRawData() {
-      return toBuilder().writeAsRawData(true).build();
+    public Write<T> withUpdateAutoTimestampDisabled() {
+      return toBuilder().disableUpdateAutoTimestamp(true).build();
     }
 
     abstract Builder<T> toBuilder();
@@ -324,7 +324,7 @@ public final class RegistryJpaIO {
               GroupIntoBatches.<Integer, T>ofSize(batchSize()).withShardedKey())
           .apply(
               "Write in batch for " + name(),
-              ParDo.of(new SqlBatchWriter<>(name(), jpaConverter(), writeAsRawData())));
+              ParDo.of(new SqlBatchWriter<>(name(), jpaConverter(), disableUpdateAutoTimestamp())));
     }
 
     static <T> Builder<T> builder() {
@@ -333,7 +333,7 @@ public final class RegistryJpaIO {
           .batchSize(DEFAULT_BATCH_SIZE)
           .shards(DEFAULT_SHARDS)
           .jpaConverter(x -> x)
-          .writeAsRawData(false);
+          .disableUpdateAutoTimestamp(false);
     }
 
     @AutoValue.Builder
@@ -347,7 +347,7 @@ public final class RegistryJpaIO {
 
       abstract Builder<T> jpaConverter(SerializableFunction<T, Object> jpaConverter);
 
-      abstract Builder<T> writeAsRawData(boolean writeAsRawData);
+      abstract Builder<T> disableUpdateAutoTimestamp(boolean writeAsRawData);
 
       abstract Write<T> build();
     }

--- a/core/src/main/java/google/registry/beam/initsql/InitSqlPipeline.java
+++ b/core/src/main/java/google/registry/beam/initsql/InitSqlPipeline.java
@@ -220,7 +220,7 @@ public class InitSqlPipeline implements Serializable {
             .withBatchSize(options.getSqlWriteBatchSize())
             .withShards(options.getSqlWriteShards())
             .withJpaConverter(Transforms::convertVersionedEntityToSqlEntity)
-            .withWriteAsRawData());
+            .withUpdateAutoTimestampDisabled());
   }
 
   private static ImmutableList<String> toKindStrings(Collection<Class<?>> entityClasses) {

--- a/core/src/main/java/google/registry/beam/initsql/InitSqlPipeline.java
+++ b/core/src/main/java/google/registry/beam/initsql/InitSqlPipeline.java
@@ -219,7 +219,8 @@ public class InitSqlPipeline implements Serializable {
             .withName(transformId)
             .withBatchSize(options.getSqlWriteBatchSize())
             .withShards(options.getSqlWriteShards())
-            .withJpaConverter(Transforms::convertVersionedEntityToSqlEntity));
+            .withJpaConverter(Transforms::convertVersionedEntityToSqlEntity)
+            .withWriteAsRawData());
   }
 
   private static ImmutableList<String> toKindStrings(Collection<Class<?>> entityClasses) {

--- a/core/src/main/java/google/registry/beam/initsql/InitSqlPipeline.java
+++ b/core/src/main/java/google/registry/beam/initsql/InitSqlPipeline.java
@@ -220,7 +220,7 @@ public class InitSqlPipeline implements Serializable {
             .withBatchSize(options.getSqlWriteBatchSize())
             .withShards(options.getSqlWriteShards())
             .withJpaConverter(Transforms::convertVersionedEntityToSqlEntity)
-            .withUpdateAutoTimestampDisabled());
+            .disableUpdateAutoTimestamp());
   }
 
   private static ImmutableList<String> toKindStrings(Collection<Class<?>> entityClasses) {

--- a/core/src/test/java/google/registry/beam/initsql/InitSqlPipelineTest.java
+++ b/core/src/test/java/google/registry/beam/initsql/InitSqlPipelineTest.java
@@ -306,6 +306,7 @@ class InitSqlPipelineTest {
               .build());
       exportDir = store.export(exportRootDir.getAbsolutePath(), ALL_KINDS, ImmutableSet.of());
       commitLogDir = Files.createDirectory(tmpDir.resolve("commits")).toFile();
+      fakeClock.advanceOneMilli();
     }
   }
 
@@ -362,6 +363,7 @@ class InitSqlPipelineTest {
         .isEqualTo(expected.getAutorenewPollMessage().getOfyKey());
     assertThat(actual.getDeletePollMessage().getOfyKey())
         .isEqualTo(expected.getDeletePollMessage().getOfyKey());
+    assertThat(actual.getUpdateTimestamp()).isEqualTo(expected.getUpdateTimestamp());
     // TODO(weiminyu): check gracePeriods and transferData when it is easier to do
   }
 }


### PR DESCRIPTION
Prevent InitSqlPipeline from changing the UpdateAutoTimestamp fields in
entities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1316)
<!-- Reviewable:end -->
