### PR TITLE
Truncate web WHOIS request path when recording metrics

### DIFF
--- a/core/src/main/java/google/registry/request/RequestMetrics.java
+++ b/core/src/main/java/google/registry/request/RequestMetrics.java
@@ -67,10 +67,16 @@ class RequestMetrics {
   private static String truncatePath(String path) {
     // We want to bucket RDAP requests by type to use less metric space,
     // e.g. "/rdap/domains" rather than "/rdap/domains/foo.tld"
+
     if (path.startsWith("/rdap")) {
       List<String> splitPath = Splitter.on("/").omitEmptyStrings().splitToList(path);
       return Streams.stream(Iterables.limit(splitPath, 2))
           .collect(Collectors.joining("/", "/", "/"));
+      // Similarly, we put all web WHOIS requests under the same path because otherwise its
+      // cardinality is unbound, and it is possible to generate a huge amount of metrics with all
+      // the different paths.
+    } else if (path.startsWith("/whois")) {
+      return "/whois";
     }
     return path;
   }


### PR DESCRIPTION
The cardinality for the paths is unbound, and could generate a huge
amount of metrics if someone is scanning our web WHOIS endpoint.

See b/209488119 for an example of such a sudden increase in metric volume.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1451)
<!-- Reviewable:end -->
