### PR TITLE
Fix sandbox cron

### DIFF
--- a/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/cron.xml
@@ -253,7 +253,7 @@
       This job runs weekly to wipe out PII fields of ContactHistory entities
       that have been in the database for a certain period of time.
     </description>
-    <schedule>every monday 14:00</schedule>
+    <schedule>every monday 15:00</schedule>
     <target>backend</target>
   </cron>
 </cronentries>

--- a/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/cron.xml
@@ -253,7 +253,7 @@
       This job runs weekly to wipe out PII fields of ContactHistory entities
       that have been in the database for a certain period of time.
     </description>
-    <schedule>every monday synchronized</schedule>
+    <schedule>every monday 14:00</schedule>
     <target>backend</target>
   </cron>
 </cronentries>


### PR DESCRIPTION
"synchronized" can only be used to specify a 24h time range that is
evenly divided by the interval value, e. g. "every 2 hours
synchronized".

https://cloud.google.com/appengine/docs/flexible/java/scheduling-jobs-with-cron-yaml#formatting_the_schedule

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1366)
<!-- Reviewable:end -->
