### PR TITLE
Change resource key type from Key to String for ResaveEntityAction

### DIFF
--- a/core/src/main/java/google/registry/batch/BatchModule.java
+++ b/core/src/main/java/google/registry/batch/BatchModule.java
@@ -33,10 +33,8 @@ import static google.registry.request.RequestParameters.extractSetOfDatetimePara
 
 import com.google.appengine.api.taskqueue.Queue;
 import com.google.common.collect.ImmutableSet;
-import com.googlecode.objectify.Key;
 import dagger.Module;
 import dagger.Provides;
-import google.registry.model.ImmutableObject;
 import google.registry.request.Parameter;
 import java.util.Optional;
 import javax.inject.Named;
@@ -79,9 +77,8 @@ public class BatchModule {
 
   @Provides
   @Parameter(PARAM_RESOURCE_KEY)
-  // TODO(b/207363014): figure out if this needs to be modified for vkey string replacement
-  static Key<ImmutableObject> provideResourceKey(HttpServletRequest req) {
-    return Key.create(extractRequiredParameter(req, PARAM_RESOURCE_KEY));
+  static String provideResourceKey(HttpServletRequest req) {
+    return extractRequiredParameter(req, PARAM_RESOURCE_KEY);
   }
 
   @Provides

--- a/core/src/main/java/google/registry/module/backend/BackendComponent.java
+++ b/core/src/main/java/google/registry/module/backend/BackendComponent.java
@@ -17,6 +17,7 @@ package google.registry.module.backend;
 import com.google.monitoring.metrics.MetricReporter;
 import dagger.Component;
 import dagger.Lazy;
+import google.registry.batch.BatchModule;
 import google.registry.bigquery.BigqueryModule;
 import google.registry.config.CloudTasksUtilsModule;
 import google.registry.config.CredentialModule;
@@ -55,6 +56,7 @@ import javax.inject.Singleton;
     modules = {
       AuthModule.class,
       BackendRequestComponentModule.class,
+      BatchModule.class,
       BigqueryModule.class,
       ConfigModule.class,
       CloudTasksUtilsModule.class,

--- a/core/src/main/java/google/registry/persistence/VKey.java
+++ b/core/src/main/java/google/registry/persistence/VKey.java
@@ -142,7 +142,7 @@ public class VKey<T> extends ImmutableObject implements Serializable {
    * "@ofy:agR0ZXN0cjELEg9FbnRpdHlHcm91cFJvb3QiCWNyb3NzLXRsZAwLEgpUZXN0T2JqZWN0IgNmb28M", where sql
    * key and ofy key values are encoded in Base64.
    */
-  public static <T> VKey<T> create(String keyString) throws Exception {
+  public static <T> VKey<T> create(String keyString) {
     if (!keyString.startsWith(CLASS_TYPE + KV_SEPARATOR)) {
       // to handle the existing ofy key string
       return fromWebsafeKey(keyString);

--- a/core/src/main/java/google/registry/tools/GetResourceByKeyCommand.java
+++ b/core/src/main/java/google/registry/tools/GetResourceByKeyCommand.java
@@ -40,7 +40,7 @@ final class GetResourceByKeyCommand implements CommandWithRemoteApi {
   boolean expand;
 
   @Override
-  public void run() throws Exception {
+  public void run() {
     for (String keyString : mainParameters) {
       System.out.println("\n");
       VKey<EppResource> resourceKey =

--- a/core/src/main/java/google/registry/tools/ResaveEntitiesCommand.java
+++ b/core/src/main/java/google/registry/tools/ResaveEntitiesCommand.java
@@ -42,7 +42,7 @@ public final class ResaveEntitiesCommand extends MutatingCommand {
   List<String> mainParameters;
 
   @Override
-  protected void init() throws Exception {
+  protected void init() {
     for (List<String> batch : partition(mainParameters, BATCH_SIZE)) {
       for (String websafeKey : batch) {
         ImmutableObject entity =

--- a/core/src/test/java/google/registry/batch/ResaveEntityActionTest.java
+++ b/core/src/test/java/google/registry/batch/ResaveEntityActionTest.java
@@ -33,8 +33,6 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
-import com.googlecode.objectify.Key;
-import google.registry.model.ImmutableObject;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.domain.GracePeriod;
 import google.registry.model.domain.rgp.GracePeriodStatus;
@@ -84,9 +82,7 @@ public class ResaveEntityActionTest {
   }
 
   private void runAction(
-      Key<ImmutableObject> resourceKey,
-      DateTime requestedTime,
-      ImmutableSortedSet<DateTime> resaveTimes) {
+      String resourceKey, DateTime requestedTime, ImmutableSortedSet<DateTime> resaveTimes) {
     ResaveEntityAction action =
         new ResaveEntityAction(
             resourceKey, requestedTime, resaveTimes, asyncTaskEnqueuer, response);
@@ -110,7 +106,10 @@ public class ResaveEntityActionTest {
             DateTime.parse("2017-01-02T10:11:00Z"));
     clock.advanceOneMilli();
     assertThat(domain.getCurrentSponsorRegistrarId()).isEqualTo("TheRegistrar");
-    runAction(Key.create(domain), DateTime.parse("2016-02-06T10:00:01Z"), ImmutableSortedSet.of());
+    runAction(
+        domain.createVKey().getOfyKey().getString(),
+        DateTime.parse("2016-02-06T10:00:01Z"),
+        ImmutableSortedSet.of());
     DomainBase resavedDomain = loadByEntity(domain);
     assertThat(resavedDomain.getCurrentSponsorRegistrarId()).isEqualTo("NewRegistrar");
     verify(response).setPayload("Entity re-saved.");
@@ -137,7 +136,10 @@ public class ResaveEntityActionTest {
     DateTime requestedTime = clock.nowUtc();
 
     assertThat(domain.getGracePeriods()).isNotEmpty();
-    runAction(Key.create(domain), requestedTime, ImmutableSortedSet.of(requestedTime.plusDays(5)));
+    runAction(
+        domain.createVKey().getOfyKey().getString(),
+        requestedTime,
+        ImmutableSortedSet.of(requestedTime.plusDays(5)));
     DomainBase resavedDomain = loadByEntity(domain);
     assertThat(resavedDomain.getGracePeriods()).isEmpty();
 

--- a/core/src/test/java/google/registry/persistence/VKeyTest.java
+++ b/core/src/test/java/google/registry/persistence/VKeyTest.java
@@ -159,19 +159,19 @@ class VKeyTest {
 
   /** Test stringify() with vkey created via different ways. */
   @Test
-  void testStringify_sqlOnlyVKey() throws Exception {
+  void testStringify_sqlOnlyVKey() {
     assertThat(VKey.createSql(TestObject.class, "foo").stringify())
         .isEqualTo("kind:TestObject@sql:rO0ABXQAA2Zvbw");
   }
 
   @Test
-  void testStringify_ofyOnlyVKey() throws Exception {
+  void testStringify_ofyOnlyVKey() {
     assertThat(VKey.createOfy(TestObject.class, Key.create(TestObject.class, "foo")).stringify())
         .isEqualTo("kind:TestObject@ofy:agR0ZXN0chMLEgpUZXN0T2JqZWN0IgNmb28M");
   }
 
   @Test
-  void testStringify_vkeyFromWebsafeKey() throws Exception {
+  void testStringify_vkeyFromWebsafeKey() {
     DomainBase domain = newDomainBase("example.com", "ROID-1", persistActiveContact("contact-1"));
     Key<DomainBase> key = Key.create(domain);
     VKey<DomainBase> vkey = VKey.fromWebsafeKey(key.getString());
@@ -183,7 +183,7 @@ class VKeyTest {
   }
 
   @Test
-  void testStringify_sqlAndOfyVKey() throws Exception {
+  void testStringify_sqlAndOfyVKey() {
     assertThat(
             VKey.create(TestObject.class, "foo", Key.create(TestObject.create("foo"))).stringify())
         .isEqualTo(
@@ -192,7 +192,7 @@ class VKeyTest {
   }
 
   @Test
-  void testStringify_asymmetricVKey() throws Exception {
+  void testStringify_asymmetricVKey() {
     assertThat(
             VKey.create(TestObject.class, "test", Key.create(TestObject.create("foo"))).stringify())
         .isEqualTo(
@@ -202,19 +202,19 @@ class VKeyTest {
 
   /** Test create() via different vkey string representations. */
   @Test
-  void testCreate_stringifedVKey_sqlOnlyVKeyString() throws Exception {
+  void testCreate_stringifedVKey_sqlOnlyVKeyString() {
     assertThat(VKey.create("kind:TestObject@sql:rO0ABXQAA2Zvbw"))
         .isEqualTo(VKey.createSql(TestObject.class, "foo"));
   }
 
   @Test
-  void testCreate_stringifedVKey_ofyOnlyVKeyString() throws Exception {
+  void testCreate_stringifedVKey_ofyOnlyVKeyString() {
     assertThat(VKey.create("kind:TestObject@ofy:agR0ZXN0chMLEgpUZXN0T2JqZWN0IgNmb28M"))
         .isEqualTo(VKey.createOfy(TestObject.class, Key.create(TestObject.class, "foo")));
   }
 
   @Test
-  void testCreate_stringifedVKey_asymmetricVKeyString() throws Exception {
+  void testCreate_stringifedVKey_asymmetricVKeyString() {
     assertThat(
             VKey.create(
                 "kind:TestObject@sql:rO0ABXQABHRlc3Q@ofy:agR0ZXN0cjELEg9Fb"
@@ -223,7 +223,7 @@ class VKeyTest {
   }
 
   @Test
-  void testCreate_stringifedVKey_sqlAndOfyVKeyString() throws Exception {
+  void testCreate_stringifedVKey_sqlAndOfyVKeyString() {
     assertThat(
             VKey.create(
                 "kind:TestObject@sql:rO0ABXQAA2Zvbw@ofy:agR0ZXN0cjELEg9Fbn"
@@ -232,7 +232,7 @@ class VKeyTest {
   }
 
   @Test
-  void testCreate_stringifyVkey_fromWebsafeKey() throws Exception {
+  void testCreate_stringifyVkey_fromWebsafeKey() {
     assertThat(
             VKey.create(
                 "kind:DomainBase@sql:rO0ABXQABlJPSUQtMQ"
@@ -245,13 +245,13 @@ class VKeyTest {
   }
 
   @Test
-  void testCreate_stringifedVKey_websafeKey() throws Exception {
+  void testCreate_stringifedVKey_websafeKey() {
     assertThat(VKey.create("agR0ZXN0chYLEgpEb21haW5CYXNlIgZST0lELTEM"))
         .isEqualTo(VKey.fromWebsafeKey("agR0ZXN0chYLEgpEb21haW5CYXNlIgZST0lELTEM"));
   }
 
   @Test
-  void testCreate_invalidStringifiedVKey_failure() throws Exception {
+  void testCreate_invalidStringifiedVKey_failure() {
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class, () -> VKey.create("kind:TestObject@sq:l@ofya:bc"));
@@ -261,7 +261,7 @@ class VKeyTest {
   }
 
   @Test
-  void testCreate_invalidOfyKeyString_failure() throws Exception {
+  void testCreate_invalidOfyKeyString_failure() {
     IllegalArgumentException thrown =
         assertThrows(IllegalArgumentException.class, () -> VKey.create("invalid"));
     assertThat(thrown).hasMessageThat().contains("Could not parse Reference");
@@ -269,21 +269,21 @@ class VKeyTest {
 
   /** Test stringify() then create() flow. */
   @Test
-  void testStringifyThenCreate_sqlOnlyVKey_testObject_stringKey_success() throws Exception {
+  void testStringifyThenCreate_sqlOnlyVKey_testObject_stringKey_success() {
     VKey<TestObject> vkey = VKey.createSql(TestObject.class, "foo");
     VKey<TestObject> newVkey = VKey.create(vkey.stringify());
     assertThat(newVkey).isEqualTo(vkey);
   }
 
   @Test
-  void testStringifyThenCreate_sqlOnlyVKey_testObject_longKey_success() throws Exception {
+  void testStringifyThenCreate_sqlOnlyVKey_testObject_longKey_success() {
     VKey<TestObject> vkey = VKey.createSql(TestObject.class, (long) 12345);
     VKey<TestObject> newVkey = VKey.create(vkey.stringify());
     assertThat(newVkey).isEqualTo(vkey);
   }
 
   @Test
-  void testCreate_createFromExistingOfyKey_success() throws Exception {
+  void testCreate_createFromExistingOfyKey_success() {
     String keyString =
         Key.create(newDomainBase("example.com", "ROID-1", persistActiveContact("contact-1")))
             .getString();
@@ -291,34 +291,34 @@ class VKeyTest {
   }
 
   @Test
-  void testStringifyThenCreate_ofyOnlyVKey_testObject_success() throws Exception {
+  void testStringifyThenCreate_ofyOnlyVKey_testObject_success() {
     VKey<TestObject> vkey =
         VKey.createOfy(TestObject.class, Key.create(TestObject.class, "tmpKey"));
     assertThat(VKey.create(vkey.stringify())).isEqualTo(vkey);
   }
 
   @Test
-  void testStringifyThenCreate_ofyOnlyVKey_testObject_websafeString_success() throws Exception {
+  void testStringifyThenCreate_ofyOnlyVKey_testObject_websafeString_success() {
     VKey<TestObject> vkey = VKey.fromWebsafeKey(Key.create(TestObject.create("foo")).getString());
     assertThat(VKey.create(vkey.stringify())).isEqualTo(vkey);
   }
 
   @Test
-  void testStringifyThenCreate_sqlAndOfyVKey_success() throws Exception {
+  void testStringifyThenCreate_sqlAndOfyVKey_success() {
     VKey<TestObject> vkey =
         VKey.create(TestObject.class, "foo", Key.create(TestObject.create("foo")));
     assertThat(VKey.create(vkey.stringify())).isEqualTo(vkey);
   }
 
   @Test
-  void testStringifyThenCreate_asymmetricVKey_success() throws Exception {
+  void testStringifyThenCreate_asymmetricVKey_success() {
     VKey<TestObject> vkey =
         VKey.create(TestObject.class, "sqlKey", Key.create(TestObject.create("foo")));
     assertThat(VKey.create(vkey.stringify())).isEqualTo(vkey);
   }
 
   @Test
-  void testStringifyThenCreate_symmetricVKey_success() throws Exception {
+  void testStringifyThenCreate_symmetricVKey_success() {
     VKey<TestObject> vkey = TestObject.create("foo").key();
     assertThat(VKey.create(vkey.stringify())).isEqualTo(vkey);
   }


### PR DESCRIPTION
Currently, in ```ResaveEntityAction```, resource key is passed in as ```Key<ImmutableObject>``` from ```BatchModule``` . The problem with this is, if the resource key is in the new vkey string representation, this action will fail because a key cannot be created in ```BatchModule``` since the extracted string is not an acceptable websafe string used by ```Key```. 

Instead of creating a ```Key<ImmutableObject>``` object then creating a vkey by calling ```VKey.from(Key<ImmutableObject> object)```, we need to replace with```VKey.create() ``` which can handle both new vkey string representation and old vkey string representation (which is ofy key in string form).  

In this PR, ```throws Exception``` is dropped from the existing ```VKey.create()``` method since there's no unexpected exception other than parsing error, which is already handled. 

This PR is the solution to the bug (b/207363014). This PR should be merged into master before [PR#1430](https://github.com/google/nomulus/pull/1430).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1475)
<!-- Reviewable:end -->
