### PR TITLE
Canonicalize domain/host names in async DS->SQL replay

### DIFF
--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -24,6 +24,7 @@ import google.registry.model.host.HostResource;
 import google.registry.model.replay.DatastoreAndSqlEntity;
 import google.registry.persistence.VKey;
 import google.registry.persistence.WithStringVKey;
+import google.registry.util.DomainNameUtils;
 import java.util.Set;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
@@ -162,6 +163,11 @@ public class DomainBase extends DomainContent
   @Override
   public DomainBase cloneProjectedAtTime(final DateTime now) {
     return cloneDomainProjectedAtTime(this, now);
+  }
+
+  @Override
+  public void beforeSqlSaveOnReplay() {
+    fullyQualifiedDomainName = DomainNameUtils.canonicalizeDomainName(fullyQualifiedDomainName);
   }
 
   @Override

--- a/core/src/main/java/google/registry/model/domain/DomainHistory.java
+++ b/core/src/main/java/google/registry/model/domain/DomainHistory.java
@@ -33,6 +33,7 @@ import google.registry.model.replay.SqlEntity;
 import google.registry.model.reporting.DomainTransactionRecord;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.persistence.VKey;
+import google.registry.util.DomainNameUtils;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Optional;
@@ -303,6 +304,8 @@ public class DomainHistory extends HistoryEntry implements SqlEntity {
   public void beforeSqlSaveOnReplay() {
     if (domainContent == null) {
       domainContent = jpaTm().getEntityManager().find(DomainBase.class, getDomainRepoId());
+      domainContent.fullyQualifiedDomainName =
+          DomainNameUtils.canonicalizeDomainName(domainContent.fullyQualifiedDomainName);
       fillAuxiliaryFieldsFromDomain(this);
     }
   }

--- a/core/src/main/java/google/registry/model/host/HostHistory.java
+++ b/core/src/main/java/google/registry/model/host/HostHistory.java
@@ -26,6 +26,7 @@ import google.registry.model.replay.DatastoreEntity;
 import google.registry.model.replay.SqlEntity;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.persistence.VKey;
+import google.registry.util.DomainNameUtils;
 import java.io.Serializable;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -141,6 +142,8 @@ public class HostHistory extends HistoryEntry implements SqlEntity, UnsafeSerial
   public void beforeSqlSaveOnReplay() {
     if (hostBase == null) {
       hostBase = jpaTm().getEntityManager().find(HostResource.class, getHostRepoId());
+      hostBase.fullyQualifiedHostName =
+          DomainNameUtils.canonicalizeDomainName(hostBase.fullyQualifiedHostName);
     }
   }
 

--- a/core/src/main/java/google/registry/model/host/HostResource.java
+++ b/core/src/main/java/google/registry/model/host/HostResource.java
@@ -22,6 +22,7 @@ import google.registry.model.annotations.ReportedOn;
 import google.registry.model.replay.DatastoreAndSqlEntity;
 import google.registry.persistence.VKey;
 import google.registry.persistence.WithStringVKey;
+import google.registry.util.DomainNameUtils;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
 
@@ -49,6 +50,11 @@ public class HostResource extends HostBase
   @Override
   public VKey<HostResource> createVKey() {
     return VKey.create(HostResource.class, getRepoId(), Key.create(this));
+  }
+
+  @Override
+  public void beforeSqlSaveOnReplay() {
+    fullyQualifiedHostName = DomainNameUtils.canonicalizeDomainName(fullyQualifiedHostName);
   }
 
   @Override

--- a/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseTest.java
@@ -921,6 +921,19 @@ public class DomainBaseTest extends EntityTestCase {
         .containsExactly(EppResourceIndex.create(Key.create(domain)));
   }
 
+  @Test
+  void testBeforeSqlSaveOnReplay_canonicalName() {
+    domain.fullyQualifiedDomainName = "EXAMPLE.COM";
+    assertThat(domain.getDomainName()).isEqualTo("EXAMPLE.COM");
+    domain.beforeSqlSaveOnReplay();
+    assertThat(domain.getDomainName()).isEqualTo("example.com");
+
+    domain.fullyQualifiedDomainName = "kittyçat.com";
+    assertThat(domain.getDomainName()).isEqualTo("kittyçat.com");
+    domain.beforeSqlSaveOnReplay();
+    assertThat(domain.getDomainName()).isEqualTo("xn--kittyat-yxa.com");
+  }
+
   static class BillEventInfo extends ImmutableObject {
     VKey<BillingEvent.Recurring> billingEventRecurring;
     Long billingEventRecurringHistoryId;

--- a/core/src/test/java/google/registry/model/host/HostResourceTest.java
+++ b/core/src/test/java/google/registry/model/host/HostResourceTest.java
@@ -319,4 +319,17 @@ class HostResourceTest extends EntityTestCase {
     assertThat(ofyTm().loadAllOf(EppResourceIndex.class))
         .containsExactly(EppResourceIndex.create(Key.create(host)));
   }
+
+  @TestOfyOnly
+  void testBeforeSqlSaveOnReplay_canonicalName() {
+    host.fullyQualifiedHostName = "NS1.EXAMPLE.COM";
+    assertThat(host.getHostName()).isEqualTo("NS1.EXAMPLE.COM");
+    host.beforeSqlSaveOnReplay();
+    assertThat(host.getHostName()).isEqualTo("ns1.example.com");
+
+    host.fullyQualifiedHostName = "ns1.kittyçat.com";
+    assertThat(host.getHostName()).isEqualTo("ns1.kittyçat.com");
+    host.beforeSqlSaveOnReplay();
+    assertThat(host.getHostName()).isEqualTo("ns1.xn--kittyat-yxa.com");
+  }
 }


### PR DESCRIPTION
We do this on host/domain creation now, but there are still some old names from before this was enforced. We should take this opportunity to canonicalize everything. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1350)
<!-- Reviewable:end -->
