### PR TITLE
Use a more efficient query to find resources in histories

### DIFF
--- a/config/presubmits.py
+++ b/config/presubmits.py
@@ -213,6 +213,7 @@ PRESUBMITS = {
         {"src/test", "ActivityReportingQueryBuilder.java",
          # This class contains helper method to make queries in Beam.
          "RegistryJpaIO.java",
+         "CreateSyntheticHistoryEntriesAction.java",
          # TODO(b/179158393): Remove everything below, which should be done
          # using Criteria
          "JpaTransactionManager.java",


### PR DESCRIPTION
SELECT EXISTS statements will be faster / use fewer read-locks than statements that try to do sorting or return full resources

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1354)
<!-- Reviewable:end -->
