### PR TITLE
Add more options to the generate escrow deposit command

### DIFF
--- a/core/src/main/java/google/registry/rde/RdeModule.java
+++ b/core/src/main/java/google/registry/rde/RdeModule.java
@@ -45,6 +45,7 @@ public abstract class RdeModule {
   public static final String PARAM_WATERMARK = "watermark";
   public static final String PARAM_WATERMARKS = "watermarks";
   public static final String PARAM_MANUAL = "manual";
+  public static final String PARAM_BEAM = "beam";
   public static final String PARAM_DIRECTORY = "directory";
   public static final String PARAM_MODE = "mode";
   public static final String PARAM_REVISION = "revision";
@@ -70,6 +71,12 @@ public abstract class RdeModule {
   @Parameter(PARAM_MANUAL)
   static boolean provideManual(HttpServletRequest req) {
     return extractBooleanParameter(req, PARAM_MANUAL);
+  }
+
+  @Provides
+  @Parameter(PARAM_BEAM)
+  static boolean provideBeam(HttpServletRequest req) {
+    return extractBooleanParameter(req, PARAM_BEAM);
   }
 
   @Provides

--- a/core/src/main/java/google/registry/tools/GenerateEscrowDepositCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateEscrowDepositCommand.java
@@ -71,16 +71,14 @@ final class GenerateEscrowDepositCommand implements CommandWithRemoteApi {
       names = {"-l", "--lenient"},
       description =
           "Whether to run RDE in LENIENT mode, which omits validation of the generated "
-              + "XML deposit files.",
-      arity = 1)
+              + "XML deposit files.")
   private Boolean lenient = false;
 
   @Parameter(
       names = {"-b", "--beam"},
       description =
           "Whether to explicitly launch the beam pipeline instead of letting the action decide"
-              + " which one to run.",
-      arity = 1)
+              + " which one to run.")
   private Boolean beam = false;
 
   @Parameter(

--- a/core/src/main/java/google/registry/tools/GenerateEscrowDepositCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateEscrowDepositCommand.java
@@ -17,6 +17,7 @@ package google.registry.tools;
 import static com.google.appengine.api.taskqueue.TaskOptions.Builder.withUrl;
 import static google.registry.model.tld.Registries.assertTldsExist;
 import static google.registry.rde.RdeModule.PARAM_DIRECTORY;
+import static google.registry.rde.RdeModule.PARAM_LENIENT;
 import static google.registry.rde.RdeModule.PARAM_MANUAL;
 import static google.registry.rde.RdeModule.PARAM_MODE;
 import static google.registry.rde.RdeModule.PARAM_REVISION;
@@ -64,6 +65,14 @@ final class GenerateEscrowDepositCommand implements CommandWithRemoteApi {
       names = {"-m", "--mode"},
       description = "Mode of operation: FULL for RDE deposits, THIN for BRDA deposits.")
   private RdeMode mode = RdeMode.FULL;
+
+  @Parameter(
+      names = {"-l", "--lenient"},
+      description =
+          "Whether to run RDE in LENIENT mode, which omits validation of the generated "
+              + "XML deposit files.",
+      arity = 1)
+  private Boolean lenient = false;
 
   @Parameter(
       names = {"-r", "--revision"},
@@ -119,6 +128,7 @@ final class GenerateEscrowDepositCommand implements CommandWithRemoteApi {
             .param(PARAM_MANUAL, String.valueOf(true))
             .param(PARAM_MODE, mode.toString())
             .param(PARAM_DIRECTORY, outdir)
+            .param(PARAM_LENIENT, lenient.toString())
             .param(PARAM_TLDS, tlds.stream().collect(Collectors.joining(",")))
             .param(
                 PARAM_WATERMARKS,

--- a/core/src/main/java/google/registry/tools/GenerateEscrowDepositCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateEscrowDepositCommand.java
@@ -16,6 +16,7 @@ package google.registry.tools;
 
 import static com.google.appengine.api.taskqueue.TaskOptions.Builder.withUrl;
 import static google.registry.model.tld.Registries.assertTldsExist;
+import static google.registry.rde.RdeModule.PARAM_BEAM;
 import static google.registry.rde.RdeModule.PARAM_DIRECTORY;
 import static google.registry.rde.RdeModule.PARAM_LENIENT;
 import static google.registry.rde.RdeModule.PARAM_MANUAL;
@@ -75,6 +76,14 @@ final class GenerateEscrowDepositCommand implements CommandWithRemoteApi {
   private Boolean lenient = false;
 
   @Parameter(
+      names = {"-b", "--beam"},
+      description =
+          "Whether to explicitly launch the beam pipeline instead of letting the action decide"
+              + " which one to run.",
+      arity = 1)
+  private Boolean beam = false;
+
+  @Parameter(
       names = {"-r", "--revision"},
       description = "Revision number. Use >0 for resends.")
   private Integer revision;
@@ -129,6 +138,7 @@ final class GenerateEscrowDepositCommand implements CommandWithRemoteApi {
             .param(PARAM_MODE, mode.toString())
             .param(PARAM_DIRECTORY, outdir)
             .param(PARAM_LENIENT, lenient.toString())
+            .param(PARAM_BEAM, beam.toString())
             .param(PARAM_TLDS, tlds.stream().collect(Collectors.joining(",")))
             .param(
                 PARAM_WATERMARKS,

--- a/core/src/main/java/google/registry/tools/GenerateEscrowDepositCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateEscrowDepositCommand.java
@@ -72,14 +72,14 @@ final class GenerateEscrowDepositCommand implements CommandWithRemoteApi {
       description =
           "Whether to run RDE in LENIENT mode, which omits validation of the generated "
               + "XML deposit files.")
-  private Boolean lenient = false;
+  private boolean lenient = false;
 
   @Parameter(
       names = {"-b", "--beam"},
       description =
           "Whether to explicitly launch the beam pipeline instead of letting the action decide"
               + " which one to run.")
-  private Boolean beam = false;
+  private boolean beam = false;
 
   @Parameter(
       names = {"-r", "--revision"},
@@ -135,8 +135,8 @@ final class GenerateEscrowDepositCommand implements CommandWithRemoteApi {
             .param(PARAM_MANUAL, String.valueOf(true))
             .param(PARAM_MODE, mode.toString())
             .param(PARAM_DIRECTORY, outdir)
-            .param(PARAM_LENIENT, lenient.toString())
-            .param(PARAM_BEAM, beam.toString())
+            .param(PARAM_LENIENT, Boolean.toString(lenient))
+            .param(PARAM_BEAM, Boolean.toString(beam))
             .param(PARAM_TLDS, tlds.stream().collect(Collectors.joining(",")))
             .param(
                 PARAM_WATERMARKS,

--- a/core/src/test/java/google/registry/tools/GenerateEscrowDepositCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateEscrowDepositCommandTest.java
@@ -212,6 +212,30 @@ public class GenerateEscrowDepositCommandTest
   }
 
   @Test
+  void testCommand_successWithBeam() throws Exception {
+    runCommand(
+        "--tld=tld",
+        "--watermark=2017-01-01T00:00:00Z",
+        "--mode=thin",
+        "--beam=true",
+        "-r 42",
+        "-o test");
+
+    assertTasksEnqueued(
+        "rde-report",
+        new TaskMatcher()
+            .url("/_dr/task/rdeStaging")
+            .header("Host", "backend.test.localhost")
+            .param("mode", "THIN")
+            .param("beam", "true")
+            .param("watermarks", "2017-01-01T00:00:00.000Z")
+            .param("tlds", "tld")
+            .param("directory", "test")
+            .param("manual", "true")
+            .param("revision", "42"));
+  }
+
+  @Test
   void testCommand_successWithDefaultValidationMode() throws Exception {
     runCommand("--tld=tld", "--watermark=2017-01-01T00:00:00Z", "--mode=thin", "-r 42", "-o test");
 
@@ -239,6 +263,7 @@ public class GenerateEscrowDepositCommandTest
             .url("/_dr/task/rdeStaging")
             .header("Host", "backend.test.localhost")
             .param("lenient", "false")
+            .param("beam", "false")
             .param("mode", "THIN")
             .param("watermarks", "2017-01-01T00:00:00.000Z")
             .param("tlds", "tld")
@@ -257,6 +282,7 @@ public class GenerateEscrowDepositCommandTest
             .header("Host", "backend.test.localhost")
             .param("mode", "FULL")
             .param("lenient", "false")
+            .param("beam", "false")
             .param("watermarks", "2017-01-01T00:00:00.000Z")
             .param("tlds", "tld")
             .param("directory", "test")
@@ -280,6 +306,7 @@ public class GenerateEscrowDepositCommandTest
             .header("Host", "backend.test.localhost")
             .param("mode", "THIN")
             .param("lenient", "false")
+            .param("beam", "false")
             .param("watermarks", "2017-01-01T00:00:00.000Z,2017-01-02T00:00:00.000Z")
             .param("tlds", "tld,anothertld")
             .param("directory", "test")

--- a/core/src/test/java/google/registry/tools/GenerateEscrowDepositCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateEscrowDepositCommandTest.java
@@ -188,7 +188,31 @@ public class GenerateEscrowDepositCommandTest
   }
 
   @Test
-  void testCommand_success() throws Exception {
+  void testCommand_successWithLenientValidationMode() throws Exception {
+    runCommand(
+        "--tld=tld",
+        "--watermark=2017-01-01T00:00:00Z",
+        "--mode=thin",
+        "--lenient=true",
+        "-r 42",
+        "-o test");
+
+    assertTasksEnqueued(
+        "rde-report",
+        new TaskMatcher()
+            .url("/_dr/task/rdeStaging")
+            .header("Host", "backend.test.localhost")
+            .param("mode", "THIN")
+            .param("lenient", "true")
+            .param("watermarks", "2017-01-01T00:00:00.000Z")
+            .param("tlds", "tld")
+            .param("directory", "test")
+            .param("manual", "true")
+            .param("revision", "42"));
+  }
+
+  @Test
+  void testCommand_successWithDefaultValidationMode() throws Exception {
     runCommand("--tld=tld", "--watermark=2017-01-01T00:00:00Z", "--mode=thin", "-r 42", "-o test");
 
     assertTasksEnqueued(
@@ -197,6 +221,7 @@ public class GenerateEscrowDepositCommandTest
             .url("/_dr/task/rdeStaging")
             .header("Host", "backend.test.localhost")
             .param("mode", "THIN")
+            .param("lenient", "false")
             .param("watermarks", "2017-01-01T00:00:00.000Z")
             .param("tlds", "tld")
             .param("directory", "test")
@@ -213,6 +238,7 @@ public class GenerateEscrowDepositCommandTest
         new TaskMatcher()
             .url("/_dr/task/rdeStaging")
             .header("Host", "backend.test.localhost")
+            .param("lenient", "false")
             .param("mode", "THIN")
             .param("watermarks", "2017-01-01T00:00:00.000Z")
             .param("tlds", "tld")
@@ -230,6 +256,7 @@ public class GenerateEscrowDepositCommandTest
             .url("/_dr/task/rdeStaging")
             .header("Host", "backend.test.localhost")
             .param("mode", "FULL")
+            .param("lenient", "false")
             .param("watermarks", "2017-01-01T00:00:00.000Z")
             .param("tlds", "tld")
             .param("directory", "test")
@@ -252,6 +279,7 @@ public class GenerateEscrowDepositCommandTest
             .url("/_dr/task/rdeStaging")
             .header("Host", "backend.test.localhost")
             .param("mode", "THIN")
+            .param("lenient", "false")
             .param("watermarks", "2017-01-01T00:00:00.000Z,2017-01-02T00:00:00.000Z")
             .param("tlds", "tld,anothertld")
             .param("directory", "test")

--- a/core/src/test/java/google/registry/tools/GenerateEscrowDepositCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateEscrowDepositCommandTest.java
@@ -193,7 +193,7 @@ public class GenerateEscrowDepositCommandTest
         "--tld=tld",
         "--watermark=2017-01-01T00:00:00Z",
         "--mode=thin",
-        "--lenient=true",
+        "--lenient",
         "-r 42",
         "-o test");
 
@@ -217,7 +217,7 @@ public class GenerateEscrowDepositCommandTest
         "--tld=tld",
         "--watermark=2017-01-01T00:00:00Z",
         "--mode=thin",
-        "--beam=true",
+        "--beam",
         "-r 42",
         "-o test");
 


### PR DESCRIPTION
This adds two new options:

1) An option to run RDE in lenient mode.
2) An option to run RDE with the new Beam pipeline regardless of the datastore setting.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1453)
<!-- Reviewable:end -->
