### PR TITLE
Ignore read-only mode in SQL->DS replication process

### DIFF
--- a/core/src/main/java/google/registry/model/EppResource.java
+++ b/core/src/main/java/google/registry/model/EppResource.java
@@ -224,10 +224,8 @@ public abstract class EppResource extends BackupGroupRoot implements Buildable {
 
   /** Used when replaying from SQL to DS to populate the Datastore indexes. */
   protected void saveIndexesToDatastore() {
-    ofyTm()
-        .putAll(
-            ForeignKeyIndex.create(this, getDeletionTime()),
-            EppResourceIndex.create(Key.create(this)));
+    ofyTm().putIgnoringReadOnly(ForeignKeyIndex.create(this, getDeletionTime()));
+    ofyTm().putIgnoringReadOnly(EppResourceIndex.create(Key.create(this)));
   }
 
   /** EppResources that are loaded via foreign keys should implement this marker interface. */

--- a/core/src/main/java/google/registry/model/replay/ReplicateToDatastoreAction.java
+++ b/core/src/main/java/google/registry/model/replay/ReplicateToDatastoreAction.java
@@ -148,7 +148,9 @@ public class ReplicateToDatastoreAction implements Runnable {
 
                 // Write the updated last transaction id to Datastore as part of this Datastore
                 // transaction.
-                auditedOfy().save().entity(lastSqlTxn.cloneWithNewTransactionId(nextTxnId));
+                auditedOfy()
+                    .saveIgnoringReadOnly()
+                    .entity(lastSqlTxn.cloneWithNewTransactionId(nextTxnId));
                 logger.atInfo().log(
                     "Finished applying single transaction Cloud SQL -> Cloud Datastore.");
               });


### PR DESCRIPTION
We need to be able to save indices and save data about the replication
even when we're in read-only mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1432)
<!-- Reviewable:end -->
