### PR TITLE
Clean up tx manager insert() signature and add convenience helper method

### DIFF
--- a/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
+++ b/core/src/main/java/google/registry/model/ofy/DatastoreTransactionManager.java
@@ -32,6 +32,7 @@ import com.google.common.collect.Streams;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.Result;
 import com.googlecode.objectify.cmd.Query;
+import google.registry.model.ImmutableObject;
 import google.registry.model.annotations.InCrossTld;
 import google.registry.model.contact.ContactHistory;
 import google.registry.model.domain.DomainHistory;
@@ -128,6 +129,11 @@ public class DatastoreTransactionManager implements TransactionManager {
   }
 
   @Override
+  public void insertAll(ImmutableObject... entities) {
+    putAll(entities);
+  }
+
+  @Override
   public void insertWithoutBackup(Object entity) {
     putWithoutBackup(entity);
   }
@@ -143,7 +149,7 @@ public class DatastoreTransactionManager implements TransactionManager {
   }
 
   @Override
-  public void putAll(Object... entities) {
+  public void putAll(ImmutableObject... entities) {
     syncIfTransactionless(
         getOfy().save().entities(toDatastoreEntities(ImmutableList.copyOf(entities))));
   }

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -313,6 +313,11 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   }
 
   @Override
+  public void insertAll(ImmutableObject... entities) {
+    insertAll(ImmutableSet.copyOf(entities));
+  }
+
+  @Override
   public void insertWithoutBackup(Object entity) {
     insert(entity);
   }
@@ -335,7 +340,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   }
 
   @Override
-  public void putAll(Object... entities) {
+  public void putAll(ImmutableObject... entities) {
     checkArgumentNotNull(entities, "entities must be specified");
     assertInTransaction();
     for (Object entity : entities) {

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
@@ -17,6 +17,7 @@ package google.registry.persistence.transaction;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import google.registry.model.ImmutableObject;
 import google.registry.model.annotations.InCrossTld;
 import google.registry.persistence.VKey;
 import java.util.NoSuchElementException;
@@ -97,6 +98,9 @@ public interface TransactionManager {
   /** Persists all new entities in the database, throws exception if any entity already exists. */
   void insertAll(ImmutableCollection<?> entities);
 
+  /** Persists all new entities in the database, throws exception if any entity already exists. */
+  void insertAll(ImmutableObject... entities);
+
   /**
    * Persists a new entity in the database without writing any backup if the underlying database is
    * Datastore.
@@ -125,7 +129,7 @@ public interface TransactionManager {
   void put(Object entity);
 
   /** Persists all new entities or updates the existing entities in the database. */
-  void putAll(Object... entities);
+  void putAll(ImmutableObject... entities);
 
   /** Persists all new entities or updates the existing entities in the database. */
   void putAll(ImmutableCollection<?> entities);

--- a/core/src/test/java/google/registry/beam/common/RegistryJpaReadTest.java
+++ b/core/src/test/java/google/registry/beam/common/RegistryJpaReadTest.java
@@ -16,6 +16,7 @@ package google.registry.beam.common;
 
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.testing.AppEngineExtension.makeRegistrar1;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.newRegistry;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
@@ -210,7 +211,6 @@ public class RegistryJpaReadTest {
                     null,
                     100L))
             .build();
-    jpaTm()
-        .transact(() -> jpaTm().insertAll(ImmutableList.of(registry, registrar, contact, domain)));
+    insertInDb(registry, registrar, contact, domain);
   }
 }

--- a/core/src/test/java/google/registry/model/contact/ContactResourceTest.java
+++ b/core/src/test/java/google/registry/model/contact/ContactResourceTest.java
@@ -22,6 +22,7 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.testing.ContactResourceSubject.assertAboutContacts;
 import static google.registry.testing.DatabaseHelper.cloneAndSetAutoTimestamps;
 import static google.registry.testing.DatabaseHelper.createTld;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.SqlHelper.assertThrowForeignKeyViolation;
 import static google.registry.testing.SqlHelper.saveRegistrar;
@@ -136,7 +137,7 @@ public class ContactResourceTest extends EntityTestCase {
 
   @Test
   void testCloudSqlPersistence_failWhenViolateForeignKeyConstraint() {
-    assertThrowForeignKeyViolation(() -> jpaTm().transact(() -> jpaTm().insert(originalContact)));
+    assertThrowForeignKeyViolation(() -> insertInDb(originalContact));
   }
 
   @Test
@@ -146,7 +147,7 @@ public class ContactResourceTest extends EntityTestCase {
     saveRegistrar("registrar3");
     saveRegistrar("gaining");
     saveRegistrar("losing");
-    jpaTm().transact(() -> jpaTm().insert(originalContact));
+    insertInDb(originalContact);
     ContactResource persisted =
         jpaTm()
             .transact(

--- a/core/src/test/java/google/registry/model/history/ContactHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/ContactHistoryTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.newContactResource;
 import static google.registry.testing.DatabaseHelper.newContactResourceWithRoid;
 import static google.registry.testing.SqlHelper.saveRegistrar;
@@ -45,11 +46,11 @@ public class ContactHistoryTest extends EntityTestCase {
     saveRegistrar("TheRegistrar");
 
     ContactResource contact = newContactResourceWithRoid("contactId", "contact1");
-    jpaTm().transact(() -> jpaTm().insert(contact));
+    insertInDb(contact);
     VKey<ContactResource> contactVKey = contact.createVKey();
     ContactResource contactFromDb = jpaTm().transact(() -> jpaTm().loadByKey(contactVKey));
     ContactHistory contactHistory = createContactHistory(contactFromDb);
-    jpaTm().transact(() -> jpaTm().insert(contactHistory));
+    insertInDb(contactHistory);
     jpaTm()
         .transact(
             () -> {
@@ -64,12 +65,12 @@ public class ContactHistoryTest extends EntityTestCase {
     saveRegistrar("TheRegistrar");
 
     ContactResource contact = newContactResourceWithRoid("contactId", "contact1");
-    jpaTm().transact(() -> jpaTm().insert(contact));
+    insertInDb(contact);
     VKey<ContactResource> contactVKey = contact.createVKey();
     ContactResource contactFromDb = jpaTm().transact(() -> jpaTm().loadByKey(contactVKey));
     ContactHistory contactHistory =
         createContactHistory(contactFromDb).asBuilder().setContact(null).build();
-    jpaTm().transact(() -> jpaTm().insert(contactHistory));
+    insertInDb(contactHistory);
 
     jpaTm()
         .transact(

--- a/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
@@ -22,6 +22,7 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.AppEngineExtension.makeRegistrar2;
 import static google.registry.testing.DatabaseHelper.createTld;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.newContactResourceWithRoid;
 import static google.registry.testing.DatabaseHelper.newDomainBase;
 import static google.registry.testing.DatabaseHelper.newHostResourceWithRoid;
@@ -74,7 +75,7 @@ public class DomainHistoryTest extends EntityTestCase {
   void testPersistence() {
     DomainBase domain = addGracePeriodForSql(createDomainWithContactsAndHosts());
     DomainHistory domainHistory = createDomainHistory(domain);
-    jpaTm().transact(() -> jpaTm().insert(domainHistory));
+    insertInDb(domainHistory);
 
     jpaTm()
         .transact(
@@ -89,7 +90,7 @@ public class DomainHistoryTest extends EntityTestCase {
   void testLegacyPersistence_nullResource() {
     DomainBase domain = addGracePeriodForSql(createDomainWithContactsAndHosts());
     DomainHistory domainHistory = createDomainHistory(domain).asBuilder().setDomain(null).build();
-    jpaTm().transact(() -> jpaTm().insert(domainHistory));
+    insertInDb(domainHistory);
 
     jpaTm()
         .transact(
@@ -175,7 +176,7 @@ public class DomainHistoryTest extends EntityTestCase {
             .setNameservers(host.createVKey())
             .build();
     tm().transact(() -> tm().insert(domain));
-    jpaTm().transact(() -> jpaTm().insert(domain));
+    insertInDb(domain);
 
     DomainHistory domainHistory = createDomainHistory(domain);
     tm().transact(() -> tm().insert(domainHistory));
@@ -185,7 +186,7 @@ public class DomainHistoryTest extends EntityTestCase {
     DomainHistory domainHistoryFromDb = tm().transact(() -> tm().loadByKey(domainHistoryVKey));
 
     // attempt to write to SQL.
-    jpaTm().transact(() -> jpaTm().insert(domainHistoryFromDb));
+    insertInDb(domainHistoryFromDb);
 
     // Reload and rewrite.
     DomainHistory domainHistoryFromDb2 = tm().transact(() -> tm().loadByKey(domainHistoryVKey));
@@ -249,7 +250,7 @@ public class DomainHistoryTest extends EntityTestCase {
             .setDsData(ImmutableSet.of(DelegationSignerData.create(1, 2, 3, new byte[] {0, 1, 2})))
             .setDnsRefreshRequestTime(Optional.of(DateTime.parse("2020-03-09T16:40:00Z")))
             .build();
-    jpaTm().transact(() -> jpaTm().insert(domain));
+    insertInDb(domain);
     return domain;
   }
 

--- a/core/src/test/java/google/registry/model/history/HostHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/HostHistoryTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.newHostResource;
 import static google.registry.testing.DatabaseHelper.newHostResourceWithRoid;
 import static google.registry.testing.SqlHelper.saveRegistrar;
@@ -45,12 +46,12 @@ public class HostHistoryTest extends EntityTestCase {
     saveRegistrar("TheRegistrar");
 
     HostResource host = newHostResourceWithRoid("ns1.example.com", "host1");
-    jpaTm().transact(() -> jpaTm().insert(host));
+    insertInDb(host);
     VKey<HostResource> hostVKey =
         VKey.create(HostResource.class, "host1", Key.create(HostResource.class, "host1"));
     HostResource hostFromDb = jpaTm().transact(() -> jpaTm().loadByKey(hostVKey));
     HostHistory hostHistory = createHostHistory(hostFromDb);
-    jpaTm().transact(() -> jpaTm().insert(hostHistory));
+    insertInDb(hostHistory);
     jpaTm()
         .transact(
             () -> {
@@ -64,11 +65,11 @@ public class HostHistoryTest extends EntityTestCase {
   void testLegacyPersistence_nullHostBase() {
     saveRegistrar("TheRegistrar");
     HostResource host = newHostResourceWithRoid("ns1.example.com", "host1");
-    jpaTm().transact(() -> jpaTm().insert(host));
+    insertInDb(host);
 
     HostResource hostFromDb = jpaTm().transact(() -> jpaTm().loadByKey(host.createVKey()));
     HostHistory hostHistory = createHostHistory(hostFromDb).asBuilder().setHost(null).build();
-    jpaTm().transact(() -> jpaTm().insert(hostHistory));
+    insertInDb(hostHistory);
 
     jpaTm()
         .transact(

--- a/core/src/test/java/google/registry/model/history/LegacyHistoryObjectTest.java
+++ b/core/src/test/java/google/registry/model/history/LegacyHistoryObjectTest.java
@@ -19,6 +19,7 @@ import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableO
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.ofyTm;
 import static google.registry.testing.DatabaseHelper.createTld;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.newContactResourceWithRoid;
 import static google.registry.testing.DatabaseHelper.newHostResourceWithRoid;
 import static google.registry.util.CollectionUtils.nullToEmpty;
@@ -128,7 +129,7 @@ public class LegacyHistoryObjectTest extends EntityTestCase {
     DomainHistory legacyDomainHistory = (DomainHistory) fromObjectify;
 
     // Next, save that from-Datastore object in SQL and verify we can load it back in
-    jpaTm().transact(() -> jpaTm().insert(legacyDomainHistory));
+    insertInDb(legacyDomainHistory);
     jpaTm()
         .transact(
             () -> {

--- a/core/src/test/java/google/registry/model/poll/PollMessageTest.java
+++ b/core/src/test/java/google/registry/model/poll/PollMessageTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.createTld;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.newDomainBase;
 import static google.registry.testing.DatabaseHelper.persistActiveContact;
 import static google.registry.testing.DatabaseHelper.persistResource;
@@ -92,14 +93,14 @@ public class PollMessageTest extends EntityTestCase {
 
   @TestSqlOnly
   void testCloudSqlSupportForPolymorphicVKey() {
-    jpaTm().transact(() -> jpaTm().insert(oneTime));
+    insertInDb(oneTime);
     PollMessage persistedOneTime =
         jpaTm()
             .transact(() -> jpaTm().loadByKey(VKey.createSql(PollMessage.class, oneTime.getId())));
     assertThat(persistedOneTime).isInstanceOf(PollMessage.OneTime.class);
     assertThat(persistedOneTime).isEqualTo(oneTime);
 
-    jpaTm().transact(() -> jpaTm().insert(autoRenew));
+    insertInDb(autoRenew);
     PollMessage persistedAutoRenew =
         jpaTm()
             .transact(

--- a/core/src/test/java/google/registry/persistence/EntityCallbacksListenerTest.java
+++ b/core/src/test/java/google/registry/persistence/EntityCallbacksListenerTest.java
@@ -18,8 +18,10 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import com.google.common.collect.ImmutableSet;
+import google.registry.model.ImmutableObject;
 import google.registry.persistence.transaction.JpaTestRules;
 import google.registry.persistence.transaction.JpaTestRules.JpaUnitTestExtension;
 import java.lang.reflect.Method;
@@ -49,7 +51,7 @@ class EntityCallbacksListenerTest {
   @Test
   void verifyAllCallbacks_executedExpectedTimes() {
     TestEntity testPersist = new TestEntity();
-    jpaTm().transact(() -> jpaTm().insert(testPersist));
+    insertInDb(testPersist);
     checkAll(testPersist, 1, 0, 0, 0);
 
     TestEntity testUpdate = new TestEntity();
@@ -100,8 +102,7 @@ class EntityCallbacksListenerTest {
 
   @Test
   void verifyCallbacksNotCalledOnCommit() {
-    TestEntity testEntity = new TestEntity();
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(new TestEntity());
 
     TestEntity testLoad =
         jpaTm().transact(() -> jpaTm().loadByKey(VKey.createSql(TestEntity.class, "id")));
@@ -263,7 +264,7 @@ class EntityCallbacksListenerTest {
   }
 
   @MappedSuperclass
-  private static class ParentEntity {
+  private static class ParentEntity extends ImmutableObject {
     @Embedded ParentEmbedded parentEmbedded = new ParentEmbedded();
     @Transient int parentPostLoad = 0;
     @Transient int parentPrePersist = 0;

--- a/core/src/test/java/google/registry/persistence/converter/AllocationTokenStatusTransitionConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/AllocationTokenStatusTransitionConverterTest.java
@@ -19,6 +19,7 @@ import static google.registry.model.domain.token.AllocationToken.TokenStatus.END
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.NOT_STARTED;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.VALID;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
 import com.google.common.collect.ImmutableSortedMap;
@@ -58,7 +59,7 @@ public class AllocationTokenStatusTransitionConverterTest {
         TimedTransitionProperty.fromValueMap(values, TokenStatusTransition.class);
     AllocationTokenStatusTransitionConverterTestEntity testEntity =
         new AllocationTokenStatusTransitionConverterTestEntity(timedTransitionProperty);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     AllocationTokenStatusTransitionConverterTestEntity persisted =
         jpaTm()
             .transact(

--- a/core/src/test/java/google/registry/persistence/converter/BillingCostTransitionConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/BillingCostTransitionConverterTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.joda.money.CurrencyUnit.USD;
 
@@ -53,7 +54,7 @@ public class BillingCostTransitionConverterTest {
     TimedTransitionProperty<Money, BillingCostTransition> timedTransitionProperty =
         TimedTransitionProperty.fromValueMap(values, BillingCostTransition.class);
     TestEntity testEntity = new TestEntity(timedTransitionProperty);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.timedTransitionProperty).containsExactlyEntriesIn(timedTransitionProperty);

--- a/core/src/test/java/google/registry/persistence/converter/BloomFilterConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/BloomFilterConverterTest.java
@@ -17,6 +17,7 @@ import static com.google.common.base.Charsets.US_ASCII;
 import static com.google.common.hash.Funnels.stringFunnel;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.hash.BloomFilter;
@@ -41,7 +42,7 @@ class BloomFilterConverterTest {
     BloomFilter<String> bloomFilter = BloomFilter.create(stringFunnel(US_ASCII), 3);
     ImmutableSet.of("foo", "bar", "baz").forEach(bloomFilter::put);
     TestEntity entity = new TestEntity(bloomFilter);
-    jpaTm().transact(() -> jpaTm().insert(entity));
+    insertInDb(entity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.bloomFilter).isEqualTo(bloomFilter);

--- a/core/src/test/java/google/registry/persistence/converter/CidrAddressBlockListConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/CidrAddressBlockListConverterTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import com.google.common.collect.ImmutableList;
 import google.registry.model.ImmutableObject;
@@ -45,7 +46,7 @@ public class CidrAddressBlockListConverterTest {
             CidrAddressBlock.create("8000::/1"),
             CidrAddressBlock.create("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128"));
     TestEntity testEntity = new TestEntity(addresses);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.addresses).isEqualTo(addresses);

--- a/core/src/test/java/google/registry/persistence/converter/CreateAutoTimestampConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/CreateAutoTimestampConverterTest.java
@@ -15,6 +15,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import google.registry.model.CreateAutoTimestamp;
 import google.registry.model.ImmutableObject;
@@ -45,7 +46,7 @@ public class CreateAutoTimestampConverterTest {
     CreateAutoTimestamp ts = CreateAutoTimestamp.create(DateTime.parse("2019-09-9T11:39:00Z"));
     TestEntity ent = new TestEntity("myinst", ts);
 
-    jpaTm().transact(() -> jpaTm().insert(ent));
+    insertInDb(ent);
     TestEntity result =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "myinst"));
     assertThat(result).isEqualTo(new TestEntity("myinst", ts));
@@ -56,7 +57,7 @@ public class CreateAutoTimestampConverterTest {
     CreateAutoTimestamp ts = CreateAutoTimestamp.create(null);
     TestEntity ent = new TestEntity("autoinit", ts);
 
-    jpaTm().transact(() -> jpaTm().insert(ent));
+    insertInDb(ent);
 
     TestEntity result =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "autoinit"));

--- a/core/src/test/java/google/registry/persistence/converter/CurrencyToBillingConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/CurrencyToBillingConverterTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.ImmutableObject;
@@ -47,7 +48,7 @@ public class CurrencyToBillingConverterTest {
             CurrencyUnit.of("CNY"),
             new BillingAccountEntry(CurrencyUnit.of("CNY"), "accountId2"));
     TestEntity testEntity = new TestEntity(currencyToBilling);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.currencyToBilling).containsExactlyEntriesIn(currencyToBilling);

--- a/core/src/test/java/google/registry/persistence/converter/CurrencyUnitConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/CurrencyUnitConverterTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.model.ImmutableObject;
@@ -39,7 +40,7 @@ public class CurrencyUnitConverterTest {
   @Test
   void roundTripConversion() {
     TestEntity entity = new TestEntity(CurrencyUnit.EUR);
-    jpaTm().transact(() -> jpaTm().insert(entity));
+    insertInDb(entity);
     assertThat(
             jpaTm()
                 .transact(

--- a/core/src/test/java/google/registry/persistence/converter/DatabaseMigrationScheduleTransitionConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/DatabaseMigrationScheduleTransitionConverterTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
 import com.google.common.collect.ImmutableSortedMap;
@@ -59,7 +60,7 @@ public class DatabaseMigrationScheduleTransitionConverterTest {
         TimedTransitionProperty.fromValueMap(values, MigrationStateTransition.class);
     DatabaseMigrationScheduleTransitionConverterTestEntity testEntity =
         new DatabaseMigrationScheduleTransitionConverterTestEntity(timedTransitionProperty);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     DatabaseMigrationScheduleTransitionConverterTestEntity persisted =
         jpaTm()
             .transact(

--- a/core/src/test/java/google/registry/persistence/converter/DateTimeConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/DateTimeConverterTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import google.registry.model.ImmutableObject;
 import google.registry.persistence.transaction.JpaTestRules;
@@ -69,7 +70,7 @@ public class DateTimeConverterTest {
   void converter_generatesTimestampWithNormalizedZone() {
     DateTime dt = parseDateTime("2019-09-01T01:01:01Z");
     TestEntity entity = new TestEntity("normalized_utc_time", dt);
-    jpaTm().transact(() -> jpaTm().insert(entity));
+    insertInDb(entity);
     TestEntity retrievedEntity =
         jpaTm()
             .transact(
@@ -82,7 +83,7 @@ public class DateTimeConverterTest {
     DateTime dt = parseDateTime("2019-09-01T01:01:01-05:00");
     TestEntity entity = new TestEntity("new_york_time", dt);
 
-    jpaTm().transact(() -> jpaTm().insert(entity));
+    insertInDb(entity);
     TestEntity retrievedEntity =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "new_york_time"));
     assertThat(retrievedEntity.dt.toString()).isEqualTo("2019-09-01T06:01:01.000Z");

--- a/core/src/test/java/google/registry/persistence/converter/DurationConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/DurationConverterTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import google.registry.model.ImmutableObject;
 import google.registry.model.replay.EntityTest.EntityForTesting;
@@ -78,7 +79,7 @@ public class DurationConverterTest {
 
   private void assertPersistedEntityHasSameDuration(Duration duration) {
     DurationTestEntity entity = new DurationTestEntity(duration);
-    jpaTm().transact(() -> jpaTm().insert(entity));
+    insertInDb(entity);
     DurationTestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(DurationTestEntity.class, "id"));
     assertThat(persisted.duration.getMillis()).isEqualTo(duration.getMillis());

--- a/core/src/test/java/google/registry/persistence/converter/InetAddressSetConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/InetAddressSetConverterTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.InetAddresses;
@@ -63,7 +64,7 @@ public class InetAddressSetConverterTest {
 
   private void verifySaveAndLoad(@Nullable Set<InetAddress> inetAddresses) {
     InetAddressSetTestEntity testEntity = new InetAddressSetTestEntity(inetAddresses);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     InetAddressSetTestEntity persisted =
         jpaTm()
             .transact(

--- a/core/src/test/java/google/registry/persistence/converter/JodaMoneyConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/JodaMoneyConverterTest.java
@@ -15,6 +15,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.ImmutableObject;
@@ -71,7 +72,7 @@ public class JodaMoneyConverterTest {
   void roundTripConversion() {
     Money money = Money.of(CurrencyUnit.USD, 100);
     TestEntity entity = new TestEntity(money);
-    jpaTm().transact(() -> jpaTm().insert(entity));
+    insertInDb(entity);
     List<?> result =
         jpaTm()
             .transact(
@@ -101,7 +102,7 @@ public class JodaMoneyConverterTest {
             "dos", Money.ofMajor(CurrencyUnit.JPY, 2000),
             "tres", Money.of(CurrencyUnit.GBP, 20));
     ComplexTestEntity entity = new ComplexTestEntity(moneyMap, myMoney, yourMoney);
-    jpaTm().transact(() -> jpaTm().insert(entity));
+    insertInDb(entity);
     List<?> result =
         jpaTm()
             .transact(

--- a/core/src/test/java/google/registry/persistence/converter/LocalDateConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/LocalDateConverterTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import google.registry.model.ImmutableObject;
 import google.registry.model.replay.EntityTest;
@@ -54,7 +55,7 @@ public class LocalDateConverterTest {
 
   private LocalDateConverterTestEntity persistAndLoadTestEntity(LocalDate date) {
     LocalDateConverterTestEntity entity = new LocalDateConverterTestEntity(date);
-    jpaTm().transact(() -> jpaTm().insert(entity));
+    insertInDb(entity);
     return jpaTm()
         .transact(
             () -> jpaTm().loadByKey(VKey.createSql(LocalDateConverterTestEntity.class, "id")));

--- a/core/src/test/java/google/registry/persistence/converter/LongVKeyConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/LongVKeyConverterTest.java
@@ -16,7 +16,9 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 
+import google.registry.model.ImmutableObject;
 import google.registry.persistence.VKey;
 import google.registry.persistence.WithLongVKey;
 import google.registry.testing.AppEngineExtension;
@@ -46,7 +48,7 @@ public class LongVKeyConverterTest {
         new TestLongEntity(
             VKey.createSql(TestLongEntity.class, 10L),
             VKey.createSql(CompositeKeyTestLongEntity.class, 20L));
-    jpaTm().transact(() -> jpaTm().insert(original));
+    insertInDb(original);
 
     TestLongEntity retrieved =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestLongEntity.class, "id"));
@@ -60,7 +62,7 @@ public class LongVKeyConverterTest {
   @Entity(name = "TestLongEntity")
   @com.googlecode.objectify.annotation.Entity
   @WithLongVKey(classNameSuffix = "LongType")
-  static class TestLongEntity {
+  static class TestLongEntity extends ImmutableObject {
     @com.googlecode.objectify.annotation.Id @Id String id = "id";
 
     VKey<TestLongEntity> number;

--- a/core/src/test/java/google/registry/persistence/converter/StatusValueSetConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StatusValueSetConverterTest.java
@@ -16,8 +16,10 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import com.google.common.collect.ImmutableSet;
+import google.registry.model.ImmutableObject;
 import google.registry.model.eppcommon.StatusValue;
 import google.registry.persistence.transaction.JpaTestRules;
 import google.registry.persistence.transaction.JpaTestRules.JpaUnitTestExtension;
@@ -39,14 +41,14 @@ public class StatusValueSetConverterTest {
     Set<StatusValue> enums = ImmutableSet.of(StatusValue.INACTIVE, StatusValue.PENDING_DELETE);
     TestEntity obj = new TestEntity("foo", enums);
 
-    jpaTm().transact(() -> jpaTm().insert(obj));
+    insertInDb(obj);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "foo"));
     assertThat(persisted.data).isEqualTo(enums);
   }
 
   @Entity(name = "TestEntity")
-  static class TestEntity {
+  static class TestEntity extends ImmutableObject {
     @Id String name;
 
     Set<StatusValue> data;

--- a/core/src/test/java/google/registry/persistence/converter/StringListConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringListConverterTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
@@ -40,7 +41,7 @@ public class StringListConverterTest {
   void roundTripConversion_returnsSameStringList() {
     List<String> tlds = ImmutableList.of("app", "dev", "how");
     TestEntity testEntity = new TestEntity(tlds);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).containsExactly("app", "dev", "how");
@@ -50,7 +51,7 @@ public class StringListConverterTest {
   void testMerge_succeeds() {
     List<String> tlds = ImmutableList.of("app", "dev", "how");
     TestEntity testEntity = new TestEntity(tlds);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     persisted.tlds = ImmutableList.of("com", "gov");
@@ -63,7 +64,7 @@ public class StringListConverterTest {
   @Test
   void testNullValue_writesAndReadsNullSuccessfully() {
     TestEntity testEntity = new TestEntity(null);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).isNull();
@@ -72,7 +73,7 @@ public class StringListConverterTest {
   @Test
   void testEmptyCollection_writesAndReadsEmptyCollectionSuccessfully() {
     TestEntity testEntity = new TestEntity(ImmutableList.of());
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).isEmpty();

--- a/core/src/test/java/google/registry/persistence/converter/StringMapConverterBaseTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringMapConverterBaseTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
@@ -49,7 +50,7 @@ public class StringMapConverterBaseTest {
   @Test
   void roundTripConversion_returnsSameMap() {
     TestEntity testEntity = new TestEntity(MAP);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.map).containsExactlyEntriesIn(MAP);
@@ -58,7 +59,7 @@ public class StringMapConverterBaseTest {
   @Test
   void testUpdateColumn_succeeds() {
     TestEntity testEntity = new TestEntity(MAP);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.map).containsExactlyEntriesIn(MAP);
@@ -72,7 +73,7 @@ public class StringMapConverterBaseTest {
   @Test
   void testNullValue_writesAndReadsNullSuccessfully() {
     TestEntity testEntity = new TestEntity(null);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.map).isNull();
@@ -81,7 +82,7 @@ public class StringMapConverterBaseTest {
   @Test
   void testEmptyMap_writesAndReadsEmptyCollectionSuccessfully() {
     TestEntity testEntity = new TestEntity(ImmutableMap.of());
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.map).isEmpty();

--- a/core/src/test/java/google/registry/persistence/converter/StringSetConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringSetConverterTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import com.google.common.collect.ImmutableSet;
 import google.registry.model.ImmutableObject;
@@ -38,7 +39,7 @@ public class StringSetConverterTest {
   void roundTripConversion_returnsSameStringList() {
     Set<String> tlds = ImmutableSet.of("app", "dev", "how");
     TestEntity testEntity = new TestEntity(tlds);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).containsExactly("app", "dev", "how");
@@ -47,7 +48,7 @@ public class StringSetConverterTest {
   @Test
   void testNullValue_writesAndReadsNullSuccessfully() {
     TestEntity testEntity = new TestEntity(null);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).isNull();
@@ -56,7 +57,7 @@ public class StringSetConverterTest {
   @Test
   void testEmptyCollection_writesAndReadsEmptyCollectionSuccessfully() {
     TestEntity testEntity = new TestEntity(ImmutableSet.of());
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).isEmpty();

--- a/core/src/test/java/google/registry/persistence/converter/StringVKeyConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringVKeyConverterTest.java
@@ -16,7 +16,9 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 
+import google.registry.model.ImmutableObject;
 import google.registry.persistence.VKey;
 import google.registry.persistence.WithStringVKey;
 import google.registry.testing.AppEngineExtension;
@@ -47,7 +49,7 @@ public class StringVKeyConverterTest {
             "TheRealSpartacus",
             VKey.createSql(TestStringEntity.class, "ImSpartacus!"),
             VKey.createSql(CompositeKeyTestStringEntity.class, "NoImSpartacus!"));
-    jpaTm().transact(() -> jpaTm().insert(original));
+    insertInDb(original);
 
     TestStringEntity retrieved =
         jpaTm()
@@ -63,7 +65,7 @@ public class StringVKeyConverterTest {
   @Entity(name = "TestStringEntity")
   @com.googlecode.objectify.annotation.Entity
   @WithStringVKey(classNameSuffix = "StringType")
-  static class TestStringEntity {
+  static class TestStringEntity extends ImmutableObject {
     @com.googlecode.objectify.annotation.Id @Id String id;
 
     VKey<TestStringEntity> other;

--- a/core/src/test/java/google/registry/persistence/converter/StringValueEnumeratedTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringValueEnumeratedTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import google.registry.model.ImmutableObject;
 import google.registry.model.registrar.Registrar.State;
@@ -38,7 +39,7 @@ public class StringValueEnumeratedTest {
   @Test
   void roundTripConversion_returnsSameEnum() {
     TestEntity testEntity = new TestEntity(State.ACTIVE);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.state).isEqualTo(State.ACTIVE);
@@ -47,7 +48,7 @@ public class StringValueEnumeratedTest {
   @Test
   void testNativeQuery_succeeds() {
     TestEntity testEntity = new TestEntity(State.DISABLED);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
 
     assertThat(
             jpaTm()

--- a/core/src/test/java/google/registry/persistence/converter/TimedTransitionPropertyConverterBaseTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/TimedTransitionPropertyConverterBaseTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -59,7 +60,7 @@ class TimedTransitionPropertyConverterBaseTest {
   @Test
   void roundTripConversion_returnsSameTimedTransitionProperty() {
     TestEntity testEntity = new TestEntity(TIMED_TRANSITION_PROPERTY);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.property).containsExactlyEntriesIn(TIMED_TRANSITION_PROPERTY);
@@ -68,7 +69,7 @@ class TimedTransitionPropertyConverterBaseTest {
   @Test
   void testUpdateColumn_succeeds() {
     TestEntity testEntity = new TestEntity(TIMED_TRANSITION_PROPERTY);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.property).containsExactlyEntriesIn(TIMED_TRANSITION_PROPERTY);
@@ -83,7 +84,7 @@ class TimedTransitionPropertyConverterBaseTest {
   @Test
   void testNullValue_writesAndReadsNullSuccessfully() {
     TestEntity testEntity = new TestEntity(null);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.property).isNull();

--- a/core/src/test/java/google/registry/persistence/converter/TldStateTransitionConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/TldStateTransitionConverterTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
 import com.google.common.collect.ImmutableSortedMap;
@@ -56,7 +57,7 @@ class TldStateTransitionConverterTest {
     TimedTransitionProperty<TldState, TldStateTransition> timedTransitionProperty =
         TimedTransitionProperty.fromValueMap(values, TldStateTransition.class);
     TestEntity testEntity = new TestEntity(timedTransitionProperty);
-    jpaTm().transact(() -> jpaTm().insert(testEntity));
+    insertInDb(testEntity);
     TestEntity persisted =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.timedTransitionProperty).containsExactlyEntriesIn(timedTransitionProperty);

--- a/core/src/test/java/google/registry/persistence/converter/ZonedDateTimeConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/ZonedDateTimeConverterTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import google.registry.model.ImmutableObject;
 import google.registry.persistence.transaction.JpaTestRules;
@@ -66,7 +67,7 @@ public class ZonedDateTimeConverterTest {
   void converter_generatesTimestampWithNormalizedZone() {
     ZonedDateTime zdt = ZonedDateTime.parse("2019-09-01T01:01:01Z");
     TestEntity entity = new TestEntity("normalized_utc_time", zdt);
-    jpaTm().transact(() -> jpaTm().insert(entity));
+    insertInDb(entity);
     TestEntity retrievedEntity =
         jpaTm()
             .transact(
@@ -79,7 +80,7 @@ public class ZonedDateTimeConverterTest {
     ZonedDateTime zdt = ZonedDateTime.parse("2019-09-01T01:01:01Z[UTC]");
     TestEntity entity = new TestEntity("non_normalized_utc_time", zdt);
 
-    jpaTm().transact(() -> jpaTm().insert(entity));
+    insertInDb(entity);
     TestEntity retrievedEntity =
         jpaTm()
             .transact(
@@ -92,7 +93,7 @@ public class ZonedDateTimeConverterTest {
     ZonedDateTime zdt = ZonedDateTime.parse("2019-09-01T01:01:01+05:00");
     TestEntity entity = new TestEntity("new_york_time", zdt);
 
-    jpaTm().transact(() -> jpaTm().insert(entity));
+    insertInDb(entity);
     TestEntity retrievedEntity =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "new_york_time"));
     assertThat(retrievedEntity.zdt.toString()).isEqualTo("2019-08-31T20:01:01Z");

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerRuleTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerRuleTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.transaction;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.model.ImmutableObject;
@@ -66,7 +67,7 @@ public class JpaTransactionManagerRuleTest {
     // This test verifies that 1) withEntityClass() has registered TestEntity and 2) The table
     // has been created, implying withProperty(HBM2DDL_AUTO, "update") worked.
     TestEntity original = new TestEntity("key", "value");
-    jpaTm().transact(() -> jpaTm().insert(original));
+    insertInDb(original);
     TestEntity retrieved =
         jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "key"));
     assertThat(retrieved).isEqualTo(original);

--- a/core/src/test/java/google/registry/schema/registrar/RegistrarContactTest.java
+++ b/core/src/test/java/google/registry/schema/registrar/RegistrarContactTest.java
@@ -17,6 +17,7 @@ package google.registry.schema.registrar;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.registrar.RegistrarContact.Type.WHOIS;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.SqlHelper.saveRegistrar;
 
 import com.google.common.collect.ImmutableSet;
@@ -65,7 +66,7 @@ class RegistrarContactTest {
 
   @Test
   void testPersistence_succeeds() {
-    jpaTm().transact(() -> jpaTm().insert(testRegistrarPoc));
+    insertInDb(testRegistrarPoc);
     RegistrarContact persisted =
         jpaTm().transact(() -> jpaTm().loadByKey(testRegistrarPoc.createVKey()));
     assertThat(persisted).isEqualTo(testRegistrarPoc);

--- a/core/src/test/java/google/registry/schema/registrar/RegistrarDaoTest.java
+++ b/core/src/test/java/google/registry/schema/registrar/RegistrarDaoTest.java
@@ -16,6 +16,7 @@ package google.registry.schema.registrar;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.testing.DatabaseHelper.insertInDb;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -71,13 +72,13 @@ public class RegistrarDaoTest {
   @Test
   void saveNew_worksSuccessfully() {
     assertThat(jpaTm().transact(() -> jpaTm().exists(testRegistrar))).isFalse();
-    jpaTm().transact(() -> jpaTm().insert(testRegistrar));
+    insertInDb(testRegistrar);
     assertThat(jpaTm().transact(() -> jpaTm().exists(testRegistrar))).isTrue();
   }
 
   @Test
   void update_worksSuccessfully() {
-    jpaTm().transact(() -> jpaTm().insert(testRegistrar));
+    insertInDb(testRegistrar);
     Registrar persisted = jpaTm().transact(() -> jpaTm().loadByKey(registrarKey));
     assertThat(persisted.getRegistrarName()).isEqualTo("registrarName");
     jpaTm()
@@ -101,7 +102,7 @@ public class RegistrarDaoTest {
   @Test
   void load_worksSuccessfully() {
     assertThat(jpaTm().transact(() -> jpaTm().exists(testRegistrar))).isFalse();
-    jpaTm().transact(() -> jpaTm().insert(testRegistrar));
+    insertInDb(testRegistrar);
     Registrar persisted = jpaTm().transact(() -> jpaTm().loadByKey(registrarKey));
 
     assertThat(persisted.getRegistrarId()).isEqualTo("registrarId");

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -68,6 +68,7 @@ import google.registry.model.Buildable;
 import google.registry.model.EppResource;
 import google.registry.model.EppResource.ForeignKeyedEppResource;
 import google.registry.model.EppResourceUtils;
+import google.registry.model.ImmutableObject;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Flag;
 import google.registry.model.billing.BillingEvent.Reason;
@@ -1373,6 +1374,16 @@ public class DatabaseHelper {
   /** Returns whether or not the given entity exists in the database. */
   public static boolean existsInDatabase(Object object) {
     return transactIfJpaTm(() -> tm().exists(object));
+  }
+
+  /** Inserts the given entity/entities into Cloud SQL in a single transaction. */
+  public static <T extends ImmutableObject> void insertInDb(T... entities) {
+    jpaTm().transact(() -> jpaTm().insertAll(entities));
+  }
+
+  /** Inserts the given entities into Cloud SQL in a single transaction. */
+  public static <T extends ImmutableObject> void insertInDb(ImmutableCollection<T> entities) {
+    jpaTm().transact(() -> jpaTm().insertAll(entities));
   }
 
   /**


### PR DESCRIPTION
This is the first of a series of PRs to clean up the type signatures on the
TransactionManager methods (which are way too generic), along with creating some
helper methods for use in tests only that don't require creating transactions
all over the place, thus reducing visual noise at callsites. This first method
is DatabaseHelper.insertInDb(), but there will be plenty of others. Note that
this is only for the Cloud SQL transaction manager -- I'm not bothering to
migrate any Datastore-only code, as that will be going away soon enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1325)
<!-- Reviewable:end -->
