### PR TITLE
Filter out empty dsData objects, not just null ones

### DIFF
--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -170,7 +170,10 @@ public class DomainBase extends DomainContent
   @Override
   public void beforeSqlSaveOnReplay() {
     fullyQualifiedDomainName = DomainNameUtils.canonicalizeDomainName(fullyQualifiedDomainName);
-    dsData = dsData.stream().filter(datum -> datum.getDigest() != null).collect(toImmutableSet());
+    dsData =
+        dsData.stream()
+            .filter(datum -> datum.getDigest() != null && datum.getDigest().length > 0)
+            .collect(toImmutableSet());
   }
 
   @Override

--- a/core/src/main/java/google/registry/model/domain/DomainHistory.java
+++ b/core/src/main/java/google/registry/model/domain/DomainHistory.java
@@ -318,7 +318,7 @@ public class DomainHistory extends HistoryEntry implements SqlEntity {
       domainHistory.nsHosts = nullToEmptyImmutableCopy(domainHistory.domainContent.nsHosts);
       domainHistory.dsDataHistories =
           nullToEmptyImmutableCopy(domainHistory.domainContent.getDsData()).stream()
-              .filter(dsData -> dsData.getDigest() != null)
+              .filter(dsData -> dsData.getDigest() != null && dsData.getDigest().length > 0)
               .map(dsData -> DomainDsDataHistory.createFrom(domainHistory.id, dsData))
               .collect(toImmutableSet());
       domainHistory.gracePeriodHistories =


### PR DESCRIPTION
Hibernate/SQL will get mad if the digest is null or empty, and
previously we only check for null. We should filter out empty digests as
well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1449)
<!-- Reviewable:end -->
