### PR TITLE
Ignore read-only mode when running commit logs / backups

### DIFF
--- a/core/src/main/java/google/registry/backup/BackupUtils.java
+++ b/core/src/main/java/google/registry/backup/BackupUtils.java
@@ -41,11 +41,12 @@ public class BackupUtils {
   }
 
   /**
-   * Converts the given {@link ImmutableObject} to a raw Datastore entity and write it to an
-   * {@link OutputStream} in delimited protocol buffer format.
+   * Converts the given {@link ImmutableObject} to a raw Datastore entity and write it to an {@link
+   * OutputStream} in delimited protocol buffer format.
    */
   static void serializeEntity(ImmutableObject entity, OutputStream stream) throws IOException {
-    EntityTranslator.convertToPb(auditedOfy().save().toEntity(entity)).writeDelimitedTo(stream);
+    EntityTranslator.convertToPb(auditedOfy().saveIgnoringReadOnly().toEntity(entity))
+        .writeDelimitedTo(stream);
   }
 
   /**

--- a/core/src/main/java/google/registry/backup/CommitLogCheckpointAction.java
+++ b/core/src/main/java/google/registry/backup/CommitLogCheckpointAction.java
@@ -74,7 +74,7 @@ public final class CommitLogCheckpointAction implements Runnable {
                 return;
               }
               auditedOfy()
-                  .saveWithoutBackup()
+                  .saveIgnoringReadOnly()
                   .entities(
                       checkpoint, CommitLogCheckpointRoot.create(checkpoint.getCheckpointTime()));
               // Enqueue a diff task between previous and current checkpoints.


### PR DESCRIPTION
We need to be able to continue running the backup and async replay code
while the database is in read-only mode

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1424)
<!-- Reviewable:end -->
