### PR TITLE
Handle Hibernate-managed child collections properly in setters

### DIFF
--- a/core/src/main/java/google/registry/model/domain/DomainContent.java
+++ b/core/src/main/java/google/registry/model/domain/DomainContent.java
@@ -505,19 +505,34 @@ public class DomainContent extends EppResource
   // Hibernate needs this in order to populate nsHosts but no one else should ever use it
   @SuppressWarnings("UnusedMethod")
   private void setNsHosts(Set<VKey<HostResource>> nsHosts) {
-    this.nsHosts = forceEmptyToNull(nsHosts);
+    if (this.nsHosts == null) {
+      this.nsHosts = forceEmptyToNull(nsHosts);
+    } else if (!this.nsHosts.equals(nsHosts)) {
+      this.nsHosts.clear();
+      this.nsHosts.addAll(nullToEmpty(nsHosts));
+    }
   }
 
   // Hibernate needs this in order to populate gracePeriods but no one else should ever use it
   @SuppressWarnings("UnusedMethod")
   private void setInternalGracePeriods(Set<GracePeriod> gracePeriods) {
-    this.gracePeriods = gracePeriods;
+    if (this.gracePeriods == null) {
+      this.gracePeriods = gracePeriods;
+    } else if (!this.gracePeriods.equals(gracePeriods)) {
+      this.gracePeriods.clear();
+      this.gracePeriods.addAll(nullToEmpty(gracePeriods));
+    }
   }
 
   // Hibernate needs this in order to populate dsData but no one else should ever use it
   @SuppressWarnings("UnusedMethod")
   private void setInternalDelegationSignerData(Set<DelegationSignerData> dsData) {
-    this.dsData = dsData;
+    if (this.dsData == null) {
+      this.dsData = dsData;
+    } else if (!this.dsData.equals(dsData)) {
+      this.dsData.clear();
+      this.dsData.addAll(nullToEmpty(dsData));
+    }
   }
 
   public final String getCurrentSponsorRegistrarId() {

--- a/core/src/main/java/google/registry/model/domain/DomainHistory.java
+++ b/core/src/main/java/google/registry/model/domain/DomainHistory.java
@@ -209,7 +209,7 @@ public class DomainHistory extends HistoryEntry implements SqlEntity {
   @SuppressWarnings("unused")
   private void setInternalDomainTransactionRecords(
       Set<DomainTransactionRecord> domainTransactionRecords) {
-    this.domainTransactionRecords = domainTransactionRecords;
+    super.setDomainTransactionRecords(domainTransactionRecords);
   }
 
   @Id

--- a/core/src/main/java/google/registry/model/reporting/HistoryEntry.java
+++ b/core/src/main/java/google/registry/model/reporting/HistoryEntry.java
@@ -16,6 +16,7 @@ package google.registry.model.reporting;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.googlecode.objectify.Key.getKind;
+import static google.registry.util.CollectionUtils.nullToEmpty;
 import static google.registry.util.CollectionUtils.nullToEmptyImmutableCopy;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
@@ -317,9 +318,13 @@ public class HistoryEntry extends ImmutableObject
 
   /** This method exists solely to satisfy Hibernate. Use the {@link Builder} instead. */
   @SuppressWarnings("UnusedMethod")
-  private void setDomainTransactionRecords(Set<DomainTransactionRecord> domainTransactionRecords) {
-    this.domainTransactionRecords =
-        domainTransactionRecords == null ? null : ImmutableSet.copyOf(domainTransactionRecords);
+  protected void setDomainTransactionRecords(Set<DomainTransactionRecord> domainTransactionRecords) {
+    if (this.domainTransactionRecords == null) {
+      this.domainTransactionRecords = domainTransactionRecords;
+    } else if (!this.domainTransactionRecords.equals(domainTransactionRecords)) {
+      this.domainTransactionRecords.clear();
+      this.domainTransactionRecords.addAll(nullToEmpty(domainTransactionRecords));
+    }
   }
 
   /**


### PR DESCRIPTION
In replay (and possibly in other cases) we're getting an exception:

Caused by: org.hibernate.HibernateException: A collection with cascade="all-delete-orphan" was no longer referenced by the owning entity instance: google.registry.model.domain.DomainHistory.internalDomainTransactionRecords

The main cause of this, according to research (StackOverflow :P) is that
when Hibernate is calling the setters for these sets of children it's
losing the connection to the previously-managed child entity (which it
needs, in order to know how to delete orphans). Thus, the solution is to
maintain the same instance of the persistent set and just add/remove
to/from it as necessary.

Note: these are the only places at which we have these relevant
collection setters that I found with a grep.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1455)
<!-- Reviewable:end -->
