### PR TITLE
Remove TmchCrl singleton from Datastore

### DIFF
--- a/core/src/main/java/google/registry/model/EntityClasses.java
+++ b/core/src/main/java/google/registry/model/EntityClasses.java
@@ -43,7 +43,6 @@ import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.server.Lock;
 import google.registry.model.server.ServerSecret;
 import google.registry.model.tld.Registry;
-import google.registry.model.tmch.TmchCrl;
 
 /** Sets of classes of the Objectify-registered entities in use throughout the model. */
 public final class EntityClasses {
@@ -85,8 +84,7 @@ public final class EntityClasses {
           Registrar.class,
           RegistrarContact.class,
           Registry.class,
-          ServerSecret.class,
-          TmchCrl.class);
+          ServerSecret.class);
 
   private EntityClasses() {}
 }

--- a/core/src/test/java/google/registry/backup/ReplayCommitLogsToSqlActionTest.java
+++ b/core/src/test/java/google/registry/backup/ReplayCommitLogsToSqlActionTest.java
@@ -67,7 +67,6 @@ import google.registry.model.replay.SqlReplayCheckpoint;
 import google.registry.model.server.Lock;
 import google.registry.model.tld.label.PremiumList;
 import google.registry.model.tld.label.PremiumList.PremiumEntry;
-import google.registry.model.tmch.TmchCrl;
 import google.registry.model.translators.VKeyTranslatorFactory;
 import google.registry.persistence.VKey;
 import google.registry.persistence.transaction.JpaTransactionManager;
@@ -482,7 +481,8 @@ public class ReplayCommitLogsToSqlActionTest {
 
     jpaTm().transact(() -> SqlReplayCheckpoint.set(now.minusMinutes(1).minusMillis(1)));
     // Save a couple deletes that aren't propagated to SQL (the objects deleted are irrelevant)
-    Key<TmchCrl> tmchCrlKey = Key.create(TmchCrl.class, 1L);
+    Key<CommitLogManifest> manifestKey =
+        CommitLogManifest.createKey(getBucketKey(1), now.minusMinutes(1));
     saveDiffFile(
         gcsUtils,
         createCheckpoint(now.minusMinutes(1)),
@@ -490,7 +490,7 @@ public class ReplayCommitLogsToSqlActionTest {
             getBucketKey(1),
             now.minusMinutes(1),
             // one object only exists in Datastore, one is dually-written (so isn't replicated)
-            ImmutableSet.of(getCrossTldKey(), tmchCrlKey)));
+            ImmutableSet.of(getCrossTldKey(), manifestKey)));
 
     runAndAssertSuccess(now.minusMinutes(1), 1, 1);
     verify(spy, times(0)).delete(any(VKey.class));

--- a/core/src/test/java/google/registry/model/tmch/TmchCrlTest.java
+++ b/core/src/test/java/google/registry/model/tmch/TmchCrlTest.java
@@ -15,39 +15,26 @@
 package google.registry.model.tmch;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.testing.DatabaseHelper.loadByEntity;
 
 import google.registry.model.EntityTestCase;
-import google.registry.testing.DualDatabaseTest;
-import google.registry.testing.TestOfyAndSql;
 import java.util.Optional;
+import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link TmchCrl}. */
-@DualDatabaseTest
 public class TmchCrlTest extends EntityTestCase {
 
   TmchCrlTest() {
     super(JpaEntityCoverageCheck.ENABLED);
   }
 
-  @TestOfyAndSql
+  @Test
   void testSuccess() {
     assertThat(TmchCrl.get()).isEqualTo(Optional.empty());
     TmchCrl.set("lolcat", "https://lol.cat");
     assertThat(TmchCrl.get().get().getCrl()).isEqualTo("lolcat");
   }
 
-  @TestOfyAndSql
-  void testDualWrite() {
-    TmchCrl expected = new TmchCrl();
-    expected.crl = "lolcat";
-    expected.url = "https://lol.cat";
-    expected.updated = fakeClock.nowUtc();
-    TmchCrl.set("lolcat", "https://lol.cat");
-    assertThat(loadByEntity(new TmchCrl())).isEqualTo(expected);
-  }
-
-  @TestOfyAndSql
+  @Test
   void testMultipleWrites() {
     TmchCrl.set("first", "https://first.cat");
     assertThat(TmchCrl.get().get().getCrl()).isEqualTo("first");

--- a/core/src/test/resources/google/registry/export/crosstld_kinds.txt
+++ b/core/src/test/resources/google/registry/export/crosstld_kinds.txt
@@ -3,4 +3,3 @@ Registrar
 RegistrarContact
 Registry
 ServerSecret
-TmchCrl

--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -789,13 +789,6 @@ enum google.registry.model.tld.Registry$TldType {
   REAL;
   TEST;
 }
-class google.registry.model.tmch.TmchCrl {
-  @Id long id;
-  @Parent com.googlecode.objectify.Key<google.registry.model.common.EntityGroupRoot> parent;
-  java.lang.String crl;
-  java.lang.String url;
-  org.joda.time.DateTime updated;
-}
 class google.registry.model.transfer.ContactTransferData {
   google.registry.model.eppcommon.Trid transferRequestTrid;
   google.registry.model.transfer.TransferStatus transferStatus;


### PR DESCRIPTION
The TmchCrl singleton has been dual-written for a long time with no issues. This change fully migrates TmchCrl to CloudSql. Since this data is rewritten everyday, a formal staged migration is not necessary. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1419)
<!-- Reviewable:end -->
