### PR TITLE
Reduce # shards in CreateSyntheticHistoryEntriesAction

### DIFF
--- a/core/src/main/java/google/registry/tools/javascrap/CreateSyntheticHistoryEntriesAction.java
+++ b/core/src/main/java/google/registry/tools/javascrap/CreateSyntheticHistoryEntriesAction.java
@@ -88,12 +88,10 @@ public class CreateSyntheticHistoryEntriesAction implements Runnable {
   /**
    * The number of shards to run the map-only mapreduce on.
    *
-   * <p>This is less than the default of 100 because we can afford it being slower, but we don't
-   * want to write out lots of large commit logs in a short period of time. If we did so, the
-   * asynchronous replication action (run every few minutes) might fall behind which may make the
-   * migration tougher.
+   * <p>This is much lower than the default of 100, or even 10, because we can afford it being slow
+   * and we want to avoid overloading SQL.
    */
-  private static final int NUM_SHARDS = 10;
+  private static final int NUM_SHARDS = 3;
 
   @Override
   public void run() {


### PR DESCRIPTION
We need these to get created (we are blocked from moving to SQL until 30
days after their creation) so reduce this to 3 in the hopes of avoiding
the SQL overloads while we debug why those are occurring in the first
place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1344)
<!-- Reviewable:end -->
