### PR TITLE
Add a reference to RDAP conformance checker

### DIFF
--- a/core/src/test/java/google/registry/rdap/RdapDomainActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapDomainActionTest.java
@@ -45,7 +45,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for {@link RdapDomainAction}. */
+/** Unit tests for {@link RdapDomainAction}.
+ *
+ * TODO(b/26872828): The next time we do any work on RDAP, consider adding the APNIC RDAP
+ * conformance checker to the unit test suite.
+ */
 class RdapDomainActionTest extends RdapActionBaseTestCase<RdapDomainAction> {
 
   RdapDomainActionTest() {


### PR DESCRIPTION
Make a note of the RDAP conformance checker for the next time that we deal
with the RDAP code - would be nice to have this in the test suite.