### PR TITLE
Improve logging/comments for commit log forks

### DIFF
--- a/core/src/main/java/google/registry/backup/GcsDiffFileLister.java
+++ b/core/src/main/java/google/registry/backup/GcsDiffFileLister.java
@@ -91,7 +91,7 @@ class GcsDiffFileLister {
 
         // If we hit a gap, quit.
         if (blobInfo == null) {
-          logger.atInfo().log(
+          logger.atWarning().log(
               "Gap discovered in sequence terminating at %s, missing file: %s",
               sequence.lastKey(), filename);
           logger.atInfo().log("Found sequence from %s to %s.", checkpointTime, lastTime);
@@ -167,6 +167,10 @@ class GcsDiffFileLister {
             break;
           }
           if (!sequence.containsKey(key)) {
+            // Recalculate the sequence for purely informational purposes.
+            logger.atWarning().log(
+                "Fork found in commit log history.  The following sequence "
+                    + "is disconnected from the sequence of the final commit:");
             constructDiffSequence(gcsBucket, upperBoundTimesToBlobInfo, fromTime, key, sequence);
             checkForMoreExtraDiffs = true;
             inconsistentFileSet = true;


### PR DESCRIPTION
It looks like the diff file lister is doing a second constructDiffSequence()
when a commit diff file is missing from the final sequence for purely
informational purposes.  However, this purpose wasn't clear when investigating
an actual case of this.

This PR adds another warning to hopefully make the log output a bit more
useful, and also promotes the "gap" log message to a warning and adds a
comment indicating the purpose of the second constructDiffSequence().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1464)
<!-- Reviewable:end -->
