### PR TITLE
Change from TaskQueueUtils to CloudTasksUtils in RdeStaging

### DIFF
--- a/core/src/main/java/google/registry/rde/RdeStagingReducer.java
+++ b/core/src/main/java/google/registry/rde/RdeStagingReducer.java
@@ -14,8 +14,6 @@
 
 package google.registry.rde;
 
-import static com.google.appengine.api.taskqueue.QueueFactory.getQueue;
-import static com.google.appengine.api.taskqueue.TaskOptions.Builder.withUrl;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static google.registry.model.common.Cursor.getCursorTimeOrStartOfTime;
@@ -26,6 +24,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.appengine.tools.mapreduce.Reducer;
 import com.google.appengine.tools.mapreduce.ReducerInput;
 import com.google.cloud.storage.BlobId;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.flogger.FluentLogger;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.gcs.GcsUtils;
@@ -36,10 +35,11 @@ import google.registry.model.rde.RdeMode;
 import google.registry.model.rde.RdeNamingUtils;
 import google.registry.model.rde.RdeRevision;
 import google.registry.model.tld.Registry;
+import google.registry.request.Action.Service;
 import google.registry.request.RequestParameters;
 import google.registry.request.lock.LockHandler;
 import google.registry.tldconfig.idn.IdnTableEnum;
-import google.registry.util.TaskQueueUtils;
+import google.registry.util.CloudTasksUtils;
 import google.registry.xjc.rdeheader.XjcRdeHeader;
 import google.registry.xjc.rdeheader.XjcRdeHeaderElement;
 import google.registry.xml.ValidationMode;
@@ -65,7 +65,7 @@ public final class RdeStagingReducer extends Reducer<PendingDeposit, DepositFrag
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
-  private final TaskQueueUtils taskQueueUtils;
+  private final CloudTasksUtils cloudTasksUtils;
   private final LockHandler lockHandler;
   private final String bucket;
   private final Duration lockTimeout;
@@ -74,14 +74,14 @@ public final class RdeStagingReducer extends Reducer<PendingDeposit, DepositFrag
   private final GcsUtils gcsUtils;
 
   RdeStagingReducer(
-      TaskQueueUtils taskQueueUtils,
+      CloudTasksUtils cloudTasksUtils,
       LockHandler lockHandler,
       String bucket,
       Duration lockTimeout,
       byte[] stagingKeyBytes,
       ValidationMode validationMode,
       GcsUtils gcsUtils) {
-    this.taskQueueUtils = taskQueueUtils;
+    this.cloudTasksUtils = cloudTasksUtils;
     this.lockHandler = lockHandler;
     this.bucket = bucket;
     this.lockTimeout = lockTimeout;
@@ -227,22 +227,30 @@ public final class RdeStagingReducer extends Reducer<PendingDeposit, DepositFrag
                   "Rolled forward %s on %s cursor to %s.", key.cursor(), tld, newPosition);
               RdeRevision.saveRevision(tld, watermark, mode, revision);
               if (mode == RdeMode.FULL) {
-                taskQueueUtils.enqueue(
-                    getQueue("rde-upload"),
-                    withUrl(RdeUploadAction.PATH).param(RequestParameters.PARAM_TLD, tld));
+                cloudTasksUtils.enqueue(
+                    "rde-upload",
+                    CloudTasksUtils.createPostTask(
+                        RdeUploadAction.PATH,
+                        Service.BACKEND.toString(),
+                        ImmutableMultimap.of(RequestParameters.PARAM_TLD, tld)));
               } else {
-                taskQueueUtils.enqueue(
-                    getQueue("brda"),
-                    withUrl(BrdaCopyAction.PATH)
-                        .param(RequestParameters.PARAM_TLD, tld)
-                        .param(RdeModule.PARAM_WATERMARK, watermark.toString()));
+                cloudTasksUtils.enqueue(
+                    "brda",
+                    CloudTasksUtils.createPostTask(
+                        BrdaCopyAction.PATH,
+                        Service.BACKEND.toString(),
+                        ImmutableMultimap.of(
+                            RequestParameters.PARAM_TLD,
+                            tld,
+                            RdeModule.PARAM_WATERMARK,
+                            watermark.toString())));
               }
             });
   }
 
   /** Injectible factory for creating {@link RdeStagingReducer}. */
   static class Factory {
-    @Inject TaskQueueUtils taskQueueUtils;
+    @Inject CloudTasksUtils cloudTasksUtils;
     @Inject LockHandler lockHandler;
     @Inject @Config("rdeBucket") String bucket;
     @Inject @Config("rdeStagingLockTimeout") Duration lockTimeout;
@@ -252,7 +260,7 @@ public final class RdeStagingReducer extends Reducer<PendingDeposit, DepositFrag
 
     RdeStagingReducer create(ValidationMode validationMode, GcsUtils gcsUtils) {
       return new RdeStagingReducer(
-          taskQueueUtils,
+          cloudTasksUtils,
           lockHandler,
           bucket,
           lockTimeout,

--- a/core/src/test/java/google/registry/rde/RdeStagingActionDatastoreTest.java
+++ b/core/src/test/java/google/registry/rde/RdeStagingActionDatastoreTest.java
@@ -25,6 +25,7 @@ import static google.registry.rde.RdeFixtures.makeHostResource;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DatabaseHelper.persistResourceWithCommitLog;
+import static google.registry.testing.TaskQueueHelper.assertAtLeastOneTaskIsEnqueued;
 import static google.registry.testing.TestDataHelper.loadFile;
 import static google.registry.tldconfig.idn.IdnTableEnum.EXTENDED_LATIN;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -196,8 +197,7 @@ public class RdeStagingActionDatastoreTest extends MapreduceTestCase<RdeStagingA
     action.run();
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.getPayload()).contains("/_ah/pipeline/status.html?root=");
-    // TODO(rachelguan): determine where task gets pushed into "mapreduce"
-    cloudTasksHelper.assertAtLeastOneTaskIsEnqueued("mapreduce");
+    assertAtLeastOneTaskIsEnqueued("mapreduce");
   }
 
   @Test
@@ -216,7 +216,7 @@ public class RdeStagingActionDatastoreTest extends MapreduceTestCase<RdeStagingA
     clock.setTo(DateTime.parse("2000-01-01T00:05:00Z"));
     action.transactionCooldown = Duration.standardMinutes(5);
     action.run();
-    cloudTasksHelper.assertAtLeastOneTaskIsEnqueued("mapreduce");
+    assertAtLeastOneTaskIsEnqueued("mapreduce");
   }
 
   @Test
@@ -304,7 +304,7 @@ public class RdeStagingActionDatastoreTest extends MapreduceTestCase<RdeStagingA
     action.run();
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.getPayload()).contains("_ah/pipeline/status.html?root=");
-    cloudTasksHelper.assertAtLeastOneTaskIsEnqueued("mapreduce");
+    assertAtLeastOneTaskIsEnqueued("mapreduce");
   }
 
   @Test

--- a/core/src/test/java/google/registry/rde/RdeStagingActionDatastoreTest.java
+++ b/core/src/test/java/google/registry/rde/RdeStagingActionDatastoreTest.java
@@ -26,6 +26,7 @@ import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DatabaseHelper.persistResourceWithCommitLog;
 import static google.registry.testing.TaskQueueHelper.assertAtLeastOneTaskIsEnqueued;
+import static google.registry.testing.TaskQueueHelper.assertNoTasksEnqueued;
 import static google.registry.testing.TestDataHelper.loadFile;
 import static google.registry.tldconfig.idn.IdnTableEnum.EXTENDED_LATIN;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -177,7 +178,7 @@ public class RdeStagingActionDatastoreTest extends MapreduceTestCase<RdeStagingA
   void testRun_noTlds_returns204() {
     action.run();
     assertThat(response.getStatus()).isEqualTo(204);
-    cloudTasksHelper.assertNoTasksEnqueued("mapreduce");
+    assertNoTasksEnqueued("mapreduce");
   }
 
   @Test
@@ -187,7 +188,7 @@ public class RdeStagingActionDatastoreTest extends MapreduceTestCase<RdeStagingA
     clock.setTo(DateTime.parse("2000-01-01TZ"));
     action.run();
     assertThat(response.getStatus()).isEqualTo(204);
-    cloudTasksHelper.assertNoTasksEnqueued("mapreduce");
+    assertNoTasksEnqueued("mapreduce");
   }
 
   @Test
@@ -207,7 +208,7 @@ public class RdeStagingActionDatastoreTest extends MapreduceTestCase<RdeStagingA
     action.transactionCooldown = Duration.standardMinutes(5);
     action.run();
     assertThat(response.getStatus()).isEqualTo(204);
-    cloudTasksHelper.assertNoTasksEnqueued("mapreduce");
+    assertNoTasksEnqueued("mapreduce");
   }
 
   @Test
@@ -466,9 +467,7 @@ public class RdeStagingActionDatastoreTest extends MapreduceTestCase<RdeStagingA
     executeTasksUntilEmpty("mapreduce", clock);
     cloudTasksHelper.assertTasksEnqueued(
         "rde-upload",
-        new CloudTasksHelper.TaskMatcher()
-            .url(RdeUploadAction.PATH)
-            .param(RequestParameters.PARAM_TLD, "lol"));
+        new TaskMatcher().url(RdeUploadAction.PATH).param(RequestParameters.PARAM_TLD, "lol"));
     cloudTasksHelper.assertTasksEnqueued(
         "brda",
         new TaskMatcher()

--- a/core/src/test/java/google/registry/testing/CloudTasksHelper.java
+++ b/core/src/test/java/google/registry/testing/CloudTasksHelper.java
@@ -169,11 +169,6 @@ public class CloudTasksHelper implements Serializable {
     }
   }
 
-  /** Ensures that the named queue contains at least one task. */
-  public void assertAtLeastOneTaskIsEnqueued(String queueName) {
-    assertThat(getTestTasksFor(queueName).isEmpty()).isFalse();
-  }
-
   private class FakeCloudTasksClient extends CloudTasksUtils.SerializableCloudTasksClient {
 
     private static final long serialVersionUID = 6661964844791720639L;

--- a/core/src/test/java/google/registry/testing/CloudTasksHelper.java
+++ b/core/src/test/java/google/registry/testing/CloudTasksHelper.java
@@ -169,6 +169,11 @@ public class CloudTasksHelper implements Serializable {
     }
   }
 
+  /** Ensures that the named queue contains at least one task. */
+  public void assertAtLeastOneTaskIsEnqueued(String queueName) {
+    assertThat(getTestTasksFor(queueName).isEmpty()).isFalse();
+  }
+
   private class FakeCloudTasksClient extends CloudTasksUtils.SerializableCloudTasksClient {
 
     private static final long serialVersionUID = 6661964844791720639L;


### PR DESCRIPTION
Most of the changes are similar to the previous TaskQueueUtils-> CloudTasksUtils PRs, except `TaskQueueHelper` is still used for the `"mapreduce"` queue. Nothing related to the "mapreduce" queue, should be changed since it is enqueued by the map reduce utils class and not controlled by `CloudTasksUtil`. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1411)
<!-- Reviewable:end -->
