### PR TITLE
Change Beam uber jar name in Nomulu release GCB config

### DIFF
--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -83,7 +83,7 @@ steps:
   - -c
   - |
     ./release/stage_beam_pipeline.sh \
-      beam_pipeline_common \
+      beamPipelineCommon \
       ${TAG_NAME} \
       ${PROJECT_ID} \
       google.registry.beam.initsql.InitSqlPipeline \


### PR DESCRIPTION
The uber jar name was changed in #1351.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1367)
<!-- Reviewable:end -->
