### PR TITLE
Copy DTRs into PersistentSet field if applicable in HistoryEntry

### DIFF
--- a/core/src/main/java/google/registry/model/domain/DomainHistory.java
+++ b/core/src/main/java/google/registry/model/domain/DomainHistory.java
@@ -209,7 +209,7 @@ public class DomainHistory extends HistoryEntry implements SqlEntity {
   @SuppressWarnings("unused")
   private void setInternalDomainTransactionRecords(
       Set<DomainTransactionRecord> domainTransactionRecords) {
-    this.domainTransactionRecords = domainTransactionRecords;
+    super.setDomainTransactionRecords(domainTransactionRecords);
   }
 
   @Id


### PR DESCRIPTION
In replay (and possibly in other cases) we're getting an exception:

Caused by: org.hibernate.HibernateException: A collection with cascade="all-delete-orphan" was no longer referenced by the owning entity instance: google.registry.model.domain.DomainHistory.internalDomainTransactionRecords

The main cause of this, according to research (StackOverflow :P) is that
when Hibernate is calling the setters for these sets of children it's
losing the connection to the previously-managed child entity (which it
needs, in order to know how to delete orphans). Thus, the solution is to
maintain the same instance of the persistent set and just add/remove
to/from it as necessary.

This is complicated by the fact that sometimes the setter is given the
persistent set (the one we want to keep) and sometimes (?) it isn't. We
will need to try this out to be sure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1456)
<!-- Reviewable:end -->
