### PR TITLE
Fix injection with BackfillRegistryLocksCommand

### DIFF
--- a/core/src/main/java/google/registry/tools/RegistryToolComponent.java
+++ b/core/src/main/java/google/registry/tools/RegistryToolComponent.java
@@ -41,6 +41,7 @@ import google.registry.request.Modules.URLFetchServiceModule;
 import google.registry.request.Modules.UrlFetchTransportModule;
 import google.registry.request.Modules.UserServiceModule;
 import google.registry.tools.AuthModule.LocalCredentialModule;
+import google.registry.tools.javascrap.BackfillRegistryLocksCommand;
 import google.registry.tools.javascrap.DeleteContactByRoidCommand;
 import google.registry.util.UtilsModule;
 import google.registry.whois.NonCachingWhoisModule;
@@ -84,6 +85,8 @@ import javax.inject.Singleton;
     })
 interface RegistryToolComponent {
   void inject(AckPollMessagesCommand command);
+
+  void inject(BackfillRegistryLocksCommand command);
 
   void inject(CheckDomainClaimsCommand command);
 

--- a/core/src/main/java/google/registry/tools/javascrap/BackfillRegistryLocksCommand.java
+++ b/core/src/main/java/google/registry/tools/javascrap/BackfillRegistryLocksCommand.java
@@ -94,7 +94,7 @@ public class BackfillRegistryLocksCommand extends ConfirmingCommand
 
   @Override
   protected String execute() {
-    ImmutableSet.Builder<DomainBase> failedDomainsBuilder = new ImmutableSet.Builder<>();
+    ImmutableSet.Builder<String> failedDomainsBuilder = new ImmutableSet.Builder<>();
     jpaTm()
         .transact(
             () -> {
@@ -114,11 +114,11 @@ public class BackfillRegistryLocksCommand extends ConfirmingCommand
                 } catch (Throwable t) {
                   logger.atSevere().withCause(t).log(
                       "Error when creating lock object for domain %s.", domainBase.getDomainName());
-                  failedDomainsBuilder.add(domainBase);
+                  failedDomainsBuilder.add(domainBase.getDomainName());
                 }
               }
             });
-    ImmutableSet<DomainBase> failedDomains = failedDomainsBuilder.build();
+    ImmutableSet<String> failedDomains = failedDomainsBuilder.build();
     if (failedDomains.isEmpty()) {
       return String.format(
           "Successfully created lock objects for %d domains.", lockedDomains.size());
@@ -126,7 +126,7 @@ public class BackfillRegistryLocksCommand extends ConfirmingCommand
       return String.format(
           "Successfully created lock objects for %d domains. We failed to create locks "
               + "for the following domains: %s",
-          lockedDomains.size() - failedDomains.size(), lockedDomains);
+          lockedDomains.size() - failedDomains.size(), failedDomains);
     }
   }
 


### PR DESCRIPTION
It would have been nice if this had failed at compile-time rather than
an NPE, but we need to make sure to specify that we need to inject this
command to get e.g. the random string generator

In addition, print out only the names of the failed domains (rather than
the entire domain object) for readability.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1337)
<!-- Reviewable:end -->
