### PR TITLE
Update terraform files and instructions

### DIFF
--- a/docs/proxy-setup.md
+++ b/docs/proxy-setup.md
@@ -105,13 +105,14 @@ mentioned above.
 
 Navigate to `proxy/terraform`, create a folder called
 `envs`, and inside it, create a folder for the environment that proxy is
-deployed to ("alpha" for example). Copy `example_config.tf` to the environment
-folder.
+deployed to ("alpha" for example). Copy `example_config.tf` and `outputs.tf`
+to the environment folder.
 
 ```bash
 $ cd proxy/terraform
 $ mkdir -p envs/alpha
 $ cp example_config.tf envs/alpha/config.tf
+$ cp outputs.tf envs/alpha
 ```
 
 Now go to the environment folder, edit the `config.tf` file and replace

--- a/proxy/terraform/example_config.tf
+++ b/proxy/terraform/example_config.tf
@@ -11,21 +11,8 @@ module "proxy" {
   proxy_project_name       = "YOUR_PROXY_PROJECT"
   gcr_project_name         = "YOUR_GCR_PROJECT"
   proxy_domain_name        = "YOUR_PROXY_DOMAIN"
-  proxy_certificate_bucket = "YOU_CERTIFICATE_BUCKET"
-}
+  proxy_certificate_bucket = "YOUR_CERTIFICATE_BUCKET"
 
-output "proxy_service_account" {
-  value = module.proxy.proxy_service_account
-}
-
-output "proxy_name_servers" {
-  value = module.proxy.proxy_name_servers
-}
-
-output "proxy_instance_groups" {
-  value = module.proxy.proxy_instance_groups
-}
-
-output "proxy_ip_addresses" {
-  value = module.proxy.proxy_ip_addresses
+  # Uncomment to disable forwarding of whois HTTP interfaces.
+  # public_web_whois         = 0
 }

--- a/proxy/terraform/modules/networking.tf
+++ b/proxy/terraform/modules/networking.tf
@@ -1,11 +1,6 @@
 resource "google_dns_managed_zone" "proxy_domain" {
   name     = "proxy-domain"
   dns_name = "${var.proxy_domain_name}."
-
-  # This is a safeguard for the google provider update to 2.8.0.
-  # cl/264641943
-  # If you like, you can remove this line after the update.
-  lifecycle { prevent_destroy = true }
 }
 
 module "proxy_networking" {
@@ -14,6 +9,7 @@ module "proxy_networking" {
   proxy_ports           = var.proxy_ports
   proxy_domain          = google_dns_managed_zone.proxy_domain.name
   proxy_domain_name     = google_dns_managed_zone.proxy_domain.dns_name
+  public_web_whois      = var.public_web_whois
 }
 
 module "proxy_networking_canary" {
@@ -23,4 +19,5 @@ module "proxy_networking_canary" {
   proxy_ports           = var.proxy_ports_canary
   proxy_domain          = google_dns_managed_zone.proxy_domain.name
   proxy_domain_name     = google_dns_managed_zone.proxy_domain.dns_name
+  public_web_whois      = var.public_web_whois
 }

--- a/proxy/terraform/modules/networking/loadbalancer.tf
+++ b/proxy/terraform/modules/networking/loadbalancer.tf
@@ -206,6 +206,7 @@ resource "google_compute_global_forwarding_rule" "https_whois_ipv4_forwarding_ru
   ip_address = google_compute_global_address.proxy_ipv4_address.address
   target     = google_compute_target_tcp_proxy.https_whois_tcp_proxy.self_link
   port_range = "443"
+  count      = var.public_web_whois
 }
 
 resource "google_compute_global_forwarding_rule" "https_whois_ipv6_forwarding_rule" {
@@ -213,6 +214,7 @@ resource "google_compute_global_forwarding_rule" "https_whois_ipv6_forwarding_ru
   ip_address = google_compute_global_address.proxy_ipv6_address.address
   target     = google_compute_target_tcp_proxy.https_whois_tcp_proxy.self_link
   port_range = "443"
+  count      = var.public_web_whois
 }
 
 resource "google_compute_global_forwarding_rule" "http_whois_ipv4_forwarding_rule" {
@@ -220,6 +222,7 @@ resource "google_compute_global_forwarding_rule" "http_whois_ipv4_forwarding_rul
   ip_address = google_compute_global_address.proxy_ipv4_address.address
   target     = google_compute_target_http_proxy.http_whois_http_proxy.self_link
   port_range = "80"
+  count      = var.public_web_whois
 }
 
 resource "google_compute_global_forwarding_rule" "http_whois_ipv6_forwarding_rule" {
@@ -227,4 +230,5 @@ resource "google_compute_global_forwarding_rule" "http_whois_ipv6_forwarding_rul
   ip_address = google_compute_global_address.proxy_ipv6_address.address
   target     = google_compute_target_http_proxy.http_whois_http_proxy.self_link
   port_range = "80"
+  count      = var.public_web_whois
 }

--- a/proxy/terraform/modules/networking/variables.tf
+++ b/proxy/terraform/modules/networking/variables.tf
@@ -1,20 +1,32 @@
-# Instance groups that the load balancer forwards traffic to.
 variable "proxy_instance_groups" {
-  type = map
+  type        = map
+  description = "Instance groups that the load balancer forwards traffic to."
 }
 
-# Suffix (such as "-canary") added to the resource names.
 variable "suffix" {
-  default = ""
+  default     = ""
+  description = "Suffix (such as '-canary') added to the resource names."
 }
 
-# Node ports exposed by the proxy.
 variable "proxy_ports" {
-  type = map
+  type        = map
+  description = "Node ports exposed by the proxy."
 }
 
-# DNS zone for the proxy domain.
-variable "proxy_domain" {}
+variable "proxy_domain" {
+  description = "DNS zone for the proxy domain."
+}
 
-# domain name of the zone.
-variable "proxy_domain_name" {}
+variable "proxy_domain_name" {
+  description = "Domain name of the zone."
+}
+
+variable "public_web_whois" {
+  type        = number
+  description = <<EOF
+    Set to 1 if the whois HTTP ports are external, 0 if not.  This is necessary
+    because our test projects are configured with
+    constraints/compute.restrictLoadBalancerCreationForTypes, which prohibits
+    forwarding external HTTP(s) connections.
+    EOF
+}

--- a/proxy/terraform/modules/variables.tf
+++ b/proxy/terraform/modules/variables.tf
@@ -1,28 +1,37 @@
-# GCP project in which the proxy runs.
-variable "proxy_project_name" {}
+variable "proxy_project_name" {
+  description = "GCP project in which the proxy runs."
+}
 
-# GCP project from which the proxy image is pulled.
-variable "gcr_project_name" {}
+variable "gcr_project_name" {
+  description = "GCP project from which the proxy image is pulled."
+}
 
-# The base domain name of the proxy, without the whois. or epp. part.
-variable "proxy_domain_name" {}
+variable "proxy_domain_name" {
+  description = <<EOF
+    The base domain name of the proxy, without the whois. or epp. part.
+    EOF
+}
 
-# The GCS bucket that stores the encrypted SSL certificate.
-variable "proxy_certificate_bucket" {}
+variable "proxy_certificate_bucket" {
+  description = <<EOF
+    The GCS bucket that stores the encrypted SSL certificate.  The "gs://"
+    prefix should be omitted.
+    EOF
+}
 
-# Cloud KMS keyring name
 variable "proxy_key_ring" {
-  default = "proxy-key-ring"
+  default     = "proxy-key-ring"
+  description = "Cloud KMS keyring name"
 }
 
-# Cloud KMS key name
 variable "proxy_key" {
-  default = "proxy-key"
+  default     = "proxy-key"
+  description = "Cloud KMS key name"
 }
 
-# Node ports exposed by the proxy.
 variable "proxy_ports" {
-  type = map
+  type        = map
+  description = "Node ports exposed by the proxy."
 
   default = {
     health_check = 30000
@@ -33,9 +42,9 @@ variable "proxy_ports" {
   }
 }
 
-# Node ports exposed by the canary proxy.
 variable "proxy_ports_canary" {
-  type = map
+  type        = map
+  description = "Node ports exposed by the canary proxy."
 
   default = {
     health_check = 31000
@@ -44,4 +53,15 @@ variable "proxy_ports_canary" {
     http-whois   = 31010
     https-whois  = 31011
   }
+}
+
+variable "public_web_whois" {
+  type        = number
+  default     = 1
+  description = <<EOF
+    Set to 1 if the whois HTTP ports are external, 0 if not.  This is necessary
+    because our test projects are configured with
+    constraints/compute.restrictLoadBalancerCreationForTypes, which prohibits
+    forwarding external HTTP(s) connections.
+    EOF
 }

--- a/proxy/terraform/outputs.tf
+++ b/proxy/terraform/outputs.tf
@@ -1,0 +1,21 @@
+output "proxy_service_account" {
+  value       = module.proxy.proxy_service_account
+  description = "Service account the proxy runs under."
+}
+
+output "proxy_name_servers" {
+  value       = module.proxy.proxy_name_servers
+  description = "Name servers for the proxy's domain."
+}
+
+output "proxy_instance_groups" {
+  value       = module.proxy.proxy_instance_groups
+  description = <<EOF
+    The name of the GCE instance group backing up the proxy's cluster.
+    EOF
+}
+
+output "proxy_ip_addresses" {
+  value       = module.proxy.proxy_ip_addresses
+  description = "The proxy IP addresses."
+}


### PR DESCRIPTION
Update proxy terraform files based on current best practices and allow
exclusion of forwarding rules for HTTP endpoints.  Specifically:
-   Add a "public_web_whois" input to allow disabling the public HTTP
    whois forwarding.
-   Add "description" fields to all variables.
-   Move outputs of the top-level module into "outputs.tf".
-   Auto-reformat using hclfmt.

Note that this change is mostly just a patch of the same changes that were applied internally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1402)
<!-- Reviewable:end -->
