### PR TITLE
Correct HTTP method in CommitLogCheckPointAction

### DIFF
--- a/core/src/main/java/google/registry/backup/CommitLogCheckpointAction.java
+++ b/core/src/main/java/google/registry/backup/CommitLogCheckpointAction.java
@@ -80,7 +80,7 @@ public final class CommitLogCheckpointAction implements Runnable {
               // Enqueue a diff task between previous and current checkpoints.
               cloudTasksUtils.enqueue(
                   QUEUE_NAME,
-                  CloudTasksUtils.createGetTask(
+                  CloudTasksUtils.createPostTask(
                       ExportCommitLogDiffAction.PATH,
                       Service.BACKEND.toString(),
                       ImmutableMultimap.of(


### PR DESCRIPTION
There's an ongoing effort to move away from App Engine API to Cloud Task APIs.  The old task APIs in CommitLogCheckPointAction.java and its test case were replaced after PR#1409 : Change TaskQueueUtils to CloudTaskUtils in CommitLogCheckPointAction (https://github.com/google/nomulus/pull/1409/files) 

The HTTP Method used for the task was not explicitly declared and the task is supposed to be created via POST instead of GET.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1413)
<!-- Reviewable:end -->
