### PR TITLE
Defer python discovery until presubmit task

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -4,3 +4,7 @@ extraction:
       packages: "npm"
     index:
       java_version: "11"
+      build_command:
+        # Just build normal classes and test classes, this speeds things up
+        # considerably and avoids problems with the installed python version.
+        - ./gradlew assemble testClasses

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -4,7 +4,3 @@ extraction:
       packages: "npm"
     index:
       java_version: "11"
-      build_command:
-        # Just build normal classes and test classes, this speeds things up
-        # considerably and avoids problems with the installed python version.
-        - ./gradlew assemble testClasses

--- a/build.gradle
+++ b/build.gradle
@@ -212,7 +212,6 @@ task runPresubmits(type: Exec) {
   args('config/presubmits.py')
 
   doFirst {
-    println "XXX checking for python version in runPresubmits"
     // Find a python version greater than 3.7.3 (this is somewhat arbitrary, we
     // know we'd like at least 3.6, but 3.7.3 is the latest that ships with
     // Debian so it seems like that should be available anywhere).

--- a/build.gradle
+++ b/build.gradle
@@ -212,6 +212,7 @@ task runPresubmits(type: Exec) {
   args('config/presubmits.py')
 
   doFirst {
+    println "XXX checking for python version in runPresubmits"
     // Find a python version greater than 3.7.3 (this is somewhat arbitrary, we
     // know we'd like at least 3.6, but 3.7.3 is the latest that ships with
     // Debian so it seems like that should be available anywhere).

--- a/build.gradle
+++ b/build.gradle
@@ -209,19 +209,22 @@ rootProject.ext {
 
 task runPresubmits(type: Exec) {
 
-  // Find a python version greater than 3.7.3 (this is somewhat arbitrary, we
-  // know we'd like at least 3.6, but 3.7.3 is the latest that ships with
-  // Debian so it seems like that should be available anywhere).
-  def MIN_PY_VER = 0x3070300
-  if (pyver('python') >= MIN_PY_VER) {
-    executable 'python'
-  } else if (pyver('/usr/bin/python3') >= MIN_PY_VER) {
-    executable '/usr/bin/python3'
-  } else {
-    throw new GradleException("No usable Python version found (build " +
-                              "requires at least python 3.7.3)");
-  }
   args('config/presubmits.py')
+
+  doFirst {
+    // Find a python version greater than 3.7.3 (this is somewhat arbitrary, we
+    // know we'd like at least 3.6, but 3.7.3 is the latest that ships with
+    // Debian so it seems like that should be available anywhere).
+    def MIN_PY_VER = 0x3070300
+    if (pyver('python') >= MIN_PY_VER) {
+      executable 'python'
+    } else if (pyver('/usr/bin/python3') >= MIN_PY_VER) {
+      executable '/usr/bin/python3'
+    } else {
+      throw new GradleException("No usable Python version found (build " +
+                                "requires at least python 3.7.3)");
+    }
+  }
 }
 
 def javadocSource = []


### PR DESCRIPTION
Our presubmit requires a version of python that is more recent than what
lgtm.com's build environments have installed. LGTM shouldn't be 
running the presubmit, but the check will happen regardless of whether 
the presubmit is run or not, since the check is in the task closure instead 
of in a task action.

Attempt to fix this by moving the check to a "doFirst" (a task action).  
This solves the problem when building locally, unfortunately there's no 
easy way to test it on lgtm.com, since lgtm.com appears to fail on a
"./gradlew clean" build of the baseline commit before even getting to
the PR and a) we don't seem to retain logs from a successful run and b)
I can't find any documentation of what lgtm.com's autobuild does by 
default.

In short, this PR fixes a problem (the build won't run at all on systems
that don't have a recent enough version of python) but there may still
be issues on lgtm.com that will require us to customize the 
build_command used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1352)
<!-- Reviewable:end -->
