### PR TITLE
Clean up a few lint warnings

### DIFF
--- a/core/src/main/java/google/registry/flows/certs/CertificateChecker.java
+++ b/core/src/main/java/google/registry/flows/certs/CertificateChecker.java
@@ -243,7 +243,7 @@ public class CertificateChecker {
      *    lastExpiringNotificationSentDate is greater than expirationWarningIntervalDays.
      */
     return !lastValidDate.after(now.plusDays(expirationWarningDays).toDate())
-        && (lastExpiringNotificationSentDate == START_OF_TIME
+        && (lastExpiringNotificationSentDate.equals(START_OF_TIME)
             || !lastExpiringNotificationSentDate
                 .plusDays(expirationWarningIntervalDays)
                 .toDate()

--- a/core/src/test/java/google/registry/backup/ReplayCommitLogsToSqlActionTest.java
+++ b/core/src/test/java/google/registry/backup/ReplayCommitLogsToSqlActionTest.java
@@ -347,7 +347,7 @@ public class ReplayCommitLogsToSqlActionTest {
         mutation);
     runAndAssertSuccess(persistenceTime.minusMinutes(1), 1, 1);
     assertAboutImmutableObjects()
-        .that(jpaTm().transact((() -> jpaTm().loadByEntity(contactResource))))
+        .that(jpaTm().transact(() -> jpaTm().loadByEntity(contactResource)))
         .isEqualExceptFields(contactResource, "revisions");
   }
 


### PR DESCRIPTION
The build is generating the following lint warnings:

core/src/main/java/google/registry/flows/certs/CertificateChecker.java:246:
warning: [ReferenceEquality] Compariso
n using reference equality instead of value equality
        && (lastExpiringNotificationSentDate == START_OF_TIME
                                             ^
    (see https://errorprone.info/bugpattern/ReferenceEquality)
core/src/test/java/google/registry/backup/ReplayCommitLogsToSqlActionTest.java:350:
warning: [UnnecessaryParenthes
es] These grouping parentheses are unnecessary; it is unlikely the code will
be misinterpreted without them
        .that(jpaTm().transact((() -> jpaTm().loadByEntity(contactResource))))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1324)
<!-- Reviewable:end -->
