### PR TITLE
Move enqueuePollTask to BackupDatastoreAction

### DIFF
--- a/core/src/main/java/google/registry/export/CheckBackupAction.java
+++ b/core/src/main/java/google/registry/export/CheckBackupAction.java
@@ -22,11 +22,6 @@ import static google.registry.request.Action.Method.POST;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
-import com.google.appengine.api.taskqueue.QueueFactory;
-import com.google.appengine.api.taskqueue.TaskHandle;
-import com.google.appengine.api.taskqueue.TaskOptions;
-import com.google.appengine.api.taskqueue.TaskOptions.Method;
-import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
@@ -178,16 +173,5 @@ public class CheckBackupAction implements Runnable {
     }
     logger.atInfo().log(message);
     response.setPayload(message);
-  }
-
-  /** Enqueue a poll task to monitor the named backup for completion. */
-  static TaskHandle enqueuePollTask(String backupId, ImmutableSet<String> kindsToLoad) {
-    return QueueFactory.getQueue(QUEUE)
-        .add(
-            TaskOptions.Builder.withUrl(PATH)
-                .method(Method.POST)
-                .countdownMillis(POLL_COUNTDOWN.getMillis())
-                .param(CHECK_BACKUP_NAME_PARAM, backupId)
-                .param(CHECK_BACKUP_KINDS_TO_LOAD_PARAM, Joiner.on(',').join(kindsToLoad)));
   }
 }

--- a/core/src/test/java/google/registry/export/CheckBackupActionTest.java
+++ b/core/src/test/java/google/registry/export/CheckBackupActionTest.java
@@ -15,8 +15,6 @@
 package google.registry.export;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.export.CheckBackupAction.CHECK_BACKUP_KINDS_TO_LOAD_PARAM;
-import static google.registry.export.CheckBackupAction.CHECK_BACKUP_NAME_PARAM;
 import static google.registry.testing.TaskQueueHelper.assertNoTasksEnqueued;
 import static google.registry.testing.TaskQueueHelper.assertTasksEnqueued;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -27,7 +25,6 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
-import com.google.common.collect.ImmutableSet;
 import google.registry.export.datastore.DatastoreAdmin;
 import google.registry.export.datastore.DatastoreAdmin.Get;
 import google.registry.export.datastore.Operation;
@@ -119,19 +116,6 @@ public class CheckBackupActionTest {
             .param("id", id)
             .param("folder", folder)
             .param("kinds", kinds));
-  }
-
-  @MockitoSettings(strictness = Strictness.LENIENT)
-  @Test
-  void testSuccess_enqueuePollTask() {
-    CheckBackupAction.enqueuePollTask("some_backup_name", ImmutableSet.of("one", "two", "three"));
-    assertTasksEnqueued(
-        CheckBackupAction.QUEUE,
-        new TaskMatcher()
-            .url(CheckBackupAction.PATH)
-            .param(CHECK_BACKUP_NAME_PARAM, "some_backup_name")
-            .param(CHECK_BACKUP_KINDS_TO_LOAD_PARAM, "one,two,three")
-            .method("POST"));
   }
 
   @Test


### PR DESCRIPTION
- enqueuePollTask() is not used in a CheckBackupAction.java, which is where it's currently resides. Since the enqueue() method call in CloudTasksUtil requires an instance of it to be created first, this requires adding CloudTasksUtils instance in BackupDatastoreAction.java and CloudTasksHelper instance in its test file. 

- remove static final String QUEUE = "export-snapshot"; // See queue.xml in BackupDatastoreAction.java since it's never used. enqueuePollTask() uses QUEUE and PATH from CheckBackupAction.java 