### PR TITLE
Add NotLoggedInException tests to flows and flow docs

### DIFF
--- a/core/src/main/java/google/registry/flows/contact/ContactCheckFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactCheckFlow.java
@@ -42,6 +42,7 @@ import javax.inject.Inject;
  * <p>This flows can check the existence of multiple contacts simultaneously.
  *
  * @error {@link google.registry.flows.exceptions.TooManyResourceChecksException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  */
 @ReportingSpec(ActivityReportField.CONTACT_CHECK)
 public final class ContactCheckFlow implements Flow {

--- a/core/src/main/java/google/registry/flows/contact/ContactCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactCreateFlow.java
@@ -51,6 +51,7 @@ import org.joda.time.DateTime;
  * An EPP flow that creates a new contact.
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link ResourceAlreadyExistsForThisClientException}
  * @error {@link ResourceCreateContentionException}
  * @error {@link ContactFlowUtils.BadInternationalizedPostalInfoException}

--- a/core/src/main/java/google/registry/flows/contact/ContactDeleteFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactDeleteFlow.java
@@ -61,6 +61,7 @@ import org.joda.time.DateTime;
  * with the success or failure message when the process is complete.
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException}
  * @error {@link google.registry.flows.exceptions.ResourceStatusProhibitsOperationException}

--- a/core/src/main/java/google/registry/flows/contact/ContactInfoFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactInfoFlow.java
@@ -46,6 +46,7 @@ import org.joda.time.DateTime;
  * ever been transferred. Any registrar can see any contact's information, but the authInfo is only
  * visible to the registrar that owns the contact or to a registrar that already supplied it.
  *
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException}
  */

--- a/core/src/main/java/google/registry/flows/contact/ContactTransferApproveFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactTransferApproveFlow.java
@@ -55,6 +55,7 @@ import org.joda.time.DateTime;
  * explicitly approve the transfer request, which then becomes effective immediately.
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}

--- a/core/src/main/java/google/registry/flows/contact/ContactTransferCancelFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactTransferCancelFlow.java
@@ -55,6 +55,7 @@ import org.joda.time.DateTime;
  * withdraw the transfer request.
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link google.registry.flows.exceptions.NotPendingTransferException}

--- a/core/src/main/java/google/registry/flows/contact/ContactTransferQueryFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactTransferQueryFlow.java
@@ -40,11 +40,12 @@ import javax.inject.Inject;
  *
  * <p>The "gaining" registrar requests a transfer from the "losing" (aka current) registrar. The
  * losing registrar has a "transfer" time period to respond (by default five days) after which the
- * transfer is automatically approved. This flow can be used by the gaining or losing registrars
- * (or anyone with the correct authId) to see the status of a transfer, which may still be pending
- * or may have been approved, rejected, cancelled or implicitly approved by virtue of the transfer
+ * transfer is automatically approved. This flow can be used by the gaining or losing registrars (or
+ * anyone with the correct authId) to see the status of a transfer, which may still be pending or
+ * may have been approved, rejected, cancelled or implicitly approved by virtue of the transfer
  * period expiring.
  *
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link google.registry.flows.exceptions.NoTransferHistoryToQueryException}

--- a/core/src/main/java/google/registry/flows/contact/ContactTransferRejectFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactTransferRejectFlow.java
@@ -54,6 +54,7 @@ import org.joda.time.DateTime;
  * reject the transfer request.
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException}

--- a/core/src/main/java/google/registry/flows/contact/ContactTransferRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactTransferRequestFlow.java
@@ -64,6 +64,7 @@ import org.joda.time.Duration;
  * request.
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link google.registry.flows.exceptions.AlreadyPendingTransferException}

--- a/core/src/main/java/google/registry/flows/contact/ContactUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactUpdateFlow.java
@@ -56,6 +56,7 @@ import org.joda.time.DateTime;
  * An EPP flow that updates a contact.
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.AddRemoveSameValueException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException}

--- a/core/src/main/java/google/registry/flows/domain/DomainCheckFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCheckFlow.java
@@ -85,6 +85,7 @@ import org.joda.time.DateTime;
  * <p>This flow also supports the EPP fee extension and can return pricing information.
  *
  * @error {@link google.registry.flows.exceptions.TooManyResourceChecksException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.FlowUtils.UnknownCurrencyEppException}
  * @error {@link DomainFlowUtils.BadDomainNameCharacterException}
  * @error {@link DomainFlowUtils.BadDomainNamePartsCountException}

--- a/core/src/main/java/google/registry/flows/domain/DomainClaimsCheckFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainClaimsCheckFlow.java
@@ -57,13 +57,14 @@ import org.joda.time.DateTime;
  * An EPP flow that checks whether domain labels are trademarked.
  *
  * @error {@link google.registry.flows.exceptions.TooManyResourceChecksException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link DomainFlowUtils.BadCommandForRegistryPhaseException}
  * @error {@link DomainFlowUtils.ClaimsPeriodEndedException}
  * @error {@link DomainFlowUtils.NotAuthorizedForTldException}
  * @error {@link DomainFlowUtils.TldDoesNotExistException}
  * @error {@link DomainClaimsCheckNotAllowedWithAllocationTokens}
  */
-@ReportingSpec(ActivityReportField.DOMAIN_CHECK)  // Claims check is a special domain check.
+@ReportingSpec(ActivityReportField.DOMAIN_CHECK) // Claims check is a special domain check.
 public final class DomainClaimsCheckFlow implements Flow {
 
   @Inject ExtensionManager extensionManager;

--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -139,6 +139,7 @@ import org.joda.time.Duration;
  * @error {@link ResourceCreateContentionException}
  * @error {@link google.registry.flows.EppException.UnimplementedExtensionException}
  * @error {@link google.registry.flows.ExtensionManager.UndeclaredServiceExtensionException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.FlowUtils.UnknownCurrencyEppException}
  * @error {@link DomainCreateFlow.AnchorTenantCreatePeriodException}
  * @error {@link DomainCreateFlow.MustHaveSignedMarksInCurrentPhaseException}

--- a/core/src/main/java/google/registry/flows/domain/DomainDeleteFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainDeleteFlow.java
@@ -105,6 +105,7 @@ import org.joda.time.Duration;
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
  * @error {@link google.registry.flows.EppException.UnimplementedExtensionException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException}
  * @error {@link google.registry.flows.exceptions.OnlyToolCanPassMetadataException}

--- a/core/src/main/java/google/registry/flows/domain/DomainInfoFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainInfoFlow.java
@@ -63,6 +63,7 @@ import org.joda.time.DateTime;
  * domain, will get a rich result with all of the domain's fields. All other requests will be
  * answered with a minimal result containing only basic information about the domain.
  *
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.FlowUtils.UnknownCurrencyEppException}
  * @error {@link google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}

--- a/core/src/main/java/google/registry/flows/domain/DomainRenewFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRenewFlow.java
@@ -95,6 +95,7 @@ import org.joda.time.Duration;
  * expired.
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.FlowUtils.UnknownCurrencyEppException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException}

--- a/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
@@ -95,6 +95,7 @@ import org.joda.time.DateTime;
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
  * @error {@link google.registry.flows.EppException.UnimplementedExtensionException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.FlowUtils.UnknownCurrencyEppException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException}

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferApproveFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferApproveFlow.java
@@ -79,6 +79,7 @@ import org.joda.time.DateTime;
  * those speculative objects are deleted and replaced with new ones with the correct approval time.
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException}

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferCancelFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferCancelFlow.java
@@ -66,6 +66,7 @@ import org.joda.time.DateTime;
  * those speculative objects are deleted.
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link google.registry.flows.exceptions.NotPendingTransferException}

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferQueryFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferQueryFlow.java
@@ -44,11 +44,12 @@ import org.joda.time.DateTime;
  *
  * <p>The "gaining" registrar requests a transfer from the "losing" (aka current) registrar. The
  * losing registrar has a "transfer" time period to respond (by default five days) after which the
- * transfer is automatically approved. This flow can be used by the gaining or losing registrars
- * (or anyone with the correct authId) to see the status of a transfer, which may still be pending
- * or may have been approved, rejected, cancelled or implicitly approved by virtue of the transfer
+ * transfer is automatically approved. This flow can be used by the gaining or losing registrars (or
+ * anyone with the correct authId) to see the status of a transfer, which may still be pending or
+ * may have been approved, rejected, cancelled or implicitly approved by virtue of the transfer
  * period expiring.
  *
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link google.registry.flows.exceptions.NoTransferHistoryToQueryException}

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferRejectFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferRejectFlow.java
@@ -68,6 +68,7 @@ import org.joda.time.DateTime;
  * those speculative objects are deleted.
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException}

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
@@ -94,6 +94,7 @@ import org.joda.time.DateTime;
  * replaced with new ones with the correct approval time).
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.FlowUtils.UnknownCurrencyEppException}
  * @error {@link google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}

--- a/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
@@ -99,6 +99,7 @@ import org.joda.time.DateTime;
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
  * @error {@link google.registry.flows.EppException.UnimplementedExtensionException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.AddRemoveSameValueException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException}

--- a/core/src/main/java/google/registry/flows/host/HostCheckFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostCheckFlow.java
@@ -42,6 +42,7 @@ import javax.inject.Inject;
  * <p>This flows can check the existence of multiple hosts simultaneously.
  *
  * @error {@link google.registry.flows.exceptions.TooManyResourceChecksException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  */
 @ReportingSpec(ActivityReportField.HOST_CHECK)
 public final class HostCheckFlow implements Flow {

--- a/core/src/main/java/google/registry/flows/host/HostCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostCreateFlow.java
@@ -67,6 +67,7 @@ import org.joda.time.DateTime;
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
  * @error {@link google.registry.flows.FlowUtils.IpAddressVersionMismatchException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link ResourceAlreadyExistsForThisClientException}
  * @error {@link ResourceCreateContentionException}
  * @error {@link HostFlowUtils.HostNameTooLongException}

--- a/core/src/main/java/google/registry/flows/host/HostDeleteFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostDeleteFlow.java
@@ -59,6 +59,7 @@ import org.joda.time.DateTime;
  * with the success or failure message when the process is complete.
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException}
  * @error {@link google.registry.flows.exceptions.ResourceStatusProhibitsOperationException}

--- a/core/src/main/java/google/registry/flows/host/HostInfoFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostInfoFlow.java
@@ -44,6 +44,7 @@ import org.joda.time.DateTime;
  * <p>The returned information included IP addresses, if any, and details of the host's most recent
  * transfer if it has ever been transferred. Any registrar can see the information for any host.
  *
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link HostFlowUtils.HostNameNotLowerCaseException}
  * @error {@link HostFlowUtils.HostNameNotNormalizedException}

--- a/core/src/main/java/google/registry/flows/host/HostUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostUpdateFlow.java
@@ -79,6 +79,7 @@ import org.joda.time.DateTime;
  * or IP addresses are added, tasks are enqueued to update DNS accordingly.
  *
  * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
+ * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.AddRemoveSameValueException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException}
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException}

--- a/core/src/test/java/google/registry/flows/ResourceFlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/ResourceFlowTestCase.java
@@ -21,10 +21,8 @@ import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableO
 import static google.registry.model.ofy.ObjectifyService.auditedOfy;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.persistence.transaction.TransactionManagerUtil.transactIfJpaTm;
-import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
 import static google.registry.testing.LogsSubject.assertAboutLogs;
 import static google.registry.testing.TaskQueueHelper.assertTasksEnqueued;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -33,7 +31,6 @@ import com.google.common.collect.Streams;
 import com.google.common.flogger.LoggerConfig;
 import com.google.common.testing.TestLogHandler;
 import com.googlecode.objectify.Key;
-import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.model.EppResource;
 import google.registry.model.contact.ContactBase;
 import google.registry.model.contact.ContactHistory;
@@ -58,7 +55,6 @@ import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.json.simple.JSONValue;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 /**
  * Base class for resource flow unit tests.
@@ -118,13 +114,6 @@ public abstract class ResourceFlowTestCase<F extends Flow, R extends EppResource
   /** Persists a testing claims list to Cloud SQL. */
   protected void persistClaimsList(ImmutableMap<String, String> labelsToKeys) {
     ClaimsListDao.save(ClaimsList.create(clock.nowUtc(), labelsToKeys));
-  }
-
-  @Test
-  void testRequiresLogin() {
-    sessionMetadata.setRegistrarId(null);
-    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
-    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   /**

--- a/core/src/test/java/google/registry/flows/contact/ContactCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactCheckFlowTest.java
@@ -21,6 +21,7 @@ import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptio
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.flows.EppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceCheckFlowTestCase;
 import google.registry.flows.exceptions.TooManyResourceChecksException;
 import google.registry.model.contact.ContactResource;
@@ -40,6 +41,13 @@ class ContactCheckFlowTest extends ResourceCheckFlowTestCase<ContactCheckFlow, C
 
   ContactCheckFlowTest() {
     setEppInput("contact_check.xml");
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/contact/ContactCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactCreateFlowTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowTestCase;
 import google.registry.flows.contact.ContactFlowUtils.BadInternationalizedPostalInfoException;
 import google.registry.flows.contact.ContactFlowUtils.DeclineContactDisclosureFieldDisallowedPolicyException;
@@ -66,6 +67,13 @@ class ContactCreateFlowTest extends ResourceFlowTestCase<ContactCreateFlow, Cont
       assertEppResourceIndexEntityFor(contact);
     }
     assertLastHistoryContainsResource(contact);
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/contact/ContactDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactDeleteFlowTest.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowTestCase;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException;
@@ -74,6 +75,13 @@ class ContactDeleteFlowTest extends ResourceFlowTestCase<ContactDeleteFlow, Cont
   @BeforeEach
   void initFlowTest() {
     setEppInput("contact_delete.xml");
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/contact/ContactInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactInfoFlowTest.java
@@ -25,6 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import google.registry.flows.EppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowTestCase;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException;
@@ -103,6 +105,13 @@ class ContactInfoFlowTest extends ResourceFlowTestCase<ContactInfoFlow, ContactR
                 .build());
     assertThat(isDeleted(contact, clock.nowUtc())).isNotEqualTo(active);
     return contact;
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferApproveFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferApproveFlowTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException;
@@ -133,6 +134,13 @@ class ContactTransferApproveFlowTest
     // Setup done; run the test.
     assertTransactionalFlow(true);
     runFlow();
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferCancelFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferCancelFlowTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.exceptions.NotPendingTransferException;
@@ -117,6 +118,13 @@ class ContactTransferCancelFlowTest
     // Setup done; run the test.
     assertTransactionalFlow(true);
     runFlow();
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferQueryFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferQueryFlowTest.java
@@ -22,6 +22,7 @@ import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptio
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.flows.EppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.exceptions.NoTransferHistoryToQueryException;
@@ -74,6 +75,13 @@ class ContactTransferQueryFlowTest
     // Setup done; run the test.
     assertTransactionalFlow(false);
     runFlow();
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferRejectFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferRejectFlowTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException;
@@ -132,6 +133,13 @@ class ContactTransferRejectFlowTest
     // Setup done; run the test.
     assertTransactionalFlow(true);
     runFlow();
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferRequestFlowTest.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.exceptions.AlreadyPendingTransferException;
@@ -151,6 +152,13 @@ class ContactTransferRequestFlowTest
     // Setup done; run the test.
     assertTransactionalFlow(true);
     runFlow();
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/contact/ContactUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactUpdateFlowTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowTestCase;
 import google.registry.flows.ResourceFlowUtils.AddRemoveSameValueException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
@@ -77,6 +78,13 @@ class ContactUpdateFlowTest extends ResourceFlowTestCase<ContactUpdateFlow, Cont
         .hasNoXml();
     assertNoBillingEvents();
     assertLastHistoryContainsResource(contact);
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
@@ -40,6 +40,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Ordering;
 import com.googlecode.objectify.Key;
 import google.registry.flows.EppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.FlowUtils.UnknownCurrencyEppException;
 import google.registry.flows.ResourceCheckFlowTestCase;
 import google.registry.flows.domain.DomainCheckFlow.OnlyCheckedNamesCanBeFeeCheckedException;
@@ -120,6 +121,13 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
   void initCheckTest() {
     createTld("tld", TldState.QUIET_PERIOD);
     persistResource(Registry.get("tld").asBuilder().setReservedLists(createReservedList()).build());
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/domain/DomainClaimsCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainClaimsCheckFlowTest.java
@@ -26,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import google.registry.flows.EppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowTestCase;
 import google.registry.flows.domain.DomainClaimsCheckFlow.DomainClaimsCheckNotAllowedWithAllocationTokens;
 import google.registry.flows.domain.DomainFlowUtils.BadCommandForRegistryPhaseException;
@@ -66,6 +67,13 @@ public class DomainClaimsCheckFlowTest
     assertNoHistory(); // Checks don't create a history event.
     assertNoBillingEvents(); // Checks are always free.
     runFlowAssertResponse(loadFile(expectedXmlFilename));
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -76,6 +76,7 @@ import google.registry.flows.EppException.ReadOnlyModeEppException;
 import google.registry.flows.EppException.UnimplementedExtensionException;
 import google.registry.flows.EppRequestSource;
 import google.registry.flows.ExtensionManager.UndeclaredServiceExtensionException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.FlowUtils.UnknownCurrencyEppException;
 import google.registry.flows.ResourceFlowTestCase;
 import google.registry.flows.domain.DomainCreateFlow.AnchorTenantCreatePeriodException;
@@ -415,6 +416,13 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   private void doSuccessfulTest() throws Exception {
     doSuccessfulTest("tld");
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
@@ -71,6 +71,7 @@ import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
 import google.registry.flows.EppException.UnimplementedExtensionException;
 import google.registry.flows.EppRequestSource;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowTestCase;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException;
@@ -292,6 +293,13 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .setEventTime(A_MONTH_FROM_NOW)
         .setAutorenewEndTime(END_OF_TIME)
         .setParent(earlierHistoryEntry);
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.googlecode.objectify.Key;
 import google.registry.flows.EppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.FlowUtils.UnknownCurrencyEppException;
 import google.registry.flows.ResourceFlowTestCase;
 import google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException;
@@ -204,6 +205,13 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
   private void doSuccessfulTestNoNameservers(String expectedXmlFilename) throws Exception {
     persistTestEntities(true);
     doSuccessfulTest(expectedXmlFilename, true);
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
@@ -44,6 +44,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
 import google.registry.flows.EppRequestSource;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.FlowUtils.UnknownCurrencyEppException;
 import google.registry.flows.ResourceFlowTestCase;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
@@ -276,6 +277,13 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, DomainBa
                 renewalClientId,
                 null),
             renewBillingEvent));
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
@@ -43,6 +43,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
 import google.registry.flows.EppException.UnimplementedExtensionException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.FlowUtils.UnknownCurrencyEppException;
 import google.registry.flows.ResourceFlowTestCase;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
@@ -146,6 +147,13 @@ class DomainRestoreRequestFlowTest
                     .createVKey())
             .build());
     clock.advanceOneMilli();
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
@@ -44,6 +44,7 @@ import com.google.common.collect.Ordering;
 import com.google.common.collect.Streams;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException;
@@ -351,6 +352,13 @@ class DomainTransferApproveFlowTest
     // Setup done; run the test.
     assertTransactionalFlow(true);
     runFlow();
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferCancelFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferCancelFlowTest.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.domain.DomainFlowUtils.NotAuthorizedForTldException;
@@ -203,6 +204,13 @@ class DomainTransferCancelFlowTest
     // Setup done; run the test.
     assertTransactionalFlow(true);
     runFlow();
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferQueryFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferQueryFlowTest.java
@@ -24,6 +24,7 @@ import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptio
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.flows.EppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.exceptions.NoTransferHistoryToQueryException;
@@ -86,6 +87,13 @@ class DomainTransferQueryFlowTest
     // Setup done; run the test.
     assertTransactionalFlow(false);
     runFlow();
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRejectFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRejectFlowTest.java
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.google.common.collect.ImmutableSet;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException;
@@ -163,6 +164,13 @@ class DomainTransferRejectFlowTest
     // Setup done; run the test.
     assertTransactionalFlow(true);
     runFlow();
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
@@ -62,6 +62,7 @@ import google.registry.batch.ResaveEntityAction;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
 import google.registry.flows.EppRequestSource;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.FlowUtils.UnknownCurrencyEppException;
 import google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
@@ -647,6 +648,13 @@ class DomainTransferRequestFlowTest
 
   private void doFailingTest(String commandFilename) throws Exception {
     runTest(commandFilename, UserPrivileges.NORMAL, ImmutableMap.of());
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
@@ -62,6 +62,7 @@ import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
 import google.registry.flows.EppException.UnimplementedExtensionException;
 import google.registry.flows.EppRequestSource;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowTestCase;
 import google.registry.flows.ResourceFlowUtils.AddRemoveSameValueException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
@@ -225,6 +226,13 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     assertNoBillingEvents();
     assertDnsTasksEnqueued("example.tld");
     assertLastHistoryContainsResource(reloadResourceByForeignKey());
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/host/HostCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostCheckFlowTest.java
@@ -21,6 +21,7 @@ import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptio
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.flows.EppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceCheckFlowTestCase;
 import google.registry.flows.exceptions.TooManyResourceChecksException;
 import google.registry.model.host.HostResource;
@@ -40,6 +41,13 @@ class HostCheckFlowTest extends ResourceCheckFlowTestCase<HostCheckFlow, HostRes
 
   HostCheckFlowTest() {
     setEppInput("host_check.xml");
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/host/HostCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostCreateFlowTest.java
@@ -38,6 +38,7 @@ import com.google.common.collect.ImmutableSet;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
 import google.registry.flows.FlowUtils.IpAddressVersionMismatchException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowTestCase;
 import google.registry.flows.exceptions.ResourceAlreadyExistsForThisClientException;
 import google.registry.flows.exceptions.ResourceCreateContentionException;
@@ -115,6 +116,13 @@ class HostCreateFlowTest extends ResourceFlowTestCase<HostCreateFlow, HostResour
     createTld(tld);
     persistActiveDomain("example.tld");
     doSuccessfulTest();
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/host/HostDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostDeleteFlowTest.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowTestCase;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException;
@@ -73,6 +74,13 @@ class HostDeleteFlowTest extends ResourceFlowTestCase<HostDeleteFlow, HostResour
   @BeforeEach
   void initFlowTest() {
     setEppInput("host_delete.xml", ImmutableMap.of("HOSTNAME", "ns1.example.tld"));
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/host/HostInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostInfoFlowTest.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.InetAddresses;
 import google.registry.flows.EppException;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowTestCase;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.host.HostFlowUtils.HostNameNotLowerCaseException;
@@ -81,6 +82,13 @@ class HostInfoFlowTest extends ResourceFlowTestCase<HostInfoFlow, HostResource> 
             .setLastEppUpdateTime(DateTime.parse("1999-12-03T09:00:00.0Z"))
             .setLastTransferTime(DateTime.parse("2000-04-08T09:00:00.0Z"))
             .build());
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/flows/host/HostUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostUpdateFlowTest.java
@@ -49,6 +49,7 @@ import com.google.common.net.InetAddresses;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ReadOnlyModeEppException;
 import google.registry.flows.EppRequestSource;
+import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowTestCase;
 import google.registry.flows.ResourceFlowUtils.AddRemoveSameValueException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
@@ -143,6 +144,13 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, HostResour
   /** Alias for better readability. */
   private String oldHostName() throws Exception {
     return getUniqueIdFromCommand();
+  }
+
+  @TestOfyAndSql
+  void testNotLoggedIn() {
+    sessionMetadata.setRegistrarId(null);
+    EppException thrown = assertThrows(NotLoggedInException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   @TestOfyAndSql

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -10,6 +10,8 @@ This flows can check the existence of multiple contacts simultaneously.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2306
     *   Too many resource checks requested in one check command.
 
@@ -21,6 +23,8 @@ An EPP flow that creates a new contact.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2005
     *   Internationalized postal infos can only contain ASCII characters.
 *   2302
@@ -45,6 +49,8 @@ or failure message when the process is complete.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2201
     *   The specified resource belongs to another client.
 *   2303
@@ -70,6 +76,8 @@ registrar that owns the contact or to a registrar that already supplied it.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2201
     *   The specified resource belongs to another client.
 *   2303
@@ -89,6 +97,8 @@ transfer request, which then becomes effective immediately.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2201
     *   The specified resource belongs to another client.
 *   2202
@@ -114,6 +124,8 @@ request.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2201
     *   Registrar is not the initiator of this transfer.
 *   2202
@@ -142,6 +154,7 @@ transfer period expiring.
 ### Errors
 
 *   2002
+    *   Registrar is not logged in.
     *   Object has no transfer history.
 *   2201
     *   Registrar is not authorized to view transfer status.
@@ -163,6 +176,8 @@ that window, this flow allows the losing client to reject the transfer request.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2201
     *   The specified resource belongs to another client.
 *   2202
@@ -189,6 +204,7 @@ or rejected, and the gaining registrar can also cancel the transfer request.
 ### Errors
 
 *   2002
+    *   Registrar is not logged in.
     *   Registrar already sponsors the object of this transfer request.
 *   2201
     *   Authorization info is required to request a transfer.
@@ -211,6 +227,8 @@ An EPP flow that updates a contact.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2004
     *   The specified status value cannot be set by clients.
 *   2005
@@ -241,6 +259,7 @@ information.
 ### Errors
 
 *   2002
+    *   Registrar is not logged in.
     *   Command is not allowed in the current registry phase.
 *   2004
     *   Unknown currency.
@@ -279,6 +298,7 @@ An EPP flow that checks whether domain labels are trademarked.
 ### Errors
 
 *   2002
+    *   Registrar is not logged in.
     *   Command is not allowed in the current registry phase.
     *   Claims checks are not allowed with allocation tokens.
 *   2004
@@ -300,6 +320,7 @@ An EPP flow that creates a new domain resource.
 
 *   2002
     *   Service extension(s) must be declared at login.
+    *   Registrar is not logged in.
     *   The current registry phase allows registrations only with signed marks.
     *   The current registry phase does not allow for general registrations.
     *   Signed marks are only allowed during sunrise.
@@ -397,6 +418,7 @@ An EPP flow that deletes a domain.
 ### Errors
 
 *   2002
+    *   Registrar is not logged in.
     *   Command is not allowed in the current registry phase.
 *   2103
     *   Specified extension is not implemented.
@@ -426,6 +448,8 @@ information about the domain.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2004
     *   Unknown currency.
 *   2202
@@ -457,6 +481,8 @@ comes in at the exact millisecond that the domain would have expired.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2003
     *   Fees must be explicitly acknowledged when performing any operations on a
         premium name.
@@ -515,6 +541,7 @@ regardless of what the original expiration time was.
 ### Errors
 
 *   2002
+    *   Registrar is not logged in.
     *   Restore command cannot have other changes specified.
 *   2003
     *   Fees must be explicitly acknowledged when performing any operations on a
@@ -566,6 +593,8 @@ replaced with new ones with the correct approval time.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2201
     *   The specified resource belongs to another client.
     *   Registrar is not authorized to access this TLD.
@@ -596,6 +625,8 @@ transfer period passed. In this flow, those speculative objects are deleted.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2201
     *   Registrar is not the initiator of this transfer.
     *   Registrar is not authorized to access this TLD.
@@ -625,6 +656,7 @@ transfer period expiring.
 ### Errors
 
 *   2002
+    *   Registrar is not logged in.
     *   Object has no transfer history.
 *   2201
     *   Registrar is not authorized to view transfer status.
@@ -650,6 +682,8 @@ transfer period passed. In this flow, those speculative objects are deleted.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2201
     *   The specified resource belongs to another client.
     *   Registrar is not authorized to access this TLD.
@@ -684,6 +718,7 @@ new ones with the correct approval time).
 ### Errors
 
 *   2002
+    *   Registrar is not logged in.
     *   Registrar already sponsors the object of this transfer request.
 *   2003
     *   Fees must be explicitly acknowledged when performing any operations on a
@@ -739,6 +774,8 @@ statuses are updated at once.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2003
     *   At least one of 'add' or 'rem' is required on a secDNS update.
     *   Fees must be explicitly acknowledged when performing an operation which
@@ -801,6 +838,8 @@ This flows can check the existence of multiple hosts simultaneously.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2306
     *   Too many resource checks requested in one check command.
 
@@ -818,6 +857,8 @@ allows creating a host name, and if necessary enqueues tasks to update DNS.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2003
     *   Subordinate hosts must have an ip address.
 *   2004
@@ -855,6 +896,8 @@ or failure message when the process is complete.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2005
     *   Host names must be in lower-case.
     *   Host names must be in normalized format.
@@ -882,6 +925,8 @@ see the information for any host.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2005
     *   Host names must be in lower-case.
     *   Host names must be in normalized format.
@@ -908,6 +953,8 @@ are enqueued to update DNS accordingly.
 
 ### Errors
 
+*   2002
+    *   Registrar is not logged in.
 *   2004
     *   The specified status value cannot be set by clients.
     *   Host names are limited to 253 characters.


### PR DESCRIPTION
This wasn't included in flows.md before because the test existed in
ResourceFlowTestCase. So even though the exception could be thrown and
even though this was tested, it wasn't picked up in the documentation
because the documentation is picked up from the corresponding concrete
test class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1437)
<!-- Reviewable:end -->
