### PR TITLE
Update the initial value for lastExpiringCertNotificationSentDate to START_OF_TIME

### DIFF
--- a/core/src/main/java/google/registry/flows/certs/CertificateChecker.java
+++ b/core/src/main/java/google/registry/flows/certs/CertificateChecker.java
@@ -33,7 +33,6 @@ import java.security.interfaces.ECPublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.Date;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import javax.inject.Inject;
 import org.bouncycastle.jcajce.provider.asymmetric.util.EC5Util;
 import org.bouncycastle.jce.ECNamedCurveTable;
@@ -228,7 +227,7 @@ public class CertificateChecker {
 
   /** Returns whether the client should receive a notification email. */
   public boolean shouldReceiveExpiringNotification(
-      @Nullable DateTime lastExpiringNotificationSentDate, String certificateStr) {
+      DateTime lastExpiringNotificationSentDate, String certificateStr) {
     X509Certificate certificate = getCertificate(certificateStr);
     DateTime now = clock.nowUtc();
     // expiration date is one day after lastValidDate
@@ -238,13 +237,13 @@ public class CertificateChecker {
     }
     /*
      * Client should receive a notification if :
-     *    1) client has never received notification and the certificate has entered
-     *    the expiring period, OR
+     *    1) client has never received notification (lastExpiringNotificationSentDate is initially
+     *    set to START_OF_TIME) and the certificate has entered the expiring period, OR
      *    2) client has received notification but the interval between now and
      *    lastExpiringNotificationSentDate is greater than expirationWarningIntervalDays.
      */
     return !lastValidDate.after(now.plusDays(expirationWarningDays).toDate())
-        && (lastExpiringNotificationSentDate == null
+        && (lastExpiringNotificationSentDate == START_OF_TIME
             || !lastExpiringNotificationSentDate
                 .plusDays(expirationWarningIntervalDays)
                 .toDate()

--- a/core/src/test/java/google/registry/flows/certs/CertificateCheckerTest.java
+++ b/core/src/test/java/google/registry/flows/certs/CertificateCheckerTest.java
@@ -262,7 +262,7 @@ class CertificateCheckerTest {
                 DateTime.parse("2021-10-01T00:00:00Z"))
             .cert();
     String certificateStr = certificateChecker.serializeCertificate(certificate);
-    assertThat(certificateChecker.shouldReceiveExpiringNotification(null, certificateStr))
+    assertThat(certificateChecker.shouldReceiveExpiringNotification(START_OF_TIME, certificateStr))
         .isFalse();
   }
 
@@ -276,7 +276,7 @@ class CertificateCheckerTest {
                 DateTime.parse("2021-10-01T00:00:00Z"))
             .cert();
     String certificateStr = certificateChecker.serializeCertificate(certificate);
-    assertThat(certificateChecker.shouldReceiveExpiringNotification(null, certificateStr))
+    assertThat(certificateChecker.shouldReceiveExpiringNotification(START_OF_TIME, certificateStr))
         .isFalse();
   }
 
@@ -307,12 +307,14 @@ class CertificateCheckerTest {
                 DateTime.parse("2021-01-30T00:00:00Z"))
             .cert();
     String certificateStr = certificateChecker.serializeCertificate(certificate);
-    assertThat(certificateChecker.shouldReceiveExpiringNotification(null, certificateStr)).isTrue();
+    assertThat(certificateChecker.shouldReceiveExpiringNotification(START_OF_TIME, certificateStr))
+        .isTrue();
   }
 
   @Test
-  void test_shouldReceiveExpiringNotification_returnsFalse_between30and15_lastSentDateIsNotNull()
-      throws Exception {
+  void
+      test_shouldReceiveExpiringNotification_returnsFalse_between30and15_lastSentDateIsNotStartOfTime()
+          throws Exception {
     fakeClock.setTo(DateTime.parse("2021-07-05T00:00:00Z"));
     X509Certificate certificate =
         SelfSignedCaCertificate.create(
@@ -329,7 +331,7 @@ class CertificateCheckerTest {
   }
 
   @Test
-  void test_shouldReceiveExpiringNotification_returnsTrue_between30and15_lastSentDateIsNull()
+  void test_shouldReceiveExpiringNotification_returnsTrue_between30and15_lastSentDateIsStartOfTime()
       throws Exception {
     fakeClock.setTo(DateTime.parse("2021-07-05T00:00:00Z"));
     X509Certificate certificate =
@@ -339,7 +341,8 @@ class CertificateCheckerTest {
                 DateTime.parse("2021-07-25T00:00:00Z"))
             .cert();
     String certificateStr = certificateChecker.serializeCertificate(certificate);
-    assertThat(certificateChecker.shouldReceiveExpiringNotification(null, certificateStr)).isTrue();
+    assertThat(certificateChecker.shouldReceiveExpiringNotification(START_OF_TIME, certificateStr))
+        .isTrue();
   }
 
   @Test


### PR DESCRIPTION
Initially, if a registrar has never received a notification email regarding expiring certificate, then lastExpiringNotificationSentDate should be null in the database. To avoid null value being the initial value, we decided to set the initial value as START_OF_TIME. 

During testing, I noticed in code that it checks if the value is null but not START_OF_TIME but the value should never be null. 

The existing code still works because the check ```!lastValidDate.after(now.plusDays(expirationWarningDays).toDate()) ``` ensures that certificate is definitely expiring within the warning period and it always checks if ```!lastExpiringNotificationSentDate
                .plusDays(expirationWarningIntervalDays)
                .toDate()
                .after(now.toDate()));```. 
For the expiring notifications that have never received anything before, 
the condition mentioned above will always remain true since ```START_OF_TIME + expirationWarningIntervalDays``` is always going to be before now. 

Here's the code in registrar regarding expiring certificate notification email: 
https://github.com/rachelguan/nomulus/blob/master/core/src/main/java/google/registry/model/registrar/Registrar.java#L462-L468

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1321)
<!-- Reviewable:end -->
