### PR TITLE
Make TaskMatcher default to POST methods

### DIFF
--- a/core/src/test/java/google/registry/testing/CloudTasksHelper.java
+++ b/core/src/test/java/google/registry/testing/CloudTasksHelper.java
@@ -188,7 +188,10 @@ public class CloudTasksHelper implements Serializable {
 
     String taskName;
     String service;
-    HttpMethod method = HttpMethod.POST;  // Task queue methods default to "POST".
+    // Task queue methods default to "POST".  This isn't obvious from the code, so we default it to
+    // POST here so that we don't accidentally create an entry with a GET method.  Should we ever
+    // actually want to do a GET, we'll set this explicitly.
+    HttpMethod method = HttpMethod.POST;
     String url;
     Multimap<String, String> headers = ArrayListMultimap.create();
     Multimap<String, String> params = ArrayListMultimap.create();

--- a/core/src/test/java/google/registry/testing/CloudTasksHelper.java
+++ b/core/src/test/java/google/registry/testing/CloudTasksHelper.java
@@ -188,9 +188,11 @@ public class CloudTasksHelper implements Serializable {
 
     String taskName;
     String service;
-    // Task queue methods default to "POST".  This isn't obvious from the code, so we default it to
-    // POST here so that we don't accidentally create an entry with a GET method.  Should we ever
-    // actually want to do a GET, we'll set this explicitly.
+    // App Engine TaskOption methods default to "POST".  This isn't obvious from the code, so we
+    // default it to POST here so that we don't accidentally create an entry with a GET method when
+    // converting to CloudTaskUtils, which requires that the method be specified explicitly.
+    // Should we ever actually want to do a GET, we'll likewise have to set this explicitly for the
+    // tests.
     HttpMethod method = HttpMethod.POST;
     String url;
     Multimap<String, String> headers = ArrayListMultimap.create();

--- a/core/src/test/java/google/registry/testing/CloudTasksHelper.java
+++ b/core/src/test/java/google/registry/testing/CloudTasksHelper.java
@@ -188,7 +188,7 @@ public class CloudTasksHelper implements Serializable {
 
     String taskName;
     String service;
-    HttpMethod method;
+    HttpMethod method = HttpMethod.POST;  // Task queue methods default to "POST".
     String url;
     Multimap<String, String> headers = ArrayListMultimap.create();
     Multimap<String, String> params = ArrayListMultimap.create();


### PR DESCRIPTION
TaskOptions.Builder.withUrl() defaults to POST methods.  Therefore, it seems
reasonable to verify that task queue methods are using the POST method,
especially given that the method must now be identified explicitly when using
CloudTaskUtils.  This check would have guarded against the bug fixed by #1413.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1418)
<!-- Reviewable:end -->
