### PR TITLE
Remove mention of bazel run

### DIFF
--- a/core/src/main/java/google/registry/tools/CommandUtilities.java
+++ b/core/src/main/java/google/registry/tools/CommandUtilities.java
@@ -53,7 +53,8 @@ class CommandUtilities {
   /** Prompts for yes/no input using promptText, defaulting to no. */
   static boolean promptForYes(String promptText) {
     checkState(
-        System.console() != null, "Unable to access stdin (are you running with bazel run?)");
+        System.console() != null,
+        "Unable to access stdin (are you running with `gradle registryTool`?), try using -f.");
     String input = System.console().readLine(promptText + " (y/N): ");
     // Null represents end-of-file (e.g. ^-D) so interpret that as a negative response.
     return input != null && Ascii.toUpperCase(input).startsWith("Y");


### PR DESCRIPTION
Also provides a workaround in the error message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1340)
<!-- Reviewable:end -->
