### PR TITLE
Retry datastore transactions during replay

### DIFF
--- a/core/src/test/java/google/registry/testing/ReplayExtension.java
+++ b/core/src/test/java/google/registry/testing/ReplayExtension.java
@@ -39,6 +39,8 @@ import google.registry.persistence.transaction.Transaction.Mutation;
 import google.registry.persistence.transaction.Transaction.Update;
 import google.registry.persistence.transaction.TransactionEntity;
 import google.registry.util.RequestStatusChecker;
+import google.registry.util.Retrier;
+import google.registry.util.SystemSleeper;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
@@ -197,6 +199,7 @@ public class ReplayExtension implements BeforeEachCallback, AfterEachCallback {
   }
 
   private void replayToOfy() {
+    Retrier retrier = new Retrier(new SystemSleeper(), 5);
     if (sqlToDsReplicator == null) {
       return;
     }
@@ -207,7 +210,9 @@ public class ReplayExtension implements BeforeEachCallback, AfterEachCallback {
       for (TransactionEntity txn : transactionBatch) {
         sqlToDsReplicator.applyTransaction(txn);
         if (compare) {
-          ofyTm().transact(() -> compareSqlTransaction(txn));
+          retrier.callWithRetry(
+              () -> ofyTm().transact(() -> compareSqlTransaction(txn)),
+              IllegalArgumentException.class);
         }
         clock.advanceOneMilli();
       }


### PR DESCRIPTION
It looks like the datastore failures we've been seeing may very well have been
due to transient failures on the part of the test datastore.  Wrap the replay
transactions in a 5x retrier to remedy.

Note that this problem would not affect the actual replay, nor does this
solution: the actual replay uses a cron job and if a specific transaction
fails it will be retried on the next cycle (though we may consider adding
retry for that, if it's not already present).