### PR TITLE
Add indexes to DomainHistory sub tables

### DIFF
--- a/db/src/main/resources/sql/er_diagram/brief_er_diagram.html
+++ b/db/src/main/resources/sql/er_diagram/brief_er_diagram.html
@@ -261,15 +261,11 @@ td.section {
     </tr> 
     <tr> 
      <td class="property_name">generated on</td> 
-<<<<<<< HEAD
-     <td class="property_value">2021-08-10 20:50:09.993881</td> 
-=======
-     <td class="property_value">2021-08-11 23:54:56.914311</td> 
->>>>>>> 475839855 (Add the domain DNS refresh request time field to the DB schema)
+     <td class="property_value">2021-09-14 16:11:21.688911</td> 
     </tr> 
     <tr>
      <td class="property_name">last flyway file</td>
-     <td id="lastFlywayFile" class="property_value">V101__domain_add_dns_refresh_request_time.sql</td>
+     <td id="lastFlywayFile" class="property_value">V102__add_indexes_to_domain_history_sub_tables.sql</td>
     </tr>
    </tbody>
   </table> 
@@ -288,11 +284,7 @@ td.section {
      generated on
     </text> 
     <text text-anchor="start" x="4055.5" y="-10.8" font-family="Helvetica,sans-Serif" font-size="14.00">
-<<<<<<< HEAD
-     2021-08-10 20:50:09.993881
-=======
-     2021-08-11 23:54:56.914311
->>>>>>> 475839855 (Add the domain DNS refresh request time field to the DB schema)
+     2021-09-14 16:11:21.688911
     </text> 
     <polygon fill="none" stroke="#888888" points="3968,-4 3968,-44 4233,-44 4233,-4 3968,-4" /> <!-- allocationtoken_a08ccbef --> 
     <g id="node1" class="node"> 

--- a/db/src/main/resources/sql/er_diagram/full_er_diagram.html
+++ b/db/src/main/resources/sql/er_diagram/full_er_diagram.html
@@ -261,15 +261,11 @@ td.section {
     </tr> 
     <tr> 
      <td class="property_name">generated on</td> 
-<<<<<<< HEAD
-     <td class="property_value">2021-08-10 20:50:07.996141</td> 
-=======
-     <td class="property_value">2021-08-11 23:54:54.724849</td> 
->>>>>>> 475839855 (Add the domain DNS refresh request time field to the DB schema)
+     <td class="property_value">2021-09-14 16:11:19.580097</td> 
     </tr> 
     <tr>
      <td class="property_name">last flyway file</td>
-     <td id="lastFlywayFile" class="property_value">V101__domain_add_dns_refresh_request_time.sql</td>
+     <td id="lastFlywayFile" class="property_value">V102__add_indexes_to_domain_history_sub_tables.sql</td>
     </tr>
    </tbody>
   </table> 
@@ -288,11 +284,7 @@ td.section {
      generated on
     </text> 
     <text text-anchor="start" x="4755.52" y="-10.8" font-family="Helvetica,sans-Serif" font-size="14.00">
-<<<<<<< HEAD
-     2021-08-10 20:50:07.996141
-=======
-     2021-08-11 23:54:54.724849
->>>>>>> 475839855 (Add the domain DNS refresh request time field to the DB schema)
+     2021-09-14 16:11:19.580097
     </text> 
     <polygon fill="none" stroke="#888888" points="4668.02,-4 4668.02,-44 4933.02,-44 4933.02,-4 4668.02,-4" /> <!-- allocationtoken_a08ccbef --> 
     <g id="node1" class="node"> 
@@ -9732,6 +9724,23 @@ td.section {
      <td class="minwidth">ds_data_history_revision_id</td> 
      <td class="minwidth">ascending</td> 
     </tr> 
+    <tr> 
+     <td colspan="3"></td> 
+    </tr> 
+    <tr> 
+     <td colspan="2" class="name">domain_history_to_ds_data_history_idx</td> 
+     <td class="description right">[non-unique index]</td> 
+    </tr> 
+    <tr> 
+     <td class="spacer"></td> 
+     <td class="minwidth">domain_repo_id</td> 
+     <td class="minwidth">ascending</td> 
+    </tr> 
+    <tr> 
+     <td class="spacer"></td> 
+     <td class="minwidth">domain_history_revision_id</td> 
+     <td class="minwidth">ascending</td> 
+    </tr> 
    </tbody>
   </table> 
   <p>&nbsp;</p> 
@@ -10625,6 +10634,23 @@ td.section {
     <tr> 
      <td class="spacer"></td> 
      <td class="minwidth">id</td> 
+     <td class="minwidth">ascending</td> 
+    </tr> 
+    <tr> 
+     <td colspan="3"></td> 
+    </tr> 
+    <tr> 
+     <td colspan="2" class="name">domain_history_to_transaction_record_idx</td> 
+     <td class="description right">[non-unique index]</td> 
+    </tr> 
+    <tr> 
+     <td class="spacer"></td> 
+     <td class="minwidth">domain_repo_id</td> 
+     <td class="minwidth">ascending</td> 
+    </tr> 
+    <tr> 
+     <td class="spacer"></td> 
+     <td class="minwidth">history_revision_id</td> 
      <td class="minwidth">ascending</td> 
     </tr> 
    </tbody>

--- a/db/src/main/resources/sql/flyway.txt
+++ b/db/src/main/resources/sql/flyway.txt
@@ -99,3 +99,4 @@ V98__add_last_expiring_cert_notification_sent_date.sql
 V99__drop_kms_secret_table.sql
 V100__database_migration_schedule.sql
 V101__domain_add_dns_refresh_request_time.sql
+V102__add_indexes_to_domain_history_sub_tables.sql

--- a/db/src/main/resources/sql/flyway/V102__add_indexes_to_domain_history_sub_tables.sql
+++ b/db/src/main/resources/sql/flyway/V102__add_indexes_to_domain_history_sub_tables.sql
@@ -1,0 +1,19 @@
+-- Copyright 2021 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+CREATE INDEX IF NOT EXISTS domain_history_to_transaction_record_idx
+  ON "DomainTransactionRecord" (domain_repo_id, history_revision_id);
+
+CREATE INDEX IF NOT EXISTS domain_history_to_ds_data_history_idx
+  ON "DomainDsDataHistory" (domain_repo_id, domain_history_revision_id);

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -1490,6 +1490,20 @@ CREATE INDEX domain_dns_refresh_request_time_idx ON public."Domain" USING btree 
 
 
 --
+-- Name: domain_history_to_ds_data_history_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX domain_history_to_ds_data_history_idx ON public."DomainDsDataHistory" USING btree (domain_repo_id, domain_history_revision_id);
+
+
+--
+-- Name: domain_history_to_transaction_record_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX domain_history_to_transaction_record_idx ON public."DomainTransactionRecord" USING btree (domain_repo_id, history_revision_id);
+
+
+--
 -- Name: idx1iy7njgb7wjmj9piml4l2g0qi; Type: INDEX; Schema: public; Owner: -
 --
 


### PR DESCRIPTION
Add indexes to DomainTransactionRecord and DomainDsDataHistory to speed
up query for DomainHistory. Without these indexes, DomainHistory loading
is extremely slow: 2 QPS with current production data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1319)
<!-- Reviewable:end -->
