### PR TITLE
Fix beam deployment script again.

### DIFF
--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -84,6 +84,7 @@ steps:
   - |
     ./release/stage_beam_pipeline.sh \
       beamPipelineCommon \
+      beam_pipeline_common \
       ${TAG_NAME} \
       ${PROJECT_ID} \
       google.registry.beam.initsql.InitSqlPipeline \

--- a/release/stage_beam_pipeline.sh
+++ b/release/stage_beam_pipeline.sh
@@ -40,19 +40,20 @@ set -e
 
 if (( "$#" < 5 ||  $(("$#" % 2)) == 0 ));
 then
-  echo "Usage: $0 uberjar_name  release_tag dev_project " \
+  echo "Usage: $0 uberjar_task uberjar_name  release_tag dev_project " \
        "main_class metadata_pathname [ main_class metadata_pathname ] ..."
   exit 1
 fi
 
-uberjar_name="$1"
-release_tag="$2"
-dev_project="$3"
-shift 3
+uberjar_task="$1"
+uberjar_name="$2"
+release_tag="$3"
+dev_project="$4"
+shift 4
 
 maven_gcs_prefix="gcs://domain-registry-maven-repository"
 nom_build_dir="$(dirname $0)/.."
-${nom_build_dir}/nom_build clean :core:"${uberjar_name}" \
+${nom_build_dir}/nom_build clean :core:"${uberjar_task}" \
     --mavenUrl="${maven_gcs_prefix}"/maven \
     --pluginsUrl="${maven_gcs_prefix}"/plugins
 


### PR DESCRIPTION
uberjar task and uberjar name are now different (beamPipelineCommon and
beam_pipeline_common, respectively). This is more idiomatic with regard
to naming conventions but we need to take two different variables now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1369)
<!-- Reviewable:end -->
