### PR TITLE
Add handling for UpdateAutoTimestamp when not in a transaction

### DIFF
--- a/core/src/test/java/google/registry/model/registrar/RegistrarTest.java
+++ b/core/src/test/java/google/registry/model/registrar/RegistrarTest.java
@@ -270,8 +270,8 @@ class RegistrarTest extends EntityTestCase {
     persistSimpleResource(
         new RegistrarContact.Builder()
             .setParent(registrar)
-            .setName("John Abused")
-            .setEmailAddress("johnabuse@example.com")
+            .setName("John Abussy")
+            .setEmailAddress("johnabussy@example.com")
             .setPhoneNumber("+1.2125551213")
             .setFaxNumber("+1.2125551213")
             // No setTypes(...)

--- a/core/src/test/java/google/registry/schema/replay/SqlEntityTest.java
+++ b/core/src/test/java/google/registry/schema/replay/SqlEntityTest.java
@@ -38,7 +38,8 @@ public class SqlEntityTest {
   final DatastoreEntityExtension datastoreEntityExtension = new DatastoreEntityExtension();
 
   @RegisterExtension
-  final AppEngineExtension database = new AppEngineExtension.Builder().withCloudSql().build();
+  final AppEngineExtension database =
+      new AppEngineExtension.Builder().withCloudSql().withoutCannedData().build();
 
   @BeforeEach
   void setup() throws Exception {
@@ -54,9 +55,10 @@ public class SqlEntityTest {
   @Test
   void getPrimaryKeyString_oneIdColumn() {
     // AppEngineExtension canned data: Registrar1
-    VKey<Registrar> key = Registrar.createVKey("NewRegistrar");
-    String expected = "NewRegistrar";
-    assertThat(tm().transact(() -> tm().loadByKey(key)).getPrimaryKeyString()).contains(expected);
+    assertThat(
+            tm().transact(() -> tm().loadByKey(Registrar.createVKey("NewRegistrar")))
+                .getPrimaryKeyString())
+        .contains("NewRegistrar");
   }
 
   @Test

--- a/core/src/test/java/google/registry/testing/AppEngineExtension.java
+++ b/core/src/test/java/google/registry/testing/AppEngineExtension.java
@@ -18,7 +18,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.io.Files.asCharSink;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.persistSimpleResources;
+import static google.registry.testing.DatabaseHelper.insertSimpleResources;
 import static google.registry.testing.DualDatabaseTestInvocationContextProvider.injectTmForDualDatabaseTest;
 import static google.registry.testing.DualDatabaseTestInvocationContextProvider.restoreTmAfterDualDatabaseTest;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
@@ -629,7 +629,7 @@ public final class AppEngineExtension implements BeforeEachCallback, AfterEachCa
 
   /** Create some fake registrars. */
   public static void loadInitialData() {
-    persistSimpleResources(
+    insertSimpleResources(
         ImmutableList.of(
             makeRegistrar1(),
             makeRegistrarContact1(),


### PR DESCRIPTION
It's not clear why this is sometimes causing test flakes, but getting better
logging involved should help clear it up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1341)
<!-- Reviewable:end -->
