### PR TITLE
Add snapshot query of multiple entity types

### DIFF
--- a/core/src/main/java/google/registry/beam/common/RegistryJpaIO.java
+++ b/core/src/main/java/google/registry/beam/common/RegistryJpaIO.java
@@ -27,6 +27,7 @@ import google.registry.model.replay.SqlEntity;
 import google.registry.persistence.transaction.JpaTransactionManager;
 import google.registry.persistence.transaction.TransactionManagerFactory;
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
@@ -116,6 +117,18 @@ public final class RegistryJpaIO {
         .build();
   }
 
+  /**
+   * Returns a {@link Read} connector that fetches a consistent snapshot of all entities of the
+   * given {@code entityTypes}.
+   */
+  public static <R, T> Read<R, T> readSnapshot(
+      Collection<Class<? extends R>> entityTypes, SerializableFunction<R, T> resultMapper) {
+    return Read.<R, T>builder()
+        .snapshotQuery(ImmutableList.copyOf(entityTypes))
+        .resultMapper(resultMapper)
+        .build();
+  }
+
   public static <T> Write<T> write() {
     return Write.<T>builder().build();
   }
@@ -195,6 +208,10 @@ public final class RegistryJpaIO {
 
       Builder<R, T> jpqlQuery(String jpql, Class<R> clazz, Map<String, Object> parameters) {
         return query(RegistryQuery.createQuery(jpql, parameters, clazz));
+      }
+
+      Builder<R, T> snapshotQuery(ImmutableList<Class<? extends R>> entityTypes) {
+        return query(RegistryQuery.createQuery(entityTypes));
       }
     }
 

--- a/core/src/test/java/google/registry/beam/common/RegistryJpaReadTest.java
+++ b/core/src/test/java/google/registry/beam/common/RegistryJpaReadTest.java
@@ -91,6 +91,19 @@ public class RegistryJpaReadTest {
   }
 
   @Test
+  void readSnapshot() {
+    Read<Object, String> read =
+        RegistryJpaIO.<Object, String>readSnapshot(
+            ImmutableList.of(Registrar.class, ContactResource.class),
+            x -> x.getClass().getSimpleName());
+    PCollection<String> snapshot = testPipeline.apply(read);
+
+    PAssert.that(snapshot)
+        .containsInAnyOrder("Registrar", "ContactResource", "ContactResource", "ContactResource");
+    testPipeline.run();
+  }
+
+  @Test
   void readWithCriteriaQuery() {
     Read<ContactResource, String> read =
         RegistryJpaIO.read(


### PR DESCRIPTION
Add a RegistryQuery that can load a consistent snapshot of multiple
entity types.

Tested on GCP with real data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1372)
<!-- Reviewable:end -->
