### PR TITLE
Always use JPA TM on Beam

### DIFF
--- a/core/src/main/java/google/registry/beam/rde/RdeIO.java
+++ b/core/src/main/java/google/registry/beam/rde/RdeIO.java
@@ -167,13 +167,13 @@ public class RdeIO {
           Optional.ofNullable(key.revision())
               .orElseGet(() -> RdeRevision.getNextRevision(tld, watermark, mode));
       String id = RdeUtil.timestampToId(watermark);
-      String prefix = options.getJobName();
-      String basename = RdeNamingUtils.makeRydeFilename(tld, watermark, mode, 1, revision);
+      String prefix =
+          options.getJobName()
+              + '/'
+              + RdeNamingUtils.makeRydeFilename(tld, watermark, mode, 1, revision);
       if (key.manual()) {
         checkState(key.directoryWithTrailingSlash() != null, "Manual subdirectory not specified");
-        prefix = prefix + "/manual/" + key.directoryWithTrailingSlash() + basename;
-      } else {
-        prefix = prefix + '/' + basename;
+        prefix = "manual/" + key.directoryWithTrailingSlash() + prefix;
       }
       BlobId xmlFilename = BlobId.of(rdeBucket, prefix + ".xml.ghostryde");
       // This file will contain the byte length (ASCII) of the raw unencrypted XML.

--- a/core/src/test/java/google/registry/beam/rde/RdePipelineTest.java
+++ b/core/src/test/java/google/registry/beam/rde/RdePipelineTest.java
@@ -497,13 +497,13 @@ public class RdePipelineTest {
 
     verifyFiles(ImmutableMap.of(brdaKey, brdaFragments, rdeKey, rdeFragments), true);
 
-    assertThat(gcsUtils.listFolderObjects("gcs-bucket", "rde-job/"))
+    assertThat(gcsUtils.listFolderObjects("gcs-bucket", "manual/test/rde-job/"))
         .containsExactly(
-            "manual/test/soy_2000-01-01_thin_S1_R0.xml.length",
-            "manual/test/soy_2000-01-01_thin_S1_R0.xml.ghostryde",
-            "manual/test/soy_2000-01-01_full_S1_R0.xml.length",
-            "manual/test/soy_2000-01-01_full_S1_R0.xml.ghostryde",
-            "manual/test/soy_2000-01-01_full_S1_R0-report.xml.ghostryde");
+            "soy_2000-01-01_thin_S1_R0.xml.length",
+            "soy_2000-01-01_thin_S1_R0.xml.ghostryde",
+            "soy_2000-01-01_full_S1_R0.xml.length",
+            "soy_2000-01-01_full_S1_R0.xml.ghostryde",
+            "soy_2000-01-01_full_S1_R0-report.xml.ghostryde");
 
     assertThat(loadCursorTime(CursorType.BRDA)).isEquivalentAccordingToCompareTo(now);
     assertThat(loadRevision(now, THIN)).isEqualTo(0);
@@ -521,7 +521,7 @@ public class RdePipelineTest {
     rdePipeline.persistData(fragments);
     pipeline.run().waitUntilFinish();
 
-    String prefix = manual ? "rde-job/manual/test/" : "rde-job/";
+    String prefix = manual ? "manual/test/rde-job/" : "rde-job/";
     String revision = manual ? "R0" : "R1";
 
     // BRDA


### PR DESCRIPTION
Beam does not have access to datastore. Using ofy on Beam always results
in an error. Normally we should use database migration state schedule to
determine which TM to use, but on Beam there's no point in doing so. By
hardcoding the TM on beam to be SQL we can start testing features before
we migrate to SQL mode, for example the new RDE pipeline.

TESTED=deployed the pipeline on production and ran a job.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1474)
<!-- Reviewable:end -->
