### PR TITLE
Include Cursor in the initial SQL population

### DIFF
--- a/core/src/main/java/google/registry/beam/initsql/InitSqlPipeline.java
+++ b/core/src/main/java/google/registry/beam/initsql/InitSqlPipeline.java
@@ -25,6 +25,7 @@ import google.registry.backup.VersionedEntity;
 import google.registry.beam.common.RegistryJpaIO;
 import google.registry.beam.initsql.Transforms.RemoveDomainBaseForeignKeys;
 import google.registry.model.billing.BillingEvent;
+import google.registry.model.common.Cursor;
 import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.domain.token.AllocationToken;
@@ -62,6 +63,7 @@ import org.joda.time.DateTime;
  * <ol>
  *   <li>{@link Registry}: Assumes that {@code PremiumList} and {@code ReservedList} have been set
  *       up in the SQL database.
+ *   <li>{@link Cursor}: Logically can depend on {@code Registry}, but without foreign key.
  *   <li>{@link Registrar}: Logically depends on {@code Registry}, Foreign key not modeled yet.
  *   <li>{@link ContactResource}: references {@code Registrar}
  *   <li>{@link RegistrarContact}: references {@code Registrar}.
@@ -101,7 +103,11 @@ public class InitSqlPipeline implements Serializable {
    */
   private static final ImmutableList<Class<?>> PHASE_ONE_ORDERED =
       ImmutableList.of(
-          Registry.class, Registrar.class, ContactResource.class, RegistrarContact.class);
+          Registry.class,
+          Cursor.class,
+          Registrar.class,
+          ContactResource.class,
+          RegistrarContact.class);
 
   /**
    * Datastore kinds to be written to the SQL database after the cleansed version of {@link

--- a/core/src/main/java/google/registry/model/common/Cursor.java
+++ b/core/src/main/java/google/registry/model/common/Cursor.java
@@ -220,10 +220,10 @@ public class Cursor extends ImmutableObject implements DatastoreAndSqlEntity {
 
   private static String getScopeFromId(String id) {
     List<String> idSplit = Splitter.on('_').splitToList(id);
-    // The "parent" is always the crossTldKey; in order to find the scope (either Registry or
-    // cross-tld-key) we have to parse the part of the ID
+    // The key is always either the cross-tld-key or the key of a TLD (whose parent is the
+    // cross-tld-key).
     Key<?> scopeKey = Key.valueOf(idSplit.get(0));
-    return scopeKey.equals(getCrossTldKey()) ? GLOBAL : scopeKey.getName();
+    return scopeKey.getParent() == null ? GLOBAL : scopeKey.getName();
   }
 
   private static CursorType getTypeFromId(String id) {

--- a/core/src/test/resources/google/registry/beam/initsql/pipeline_golden.dot
+++ b/core/src/test/resources/google/registry/beam/initsql/pipeline_golden.dot
@@ -361,88 +361,88 @@ digraph {
             }
         }
         subgraph cluster_136 {
-            label = "Write to Sql: Transforms:Registrar"
+            label = "Write to Sql: Transforms:Cursor"
             subgraph cluster_137 {
-                label = "Write to Sql: Transforms:Registrar/Shard data Transforms:Registrar"
+                label = "Write to Sql: Transforms:Cursor/Shard data Transforms:Cursor"
                 subgraph cluster_138 {
-                    label = "Write to Sql: Transforms:Registrar/Shard data Transforms:Registrar/AddKeys"
+                    label = "Write to Sql: Transforms:Cursor/Shard data Transforms:Cursor/AddKeys"
                     subgraph cluster_139 {
-                        label = "Write to Sql: Transforms:Registrar/Shard data Transforms:Registrar/AddKeys/Map"
+                        label = "Write to Sql: Transforms:Cursor/Shard data Transforms:Cursor/AddKeys/Map"
                         140 [label="ParMultiDo(Anonymous)"]
                         135 -> 140 [style=solid label=""]
                     }
                 }
             }
             subgraph cluster_141 {
-                label = "Write to Sql: Transforms:Registrar/Group into batches Transforms:Registrar"
+                label = "Write to Sql: Transforms:Cursor/Group into batches Transforms:Cursor"
                 subgraph cluster_142 {
-                    label = "Write to Sql: Transforms:Registrar/Group into batches Transforms:Registrar/MapElements"
+                    label = "Write to Sql: Transforms:Cursor/Group into batches Transforms:Cursor/MapElements"
                     subgraph cluster_143 {
-                        label = "Write to Sql: Transforms:Registrar/Group into batches Transforms:Registrar/MapElements/Map"
+                        label = "Write to Sql: Transforms:Cursor/Group into batches Transforms:Cursor/MapElements/Map"
                         144 [label="ParMultiDo(Anonymous)"]
                         140 -> 144 [style=solid label=""]
                     }
                 }
                 subgraph cluster_145 {
-                    label = "Write to Sql: Transforms:Registrar/Group into batches Transforms:Registrar/ParDo(GroupIntoBatches)"
+                    label = "Write to Sql: Transforms:Cursor/Group into batches Transforms:Cursor/ParDo(GroupIntoBatches)"
                     146 [label="ParMultiDo(GroupIntoBatches)"]
                     144 -> 146 [style=solid label=""]
                 }
             }
             subgraph cluster_147 {
-                label = "Write to Sql: Transforms:Registrar/Write in batch for Transforms:Registrar"
+                label = "Write to Sql: Transforms:Cursor/Write in batch for Transforms:Cursor"
                 148 [label="ParMultiDo(SqlBatchWriter)"]
                 146 -> 148 [style=solid label=""]
             }
         }
         subgraph cluster_149 {
-            label = "Wait on Transforms:Registrar"
+            label = "Wait on Transforms:Cursor"
             subgraph cluster_150 {
-                label = "Wait on Transforms:Registrar/To wait view 0"
+                label = "Wait on Transforms:Cursor/To wait view 0"
                 subgraph cluster_151 {
-                    label = "Wait on Transforms:Registrar/To wait view 0/Window.Into()"
+                    label = "Wait on Transforms:Cursor/To wait view 0/Window.Into()"
                     152 [label="Flatten.PCollections"]
                     148 -> 152 [style=solid label=""]
                 }
                 subgraph cluster_153 {
-                    label = "Wait on Transforms:Registrar/To wait view 0/ParDo(CollectWindows)"
+                    label = "Wait on Transforms:Cursor/To wait view 0/ParDo(CollectWindows)"
                     154 [label="ParMultiDo(CollectWindows)"]
                     152 -> 154 [style=solid label=""]
                 }
                 subgraph cluster_155 {
-                    label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any"
+                    label = "Wait on Transforms:Cursor/To wait view 0/Sample.Any"
                     subgraph cluster_156 {
-                        label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
+                        label = "Wait on Transforms:Cursor/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
                         subgraph cluster_157 {
-                            label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
+                            label = "Wait on Transforms:Cursor/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
                             subgraph cluster_158 {
-                                label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
+                                label = "Wait on Transforms:Cursor/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
                                 subgraph cluster_159 {
-                                    label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
+                                    label = "Wait on Transforms:Cursor/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
                                     160 [label="ParMultiDo(Anonymous)"]
                                     154 -> 160 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_161 {
-                            label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
+                            label = "Wait on Transforms:Cursor/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
                             162 [label="GroupByKey"]
                             160 -> 162 [style=solid label=""]
                             subgraph cluster_163 {
-                                label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
+                                label = "Wait on Transforms:Cursor/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
                                 subgraph cluster_164 {
-                                    label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
+                                    label = "Wait on Transforms:Cursor/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
                                     165 [label="ParMultiDo(Anonymous)"]
                                     162 -> 165 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_166 {
-                            label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
+                            label = "Wait on Transforms:Cursor/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
                             subgraph cluster_167 {
-                                label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
+                                label = "Wait on Transforms:Cursor/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
                                 subgraph cluster_168 {
-                                    label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
+                                    label = "Wait on Transforms:Cursor/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
                                     169 [label="ParMultiDo(Anonymous)"]
                                     165 -> 169 [style=solid label=""]
                                 }
@@ -450,11 +450,11 @@ digraph {
                         }
                     }
                     subgraph cluster_170 {
-                        label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Flatten.Iterables"
+                        label = "Wait on Transforms:Cursor/To wait view 0/Sample.Any/Flatten.Iterables"
                         subgraph cluster_171 {
-                            label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
+                            label = "Wait on Transforms:Cursor/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
                             subgraph cluster_172 {
-                                label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
+                                label = "Wait on Transforms:Cursor/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
                                 173 [label="ParMultiDo(Anonymous)"]
                                 169 -> 173 [style=solid label=""]
                             }
@@ -462,11 +462,11 @@ digraph {
                     }
                 }
                 subgraph cluster_174 {
-                    label = "Wait on Transforms:Registrar/To wait view 0/View.AsList"
+                    label = "Wait on Transforms:Cursor/To wait view 0/View.AsList"
                     subgraph cluster_175 {
-                        label = "Wait on Transforms:Registrar/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
+                        label = "Wait on Transforms:Cursor/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
                         subgraph cluster_176 {
-                            label = "Wait on Transforms:Registrar/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
+                            label = "Wait on Transforms:Cursor/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
                             177 [label="ParMultiDo(VoidKeyToMultimapMaterialization)"]
                             173 -> 177 [style=solid label=""]
                         }
@@ -476,9 +476,9 @@ digraph {
                 }
             }
             subgraph cluster_179 {
-                label = "Wait on Transforms:Registrar/Wait"
+                label = "Wait on Transforms:Cursor/Wait"
                 subgraph cluster_180 {
-                    label = "Wait on Transforms:Registrar/Wait/Map"
+                    label = "Wait on Transforms:Cursor/Wait/Map"
                     181 [label="ParMultiDo(Anonymous)"]
                     89 -> 181 [style=solid label=""]
                     177 -> 181 [style=dashed label=""]
@@ -486,88 +486,88 @@ digraph {
             }
         }
         subgraph cluster_182 {
-            label = "Write to Sql: Transforms:ContactResource"
+            label = "Write to Sql: Transforms:Registrar"
             subgraph cluster_183 {
-                label = "Write to Sql: Transforms:ContactResource/Shard data Transforms:ContactResource"
+                label = "Write to Sql: Transforms:Registrar/Shard data Transforms:Registrar"
                 subgraph cluster_184 {
-                    label = "Write to Sql: Transforms:ContactResource/Shard data Transforms:ContactResource/AddKeys"
+                    label = "Write to Sql: Transforms:Registrar/Shard data Transforms:Registrar/AddKeys"
                     subgraph cluster_185 {
-                        label = "Write to Sql: Transforms:ContactResource/Shard data Transforms:ContactResource/AddKeys/Map"
+                        label = "Write to Sql: Transforms:Registrar/Shard data Transforms:Registrar/AddKeys/Map"
                         186 [label="ParMultiDo(Anonymous)"]
                         181 -> 186 [style=solid label=""]
                     }
                 }
             }
             subgraph cluster_187 {
-                label = "Write to Sql: Transforms:ContactResource/Group into batches Transforms:ContactResource"
+                label = "Write to Sql: Transforms:Registrar/Group into batches Transforms:Registrar"
                 subgraph cluster_188 {
-                    label = "Write to Sql: Transforms:ContactResource/Group into batches Transforms:ContactResource/MapElements"
+                    label = "Write to Sql: Transforms:Registrar/Group into batches Transforms:Registrar/MapElements"
                     subgraph cluster_189 {
-                        label = "Write to Sql: Transforms:ContactResource/Group into batches Transforms:ContactResource/MapElements/Map"
+                        label = "Write to Sql: Transforms:Registrar/Group into batches Transforms:Registrar/MapElements/Map"
                         190 [label="ParMultiDo(Anonymous)"]
                         186 -> 190 [style=solid label=""]
                     }
                 }
                 subgraph cluster_191 {
-                    label = "Write to Sql: Transforms:ContactResource/Group into batches Transforms:ContactResource/ParDo(GroupIntoBatches)"
+                    label = "Write to Sql: Transforms:Registrar/Group into batches Transforms:Registrar/ParDo(GroupIntoBatches)"
                     192 [label="ParMultiDo(GroupIntoBatches)"]
                     190 -> 192 [style=solid label=""]
                 }
             }
             subgraph cluster_193 {
-                label = "Write to Sql: Transforms:ContactResource/Write in batch for Transforms:ContactResource"
+                label = "Write to Sql: Transforms:Registrar/Write in batch for Transforms:Registrar"
                 194 [label="ParMultiDo(SqlBatchWriter)"]
                 192 -> 194 [style=solid label=""]
             }
         }
         subgraph cluster_195 {
-            label = "Wait on Transforms:ContactResource"
+            label = "Wait on Transforms:Registrar"
             subgraph cluster_196 {
-                label = "Wait on Transforms:ContactResource/To wait view 0"
+                label = "Wait on Transforms:Registrar/To wait view 0"
                 subgraph cluster_197 {
-                    label = "Wait on Transforms:ContactResource/To wait view 0/Window.Into()"
+                    label = "Wait on Transforms:Registrar/To wait view 0/Window.Into()"
                     198 [label="Flatten.PCollections"]
                     194 -> 198 [style=solid label=""]
                 }
                 subgraph cluster_199 {
-                    label = "Wait on Transforms:ContactResource/To wait view 0/ParDo(CollectWindows)"
+                    label = "Wait on Transforms:Registrar/To wait view 0/ParDo(CollectWindows)"
                     200 [label="ParMultiDo(CollectWindows)"]
                     198 -> 200 [style=solid label=""]
                 }
                 subgraph cluster_201 {
-                    label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any"
+                    label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any"
                     subgraph cluster_202 {
-                        label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
+                        label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
                         subgraph cluster_203 {
-                            label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
+                            label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
                             subgraph cluster_204 {
-                                label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
+                                label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
                                 subgraph cluster_205 {
-                                    label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
+                                    label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
                                     206 [label="ParMultiDo(Anonymous)"]
                                     200 -> 206 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_207 {
-                            label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
+                            label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
                             208 [label="GroupByKey"]
                             206 -> 208 [style=solid label=""]
                             subgraph cluster_209 {
-                                label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
+                                label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
                                 subgraph cluster_210 {
-                                    label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
+                                    label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
                                     211 [label="ParMultiDo(Anonymous)"]
                                     208 -> 211 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_212 {
-                            label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
+                            label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
                             subgraph cluster_213 {
-                                label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
+                                label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
                                 subgraph cluster_214 {
-                                    label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
+                                    label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
                                     215 [label="ParMultiDo(Anonymous)"]
                                     211 -> 215 [style=solid label=""]
                                 }
@@ -575,11 +575,11 @@ digraph {
                         }
                     }
                     subgraph cluster_216 {
-                        label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Flatten.Iterables"
+                        label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Flatten.Iterables"
                         subgraph cluster_217 {
-                            label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
+                            label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
                             subgraph cluster_218 {
-                                label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
+                                label = "Wait on Transforms:Registrar/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
                                 219 [label="ParMultiDo(Anonymous)"]
                                 215 -> 219 [style=solid label=""]
                             }
@@ -587,11 +587,11 @@ digraph {
                     }
                 }
                 subgraph cluster_220 {
-                    label = "Wait on Transforms:ContactResource/To wait view 0/View.AsList"
+                    label = "Wait on Transforms:Registrar/To wait view 0/View.AsList"
                     subgraph cluster_221 {
-                        label = "Wait on Transforms:ContactResource/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
+                        label = "Wait on Transforms:Registrar/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
                         subgraph cluster_222 {
-                            label = "Wait on Transforms:ContactResource/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
+                            label = "Wait on Transforms:Registrar/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
                             223 [label="ParMultiDo(VoidKeyToMultimapMaterialization)"]
                             219 -> 223 [style=solid label=""]
                         }
@@ -601,9 +601,9 @@ digraph {
                 }
             }
             subgraph cluster_225 {
-                label = "Wait on Transforms:ContactResource/Wait"
+                label = "Wait on Transforms:Registrar/Wait"
                 subgraph cluster_226 {
-                    label = "Wait on Transforms:ContactResource/Wait/Map"
+                    label = "Wait on Transforms:Registrar/Wait/Map"
                     227 [label="ParMultiDo(Anonymous)"]
                     89 -> 227 [style=solid label=""]
                     223 -> 227 [style=dashed label=""]
@@ -611,218 +611,218 @@ digraph {
             }
         }
         subgraph cluster_228 {
-            label = "Write to Sql: Transforms:RegistrarContact"
+            label = "Write to Sql: Transforms:ContactResource"
             subgraph cluster_229 {
-                label = "Write to Sql: Transforms:RegistrarContact/Shard data Transforms:RegistrarContact"
+                label = "Write to Sql: Transforms:ContactResource/Shard data Transforms:ContactResource"
                 subgraph cluster_230 {
-                    label = "Write to Sql: Transforms:RegistrarContact/Shard data Transforms:RegistrarContact/AddKeys"
+                    label = "Write to Sql: Transforms:ContactResource/Shard data Transforms:ContactResource/AddKeys"
                     subgraph cluster_231 {
-                        label = "Write to Sql: Transforms:RegistrarContact/Shard data Transforms:RegistrarContact/AddKeys/Map"
+                        label = "Write to Sql: Transforms:ContactResource/Shard data Transforms:ContactResource/AddKeys/Map"
                         232 [label="ParMultiDo(Anonymous)"]
                         227 -> 232 [style=solid label=""]
                     }
                 }
             }
             subgraph cluster_233 {
-                label = "Write to Sql: Transforms:RegistrarContact/Group into batches Transforms:RegistrarContact"
+                label = "Write to Sql: Transforms:ContactResource/Group into batches Transforms:ContactResource"
                 subgraph cluster_234 {
-                    label = "Write to Sql: Transforms:RegistrarContact/Group into batches Transforms:RegistrarContact/MapElements"
+                    label = "Write to Sql: Transforms:ContactResource/Group into batches Transforms:ContactResource/MapElements"
                     subgraph cluster_235 {
-                        label = "Write to Sql: Transforms:RegistrarContact/Group into batches Transforms:RegistrarContact/MapElements/Map"
+                        label = "Write to Sql: Transforms:ContactResource/Group into batches Transforms:ContactResource/MapElements/Map"
                         236 [label="ParMultiDo(Anonymous)"]
                         232 -> 236 [style=solid label=""]
                     }
                 }
                 subgraph cluster_237 {
-                    label = "Write to Sql: Transforms:RegistrarContact/Group into batches Transforms:RegistrarContact/ParDo(GroupIntoBatches)"
+                    label = "Write to Sql: Transforms:ContactResource/Group into batches Transforms:ContactResource/ParDo(GroupIntoBatches)"
                     238 [label="ParMultiDo(GroupIntoBatches)"]
                     236 -> 238 [style=solid label=""]
                 }
             }
             subgraph cluster_239 {
-                label = "Write to Sql: Transforms:RegistrarContact/Write in batch for Transforms:RegistrarContact"
+                label = "Write to Sql: Transforms:ContactResource/Write in batch for Transforms:ContactResource"
                 240 [label="ParMultiDo(SqlBatchWriter)"]
                 238 -> 240 [style=solid label=""]
             }
         }
         subgraph cluster_241 {
-            label = "Remove circular foreign keys from DomainBase"
-            242 [label="ParMultiDo(RemoveDomainBaseForeignKeys)"]
-            89 -> 242 [style=solid label=""]
-        }
-        subgraph cluster_243 {
-            label = "Wait on phase one"
-            subgraph cluster_244 {
-                label = "Wait on phase one/To wait view 0"
+            label = "Wait on Transforms:ContactResource"
+            subgraph cluster_242 {
+                label = "Wait on Transforms:ContactResource/To wait view 0"
+                subgraph cluster_243 {
+                    label = "Wait on Transforms:ContactResource/To wait view 0/Window.Into()"
+                    244 [label="Flatten.PCollections"]
+                    240 -> 244 [style=solid label=""]
+                }
                 subgraph cluster_245 {
-                    label = "Wait on phase one/To wait view 0/Window.Into()"
-                    246 [label="Flatten.PCollections"]
-                    240 -> 246 [style=solid label=""]
+                    label = "Wait on Transforms:ContactResource/To wait view 0/ParDo(CollectWindows)"
+                    246 [label="ParMultiDo(CollectWindows)"]
+                    244 -> 246 [style=solid label=""]
                 }
                 subgraph cluster_247 {
-                    label = "Wait on phase one/To wait view 0/ParDo(CollectWindows)"
-                    248 [label="ParMultiDo(CollectWindows)"]
-                    246 -> 248 [style=solid label=""]
-                }
-                subgraph cluster_249 {
-                    label = "Wait on phase one/To wait view 0/Sample.Any"
-                    subgraph cluster_250 {
-                        label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
-                        subgraph cluster_251 {
-                            label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
-                            subgraph cluster_252 {
-                                label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
-                                subgraph cluster_253 {
-                                    label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
-                                    254 [label="ParMultiDo(Anonymous)"]
-                                    248 -> 254 [style=solid label=""]
+                    label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any"
+                    subgraph cluster_248 {
+                        label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
+                        subgraph cluster_249 {
+                            label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
+                            subgraph cluster_250 {
+                                label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
+                                subgraph cluster_251 {
+                                    label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
+                                    252 [label="ParMultiDo(Anonymous)"]
+                                    246 -> 252 [style=solid label=""]
                                 }
                             }
                         }
-                        subgraph cluster_255 {
-                            label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
-                            256 [label="GroupByKey"]
-                            254 -> 256 [style=solid label=""]
-                            subgraph cluster_257 {
-                                label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
-                                subgraph cluster_258 {
-                                    label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
-                                    259 [label="ParMultiDo(Anonymous)"]
-                                    256 -> 259 [style=solid label=""]
+                        subgraph cluster_253 {
+                            label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
+                            254 [label="GroupByKey"]
+                            252 -> 254 [style=solid label=""]
+                            subgraph cluster_255 {
+                                label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
+                                subgraph cluster_256 {
+                                    label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
+                                    257 [label="ParMultiDo(Anonymous)"]
+                                    254 -> 257 [style=solid label=""]
                                 }
                             }
                         }
-                        subgraph cluster_260 {
-                            label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
-                            subgraph cluster_261 {
-                                label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
-                                subgraph cluster_262 {
-                                    label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
-                                    263 [label="ParMultiDo(Anonymous)"]
-                                    259 -> 263 [style=solid label=""]
+                        subgraph cluster_258 {
+                            label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
+                            subgraph cluster_259 {
+                                label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
+                                subgraph cluster_260 {
+                                    label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
+                                    261 [label="ParMultiDo(Anonymous)"]
+                                    257 -> 261 [style=solid label=""]
                                 }
                             }
                         }
                     }
-                    subgraph cluster_264 {
-                        label = "Wait on phase one/To wait view 0/Sample.Any/Flatten.Iterables"
-                        subgraph cluster_265 {
-                            label = "Wait on phase one/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
-                            subgraph cluster_266 {
-                                label = "Wait on phase one/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
-                                267 [label="ParMultiDo(Anonymous)"]
-                                263 -> 267 [style=solid label=""]
+                    subgraph cluster_262 {
+                        label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Flatten.Iterables"
+                        subgraph cluster_263 {
+                            label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
+                            subgraph cluster_264 {
+                                label = "Wait on Transforms:ContactResource/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
+                                265 [label="ParMultiDo(Anonymous)"]
+                                261 -> 265 [style=solid label=""]
                             }
                         }
                     }
                 }
-                subgraph cluster_268 {
-                    label = "Wait on phase one/To wait view 0/View.AsList"
-                    subgraph cluster_269 {
-                        label = "Wait on phase one/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
-                        subgraph cluster_270 {
-                            label = "Wait on phase one/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
-                            271 [label="ParMultiDo(VoidKeyToMultimapMaterialization)"]
-                            267 -> 271 [style=solid label=""]
+                subgraph cluster_266 {
+                    label = "Wait on Transforms:ContactResource/To wait view 0/View.AsList"
+                    subgraph cluster_267 {
+                        label = "Wait on Transforms:ContactResource/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
+                        subgraph cluster_268 {
+                            label = "Wait on Transforms:ContactResource/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
+                            269 [label="ParMultiDo(VoidKeyToMultimapMaterialization)"]
+                            265 -> 269 [style=solid label=""]
                         }
                     }
-                    272 [label="View.CreatePCollectionView"]
-                    271 -> 272 [style=solid label=""]
+                    270 [label="View.CreatePCollectionView"]
+                    269 -> 270 [style=solid label=""]
                 }
             }
-            subgraph cluster_273 {
-                label = "Wait on phase one/Wait"
-                subgraph cluster_274 {
-                    label = "Wait on phase one/Wait/Map"
-                    275 [label="ParMultiDo(Anonymous)"]
-                    242 -> 275 [style=solid label=""]
-                    271 -> 275 [style=dashed label=""]
+            subgraph cluster_271 {
+                label = "Wait on Transforms:ContactResource/Wait"
+                subgraph cluster_272 {
+                    label = "Wait on Transforms:ContactResource/Wait/Map"
+                    273 [label="ParMultiDo(Anonymous)"]
+                    89 -> 273 [style=solid label=""]
+                    269 -> 273 [style=dashed label=""]
                 }
             }
         }
-        subgraph cluster_276 {
-            label = "Write to Sql: DomainBase without circular foreign keys"
-            subgraph cluster_277 {
-                label = "Write to Sql: DomainBase without circular foreign keys/Shard data DomainBase without circular foreign keys"
-                subgraph cluster_278 {
-                    label = "Write to Sql: DomainBase without circular foreign keys/Shard data DomainBase without circular foreign keys/AddKeys"
-                    subgraph cluster_279 {
-                        label = "Write to Sql: DomainBase without circular foreign keys/Shard data DomainBase without circular foreign keys/AddKeys/Map"
-                        280 [label="ParMultiDo(Anonymous)"]
-                        275 -> 280 [style=solid label=""]
+        subgraph cluster_274 {
+            label = "Write to Sql: Transforms:RegistrarContact"
+            subgraph cluster_275 {
+                label = "Write to Sql: Transforms:RegistrarContact/Shard data Transforms:RegistrarContact"
+                subgraph cluster_276 {
+                    label = "Write to Sql: Transforms:RegistrarContact/Shard data Transforms:RegistrarContact/AddKeys"
+                    subgraph cluster_277 {
+                        label = "Write to Sql: Transforms:RegistrarContact/Shard data Transforms:RegistrarContact/AddKeys/Map"
+                        278 [label="ParMultiDo(Anonymous)"]
+                        273 -> 278 [style=solid label=""]
                     }
                 }
             }
-            subgraph cluster_281 {
-                label = "Write to Sql: DomainBase without circular foreign keys/Group into batches DomainBase without circular foreign keys"
-                subgraph cluster_282 {
-                    label = "Write to Sql: DomainBase without circular foreign keys/Group into batches DomainBase without circular foreign keys/MapElements"
-                    subgraph cluster_283 {
-                        label = "Write to Sql: DomainBase without circular foreign keys/Group into batches DomainBase without circular foreign keys/MapElements/Map"
-                        284 [label="ParMultiDo(Anonymous)"]
-                        280 -> 284 [style=solid label=""]
+            subgraph cluster_279 {
+                label = "Write to Sql: Transforms:RegistrarContact/Group into batches Transforms:RegistrarContact"
+                subgraph cluster_280 {
+                    label = "Write to Sql: Transforms:RegistrarContact/Group into batches Transforms:RegistrarContact/MapElements"
+                    subgraph cluster_281 {
+                        label = "Write to Sql: Transforms:RegistrarContact/Group into batches Transforms:RegistrarContact/MapElements/Map"
+                        282 [label="ParMultiDo(Anonymous)"]
+                        278 -> 282 [style=solid label=""]
                     }
                 }
-                subgraph cluster_285 {
-                    label = "Write to Sql: DomainBase without circular foreign keys/Group into batches DomainBase without circular foreign keys/ParDo(GroupIntoBatches)"
-                    286 [label="ParMultiDo(GroupIntoBatches)"]
-                    284 -> 286 [style=solid label=""]
+                subgraph cluster_283 {
+                    label = "Write to Sql: Transforms:RegistrarContact/Group into batches Transforms:RegistrarContact/ParDo(GroupIntoBatches)"
+                    284 [label="ParMultiDo(GroupIntoBatches)"]
+                    282 -> 284 [style=solid label=""]
                 }
             }
-            subgraph cluster_287 {
-                label = "Write to Sql: DomainBase without circular foreign keys/Write in batch for DomainBase without circular foreign keys"
-                288 [label="ParMultiDo(SqlBatchWriter)"]
-                286 -> 288 [style=solid label=""]
+            subgraph cluster_285 {
+                label = "Write to Sql: Transforms:RegistrarContact/Write in batch for Transforms:RegistrarContact"
+                286 [label="ParMultiDo(SqlBatchWriter)"]
+                284 -> 286 [style=solid label=""]
             }
+        }
+        subgraph cluster_287 {
+            label = "Remove circular foreign keys from DomainBase"
+            288 [label="ParMultiDo(RemoveDomainBaseForeignKeys)"]
+            89 -> 288 [style=solid label=""]
         }
         subgraph cluster_289 {
-            label = "Wait on DomainBaseNoFkeys"
+            label = "Wait on phase one"
             subgraph cluster_290 {
-                label = "Wait on DomainBaseNoFkeys/To wait view 0"
+                label = "Wait on phase one/To wait view 0"
                 subgraph cluster_291 {
-                    label = "Wait on DomainBaseNoFkeys/To wait view 0/Window.Into()"
+                    label = "Wait on phase one/To wait view 0/Window.Into()"
                     292 [label="Flatten.PCollections"]
-                    288 -> 292 [style=solid label=""]
+                    286 -> 292 [style=solid label=""]
                 }
                 subgraph cluster_293 {
-                    label = "Wait on DomainBaseNoFkeys/To wait view 0/ParDo(CollectWindows)"
+                    label = "Wait on phase one/To wait view 0/ParDo(CollectWindows)"
                     294 [label="ParMultiDo(CollectWindows)"]
                     292 -> 294 [style=solid label=""]
                 }
                 subgraph cluster_295 {
-                    label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any"
+                    label = "Wait on phase one/To wait view 0/Sample.Any"
                     subgraph cluster_296 {
-                        label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
+                        label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
                         subgraph cluster_297 {
-                            label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
+                            label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
                             subgraph cluster_298 {
-                                label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
+                                label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
                                 subgraph cluster_299 {
-                                    label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
+                                    label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
                                     300 [label="ParMultiDo(Anonymous)"]
                                     294 -> 300 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_301 {
-                            label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
+                            label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
                             302 [label="GroupByKey"]
                             300 -> 302 [style=solid label=""]
                             subgraph cluster_303 {
-                                label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
+                                label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
                                 subgraph cluster_304 {
-                                    label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
+                                    label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
                                     305 [label="ParMultiDo(Anonymous)"]
                                     302 -> 305 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_306 {
-                            label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
+                            label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
                             subgraph cluster_307 {
-                                label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
+                                label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
                                 subgraph cluster_308 {
-                                    label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
+                                    label = "Wait on phase one/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
                                     309 [label="ParMultiDo(Anonymous)"]
                                     305 -> 309 [style=solid label=""]
                                 }
@@ -830,11 +830,11 @@ digraph {
                         }
                     }
                     subgraph cluster_310 {
-                        label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Flatten.Iterables"
+                        label = "Wait on phase one/To wait view 0/Sample.Any/Flatten.Iterables"
                         subgraph cluster_311 {
-                            label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
+                            label = "Wait on phase one/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
                             subgraph cluster_312 {
-                                label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
+                                label = "Wait on phase one/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
                                 313 [label="ParMultiDo(Anonymous)"]
                                 309 -> 313 [style=solid label=""]
                             }
@@ -842,11 +842,11 @@ digraph {
                     }
                 }
                 subgraph cluster_314 {
-                    label = "Wait on DomainBaseNoFkeys/To wait view 0/View.AsList"
+                    label = "Wait on phase one/To wait view 0/View.AsList"
                     subgraph cluster_315 {
-                        label = "Wait on DomainBaseNoFkeys/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
+                        label = "Wait on phase one/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
                         subgraph cluster_316 {
-                            label = "Wait on DomainBaseNoFkeys/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
+                            label = "Wait on phase one/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
                             317 [label="ParMultiDo(VoidKeyToMultimapMaterialization)"]
                             313 -> 317 [style=solid label=""]
                         }
@@ -856,98 +856,98 @@ digraph {
                 }
             }
             subgraph cluster_319 {
-                label = "Wait on DomainBaseNoFkeys/Wait"
+                label = "Wait on phase one/Wait"
                 subgraph cluster_320 {
-                    label = "Wait on DomainBaseNoFkeys/Wait/Map"
+                    label = "Wait on phase one/Wait/Map"
                     321 [label="ParMultiDo(Anonymous)"]
-                    89 -> 321 [style=solid label=""]
+                    288 -> 321 [style=solid label=""]
                     317 -> 321 [style=dashed label=""]
                 }
             }
         }
         subgraph cluster_322 {
-            label = "Write to Sql: Transforms:HostResource"
+            label = "Write to Sql: DomainBase without circular foreign keys"
             subgraph cluster_323 {
-                label = "Write to Sql: Transforms:HostResource/Shard data Transforms:HostResource"
+                label = "Write to Sql: DomainBase without circular foreign keys/Shard data DomainBase without circular foreign keys"
                 subgraph cluster_324 {
-                    label = "Write to Sql: Transforms:HostResource/Shard data Transforms:HostResource/AddKeys"
+                    label = "Write to Sql: DomainBase without circular foreign keys/Shard data DomainBase without circular foreign keys/AddKeys"
                     subgraph cluster_325 {
-                        label = "Write to Sql: Transforms:HostResource/Shard data Transforms:HostResource/AddKeys/Map"
+                        label = "Write to Sql: DomainBase without circular foreign keys/Shard data DomainBase without circular foreign keys/AddKeys/Map"
                         326 [label="ParMultiDo(Anonymous)"]
                         321 -> 326 [style=solid label=""]
                     }
                 }
             }
             subgraph cluster_327 {
-                label = "Write to Sql: Transforms:HostResource/Group into batches Transforms:HostResource"
+                label = "Write to Sql: DomainBase without circular foreign keys/Group into batches DomainBase without circular foreign keys"
                 subgraph cluster_328 {
-                    label = "Write to Sql: Transforms:HostResource/Group into batches Transforms:HostResource/MapElements"
+                    label = "Write to Sql: DomainBase without circular foreign keys/Group into batches DomainBase without circular foreign keys/MapElements"
                     subgraph cluster_329 {
-                        label = "Write to Sql: Transforms:HostResource/Group into batches Transforms:HostResource/MapElements/Map"
+                        label = "Write to Sql: DomainBase without circular foreign keys/Group into batches DomainBase without circular foreign keys/MapElements/Map"
                         330 [label="ParMultiDo(Anonymous)"]
                         326 -> 330 [style=solid label=""]
                     }
                 }
                 subgraph cluster_331 {
-                    label = "Write to Sql: Transforms:HostResource/Group into batches Transforms:HostResource/ParDo(GroupIntoBatches)"
+                    label = "Write to Sql: DomainBase without circular foreign keys/Group into batches DomainBase without circular foreign keys/ParDo(GroupIntoBatches)"
                     332 [label="ParMultiDo(GroupIntoBatches)"]
                     330 -> 332 [style=solid label=""]
                 }
             }
             subgraph cluster_333 {
-                label = "Write to Sql: Transforms:HostResource/Write in batch for Transforms:HostResource"
+                label = "Write to Sql: DomainBase without circular foreign keys/Write in batch for DomainBase without circular foreign keys"
                 334 [label="ParMultiDo(SqlBatchWriter)"]
                 332 -> 334 [style=solid label=""]
             }
         }
         subgraph cluster_335 {
-            label = "Wait on Transforms:HostResource"
+            label = "Wait on DomainBaseNoFkeys"
             subgraph cluster_336 {
-                label = "Wait on Transforms:HostResource/To wait view 0"
+                label = "Wait on DomainBaseNoFkeys/To wait view 0"
                 subgraph cluster_337 {
-                    label = "Wait on Transforms:HostResource/To wait view 0/Window.Into()"
+                    label = "Wait on DomainBaseNoFkeys/To wait view 0/Window.Into()"
                     338 [label="Flatten.PCollections"]
                     334 -> 338 [style=solid label=""]
                 }
                 subgraph cluster_339 {
-                    label = "Wait on Transforms:HostResource/To wait view 0/ParDo(CollectWindows)"
+                    label = "Wait on DomainBaseNoFkeys/To wait view 0/ParDo(CollectWindows)"
                     340 [label="ParMultiDo(CollectWindows)"]
                     338 -> 340 [style=solid label=""]
                 }
                 subgraph cluster_341 {
-                    label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any"
+                    label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any"
                     subgraph cluster_342 {
-                        label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
+                        label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
                         subgraph cluster_343 {
-                            label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
+                            label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
                             subgraph cluster_344 {
-                                label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
+                                label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
                                 subgraph cluster_345 {
-                                    label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
+                                    label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
                                     346 [label="ParMultiDo(Anonymous)"]
                                     340 -> 346 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_347 {
-                            label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
+                            label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
                             348 [label="GroupByKey"]
                             346 -> 348 [style=solid label=""]
                             subgraph cluster_349 {
-                                label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
+                                label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
                                 subgraph cluster_350 {
-                                    label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
+                                    label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
                                     351 [label="ParMultiDo(Anonymous)"]
                                     348 -> 351 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_352 {
-                            label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
+                            label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
                             subgraph cluster_353 {
-                                label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
+                                label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
                                 subgraph cluster_354 {
-                                    label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
+                                    label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
                                     355 [label="ParMultiDo(Anonymous)"]
                                     351 -> 355 [style=solid label=""]
                                 }
@@ -955,11 +955,11 @@ digraph {
                         }
                     }
                     subgraph cluster_356 {
-                        label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Flatten.Iterables"
+                        label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Flatten.Iterables"
                         subgraph cluster_357 {
-                            label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
+                            label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
                             subgraph cluster_358 {
-                                label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
+                                label = "Wait on DomainBaseNoFkeys/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
                                 359 [label="ParMultiDo(Anonymous)"]
                                 355 -> 359 [style=solid label=""]
                             }
@@ -967,11 +967,11 @@ digraph {
                     }
                 }
                 subgraph cluster_360 {
-                    label = "Wait on Transforms:HostResource/To wait view 0/View.AsList"
+                    label = "Wait on DomainBaseNoFkeys/To wait view 0/View.AsList"
                     subgraph cluster_361 {
-                        label = "Wait on Transforms:HostResource/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
+                        label = "Wait on DomainBaseNoFkeys/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
                         subgraph cluster_362 {
-                            label = "Wait on Transforms:HostResource/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
+                            label = "Wait on DomainBaseNoFkeys/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
                             363 [label="ParMultiDo(VoidKeyToMultimapMaterialization)"]
                             359 -> 363 [style=solid label=""]
                         }
@@ -981,9 +981,9 @@ digraph {
                 }
             }
             subgraph cluster_365 {
-                label = "Wait on Transforms:HostResource/Wait"
+                label = "Wait on DomainBaseNoFkeys/Wait"
                 subgraph cluster_366 {
-                    label = "Wait on Transforms:HostResource/Wait/Map"
+                    label = "Wait on DomainBaseNoFkeys/Wait/Map"
                     367 [label="ParMultiDo(Anonymous)"]
                     89 -> 367 [style=solid label=""]
                     363 -> 367 [style=dashed label=""]
@@ -991,88 +991,88 @@ digraph {
             }
         }
         subgraph cluster_368 {
-            label = "Write to Sql: Transforms:HistoryEntry"
+            label = "Write to Sql: Transforms:HostResource"
             subgraph cluster_369 {
-                label = "Write to Sql: Transforms:HistoryEntry/Shard data Transforms:HistoryEntry"
+                label = "Write to Sql: Transforms:HostResource/Shard data Transforms:HostResource"
                 subgraph cluster_370 {
-                    label = "Write to Sql: Transforms:HistoryEntry/Shard data Transforms:HistoryEntry/AddKeys"
+                    label = "Write to Sql: Transforms:HostResource/Shard data Transforms:HostResource/AddKeys"
                     subgraph cluster_371 {
-                        label = "Write to Sql: Transforms:HistoryEntry/Shard data Transforms:HistoryEntry/AddKeys/Map"
+                        label = "Write to Sql: Transforms:HostResource/Shard data Transforms:HostResource/AddKeys/Map"
                         372 [label="ParMultiDo(Anonymous)"]
                         367 -> 372 [style=solid label=""]
                     }
                 }
             }
             subgraph cluster_373 {
-                label = "Write to Sql: Transforms:HistoryEntry/Group into batches Transforms:HistoryEntry"
+                label = "Write to Sql: Transforms:HostResource/Group into batches Transforms:HostResource"
                 subgraph cluster_374 {
-                    label = "Write to Sql: Transforms:HistoryEntry/Group into batches Transforms:HistoryEntry/MapElements"
+                    label = "Write to Sql: Transforms:HostResource/Group into batches Transforms:HostResource/MapElements"
                     subgraph cluster_375 {
-                        label = "Write to Sql: Transforms:HistoryEntry/Group into batches Transforms:HistoryEntry/MapElements/Map"
+                        label = "Write to Sql: Transforms:HostResource/Group into batches Transforms:HostResource/MapElements/Map"
                         376 [label="ParMultiDo(Anonymous)"]
                         372 -> 376 [style=solid label=""]
                     }
                 }
                 subgraph cluster_377 {
-                    label = "Write to Sql: Transforms:HistoryEntry/Group into batches Transforms:HistoryEntry/ParDo(GroupIntoBatches)"
+                    label = "Write to Sql: Transforms:HostResource/Group into batches Transforms:HostResource/ParDo(GroupIntoBatches)"
                     378 [label="ParMultiDo(GroupIntoBatches)"]
                     376 -> 378 [style=solid label=""]
                 }
             }
             subgraph cluster_379 {
-                label = "Write to Sql: Transforms:HistoryEntry/Write in batch for Transforms:HistoryEntry"
+                label = "Write to Sql: Transforms:HostResource/Write in batch for Transforms:HostResource"
                 380 [label="ParMultiDo(SqlBatchWriter)"]
                 378 -> 380 [style=solid label=""]
             }
         }
         subgraph cluster_381 {
-            label = "Wait on Transforms:HistoryEntry"
+            label = "Wait on Transforms:HostResource"
             subgraph cluster_382 {
-                label = "Wait on Transforms:HistoryEntry/To wait view 0"
+                label = "Wait on Transforms:HostResource/To wait view 0"
                 subgraph cluster_383 {
-                    label = "Wait on Transforms:HistoryEntry/To wait view 0/Window.Into()"
+                    label = "Wait on Transforms:HostResource/To wait view 0/Window.Into()"
                     384 [label="Flatten.PCollections"]
                     380 -> 384 [style=solid label=""]
                 }
                 subgraph cluster_385 {
-                    label = "Wait on Transforms:HistoryEntry/To wait view 0/ParDo(CollectWindows)"
+                    label = "Wait on Transforms:HostResource/To wait view 0/ParDo(CollectWindows)"
                     386 [label="ParMultiDo(CollectWindows)"]
                     384 -> 386 [style=solid label=""]
                 }
                 subgraph cluster_387 {
-                    label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any"
+                    label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any"
                     subgraph cluster_388 {
-                        label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
+                        label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
                         subgraph cluster_389 {
-                            label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
+                            label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
                             subgraph cluster_390 {
-                                label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
+                                label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
                                 subgraph cluster_391 {
-                                    label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
+                                    label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
                                     392 [label="ParMultiDo(Anonymous)"]
                                     386 -> 392 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_393 {
-                            label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
+                            label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
                             394 [label="GroupByKey"]
                             392 -> 394 [style=solid label=""]
                             subgraph cluster_395 {
-                                label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
+                                label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
                                 subgraph cluster_396 {
-                                    label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
+                                    label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
                                     397 [label="ParMultiDo(Anonymous)"]
                                     394 -> 397 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_398 {
-                            label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
+                            label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
                             subgraph cluster_399 {
-                                label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
+                                label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
                                 subgraph cluster_400 {
-                                    label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
+                                    label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
                                     401 [label="ParMultiDo(Anonymous)"]
                                     397 -> 401 [style=solid label=""]
                                 }
@@ -1080,11 +1080,11 @@ digraph {
                         }
                     }
                     subgraph cluster_402 {
-                        label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Flatten.Iterables"
+                        label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Flatten.Iterables"
                         subgraph cluster_403 {
-                            label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
+                            label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
                             subgraph cluster_404 {
-                                label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
+                                label = "Wait on Transforms:HostResource/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
                                 405 [label="ParMultiDo(Anonymous)"]
                                 401 -> 405 [style=solid label=""]
                             }
@@ -1092,11 +1092,11 @@ digraph {
                     }
                 }
                 subgraph cluster_406 {
-                    label = "Wait on Transforms:HistoryEntry/To wait view 0/View.AsList"
+                    label = "Wait on Transforms:HostResource/To wait view 0/View.AsList"
                     subgraph cluster_407 {
-                        label = "Wait on Transforms:HistoryEntry/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
+                        label = "Wait on Transforms:HostResource/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
                         subgraph cluster_408 {
-                            label = "Wait on Transforms:HistoryEntry/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
+                            label = "Wait on Transforms:HostResource/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
                             409 [label="ParMultiDo(VoidKeyToMultimapMaterialization)"]
                             405 -> 409 [style=solid label=""]
                         }
@@ -1106,9 +1106,9 @@ digraph {
                 }
             }
             subgraph cluster_411 {
-                label = "Wait on Transforms:HistoryEntry/Wait"
+                label = "Wait on Transforms:HostResource/Wait"
                 subgraph cluster_412 {
-                    label = "Wait on Transforms:HistoryEntry/Wait/Map"
+                    label = "Wait on Transforms:HostResource/Wait/Map"
                     413 [label="ParMultiDo(Anonymous)"]
                     89 -> 413 [style=solid label=""]
                     409 -> 413 [style=dashed label=""]
@@ -1116,88 +1116,88 @@ digraph {
             }
         }
         subgraph cluster_414 {
-            label = "Write to Sql: Transforms:AllocationToken"
+            label = "Write to Sql: Transforms:HistoryEntry"
             subgraph cluster_415 {
-                label = "Write to Sql: Transforms:AllocationToken/Shard data Transforms:AllocationToken"
+                label = "Write to Sql: Transforms:HistoryEntry/Shard data Transforms:HistoryEntry"
                 subgraph cluster_416 {
-                    label = "Write to Sql: Transforms:AllocationToken/Shard data Transforms:AllocationToken/AddKeys"
+                    label = "Write to Sql: Transforms:HistoryEntry/Shard data Transforms:HistoryEntry/AddKeys"
                     subgraph cluster_417 {
-                        label = "Write to Sql: Transforms:AllocationToken/Shard data Transforms:AllocationToken/AddKeys/Map"
+                        label = "Write to Sql: Transforms:HistoryEntry/Shard data Transforms:HistoryEntry/AddKeys/Map"
                         418 [label="ParMultiDo(Anonymous)"]
                         413 -> 418 [style=solid label=""]
                     }
                 }
             }
             subgraph cluster_419 {
-                label = "Write to Sql: Transforms:AllocationToken/Group into batches Transforms:AllocationToken"
+                label = "Write to Sql: Transforms:HistoryEntry/Group into batches Transforms:HistoryEntry"
                 subgraph cluster_420 {
-                    label = "Write to Sql: Transforms:AllocationToken/Group into batches Transforms:AllocationToken/MapElements"
+                    label = "Write to Sql: Transforms:HistoryEntry/Group into batches Transforms:HistoryEntry/MapElements"
                     subgraph cluster_421 {
-                        label = "Write to Sql: Transforms:AllocationToken/Group into batches Transforms:AllocationToken/MapElements/Map"
+                        label = "Write to Sql: Transforms:HistoryEntry/Group into batches Transforms:HistoryEntry/MapElements/Map"
                         422 [label="ParMultiDo(Anonymous)"]
                         418 -> 422 [style=solid label=""]
                     }
                 }
                 subgraph cluster_423 {
-                    label = "Write to Sql: Transforms:AllocationToken/Group into batches Transforms:AllocationToken/ParDo(GroupIntoBatches)"
+                    label = "Write to Sql: Transforms:HistoryEntry/Group into batches Transforms:HistoryEntry/ParDo(GroupIntoBatches)"
                     424 [label="ParMultiDo(GroupIntoBatches)"]
                     422 -> 424 [style=solid label=""]
                 }
             }
             subgraph cluster_425 {
-                label = "Write to Sql: Transforms:AllocationToken/Write in batch for Transforms:AllocationToken"
+                label = "Write to Sql: Transforms:HistoryEntry/Write in batch for Transforms:HistoryEntry"
                 426 [label="ParMultiDo(SqlBatchWriter)"]
                 424 -> 426 [style=solid label=""]
             }
         }
         subgraph cluster_427 {
-            label = "Wait on Transforms:AllocationToken"
+            label = "Wait on Transforms:HistoryEntry"
             subgraph cluster_428 {
-                label = "Wait on Transforms:AllocationToken/To wait view 0"
+                label = "Wait on Transforms:HistoryEntry/To wait view 0"
                 subgraph cluster_429 {
-                    label = "Wait on Transforms:AllocationToken/To wait view 0/Window.Into()"
+                    label = "Wait on Transforms:HistoryEntry/To wait view 0/Window.Into()"
                     430 [label="Flatten.PCollections"]
                     426 -> 430 [style=solid label=""]
                 }
                 subgraph cluster_431 {
-                    label = "Wait on Transforms:AllocationToken/To wait view 0/ParDo(CollectWindows)"
+                    label = "Wait on Transforms:HistoryEntry/To wait view 0/ParDo(CollectWindows)"
                     432 [label="ParMultiDo(CollectWindows)"]
                     430 -> 432 [style=solid label=""]
                 }
                 subgraph cluster_433 {
-                    label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any"
+                    label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any"
                     subgraph cluster_434 {
-                        label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
+                        label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
                         subgraph cluster_435 {
-                            label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
+                            label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
                             subgraph cluster_436 {
-                                label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
+                                label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
                                 subgraph cluster_437 {
-                                    label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
+                                    label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
                                     438 [label="ParMultiDo(Anonymous)"]
                                     432 -> 438 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_439 {
-                            label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
+                            label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
                             440 [label="GroupByKey"]
                             438 -> 440 [style=solid label=""]
                             subgraph cluster_441 {
-                                label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
+                                label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
                                 subgraph cluster_442 {
-                                    label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
+                                    label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
                                     443 [label="ParMultiDo(Anonymous)"]
                                     440 -> 443 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_444 {
-                            label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
+                            label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
                             subgraph cluster_445 {
-                                label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
+                                label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
                                 subgraph cluster_446 {
-                                    label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
+                                    label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
                                     447 [label="ParMultiDo(Anonymous)"]
                                     443 -> 447 [style=solid label=""]
                                 }
@@ -1205,11 +1205,11 @@ digraph {
                         }
                     }
                     subgraph cluster_448 {
-                        label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Flatten.Iterables"
+                        label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Flatten.Iterables"
                         subgraph cluster_449 {
-                            label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
+                            label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
                             subgraph cluster_450 {
-                                label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
+                                label = "Wait on Transforms:HistoryEntry/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
                                 451 [label="ParMultiDo(Anonymous)"]
                                 447 -> 451 [style=solid label=""]
                             }
@@ -1217,11 +1217,11 @@ digraph {
                     }
                 }
                 subgraph cluster_452 {
-                    label = "Wait on Transforms:AllocationToken/To wait view 0/View.AsList"
+                    label = "Wait on Transforms:HistoryEntry/To wait view 0/View.AsList"
                     subgraph cluster_453 {
-                        label = "Wait on Transforms:AllocationToken/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
+                        label = "Wait on Transforms:HistoryEntry/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
                         subgraph cluster_454 {
-                            label = "Wait on Transforms:AllocationToken/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
+                            label = "Wait on Transforms:HistoryEntry/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
                             455 [label="ParMultiDo(VoidKeyToMultimapMaterialization)"]
                             451 -> 455 [style=solid label=""]
                         }
@@ -1231,9 +1231,9 @@ digraph {
                 }
             }
             subgraph cluster_457 {
-                label = "Wait on Transforms:AllocationToken/Wait"
+                label = "Wait on Transforms:HistoryEntry/Wait"
                 subgraph cluster_458 {
-                    label = "Wait on Transforms:AllocationToken/Wait/Map"
+                    label = "Wait on Transforms:HistoryEntry/Wait/Map"
                     459 [label="ParMultiDo(Anonymous)"]
                     89 -> 459 [style=solid label=""]
                     455 -> 459 [style=dashed label=""]
@@ -1241,88 +1241,88 @@ digraph {
             }
         }
         subgraph cluster_460 {
-            label = "Write to Sql: Transforms:Recurring"
+            label = "Write to Sql: Transforms:AllocationToken"
             subgraph cluster_461 {
-                label = "Write to Sql: Transforms:Recurring/Shard data Transforms:Recurring"
+                label = "Write to Sql: Transforms:AllocationToken/Shard data Transforms:AllocationToken"
                 subgraph cluster_462 {
-                    label = "Write to Sql: Transforms:Recurring/Shard data Transforms:Recurring/AddKeys"
+                    label = "Write to Sql: Transforms:AllocationToken/Shard data Transforms:AllocationToken/AddKeys"
                     subgraph cluster_463 {
-                        label = "Write to Sql: Transforms:Recurring/Shard data Transforms:Recurring/AddKeys/Map"
+                        label = "Write to Sql: Transforms:AllocationToken/Shard data Transforms:AllocationToken/AddKeys/Map"
                         464 [label="ParMultiDo(Anonymous)"]
                         459 -> 464 [style=solid label=""]
                     }
                 }
             }
             subgraph cluster_465 {
-                label = "Write to Sql: Transforms:Recurring/Group into batches Transforms:Recurring"
+                label = "Write to Sql: Transforms:AllocationToken/Group into batches Transforms:AllocationToken"
                 subgraph cluster_466 {
-                    label = "Write to Sql: Transforms:Recurring/Group into batches Transforms:Recurring/MapElements"
+                    label = "Write to Sql: Transforms:AllocationToken/Group into batches Transforms:AllocationToken/MapElements"
                     subgraph cluster_467 {
-                        label = "Write to Sql: Transforms:Recurring/Group into batches Transforms:Recurring/MapElements/Map"
+                        label = "Write to Sql: Transforms:AllocationToken/Group into batches Transforms:AllocationToken/MapElements/Map"
                         468 [label="ParMultiDo(Anonymous)"]
                         464 -> 468 [style=solid label=""]
                     }
                 }
                 subgraph cluster_469 {
-                    label = "Write to Sql: Transforms:Recurring/Group into batches Transforms:Recurring/ParDo(GroupIntoBatches)"
+                    label = "Write to Sql: Transforms:AllocationToken/Group into batches Transforms:AllocationToken/ParDo(GroupIntoBatches)"
                     470 [label="ParMultiDo(GroupIntoBatches)"]
                     468 -> 470 [style=solid label=""]
                 }
             }
             subgraph cluster_471 {
-                label = "Write to Sql: Transforms:Recurring/Write in batch for Transforms:Recurring"
+                label = "Write to Sql: Transforms:AllocationToken/Write in batch for Transforms:AllocationToken"
                 472 [label="ParMultiDo(SqlBatchWriter)"]
                 470 -> 472 [style=solid label=""]
             }
         }
         subgraph cluster_473 {
-            label = "Wait on Transforms:Recurring"
+            label = "Wait on Transforms:AllocationToken"
             subgraph cluster_474 {
-                label = "Wait on Transforms:Recurring/To wait view 0"
+                label = "Wait on Transforms:AllocationToken/To wait view 0"
                 subgraph cluster_475 {
-                    label = "Wait on Transforms:Recurring/To wait view 0/Window.Into()"
+                    label = "Wait on Transforms:AllocationToken/To wait view 0/Window.Into()"
                     476 [label="Flatten.PCollections"]
                     472 -> 476 [style=solid label=""]
                 }
                 subgraph cluster_477 {
-                    label = "Wait on Transforms:Recurring/To wait view 0/ParDo(CollectWindows)"
+                    label = "Wait on Transforms:AllocationToken/To wait view 0/ParDo(CollectWindows)"
                     478 [label="ParMultiDo(CollectWindows)"]
                     476 -> 478 [style=solid label=""]
                 }
                 subgraph cluster_479 {
-                    label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any"
+                    label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any"
                     subgraph cluster_480 {
-                        label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
+                        label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
                         subgraph cluster_481 {
-                            label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
+                            label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
                             subgraph cluster_482 {
-                                label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
+                                label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
                                 subgraph cluster_483 {
-                                    label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
+                                    label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
                                     484 [label="ParMultiDo(Anonymous)"]
                                     478 -> 484 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_485 {
-                            label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
+                            label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
                             486 [label="GroupByKey"]
                             484 -> 486 [style=solid label=""]
                             subgraph cluster_487 {
-                                label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
+                                label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
                                 subgraph cluster_488 {
-                                    label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
+                                    label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
                                     489 [label="ParMultiDo(Anonymous)"]
                                     486 -> 489 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_490 {
-                            label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
+                            label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
                             subgraph cluster_491 {
-                                label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
+                                label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
                                 subgraph cluster_492 {
-                                    label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
+                                    label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
                                     493 [label="ParMultiDo(Anonymous)"]
                                     489 -> 493 [style=solid label=""]
                                 }
@@ -1330,11 +1330,11 @@ digraph {
                         }
                     }
                     subgraph cluster_494 {
-                        label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Flatten.Iterables"
+                        label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Flatten.Iterables"
                         subgraph cluster_495 {
-                            label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
+                            label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
                             subgraph cluster_496 {
-                                label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
+                                label = "Wait on Transforms:AllocationToken/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
                                 497 [label="ParMultiDo(Anonymous)"]
                                 493 -> 497 [style=solid label=""]
                             }
@@ -1342,11 +1342,11 @@ digraph {
                     }
                 }
                 subgraph cluster_498 {
-                    label = "Wait on Transforms:Recurring/To wait view 0/View.AsList"
+                    label = "Wait on Transforms:AllocationToken/To wait view 0/View.AsList"
                     subgraph cluster_499 {
-                        label = "Wait on Transforms:Recurring/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
+                        label = "Wait on Transforms:AllocationToken/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
                         subgraph cluster_500 {
-                            label = "Wait on Transforms:Recurring/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
+                            label = "Wait on Transforms:AllocationToken/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
                             501 [label="ParMultiDo(VoidKeyToMultimapMaterialization)"]
                             497 -> 501 [style=solid label=""]
                         }
@@ -1356,9 +1356,9 @@ digraph {
                 }
             }
             subgraph cluster_503 {
-                label = "Wait on Transforms:Recurring/Wait"
+                label = "Wait on Transforms:AllocationToken/Wait"
                 subgraph cluster_504 {
-                    label = "Wait on Transforms:Recurring/Wait/Map"
+                    label = "Wait on Transforms:AllocationToken/Wait/Map"
                     505 [label="ParMultiDo(Anonymous)"]
                     89 -> 505 [style=solid label=""]
                     501 -> 505 [style=dashed label=""]
@@ -1366,88 +1366,88 @@ digraph {
             }
         }
         subgraph cluster_506 {
-            label = "Write to Sql: Transforms:OneTime"
+            label = "Write to Sql: Transforms:Recurring"
             subgraph cluster_507 {
-                label = "Write to Sql: Transforms:OneTime/Shard data Transforms:OneTime"
+                label = "Write to Sql: Transforms:Recurring/Shard data Transforms:Recurring"
                 subgraph cluster_508 {
-                    label = "Write to Sql: Transforms:OneTime/Shard data Transforms:OneTime/AddKeys"
+                    label = "Write to Sql: Transforms:Recurring/Shard data Transforms:Recurring/AddKeys"
                     subgraph cluster_509 {
-                        label = "Write to Sql: Transforms:OneTime/Shard data Transforms:OneTime/AddKeys/Map"
+                        label = "Write to Sql: Transforms:Recurring/Shard data Transforms:Recurring/AddKeys/Map"
                         510 [label="ParMultiDo(Anonymous)"]
                         505 -> 510 [style=solid label=""]
                     }
                 }
             }
             subgraph cluster_511 {
-                label = "Write to Sql: Transforms:OneTime/Group into batches Transforms:OneTime"
+                label = "Write to Sql: Transforms:Recurring/Group into batches Transforms:Recurring"
                 subgraph cluster_512 {
-                    label = "Write to Sql: Transforms:OneTime/Group into batches Transforms:OneTime/MapElements"
+                    label = "Write to Sql: Transforms:Recurring/Group into batches Transforms:Recurring/MapElements"
                     subgraph cluster_513 {
-                        label = "Write to Sql: Transforms:OneTime/Group into batches Transforms:OneTime/MapElements/Map"
+                        label = "Write to Sql: Transforms:Recurring/Group into batches Transforms:Recurring/MapElements/Map"
                         514 [label="ParMultiDo(Anonymous)"]
                         510 -> 514 [style=solid label=""]
                     }
                 }
                 subgraph cluster_515 {
-                    label = "Write to Sql: Transforms:OneTime/Group into batches Transforms:OneTime/ParDo(GroupIntoBatches)"
+                    label = "Write to Sql: Transforms:Recurring/Group into batches Transforms:Recurring/ParDo(GroupIntoBatches)"
                     516 [label="ParMultiDo(GroupIntoBatches)"]
                     514 -> 516 [style=solid label=""]
                 }
             }
             subgraph cluster_517 {
-                label = "Write to Sql: Transforms:OneTime/Write in batch for Transforms:OneTime"
+                label = "Write to Sql: Transforms:Recurring/Write in batch for Transforms:Recurring"
                 518 [label="ParMultiDo(SqlBatchWriter)"]
                 516 -> 518 [style=solid label=""]
             }
         }
         subgraph cluster_519 {
-            label = "Wait on Transforms:OneTime"
+            label = "Wait on Transforms:Recurring"
             subgraph cluster_520 {
-                label = "Wait on Transforms:OneTime/To wait view 0"
+                label = "Wait on Transforms:Recurring/To wait view 0"
                 subgraph cluster_521 {
-                    label = "Wait on Transforms:OneTime/To wait view 0/Window.Into()"
+                    label = "Wait on Transforms:Recurring/To wait view 0/Window.Into()"
                     522 [label="Flatten.PCollections"]
                     518 -> 522 [style=solid label=""]
                 }
                 subgraph cluster_523 {
-                    label = "Wait on Transforms:OneTime/To wait view 0/ParDo(CollectWindows)"
+                    label = "Wait on Transforms:Recurring/To wait view 0/ParDo(CollectWindows)"
                     524 [label="ParMultiDo(CollectWindows)"]
                     522 -> 524 [style=solid label=""]
                 }
                 subgraph cluster_525 {
-                    label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any"
+                    label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any"
                     subgraph cluster_526 {
-                        label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
+                        label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
                         subgraph cluster_527 {
-                            label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
+                            label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
                             subgraph cluster_528 {
-                                label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
+                                label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
                                 subgraph cluster_529 {
-                                    label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
+                                    label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
                                     530 [label="ParMultiDo(Anonymous)"]
                                     524 -> 530 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_531 {
-                            label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
+                            label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
                             532 [label="GroupByKey"]
                             530 -> 532 [style=solid label=""]
                             subgraph cluster_533 {
-                                label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
+                                label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
                                 subgraph cluster_534 {
-                                    label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
+                                    label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
                                     535 [label="ParMultiDo(Anonymous)"]
                                     532 -> 535 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_536 {
-                            label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
+                            label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
                             subgraph cluster_537 {
-                                label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
+                                label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
                                 subgraph cluster_538 {
-                                    label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
+                                    label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
                                     539 [label="ParMultiDo(Anonymous)"]
                                     535 -> 539 [style=solid label=""]
                                 }
@@ -1455,11 +1455,11 @@ digraph {
                         }
                     }
                     subgraph cluster_540 {
-                        label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Flatten.Iterables"
+                        label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Flatten.Iterables"
                         subgraph cluster_541 {
-                            label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
+                            label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
                             subgraph cluster_542 {
-                                label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
+                                label = "Wait on Transforms:Recurring/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
                                 543 [label="ParMultiDo(Anonymous)"]
                                 539 -> 543 [style=solid label=""]
                             }
@@ -1467,11 +1467,11 @@ digraph {
                     }
                 }
                 subgraph cluster_544 {
-                    label = "Wait on Transforms:OneTime/To wait view 0/View.AsList"
+                    label = "Wait on Transforms:Recurring/To wait view 0/View.AsList"
                     subgraph cluster_545 {
-                        label = "Wait on Transforms:OneTime/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
+                        label = "Wait on Transforms:Recurring/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
                         subgraph cluster_546 {
-                            label = "Wait on Transforms:OneTime/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
+                            label = "Wait on Transforms:Recurring/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
                             547 [label="ParMultiDo(VoidKeyToMultimapMaterialization)"]
                             543 -> 547 [style=solid label=""]
                         }
@@ -1481,9 +1481,9 @@ digraph {
                 }
             }
             subgraph cluster_549 {
-                label = "Wait on Transforms:OneTime/Wait"
+                label = "Wait on Transforms:Recurring/Wait"
                 subgraph cluster_550 {
-                    label = "Wait on Transforms:OneTime/Wait/Map"
+                    label = "Wait on Transforms:Recurring/Wait/Map"
                     551 [label="ParMultiDo(Anonymous)"]
                     89 -> 551 [style=solid label=""]
                     547 -> 551 [style=dashed label=""]
@@ -1491,88 +1491,88 @@ digraph {
             }
         }
         subgraph cluster_552 {
-            label = "Write to Sql: Transforms:Cancellation"
+            label = "Write to Sql: Transforms:OneTime"
             subgraph cluster_553 {
-                label = "Write to Sql: Transforms:Cancellation/Shard data Transforms:Cancellation"
+                label = "Write to Sql: Transforms:OneTime/Shard data Transforms:OneTime"
                 subgraph cluster_554 {
-                    label = "Write to Sql: Transforms:Cancellation/Shard data Transforms:Cancellation/AddKeys"
+                    label = "Write to Sql: Transforms:OneTime/Shard data Transforms:OneTime/AddKeys"
                     subgraph cluster_555 {
-                        label = "Write to Sql: Transforms:Cancellation/Shard data Transforms:Cancellation/AddKeys/Map"
+                        label = "Write to Sql: Transforms:OneTime/Shard data Transforms:OneTime/AddKeys/Map"
                         556 [label="ParMultiDo(Anonymous)"]
                         551 -> 556 [style=solid label=""]
                     }
                 }
             }
             subgraph cluster_557 {
-                label = "Write to Sql: Transforms:Cancellation/Group into batches Transforms:Cancellation"
+                label = "Write to Sql: Transforms:OneTime/Group into batches Transforms:OneTime"
                 subgraph cluster_558 {
-                    label = "Write to Sql: Transforms:Cancellation/Group into batches Transforms:Cancellation/MapElements"
+                    label = "Write to Sql: Transforms:OneTime/Group into batches Transforms:OneTime/MapElements"
                     subgraph cluster_559 {
-                        label = "Write to Sql: Transforms:Cancellation/Group into batches Transforms:Cancellation/MapElements/Map"
+                        label = "Write to Sql: Transforms:OneTime/Group into batches Transforms:OneTime/MapElements/Map"
                         560 [label="ParMultiDo(Anonymous)"]
                         556 -> 560 [style=solid label=""]
                     }
                 }
                 subgraph cluster_561 {
-                    label = "Write to Sql: Transforms:Cancellation/Group into batches Transforms:Cancellation/ParDo(GroupIntoBatches)"
+                    label = "Write to Sql: Transforms:OneTime/Group into batches Transforms:OneTime/ParDo(GroupIntoBatches)"
                     562 [label="ParMultiDo(GroupIntoBatches)"]
                     560 -> 562 [style=solid label=""]
                 }
             }
             subgraph cluster_563 {
-                label = "Write to Sql: Transforms:Cancellation/Write in batch for Transforms:Cancellation"
+                label = "Write to Sql: Transforms:OneTime/Write in batch for Transforms:OneTime"
                 564 [label="ParMultiDo(SqlBatchWriter)"]
                 562 -> 564 [style=solid label=""]
             }
         }
         subgraph cluster_565 {
-            label = "Wait on Transforms:Cancellation"
+            label = "Wait on Transforms:OneTime"
             subgraph cluster_566 {
-                label = "Wait on Transforms:Cancellation/To wait view 0"
+                label = "Wait on Transforms:OneTime/To wait view 0"
                 subgraph cluster_567 {
-                    label = "Wait on Transforms:Cancellation/To wait view 0/Window.Into()"
+                    label = "Wait on Transforms:OneTime/To wait view 0/Window.Into()"
                     568 [label="Flatten.PCollections"]
                     564 -> 568 [style=solid label=""]
                 }
                 subgraph cluster_569 {
-                    label = "Wait on Transforms:Cancellation/To wait view 0/ParDo(CollectWindows)"
+                    label = "Wait on Transforms:OneTime/To wait view 0/ParDo(CollectWindows)"
                     570 [label="ParMultiDo(CollectWindows)"]
                     568 -> 570 [style=solid label=""]
                 }
                 subgraph cluster_571 {
-                    label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any"
+                    label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any"
                     subgraph cluster_572 {
-                        label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
+                        label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
                         subgraph cluster_573 {
-                            label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
+                            label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
                             subgraph cluster_574 {
-                                label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
+                                label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
                                 subgraph cluster_575 {
-                                    label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
+                                    label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
                                     576 [label="ParMultiDo(Anonymous)"]
                                     570 -> 576 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_577 {
-                            label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
+                            label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
                             578 [label="GroupByKey"]
                             576 -> 578 [style=solid label=""]
                             subgraph cluster_579 {
-                                label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
+                                label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
                                 subgraph cluster_580 {
-                                    label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
+                                    label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
                                     581 [label="ParMultiDo(Anonymous)"]
                                     578 -> 581 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_582 {
-                            label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
+                            label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
                             subgraph cluster_583 {
-                                label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
+                                label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
                                 subgraph cluster_584 {
-                                    label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
+                                    label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
                                     585 [label="ParMultiDo(Anonymous)"]
                                     581 -> 585 [style=solid label=""]
                                 }
@@ -1580,11 +1580,11 @@ digraph {
                         }
                     }
                     subgraph cluster_586 {
-                        label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Flatten.Iterables"
+                        label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Flatten.Iterables"
                         subgraph cluster_587 {
-                            label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
+                            label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
                             subgraph cluster_588 {
-                                label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
+                                label = "Wait on Transforms:OneTime/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
                                 589 [label="ParMultiDo(Anonymous)"]
                                 585 -> 589 [style=solid label=""]
                             }
@@ -1592,11 +1592,11 @@ digraph {
                     }
                 }
                 subgraph cluster_590 {
-                    label = "Wait on Transforms:Cancellation/To wait view 0/View.AsList"
+                    label = "Wait on Transforms:OneTime/To wait view 0/View.AsList"
                     subgraph cluster_591 {
-                        label = "Wait on Transforms:Cancellation/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
+                        label = "Wait on Transforms:OneTime/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
                         subgraph cluster_592 {
-                            label = "Wait on Transforms:Cancellation/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
+                            label = "Wait on Transforms:OneTime/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
                             593 [label="ParMultiDo(VoidKeyToMultimapMaterialization)"]
                             589 -> 593 [style=solid label=""]
                         }
@@ -1606,9 +1606,9 @@ digraph {
                 }
             }
             subgraph cluster_595 {
-                label = "Wait on Transforms:Cancellation/Wait"
+                label = "Wait on Transforms:OneTime/Wait"
                 subgraph cluster_596 {
-                    label = "Wait on Transforms:Cancellation/Wait/Map"
+                    label = "Wait on Transforms:OneTime/Wait/Map"
                     597 [label="ParMultiDo(Anonymous)"]
                     89 -> 597 [style=solid label=""]
                     593 -> 597 [style=dashed label=""]
@@ -1616,88 +1616,88 @@ digraph {
             }
         }
         subgraph cluster_598 {
-            label = "Write to Sql: Transforms:PollMessage"
+            label = "Write to Sql: Transforms:Cancellation"
             subgraph cluster_599 {
-                label = "Write to Sql: Transforms:PollMessage/Shard data Transforms:PollMessage"
+                label = "Write to Sql: Transforms:Cancellation/Shard data Transforms:Cancellation"
                 subgraph cluster_600 {
-                    label = "Write to Sql: Transforms:PollMessage/Shard data Transforms:PollMessage/AddKeys"
+                    label = "Write to Sql: Transforms:Cancellation/Shard data Transforms:Cancellation/AddKeys"
                     subgraph cluster_601 {
-                        label = "Write to Sql: Transforms:PollMessage/Shard data Transforms:PollMessage/AddKeys/Map"
+                        label = "Write to Sql: Transforms:Cancellation/Shard data Transforms:Cancellation/AddKeys/Map"
                         602 [label="ParMultiDo(Anonymous)"]
                         597 -> 602 [style=solid label=""]
                     }
                 }
             }
             subgraph cluster_603 {
-                label = "Write to Sql: Transforms:PollMessage/Group into batches Transforms:PollMessage"
+                label = "Write to Sql: Transforms:Cancellation/Group into batches Transforms:Cancellation"
                 subgraph cluster_604 {
-                    label = "Write to Sql: Transforms:PollMessage/Group into batches Transforms:PollMessage/MapElements"
+                    label = "Write to Sql: Transforms:Cancellation/Group into batches Transforms:Cancellation/MapElements"
                     subgraph cluster_605 {
-                        label = "Write to Sql: Transforms:PollMessage/Group into batches Transforms:PollMessage/MapElements/Map"
+                        label = "Write to Sql: Transforms:Cancellation/Group into batches Transforms:Cancellation/MapElements/Map"
                         606 [label="ParMultiDo(Anonymous)"]
                         602 -> 606 [style=solid label=""]
                     }
                 }
                 subgraph cluster_607 {
-                    label = "Write to Sql: Transforms:PollMessage/Group into batches Transforms:PollMessage/ParDo(GroupIntoBatches)"
+                    label = "Write to Sql: Transforms:Cancellation/Group into batches Transforms:Cancellation/ParDo(GroupIntoBatches)"
                     608 [label="ParMultiDo(GroupIntoBatches)"]
                     606 -> 608 [style=solid label=""]
                 }
             }
             subgraph cluster_609 {
-                label = "Write to Sql: Transforms:PollMessage/Write in batch for Transforms:PollMessage"
+                label = "Write to Sql: Transforms:Cancellation/Write in batch for Transforms:Cancellation"
                 610 [label="ParMultiDo(SqlBatchWriter)"]
                 608 -> 610 [style=solid label=""]
             }
         }
         subgraph cluster_611 {
-            label = "Wait on Transforms:PollMessage"
+            label = "Wait on Transforms:Cancellation"
             subgraph cluster_612 {
-                label = "Wait on Transforms:PollMessage/To wait view 0"
+                label = "Wait on Transforms:Cancellation/To wait view 0"
                 subgraph cluster_613 {
-                    label = "Wait on Transforms:PollMessage/To wait view 0/Window.Into()"
+                    label = "Wait on Transforms:Cancellation/To wait view 0/Window.Into()"
                     614 [label="Flatten.PCollections"]
                     610 -> 614 [style=solid label=""]
                 }
                 subgraph cluster_615 {
-                    label = "Wait on Transforms:PollMessage/To wait view 0/ParDo(CollectWindows)"
+                    label = "Wait on Transforms:Cancellation/To wait view 0/ParDo(CollectWindows)"
                     616 [label="ParMultiDo(CollectWindows)"]
                     614 -> 616 [style=solid label=""]
                 }
                 subgraph cluster_617 {
-                    label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any"
+                    label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any"
                     subgraph cluster_618 {
-                        label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
+                        label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
                         subgraph cluster_619 {
-                            label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
+                            label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
                             subgraph cluster_620 {
-                                label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
+                                label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
                                 subgraph cluster_621 {
-                                    label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
+                                    label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
                                     622 [label="ParMultiDo(Anonymous)"]
                                     616 -> 622 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_623 {
-                            label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
+                            label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
                             624 [label="GroupByKey"]
                             622 -> 624 [style=solid label=""]
                             subgraph cluster_625 {
-                                label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
+                                label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
                                 subgraph cluster_626 {
-                                    label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
+                                    label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
                                     627 [label="ParMultiDo(Anonymous)"]
                                     624 -> 627 [style=solid label=""]
                                 }
                             }
                         }
                         subgraph cluster_628 {
-                            label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
+                            label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
                             subgraph cluster_629 {
-                                label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
+                                label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
                                 subgraph cluster_630 {
-                                    label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
+                                    label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
                                     631 [label="ParMultiDo(Anonymous)"]
                                     627 -> 631 [style=solid label=""]
                                 }
@@ -1705,11 +1705,11 @@ digraph {
                         }
                     }
                     subgraph cluster_632 {
-                        label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Flatten.Iterables"
+                        label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Flatten.Iterables"
                         subgraph cluster_633 {
-                            label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
+                            label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
                             subgraph cluster_634 {
-                                label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
+                                label = "Wait on Transforms:Cancellation/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
                                 635 [label="ParMultiDo(Anonymous)"]
                                 631 -> 635 [style=solid label=""]
                             }
@@ -1717,11 +1717,11 @@ digraph {
                     }
                 }
                 subgraph cluster_636 {
-                    label = "Wait on Transforms:PollMessage/To wait view 0/View.AsList"
+                    label = "Wait on Transforms:Cancellation/To wait view 0/View.AsList"
                     subgraph cluster_637 {
-                        label = "Wait on Transforms:PollMessage/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
+                        label = "Wait on Transforms:Cancellation/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
                         subgraph cluster_638 {
-                            label = "Wait on Transforms:PollMessage/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
+                            label = "Wait on Transforms:Cancellation/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
                             639 [label="ParMultiDo(VoidKeyToMultimapMaterialization)"]
                             635 -> 639 [style=solid label=""]
                         }
@@ -1731,9 +1731,9 @@ digraph {
                 }
             }
             subgraph cluster_641 {
-                label = "Wait on Transforms:PollMessage/Wait"
+                label = "Wait on Transforms:Cancellation/Wait"
                 subgraph cluster_642 {
-                    label = "Wait on Transforms:PollMessage/Wait/Map"
+                    label = "Wait on Transforms:Cancellation/Wait/Map"
                     643 [label="ParMultiDo(Anonymous)"]
                     89 -> 643 [style=solid label=""]
                     639 -> 643 [style=dashed label=""]
@@ -1741,38 +1741,163 @@ digraph {
             }
         }
         subgraph cluster_644 {
-            label = "Write to Sql: Transforms:DomainBase"
+            label = "Write to Sql: Transforms:PollMessage"
             subgraph cluster_645 {
-                label = "Write to Sql: Transforms:DomainBase/Shard data Transforms:DomainBase"
+                label = "Write to Sql: Transforms:PollMessage/Shard data Transforms:PollMessage"
                 subgraph cluster_646 {
-                    label = "Write to Sql: Transforms:DomainBase/Shard data Transforms:DomainBase/AddKeys"
+                    label = "Write to Sql: Transforms:PollMessage/Shard data Transforms:PollMessage/AddKeys"
                     subgraph cluster_647 {
-                        label = "Write to Sql: Transforms:DomainBase/Shard data Transforms:DomainBase/AddKeys/Map"
+                        label = "Write to Sql: Transforms:PollMessage/Shard data Transforms:PollMessage/AddKeys/Map"
                         648 [label="ParMultiDo(Anonymous)"]
                         643 -> 648 [style=solid label=""]
                     }
                 }
             }
             subgraph cluster_649 {
-                label = "Write to Sql: Transforms:DomainBase/Group into batches Transforms:DomainBase"
+                label = "Write to Sql: Transforms:PollMessage/Group into batches Transforms:PollMessage"
                 subgraph cluster_650 {
-                    label = "Write to Sql: Transforms:DomainBase/Group into batches Transforms:DomainBase/MapElements"
+                    label = "Write to Sql: Transforms:PollMessage/Group into batches Transforms:PollMessage/MapElements"
                     subgraph cluster_651 {
-                        label = "Write to Sql: Transforms:DomainBase/Group into batches Transforms:DomainBase/MapElements/Map"
+                        label = "Write to Sql: Transforms:PollMessage/Group into batches Transforms:PollMessage/MapElements/Map"
                         652 [label="ParMultiDo(Anonymous)"]
                         648 -> 652 [style=solid label=""]
                     }
                 }
                 subgraph cluster_653 {
-                    label = "Write to Sql: Transforms:DomainBase/Group into batches Transforms:DomainBase/ParDo(GroupIntoBatches)"
+                    label = "Write to Sql: Transforms:PollMessage/Group into batches Transforms:PollMessage/ParDo(GroupIntoBatches)"
                     654 [label="ParMultiDo(GroupIntoBatches)"]
                     652 -> 654 [style=solid label=""]
                 }
             }
             subgraph cluster_655 {
-                label = "Write to Sql: Transforms:DomainBase/Write in batch for Transforms:DomainBase"
+                label = "Write to Sql: Transforms:PollMessage/Write in batch for Transforms:PollMessage"
                 656 [label="ParMultiDo(SqlBatchWriter)"]
                 654 -> 656 [style=solid label=""]
+            }
+        }
+        subgraph cluster_657 {
+            label = "Wait on Transforms:PollMessage"
+            subgraph cluster_658 {
+                label = "Wait on Transforms:PollMessage/To wait view 0"
+                subgraph cluster_659 {
+                    label = "Wait on Transforms:PollMessage/To wait view 0/Window.Into()"
+                    660 [label="Flatten.PCollections"]
+                    656 -> 660 [style=solid label=""]
+                }
+                subgraph cluster_661 {
+                    label = "Wait on Transforms:PollMessage/To wait view 0/ParDo(CollectWindows)"
+                    662 [label="ParMultiDo(CollectWindows)"]
+                    660 -> 662 [style=solid label=""]
+                }
+                subgraph cluster_663 {
+                    label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any"
+                    subgraph cluster_664 {
+                        label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)"
+                        subgraph cluster_665 {
+                            label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys"
+                            subgraph cluster_666 {
+                                label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys"
+                                subgraph cluster_667 {
+                                    label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/WithKeys/AddKeys/Map"
+                                    668 [label="ParMultiDo(Anonymous)"]
+                                    662 -> 668 [style=solid label=""]
+                                }
+                            }
+                        }
+                        subgraph cluster_669 {
+                            label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)"
+                            670 [label="GroupByKey"]
+                            668 -> 670 [style=solid label=""]
+                            subgraph cluster_671 {
+                                label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues"
+                                subgraph cluster_672 {
+                                    label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Combine.perKey(SampleAny)/Combine.GroupedValues/ParDo(Anonymous)"
+                                    673 [label="ParMultiDo(Anonymous)"]
+                                    670 -> 673 [style=solid label=""]
+                                }
+                            }
+                        }
+                        subgraph cluster_674 {
+                            label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values"
+                            subgraph cluster_675 {
+                                label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values"
+                                subgraph cluster_676 {
+                                    label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Combine.globally(SampleAny)/Values/Values/Map"
+                                    677 [label="ParMultiDo(Anonymous)"]
+                                    673 -> 677 [style=solid label=""]
+                                }
+                            }
+                        }
+                    }
+                    subgraph cluster_678 {
+                        label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Flatten.Iterables"
+                        subgraph cluster_679 {
+                            label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables"
+                            subgraph cluster_680 {
+                                label = "Wait on Transforms:PollMessage/To wait view 0/Sample.Any/Flatten.Iterables/FlattenIterables/FlatMap"
+                                681 [label="ParMultiDo(Anonymous)"]
+                                677 -> 681 [style=solid label=""]
+                            }
+                        }
+                    }
+                }
+                subgraph cluster_682 {
+                    label = "Wait on Transforms:PollMessage/To wait view 0/View.AsList"
+                    subgraph cluster_683 {
+                        label = "Wait on Transforms:PollMessage/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization"
+                        subgraph cluster_684 {
+                            label = "Wait on Transforms:PollMessage/To wait view 0/View.AsList/View.VoidKeyToMultimapMaterialization/ParDo(VoidKeyToMultimapMaterialization)"
+                            685 [label="ParMultiDo(VoidKeyToMultimapMaterialization)"]
+                            681 -> 685 [style=solid label=""]
+                        }
+                    }
+                    686 [label="View.CreatePCollectionView"]
+                    685 -> 686 [style=solid label=""]
+                }
+            }
+            subgraph cluster_687 {
+                label = "Wait on Transforms:PollMessage/Wait"
+                subgraph cluster_688 {
+                    label = "Wait on Transforms:PollMessage/Wait/Map"
+                    689 [label="ParMultiDo(Anonymous)"]
+                    89 -> 689 [style=solid label=""]
+                    685 -> 689 [style=dashed label=""]
+                }
+            }
+        }
+        subgraph cluster_690 {
+            label = "Write to Sql: Transforms:DomainBase"
+            subgraph cluster_691 {
+                label = "Write to Sql: Transforms:DomainBase/Shard data Transforms:DomainBase"
+                subgraph cluster_692 {
+                    label = "Write to Sql: Transforms:DomainBase/Shard data Transforms:DomainBase/AddKeys"
+                    subgraph cluster_693 {
+                        label = "Write to Sql: Transforms:DomainBase/Shard data Transforms:DomainBase/AddKeys/Map"
+                        694 [label="ParMultiDo(Anonymous)"]
+                        689 -> 694 [style=solid label=""]
+                    }
+                }
+            }
+            subgraph cluster_695 {
+                label = "Write to Sql: Transforms:DomainBase/Group into batches Transforms:DomainBase"
+                subgraph cluster_696 {
+                    label = "Write to Sql: Transforms:DomainBase/Group into batches Transforms:DomainBase/MapElements"
+                    subgraph cluster_697 {
+                        label = "Write to Sql: Transforms:DomainBase/Group into batches Transforms:DomainBase/MapElements/Map"
+                        698 [label="ParMultiDo(Anonymous)"]
+                        694 -> 698 [style=solid label=""]
+                    }
+                }
+                subgraph cluster_699 {
+                    label = "Write to Sql: Transforms:DomainBase/Group into batches Transforms:DomainBase/ParDo(GroupIntoBatches)"
+                    700 [label="ParMultiDo(GroupIntoBatches)"]
+                    698 -> 700 [style=solid label=""]
+                }
+            }
+            subgraph cluster_701 {
+                label = "Write to Sql: Transforms:DomainBase/Write in batch for Transforms:DomainBase"
+                702 [label="ParMultiDo(SqlBatchWriter)"]
+                700 -> 702 [style=solid label=""]
             }
         }
     }


### PR DESCRIPTION
The test for this also required a bit of a fix in the Cursor scope
initialization. If you persist a Key<?> in some object in Datastore, it
persists just the standard data you'd expect, basically the parent, the
kind, and the object's ID/name. Then, when you load it back in from
Datastore it uses the app ID of whatever environment you're loading in
(the Key contains this info even though it isn't included in the
toString() of Key)

If you persist the websafe string format of a Key (which is what we do
for Cursors), it includes the app ID so when you load it, it contains
the old app ID not the new one (if the app ID has changed).

In the pipelines, we use the standard default environment which has a
different app ID from the test environment that's set up by the
DatastoreEntityExtension.

As a result, we should check in Cursor to see if the key is *any*
cross-tld-key, rather than the exact one that exists within this app
environment.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1323)
<!-- Reviewable:end -->
