### PR TITLE
Add replicateToDatastore to non-prod cron files

### DIFF
--- a/core/src/main/java/google/registry/env/alpha/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/alpha/default/WEB-INF/cron.xml
@@ -209,6 +209,15 @@
   </cron>
 
   <cron>
+    <url><![CDATA[/_dr/cron/replicateToDatastore]]></url>
+    <description>
+      Replays recent transactions from SQL to the Datastore secondary backend.
+    </description>
+    <schedule>every 3 minutes</schedule>
+    <target>backend</target>
+  </cron>
+
+  <cron>
     <url><![CDATA[/_dr/cron/readDnsQueue?jitterSeconds=45]]></url>
     <description>
       Lease all tasks from the dns-pull queue, group by TLD, and invoke PublishDnsUpdates for each

--- a/core/src/main/java/google/registry/env/crash/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/crash/default/WEB-INF/cron.xml
@@ -211,6 +211,15 @@
   </cron>
   -->
 
+  <cron>
+    <url><![CDATA[/_dr/cron/replicateToDatastore]]></url>
+    <description>
+      Replays recent transactions from SQL to the Datastore secondary backend.
+    </description>
+    <schedule>every 3 minutes</schedule>
+    <target>backend</target>
+  </cron>
+
   <!--
     The next two wipeout jobs are required when crash has production data.
    -->

--- a/core/src/main/java/google/registry/env/qa/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/qa/default/WEB-INF/cron.xml
@@ -121,6 +121,15 @@
   </cron>
 
   <cron>
+    <url><![CDATA[/_dr/cron/replicateToDatastore]]></url>
+    <description>
+      Replays recent transactions from SQL to the Datastore secondary backend.
+    </description>
+    <schedule>every 3 minutes</schedule>
+    <target>backend</target>
+  </cron>
+
+  <cron>
     <url><![CDATA[/_dr/cron/commitLogCheckpoint]]></url>
     <description>
       This job checkpoints the commit log buckets and exports the diff since last checkpoint to GCS.

--- a/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/cron.xml
@@ -248,6 +248,15 @@
   </cron>
 
   <cron>
+    <url><![CDATA[/_dr/cron/replicateToDatastore]]></url>
+    <description>
+      Replays recent transactions from SQL to the Datastore secondary backend.
+    </description>
+    <schedule>every 3 minutes</schedule>
+    <target>backend</target>
+  </cron>
+
+  <cron>
     <url><![CDATA[/_dr/task/wipeOutContactHistoryPii]]></url>
     <description>
       This job runs weekly to wipe out PII fields of ContactHistory entities


### PR DESCRIPTION
This shouldn't do anything yet (since ReplicateToDatastoreAction checks the
migration state before doing anything) but we'll want to have this in
place.

We can add it to the prod file after verifying no errors with this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1450)
<!-- Reviewable:end -->
