### PR TITLE
Add method to show readable key info

### DIFF
--- a/core/src/main/java/google/registry/persistence/VKey.java
+++ b/core/src/main/java/google/registry/persistence/VKey.java
@@ -311,4 +311,31 @@ public class VKey<T> extends ImmutableObject implements Serializable {
     }
     return key;
   }
+
+  /**
+   * Constructs the readable string representation of a {@link VKey}.
+   *
+   * <p>This readable string representation of a vkey contains its type and its sql key or ofy key,
+   * or both.
+   */
+  @Override
+  public String toString() {
+    if (maybeGetOfyKey().isPresent() && maybeGetSqlKey().isPresent()) {
+      return String.format(
+          "VKey<%s>(%s:%s,%s:%s)",
+          getKind().getSimpleName(),
+          SQL_LOOKUP_KEY,
+          getSqlKey().toString(),
+          OFY_LOOKUP_KEY,
+          getOfyKey().getName());
+    } else if (maybeGetSqlKey().isPresent()) {
+      return String.format(
+          "VKey<%s>(%s:%s)", getKind().getSimpleName(), SQL_LOOKUP_KEY, getSqlKey().toString());
+    } else if (maybeGetOfyKey().isPresent()) {
+      return String.format(
+          "VKey<%s>(%s:%s)", getKind().getSimpleName(), OFY_LOOKUP_KEY, getOfyKey().getName());
+    } else {
+      throw new IllegalStateException("VKey should contain at least one form of key");
+    }
+  }
 }

--- a/core/src/main/java/google/registry/persistence/VKey.java
+++ b/core/src/main/java/google/registry/persistence/VKey.java
@@ -323,19 +323,17 @@ public class VKey<T> extends ImmutableObject implements Serializable {
     if (maybeGetOfyKey().isPresent() && maybeGetSqlKey().isPresent()) {
       return String.format(
           "VKey<%s>(%s:%s,%s:%s)",
-          getKind().getSimpleName(),
-          SQL_LOOKUP_KEY,
-          getSqlKey().toString(),
-          OFY_LOOKUP_KEY,
-          getOfyKey().getName());
+          getKind().getSimpleName(), SQL_LOOKUP_KEY, sqlKey, OFY_LOOKUP_KEY, ofyKeyToString());
     } else if (maybeGetSqlKey().isPresent()) {
-      return String.format(
-          "VKey<%s>(%s:%s)", getKind().getSimpleName(), SQL_LOOKUP_KEY, getSqlKey().toString());
+      return String.format("VKey<%s>(%s:%s)", getKind().getSimpleName(), SQL_LOOKUP_KEY, sqlKey);
     } else if (maybeGetOfyKey().isPresent()) {
-      return String.format(
-          "VKey<%s>(%s:%s)", getKind().getSimpleName(), OFY_LOOKUP_KEY, getOfyKey().getName());
+      return String.format("VKey<%s>(%s:%s)", ofyKey.getKind(), OFY_LOOKUP_KEY, ofyKeyToString());
     } else {
       throw new IllegalStateException("VKey should contain at least one form of key");
     }
+  }
+
+  private String ofyKeyToString() {
+    return ofyKey.getName() == null ? String.valueOf(ofyKey.getId()) : ofyKey.getName();
   }
 }

--- a/core/src/main/java/google/registry/tools/GetResourceByKeyCommand.java
+++ b/core/src/main/java/google/registry/tools/GetResourceByKeyCommand.java
@@ -48,7 +48,7 @@ final class GetResourceByKeyCommand implements CommandWithRemoteApi {
       EppResource resource =
           checkNotNull(
               auditedOfy().load().key(resourceKey.getOfyKey()).now(),
-              "Could not load resource for key: " + resourceKey.getOfyKey());
+              "Could not load resource for key: " + resourceKey);
       System.out.println(expand ? resource.toHydratedString() : resource.toString());
     }
   }

--- a/core/src/test/java/google/registry/persistence/VKeyTest.java
+++ b/core/src/test/java/google/registry/persistence/VKeyTest.java
@@ -418,6 +418,25 @@ class VKeyTest {
     assertThat(VKey.create(vkeyStringFromQueue)).isEqualTo(vkey);
   }
 
+  @Test
+  void testToString_sqlOnlyVKey() {
+    assertThat(VKey.createSql(TestObject.class, "testId").toString())
+        .isEqualTo("VKey<TestObject>(sql:testId)");
+  }
+
+  @Test
+  void testToString_ofyOnlyVKey() {
+    assertThat(VKey.createOfy(TestObject.class, Key.create(TestObject.class, "testId")).toString())
+        .isEqualTo("VKey<TestObject>(ofy:testId)");
+  }
+
+  @Test
+  void testToString_sqlAndOfyVKey() {
+    assertThat(
+            VKey.create(TestObject.class, "foo", Key.create(TestObject.create("ofy"))).toString())
+        .isEqualTo("VKey<TestObject>(sql:foo,ofy:ofy)");
+  }
+
   @Entity
   static class OtherObject {}
 }

--- a/core/src/test/java/google/registry/persistence/VKeyTest.java
+++ b/core/src/test/java/google/registry/persistence/VKeyTest.java
@@ -425,9 +425,16 @@ class VKeyTest {
   }
 
   @Test
-  void testToString_ofyOnlyVKey() {
-    assertThat(VKey.createOfy(TestObject.class, Key.create(TestObject.class, "testId")).toString())
-        .isEqualTo("VKey<TestObject>(ofy:testId)");
+  void testToString_ofyOnlyVKey_withName() {
+    assertThat(
+            VKey.createOfy(TestObject.class, Key.create(TestObject.class, "testName")).toString())
+        .isEqualTo("VKey<TestObject>(ofy:testName)");
+  }
+
+  @Test
+  void testToString_ofyOnlyVKey_withId() {
+    assertThat(VKey.createOfy(TestObject.class, Key.create(TestObject.class, 12345)).toString())
+        .isEqualTo("VKey<TestObject>(ofy:12345)");
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/GetResourceByKeyCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetResourceByKeyCommandTest.java
@@ -79,7 +79,7 @@ class GetResourceByKeyCommandTest extends CommandTestCase<GetResourceByKeyComman
                     "agR0ZXN0chULEgpEb21haW5CYXNlIgU0LVRMRAw"));
     assertThat(thrown)
         .hasMessageThat()
-        .contains("Could not load resource for key: Key<?>(DomainBase(\"4-TLD\"))");
+        .contains("Could not load resource for key: VKey<DomainBase>(sql:4-TLD,ofy:4-TLD)");
   }
 
   @Test
@@ -128,7 +128,7 @@ class GetResourceByKeyCommandTest extends CommandTestCase<GetResourceByKeyComman
                     "agR0ZXN0chsLEg9Db250YWN0UmVzb3VyY2UiBjMtUk9JRAw"));
     assertThat(thrown)
         .hasMessageThat()
-        .contains("Could not load resource for key: Key<?>(ContactResource(\"3-ROID\"))");
+        .contains("Could not load resource for key: VKey<ContactResource>(sql:3-ROID,ofy:3-ROID)");
   }
 
   @Test
@@ -177,7 +177,7 @@ class GetResourceByKeyCommandTest extends CommandTestCase<GetResourceByKeyComman
                     "agR0ZXN0chgLEgxIb3N0UmVzb3VyY2UiBjMtUk9JRAw"));
     assertThat(thrown)
         .hasMessageThat()
-        .contains("Could not load resource for key: Key<?>(HostResource(\"3-ROID\"))");
+        .contains("Could not load resource for key: VKey<HostResource>(sql:3-ROID,ofy:3-ROID)");
   }
 
   @Test
@@ -210,7 +210,7 @@ class GetResourceByKeyCommandTest extends CommandTestCase<GetResourceByKeyComman
             () -> runCommand("agR0ZXN0chULEgpEb21haW5CYXNlIgUyLVRMRAw"));
     assertThat(thrown)
         .hasMessageThat()
-        .contains("Could not load resource for key: Key<?>(DomainBase(\"2-TLD\"))");
+        .contains("Could not load resource for key: VKey<DomainBase>(sql:2-TLD,ofy:2-TLD)");
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/SetupOteCommandTest.java
+++ b/core/src/test/java/google/registry/tools/SetupOteCommandTest.java
@@ -331,7 +331,9 @@ class SetupOteCommandTest extends CommandTestCase<SetupOteCommand> {
                     "--registrar=blobio",
                     "--email=contact@email.com",
                     "--certfile=" + getCertFilename()));
-    assertThat(thrown).hasMessageThat().contains("Registry(\"blobio-sunrise\")");
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains("VKey<Registry>(sql:blobio-sunrise,ofy:blobio-sunrise)");
   }
 
   @Test
@@ -367,7 +369,7 @@ class SetupOteCommandTest extends CommandTestCase<SetupOteCommand> {
                     "--registrar=blobio",
                     "--email=contact@email.com",
                     "--certfile=" + getCertFilename()));
-    assertThat(thrown).hasMessageThat().contains("Registrar(\"blobio-1\")");
+    assertThat(thrown).hasMessageThat().contains("VKey<Registrar>(sql:blobio-1,ofy:blobio-1)");
   }
 
   @Test


### PR DESCRIPTION
Currently, there's only pretty print ofy key info not vkey. If we are replacing ofy keys with vkeys, we need to replace the output statement about ofy keys with vkeys' as well. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1431)
<!-- Reviewable:end -->
