### PR TITLE
Fix ReadOnlyCheckingQuery's streaming method

### DIFF
--- a/core/src/main/java/google/registry/persistence/transaction/ReadOnlyCheckingQuery.java
+++ b/core/src/main/java/google/registry/persistence/transaction/ReadOnlyCheckingQuery.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 import javax.persistence.FlushModeType;
 import javax.persistence.LockModeType;
 import javax.persistence.Parameter;
@@ -39,6 +40,11 @@ class ReadOnlyCheckingQuery implements Query {
   @Override
   public List getResultList() {
     return delegate.getResultList();
+  }
+
+  @Override
+  public Stream getResultStream() {
+    return delegate.getResultStream();
   }
 
   @Override


### PR DESCRIPTION
Following up to PR 1314: fix one more query defaulting to List when
stream() is invoked.

This fixes the Spec11Pipeline's query.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1329)
<!-- Reviewable:end -->
