### PR TITLE
Find a suitable version of python.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,7 +212,7 @@ task runPresubmits(type: Exec) {
   // Find a python version greater than 3.7.3 (this is somewhat arbitrary, we
   // know we'd like at least 3.6, but 3.7.3 is the latest that ships with
   // Debian so it seems like that should be available anywhere).
-  def MIN_PY_VER = 0x3060000 // should be 0x3070300
+  def MIN_PY_VER = 0x3070300
   if (pyver('python') >= MIN_PY_VER) {
     executable 'python'
   } else if (pyver('/usr/bin/python3') >= MIN_PY_VER) {

--- a/build.gradle
+++ b/build.gradle
@@ -209,6 +209,9 @@ rootProject.ext {
 
 task runPresubmits(type: Exec) {
 
+  // XXX hack to view available versions.
+  println "XXX pyenv versions: ${ext.execInBash("pyenv versions")}"
+
   // Find a python version greater than 3.7.3 (this is somewhat arbitrary, we
   // know we'd like at least 3.6, but 3.7.3 is the latest that ships with
   // Debian so it seems like that should be available anywhere).

--- a/build.gradle
+++ b/build.gradle
@@ -196,8 +196,31 @@ allprojects {
   }
 }
 
+rootProject.ext {
+  pyver = { exe ->
+    try {
+      ext.execInBash(
+          exe + " -c 'import sys; print(sys.hexversion)'", "/") as Integer
+    } catch (org.gradle.process.internal.ExecException e) {
+      return -1;
+    }
+  }
+}
+
 task runPresubmits(type: Exec) {
-  executable '/usr/bin/python3'
+
+  // Find a python version greater than 3.7.3 (this is somewhat arbitrary, we
+  // know we'd like at least 3.6, but 3.7.3 is the latest that ships with
+  // Debian so it seems like that should be available anywhere).
+  def MIN_PY_VER = 0x3070300;
+  if (pyver('python') >= MIN_PY_VER) {
+    executable 'python'
+  } else if (pyver('/usr/bin/python3') >= MIN_PY_VER) {
+    executable '/usr/bin/python3'
+  } else {
+    throw new GradleException("No usable Python version found (build " +
+                              "requires at least python 3.7.3)");
+  }
   args('config/presubmits.py')
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -209,9 +209,6 @@ rootProject.ext {
 
 task runPresubmits(type: Exec) {
 
-  // XXX hack to view available versions.
-  println "XXX pyenv versions: ${execInBash("pyenv versions", "/")}"
-
   // Find a python version greater than 3.7.3 (this is somewhat arbitrary, we
   // know we'd like at least 3.6, but 3.7.3 is the latest that ships with
   // Debian so it seems like that should be available anywhere).

--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ rootProject.ext {
 task runPresubmits(type: Exec) {
 
   // XXX hack to view available versions.
-  println "XXX pyenv versions: ${ext.execInBash("pyenv versions")}"
+  println "XXX pyenv versions: ${execInBash("pyenv versions", "/")}"
 
   // Find a python version greater than 3.7.3 (this is somewhat arbitrary, we
   // know we'd like at least 3.6, but 3.7.3 is the latest that ships with

--- a/build.gradle
+++ b/build.gradle
@@ -212,7 +212,7 @@ task runPresubmits(type: Exec) {
   // Find a python version greater than 3.7.3 (this is somewhat arbitrary, we
   // know we'd like at least 3.6, but 3.7.3 is the latest that ships with
   // Debian so it seems like that should be available anywhere).
-  def MIN_PY_VER = 0x3070300;
+  def MIN_PY_VER = 0x3060000 // should be 0x3070300
   if (pyver('python') >= MIN_PY_VER) {
     executable 'python'
   } else if (pyver('/usr/bin/python3') >= MIN_PY_VER) {

--- a/config/presubmits.py
+++ b/config/presubmits.py
@@ -315,6 +315,7 @@ def get_files():
 
 
 if __name__ == "__main__":
+  print('python version is %s' % sys.version)
   failed = False
   for file in get_files():
     error_messages = []


### PR DESCRIPTION
When running presubmit, we were using /usr/bin/python3, which works fine on
systems that have a reasonably recent python version there.  However, our CI
system has a very old version of python there and prefers the use of "pyenv"
to modify the PATH to provide the desired version of python as simply
"python".  So add a check to use the first of "python" or "/usr/bin/python3"
that is at least version 3.7.3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1338)
<!-- Reviewable:end -->
