### PR TITLE
Use debian10 image for builder, not ubuntu1804

### DIFF
--- a/release/builder/Dockerfile
+++ b/release/builder/Dockerfile
@@ -19,7 +19,7 @@
 # 3. Google Cloud SDK for generating the WARs.
 # 4. Git to manipulate the private and the merged repos.
 # 5. Docker to build and push images.
-FROM marketplace.gcr.io/google/ubuntu1804
+FROM marketplace.gcr.io/google/debian10
 ENV DEBIAN_FRONTEND=noninteractive LANG=en_US.UTF-8
 ADD ./build.sh .
 RUN ["bash", "./build.sh"]

--- a/release/builder/build.sh
+++ b/release/builder/build.sh
@@ -27,6 +27,8 @@ apt-get install python -y
 # (introduced in 3.7) for nom_build
 apt-get install python3-pip -y
 python3 -m pip install dataclasses
+# Install curl.
+apt-get install curl -y
 # Install Node
 curl -sL https://deb.nodesource.com/setup_current.x | bash -
 apt-get install -y nodejs


### PR DESCRIPTION
The debian10 image is generally a bit more recent and, in particular, includes
python 3.7.3, which we're currently using as a baseline for our builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1345)
<!-- Reviewable:end -->
