### PR TITLE
Add a command to compare two escrow  deposits

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -676,9 +676,9 @@ Optional<List<String>> getToolArgsList() {
 
 // To run the nomulus tools with these command line tokens:
 // "--foo", "bar baz", "--qux=quz"
-//   gradle registryTool --args="--foo 'bar baz' --qux=quz"
+//   gradle core:registryTool --args="--foo 'bar baz' --qux=quz"
 // or:
-//   gradle registryTool --PtoolArgs="--foo|bar baz|--qux=quz"
+//   gradle core:registryTool -PtoolArgs="--foo|bar baz|--qux=quz"
 // Note that the delimiting pipe can be backslash escaped if it is part of a
 // parameter.
 ext.createToolTask = {

--- a/core/src/main/java/google/registry/tools/RegistryTool.java
+++ b/core/src/main/java/google/registry/tools/RegistryTool.java
@@ -17,6 +17,7 @@ package google.registry.tools;
 import com.google.common.collect.ImmutableMap;
 import google.registry.tools.javascrap.BackfillRegistryLocksCommand;
 import google.registry.tools.javascrap.BackfillSpec11ThreatMatchesCommand;
+import google.registry.tools.javascrap.CompareEscrowDepositsCommand;
 import google.registry.tools.javascrap.DeleteContactByRoidCommand;
 import google.registry.tools.javascrap.HardDeleteHostCommand;
 import google.registry.tools.javascrap.PopulateNullRegistrarFieldsCommand;
@@ -40,6 +41,7 @@ public final class RegistryTool {
           .put("canonicalize_labels", CanonicalizeLabelsCommand.class)
           .put("check_domain", CheckDomainCommand.class)
           .put("check_domain_claims", CheckDomainClaimsCommand.class)
+          .put("compare_escrow_deposits", CompareEscrowDepositsCommand.class)
           .put("convert_idn", ConvertIdnCommand.class)
           .put("count_domains", CountDomainsCommand.class)
           .put("create_anchor_tenant", CreateAnchorTenantCommand.class)

--- a/core/src/main/java/google/registry/tools/RegistryToolComponent.java
+++ b/core/src/main/java/google/registry/tools/RegistryToolComponent.java
@@ -42,6 +42,7 @@ import google.registry.request.Modules.UrlFetchTransportModule;
 import google.registry.request.Modules.UserServiceModule;
 import google.registry.tools.AuthModule.LocalCredentialModule;
 import google.registry.tools.javascrap.BackfillRegistryLocksCommand;
+import google.registry.tools.javascrap.CompareEscrowDepositsCommand;
 import google.registry.tools.javascrap.DeleteContactByRoidCommand;
 import google.registry.tools.javascrap.HardDeleteHostCommand;
 import google.registry.util.UtilsModule;
@@ -92,6 +93,8 @@ interface RegistryToolComponent {
   void inject(CheckDomainClaimsCommand command);
 
   void inject(CheckDomainCommand command);
+
+  void inject(CompareEscrowDepositsCommand command);
 
   void inject(CountDomainsCommand command);
 

--- a/core/src/main/java/google/registry/tools/javascrap/CompareEscrowDepositsCommand.java
+++ b/core/src/main/java/google/registry/tools/javascrap/CompareEscrowDepositsCommand.java
@@ -1,0 +1,130 @@
+// Copyright 2017 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.tools.javascrap;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Sets.difference;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import google.registry.keyring.api.Keyring;
+import google.registry.model.annotations.DeleteAfterMigration;
+import google.registry.rde.Ghostryde;
+import google.registry.tools.Command;
+import google.registry.tools.params.PathParameter;
+import google.registry.xjc.XjcXmlTransformer;
+import google.registry.xjc.rde.XjcRdeDeposit;
+import google.registry.xjc.rdedomain.XjcRdeDomain;
+import google.registry.xjc.rderegistrar.XjcRdeRegistrar;
+import google.registry.xml.XmlException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.xml.bind.JAXBElement;
+
+/**
+ * Command to view and schema validate an XML RDE escrow deposit.
+ *
+ * <p>Note that this command only makes sure that both deposits contain the same registrars and
+ * domains, regardless of the order. To verify that they are indeed equivalent one still needs to
+ * verify internal consistency within each deposit (i.e. to check that all hosts and contacts
+ * referenced by domains are included in the deposit) by calling {@code
+ * google.registry.tools.ValidateEscrowDepositCommand}.
+ */
+@DeleteAfterMigration
+@Parameters(separators = " =", commandDescription = "Compare two XML escrow deposits.")
+public final class CompareEscrowDepositsCommand implements Command {
+
+  @Parameter(
+      names = {"-i1", "--input1"},
+      description = "XML escrow deposit file 1. May be plain XML or an XML GhostRyDE file.",
+      validateWith = PathParameter.InputFile.class)
+  private Path input1 = null;
+
+  @Parameter(
+      names = {"-i2", "--input2"},
+      description = "XML escrow deposit file 2. May be plain XML or an XML GhostRyDE file.",
+      validateWith = PathParameter.InputFile.class)
+  private Path input2 = null;
+
+  @Inject Provider<Keyring> keyring;
+
+  private XjcRdeDeposit getDeposit(Path input) throws IOException, XmlException {
+    InputStream fileStream = Files.newInputStream(input);
+    InputStream inputStream = fileStream;
+    if (input.toString().endsWith(".ghostryde")) {
+      inputStream = Ghostryde.decoder(fileStream, keyring.get().getRdeStagingDecryptionKey());
+    }
+    return XjcXmlTransformer.unmarshal(XjcRdeDeposit.class, inputStream);
+  }
+
+  @Override
+  public void run() throws Exception {
+    XjcRdeDeposit deposit1 = getDeposit(input1);
+    XjcRdeDeposit deposit2 = getDeposit(input2);
+    compareXmlDeposits(deposit1, deposit2);
+  }
+
+  private static void process(XjcRdeDeposit deposit, Set<String> domains, Set<String> registrars) {
+    for (JAXBElement<?> item : deposit.getContents().getContents()) {
+      if (XjcRdeDomain.class.isAssignableFrom(item.getDeclaredType())) {
+        XjcRdeDomain domain = (XjcRdeDomain) item.getValue();
+        domains.add(checkNotNull(domain.getName()));
+      } else if (XjcRdeRegistrar.class.isAssignableFrom(item.getDeclaredType())) {
+        XjcRdeRegistrar registrar = (XjcRdeRegistrar) item.getValue();
+        registrars.add(checkNotNull(registrar.getId()));
+      }
+    }
+  }
+
+  private static boolean printUniqueElements(
+      Set<String> set1, Set<String> set2, String element, String deposit) {
+    ImmutableList<String> uniqueElements = ImmutableList.copyOf(difference(set1, set2));
+    if (!uniqueElements.isEmpty()) {
+      System.out.printf(
+          "%s only in %s:\n%s\n", element, deposit, Joiner.on("\n").join(uniqueElements));
+      return false;
+    }
+    return true;
+  }
+
+  private static void compareXmlDeposits(XjcRdeDeposit deposit1, XjcRdeDeposit deposit2) {
+    Set<String> domains1 = new HashSet<>();
+    Set<String> domains2 = new HashSet<>();
+    Set<String> registrars1 = new HashSet<>();
+    Set<String> registrars2 = new HashSet<>();
+    process(deposit1, domains1, registrars1);
+    process(deposit2, domains2, registrars2);
+    boolean good = true;
+    good &= printUniqueElements(domains1, domains2, "domains", "deposit1");
+    good &= printUniqueElements(domains2, domains1, "domains", "deposit2");
+    good &= printUniqueElements(registrars1, registrars2, "registrars", "deposit1");
+    good &= printUniqueElements(registrars2, registrars1, "registrars", "deposit2");
+    if (good) {
+      System.out.println(
+          "The two deposits contain the same domains and registrars. "
+              + "You still need to run validate_escrow_deposit to check reference consistency.");
+    } else {
+      System.out.println("The two deposits differ.");
+    }
+  }
+}

--- a/core/src/main/java/google/registry/tools/javascrap/CompareEscrowDepositsCommand.java
+++ b/core/src/main/java/google/registry/tools/javascrap/CompareEscrowDepositsCommand.java
@@ -1,4 +1,4 @@
-// Copyright 2017 The Nomulus Authors. All Rights Reserved.
+// Copyright 2022 The Nomulus Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 package google.registry.tools.javascrap;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Sets.difference;
 
@@ -36,6 +37,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -55,16 +57,10 @@ import javax.xml.bind.JAXBElement;
 public final class CompareEscrowDepositsCommand implements Command {
 
   @Parameter(
-      names = {"-i1", "--input1"},
-      description = "XML escrow deposit file 1. May be plain XML or an XML GhostRyDE file.",
+      description =
+          "Two XML escrow deposit files. Each may be a plain XML or an XML GhostRyDE file.",
       validateWith = PathParameter.InputFile.class)
-  private Path input1 = null;
-
-  @Parameter(
-      names = {"-i2", "--input2"},
-      description = "XML escrow deposit file 2. May be plain XML or an XML GhostRyDE file.",
-      validateWith = PathParameter.InputFile.class)
-  private Path input2 = null;
+  private List<Path> inputs;
 
   @Inject Provider<Keyring> keyring;
 
@@ -79,8 +75,12 @@ public final class CompareEscrowDepositsCommand implements Command {
 
   @Override
   public void run() throws Exception {
-    XjcRdeDeposit deposit1 = getDeposit(input1);
-    XjcRdeDeposit deposit2 = getDeposit(input2);
+    checkArgument(
+        inputs.size() == 2,
+        "Must supply 2 files to compare, but %s was/were supplied.",
+        inputs.size());
+    XjcRdeDeposit deposit1 = getDeposit(inputs.get(0));
+    XjcRdeDeposit deposit2 = getDeposit(inputs.get(1));
     compareXmlDeposits(deposit1, deposit2);
   }
 

--- a/core/src/test/java/google/registry/tools/CommandTestCase.java
+++ b/core/src/test/java/google/registry/tools/CommandTestCase.java
@@ -134,7 +134,7 @@ public abstract class CommandTestCase<C extends Command> {
   }
 
   /** Writes the data to a named temporary file and then returns a path to the file. */
-  private String writeToNamedTmpFile(String filename, byte[] data) throws IOException {
+  protected String writeToNamedTmpFile(String filename, byte[] data) throws IOException {
     Path tmpFile = tmpDir.resolve(filename);
     Files.write(data, tmpFile.toFile());
     return tmpFile.toString();
@@ -151,7 +151,7 @@ public abstract class CommandTestCase<C extends Command> {
   }
 
   /** Writes the data to a temporary file and then returns a path to the file. */
-  String writeToTmpFile(byte[] data) throws IOException {
+  public String writeToTmpFile(byte[] data) throws IOException {
     return writeToNamedTmpFile("tmp_file", data);
   }
 
@@ -220,7 +220,7 @@ public abstract class CommandTestCase<C extends Command> {
     assertThat(getStderrAsString()).doesNotContain(expected);
   }
 
-  String getStdoutAsString() {
+  protected String getStdoutAsString() {
     return new String(stdout.toByteArray(), UTF_8);
   }
 

--- a/core/src/test/java/google/registry/tools/javascrap/CompareEscrowDepositsCommandTest.java
+++ b/core/src/test/java/google/registry/tools/javascrap/CompareEscrowDepositsCommandTest.java
@@ -1,0 +1,52 @@
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.tools.javascrap;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import google.registry.rde.RdeTestData;
+import google.registry.tools.CommandTestCase;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link CompareEscrowDepositsCommand}. */
+class CompareEscrowDepositsCommandTest extends CommandTestCase<CompareEscrowDepositsCommand> {
+
+  @Test
+  void testSuccess_sameContentDifferentOrder() throws Exception {
+    String file1 = writeToNamedTmpFile("file1", RdeTestData.loadBytes("deposit_full.xml").read());
+    String file2 =
+        writeToNamedTmpFile("file2", RdeTestData.loadBytes("deposit_full_out_of_order.xml").read());
+    runCommand("-i1=" + file1, "-i2=" + file2);
+    assertThat(getStdoutAsString())
+        .contains("The two deposits contain the same domains and registrars.");
+  }
+
+  @Test
+  void testSuccess_differentContent() throws Exception {
+    String file1 = writeToNamedTmpFile("file1", RdeTestData.loadBytes("deposit_full.xml").read());
+    String file2 =
+        writeToNamedTmpFile("file2", RdeTestData.loadBytes("deposit_full_different.xml").read());
+    runCommand("-i1=" + file1, "-i2=" + file2);
+    assertThat(getStdoutAsString())
+        .isEqualTo(
+            "domains only in deposit1:\n"
+                + "example2.test\n"
+                + "domains only in deposit2:\n"
+                + "example3.test\n"
+                + "registrars only in deposit2:\n"
+                + "RegistrarY\n"
+                + "The two deposits differ.\n");
+  }
+}

--- a/core/src/test/java/google/registry/tools/javascrap/CompareEscrowDepositsCommandTest.java
+++ b/core/src/test/java/google/registry/tools/javascrap/CompareEscrowDepositsCommandTest.java
@@ -15,20 +15,31 @@
 package google.registry.tools.javascrap;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.rde.RdeTestData;
 import google.registry.tools.CommandTestCase;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link CompareEscrowDepositsCommand}. */
 class CompareEscrowDepositsCommandTest extends CommandTestCase<CompareEscrowDepositsCommand> {
 
   @Test
+  void testFailure_wrongNumberOfFiles() throws Exception {
+    String file1 = writeToNamedTmpFile("file1", "foo".getBytes(StandardCharsets.UTF_8));
+    String file2 = writeToNamedTmpFile("file2", "bar".getBytes(StandardCharsets.UTF_8));
+    String file3 = writeToNamedTmpFile("file3", "baz".getBytes(StandardCharsets.UTF_8));
+    assertThrows(IllegalArgumentException.class, () -> runCommand(file1));
+    assertThrows(IllegalArgumentException.class, () -> runCommand(file1, file2, file3));
+  }
+
+  @Test
   void testSuccess_sameContentDifferentOrder() throws Exception {
     String file1 = writeToNamedTmpFile("file1", RdeTestData.loadBytes("deposit_full.xml").read());
     String file2 =
         writeToNamedTmpFile("file2", RdeTestData.loadBytes("deposit_full_out_of_order.xml").read());
-    runCommand("-i1=" + file1, "-i2=" + file2);
+    runCommand(file1, file2);
     assertThat(getStdoutAsString())
         .contains("The two deposits contain the same domains and registrars.");
   }
@@ -38,7 +49,7 @@ class CompareEscrowDepositsCommandTest extends CommandTestCase<CompareEscrowDepo
     String file1 = writeToNamedTmpFile("file1", RdeTestData.loadBytes("deposit_full.xml").read());
     String file2 =
         writeToNamedTmpFile("file2", RdeTestData.loadBytes("deposit_full_different.xml").read());
-    runCommand("-i1=" + file1, "-i2=" + file2);
+    runCommand(file1, file2);
     assertThat(getStdoutAsString())
         .isEqualTo(
             "domains only in deposit1:\n"

--- a/core/src/test/resources/google/registry/rde/deposit_full_different.xml
+++ b/core/src/test/resources/google/registry/rde/deposit_full_different.xml
@@ -1,0 +1,295 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rde:deposit type="FULL" id="20101017001" prevId="20101010001"
+  xmlns:domain="urn:ietf:params:xml:ns:domain-1.0"
+  xmlns:contact="urn:ietf:params:xml:ns:contact-1.0"
+  xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1"
+  xmlns:rde="urn:ietf:params:xml:ns:rde-1.0"
+  xmlns:rdeHeader="urn:ietf:params:xml:ns:rdeHeader-1.0"
+  xmlns:rdeDom="urn:ietf:params:xml:ns:rdeDomain-1.0"
+  xmlns:rdeHost="urn:ietf:params:xml:ns:rdeHost-1.0"
+  xmlns:rdeContact="urn:ietf:params:xml:ns:rdeContact-1.0"
+  xmlns:rdeRegistrar="urn:ietf:params:xml:ns:rdeRegistrar-1.0"
+  xmlns:rdeIDN="urn:ietf:params:xml:ns:rdeIDN-1.0"
+  xmlns:rdeNNDN="urn:ietf:params:xml:ns:rdeNNDN-1.0"
+  xmlns:rdeEppParams="urn:ietf:params:xml:ns:rdeEppParams-1.0"
+  xmlns:rdePolicy="urn:ietf:params:xml:ns:rdePolicy-1.0"
+  xmlns:epp="urn:ietf:params:xml:ns:epp-1.0">
+
+  <rde:watermark>2010-10-17T00:00:00Z</rde:watermark>
+  <rde:rdeMenu>
+    <rde:version>1.0</rde:version>
+    <rde:objURI>urn:ietf:params:xml:ns:rdeHeader-1.0</rde:objURI>
+    <rde:objURI>urn:ietf:params:xml:ns:rdeContact-1.0</rde:objURI>
+    <rde:objURI>urn:ietf:params:xml:ns:rdeHost-1.0</rde:objURI>
+    <rde:objURI>urn:ietf:params:xml:ns:rdeDomain-1.0</rde:objURI>
+    <rde:objURI>urn:ietf:params:xml:ns:rdeRegistrar-1.0</rde:objURI>
+    <rde:objURI>urn:ietf:params:xml:ns:rdeIDN-1.0</rde:objURI>
+    <rde:objURI>urn:ietf:params:xml:ns:rdeNNDN-1.0</rde:objURI>
+    <rde:objURI>urn:ietf:params:xml:ns:rdeEppParams-1.0</rde:objURI>
+  </rde:rdeMenu>
+
+  <!-- Contents -->
+  <rde:contents>
+    <!-- Header -->
+    <rdeHeader:header>
+      <rdeHeader:tld>test</rdeHeader:tld>
+      <rdeHeader:count
+        uri="urn:ietf:params:xml:ns:rdeDomain-1.0">2
+        </rdeHeader:count>
+      <rdeHeader:count
+        uri="urn:ietf:params:xml:ns:rdeHost-1.0">1
+        </rdeHeader:count>
+      <rdeHeader:count
+        uri="urn:ietf:params:xml:ns:rdeContact-1.0">1
+        </rdeHeader:count>
+      <rdeHeader:count
+        uri="urn:ietf:params:xml:ns:rdeRegistrar-1.0">1
+    </rdeHeader:count>
+      <rdeHeader:count
+        uri="urn:ietf:params:xml:ns:rdeIDN-1.0">1
+        </rdeHeader:count>
+      <rdeHeader:count
+        uri="urn:ietf:params:xml:ns:rdeNNDN-1.0">1
+        </rdeHeader:count>
+      <rdeHeader:count
+        uri="urn:ietf:params:xml:ns:rdeEppParams-1.0">1
+    </rdeHeader:count>
+    </rdeHeader:header>
+
+    <!-- Domain: example1.test -->
+    <rdeDom:domain>
+      <rdeDom:name>example1.test</rdeDom:name>
+      <rdeDom:roid>Dexample1-TEST</rdeDom:roid>
+      <rdeDom:status s="ok"/>
+      <rdeDom:registrant>jd1234</rdeDom:registrant>
+      <rdeDom:contact type="admin">sh8013</rdeDom:contact>
+      <rdeDom:contact type="tech">sh8013</rdeDom:contact>
+      <rdeDom:ns>
+        <domain:hostObj>ns1.example.com</domain:hostObj>
+        <domain:hostObj>ns1.example1.test</domain:hostObj>
+      </rdeDom:ns>
+      <rdeDom:clID>RegistrarX</rdeDom:clID>
+      <rdeDom:crRr client="jdoe">RegistrarX</rdeDom:crRr>
+      <rdeDom:crDate>1999-04-03T22:00:00.0Z</rdeDom:crDate>
+      <rdeDom:exDate>2015-04-03T22:00:00.0Z</rdeDom:exDate>
+    </rdeDom:domain>
+
+    <!-- Domain: example3.test -->
+    <rdeDom:domain>
+      <rdeDom:name>example3.test</rdeDom:name>
+      <rdeDom:roid>Dexample3-TEST</rdeDom:roid>
+      <rdeDom:status s="ok"/>
+      <rdeDom:status s="clientUpdateProhibited"/>
+      <rdeDom:registrant>jd1234</rdeDom:registrant>
+      <rdeDom:contact type="admin">sh8013</rdeDom:contact>
+      <rdeDom:contact type="tech">sh8013</rdeDom:contact>
+      <rdeDom:clID>RegistrarY</rdeDom:clID>
+      <rdeDom:crRr>RegistrarY</rdeDom:crRr>
+      <rdeDom:crDate>1999-04-03T22:00:00.0Z</rdeDom:crDate>
+      <rdeDom:exDate>2015-04-03T22:00:00.0Z</rdeDom:exDate>
+    </rdeDom:domain>
+
+    <!-- Host: ns1.example.com -->
+    <rdeHost:host>
+      <rdeHost:name>ns1.example.com</rdeHost:name>
+      <rdeHost:roid>Hns1_example_com-TEST</rdeHost:roid>
+      <rdeHost:status s="ok"/>
+      <rdeHost:status s="linked"/>
+      <rdeHost:addr ip="v4">192.0.2.2</rdeHost:addr>
+      <rdeHost:addr ip="v4">192.0.2.29</rdeHost:addr>
+      <rdeHost:addr ip="v6">1080:0:0:0:8:800:200C:417A
+      </rdeHost:addr>
+      <rdeHost:clID>RegistrarX</rdeHost:clID>
+      <rdeHost:crRr>RegistrarX</rdeHost:crRr>
+      <rdeHost:crDate>1999-05-08T12:10:00.0Z</rdeHost:crDate>
+      <rdeHost:upRr>RegistrarX</rdeHost:upRr>
+      <rdeHost:upDate>2009-10-03T09:34:00.0Z</rdeHost:upDate>
+    </rdeHost:host>
+
+    <!-- Host: ns1.example1.test -->
+    <rdeHost:host>
+      <rdeHost:name>ns1.example1.test</rdeHost:name>
+      <rdeHost:roid>Hns1_example1_test-TEST</rdeHost:roid>
+      <rdeHost:status s="ok"/>
+      <rdeHost:status s="linked"/>
+      <rdeHost:addr ip="v4">192.0.2.2</rdeHost:addr>
+      <rdeHost:addr ip="v4">192.0.2.29</rdeHost:addr>
+      <rdeHost:addr ip="v6">1080:0:0:0:8:800:200C:417A
+      </rdeHost:addr>
+      <rdeHost:clID>RegistrarX</rdeHost:clID>
+      <rdeHost:crRr>RegistrarX</rdeHost:crRr>
+      <rdeHost:crDate>1999-05-08T12:10:00.0Z</rdeHost:crDate>
+      <rdeHost:upRr>RegistrarX</rdeHost:upRr>
+      <rdeHost:upDate>2009-10-03T09:34:00.0Z</rdeHost:upDate>
+    </rdeHost:host>
+
+    <!-- Contact: sh8013 -->
+    <rdeContact:contact>
+      <rdeContact:id>sh8013</rdeContact:id>
+      <rdeContact:roid>Csh8013-TEST</rdeContact:roid>
+      <rdeContact:status s="linked"/>
+      <rdeContact:status s="clientDeleteProhibited"/>
+      <rdeContact:postalInfo type="int">
+        <contact:name>John Doe</contact:name>
+        <contact:org>Example Inc.</contact:org>
+        <contact:addr>
+          <contact:street>123 Example Dr.</contact:street>
+          <contact:street>Suite 100</contact:street>
+          <contact:city>Dulles</contact:city>
+          <contact:sp>VA</contact:sp>
+          <contact:pc>20166-6503</contact:pc>
+          <contact:cc>US</contact:cc>
+        </contact:addr>
+      </rdeContact:postalInfo>
+      <rdeContact:voice x="1234">+1.7035555555
+      </rdeContact:voice>
+      <rdeContact:fax>+1.7035555556
+      </rdeContact:fax>
+      <rdeContact:email>jdoe@example.test
+      </rdeContact:email>
+      <rdeContact:clID>RegistrarX</rdeContact:clID>
+      <rdeContact:crRr client="jdoe">RegistrarX
+      </rdeContact:crRr>
+      <rdeContact:crDate>2009-09-13T08:01:00.0Z</rdeContact:crDate>
+      <rdeContact:upRr client="jdoe">RegistrarX
+      </rdeContact:upRr>
+      <rdeContact:upDate>2009-11-26T09:10:00.0Z</rdeContact:upDate>
+      <rdeContact:trDate>2009-12-03T09:05:00.0Z</rdeContact:trDate>
+      <rdeContact:disclose flag="0">
+        <contact:voice/>
+        <contact:email/>
+      </rdeContact:disclose>
+    </rdeContact:contact>
+
+    <!-- Registrar: RegistrarX -->
+    <rdeRegistrar:registrar>
+      <rdeRegistrar:id>RegistrarX</rdeRegistrar:id>
+      <rdeRegistrar:name>Registrar X</rdeRegistrar:name>
+      <rdeRegistrar:gurid>123</rdeRegistrar:gurid>
+      <rdeRegistrar:status>ok</rdeRegistrar:status>
+      <rdeRegistrar:postalInfo type="int">
+        <rdeRegistrar:addr>
+          <rdeRegistrar:street>123 Example Dr.
+          </rdeRegistrar:street>
+          <rdeRegistrar:street>Suite 100
+          </rdeRegistrar:street>
+          <rdeRegistrar:city>Dulles</rdeRegistrar:city>
+          <rdeRegistrar:sp>VA</rdeRegistrar:sp>
+          <rdeRegistrar:pc>20166-6503</rdeRegistrar:pc>
+          <rdeRegistrar:cc>US</rdeRegistrar:cc>
+        </rdeRegistrar:addr>
+      </rdeRegistrar:postalInfo>
+      <rdeRegistrar:voice x="1234">+1.7035555555
+      </rdeRegistrar:voice>
+      <rdeRegistrar:fax>+1.7035555556
+      </rdeRegistrar:fax>
+      <rdeRegistrar:email>jdoe@example.test
+      </rdeRegistrar:email>
+      <rdeRegistrar:url>http://www.example.test
+      </rdeRegistrar:url>
+      <rdeRegistrar:whoisInfo>
+        <rdeRegistrar:name>whois.example.test
+        </rdeRegistrar:name>
+        <rdeRegistrar:url>http://whois.example.test
+        </rdeRegistrar:url>
+      </rdeRegistrar:whoisInfo>
+      <rdeRegistrar:crDate>2005-04-23T11:49:00.0Z</rdeRegistrar:crDate>
+      <rdeRegistrar:upDate>2009-02-17T17:51:00.0Z</rdeRegistrar:upDate>
+    </rdeRegistrar:registrar>
+
+    <!-- Registrar: RegistrarY -->
+    <rdeRegistrar:registrar>
+      <rdeRegistrar:id>RegistrarY</rdeRegistrar:id>
+      <rdeRegistrar:name>Registrar Y</rdeRegistrar:name>
+      <rdeRegistrar:gurid>1234</rdeRegistrar:gurid>
+      <rdeRegistrar:status>ok</rdeRegistrar:status>
+      <rdeRegistrar:postalInfo type="int">
+        <rdeRegistrar:addr>
+          <rdeRegistrar:street>123 Example Dr.
+          </rdeRegistrar:street>
+          <rdeRegistrar:street>Suite 100
+          </rdeRegistrar:street>
+          <rdeRegistrar:city>Dulles</rdeRegistrar:city>
+          <rdeRegistrar:sp>VA</rdeRegistrar:sp>
+          <rdeRegistrar:pc>20166-6503</rdeRegistrar:pc>
+          <rdeRegistrar:cc>US</rdeRegistrar:cc>
+        </rdeRegistrar:addr>
+      </rdeRegistrar:postalInfo>
+      <rdeRegistrar:voice x="1234">+1.7035555555
+      </rdeRegistrar:voice>
+      <rdeRegistrar:fax>+1.7035555556
+      </rdeRegistrar:fax>
+      <rdeRegistrar:email>jdoe@example.test
+      </rdeRegistrar:email>
+      <rdeRegistrar:url>http://www.example.test
+      </rdeRegistrar:url>
+      <rdeRegistrar:whoisInfo>
+        <rdeRegistrar:name>whois.example.test
+        </rdeRegistrar:name>
+        <rdeRegistrar:url>http://whois.example.test
+        </rdeRegistrar:url>
+      </rdeRegistrar:whoisInfo>
+      <rdeRegistrar:crDate>2005-04-23T11:49:00.0Z</rdeRegistrar:crDate>
+      <rdeRegistrar:upDate>2009-02-17T17:51:00.0Z</rdeRegistrar:upDate>
+    </rdeRegistrar:registrar>
+
+    <!-- IDN Table -->
+    <rdeIDN:idnTableRef id="pt-BR">
+      <rdeIDN:url>
+http://www.iana.org/domains/idn-tables/tables/br_pt-br_1.0.html
+      </rdeIDN:url>
+      <rdeIDN:urlPolicy>
+        http://registro.br/dominio/regras.html
+      </rdeIDN:urlPolicy>
+    </rdeIDN:idnTableRef>
+
+    <!-- NNDN: pinguino.test -->
+    <rdeNNDN:NNDN>
+      <rdeNNDN:aName>xn--exampl-gva.test</rdeNNDN:aName>
+      <rdeNNDN:idnTableId>pt-BR</rdeNNDN:idnTableId>
+      <rdeNNDN:originalName>example1.test</rdeNNDN:originalName>
+      <rdeNNDN:nameState>withheld</rdeNNDN:nameState>
+      <rdeNNDN:crDate>2005-04-23T11:49:00.0Z</rdeNNDN:crDate>
+    </rdeNNDN:NNDN>
+
+    <!-- EppParams -->
+    <rdeEppParams:eppParams>
+      <rdeEppParams:version>1.0</rdeEppParams:version>
+      <rdeEppParams:lang>en</rdeEppParams:lang>
+      <rdeEppParams:objURI>
+        urn:ietf:params:xml:ns:domain-1.0
+      </rdeEppParams:objURI>
+      <rdeEppParams:objURI>
+        urn:ietf:params:xml:ns:contact-1.0
+      </rdeEppParams:objURI>
+      <rdeEppParams:objURI>
+        urn:ietf:params:xml:ns:host-1.0
+      </rdeEppParams:objURI>
+      <rdeEppParams:svcExtension>
+        <epp:extURI>urn:ietf:params:xml:ns:rgp-1.0
+        </epp:extURI>
+        <epp:extURI>urn:ietf:params:xml:ns:secDNS-1.1
+        </epp:extURI>
+      </rdeEppParams:svcExtension>
+      <rdeEppParams:dcp>
+      <epp:access><epp:all/></epp:access>
+        <epp:statement>
+          <epp:purpose>
+            <epp:admin/>
+            <epp:prov/>
+          </epp:purpose>
+          <epp:recipient>
+            <epp:ours/>
+            <epp:public/>
+          </epp:recipient>
+          <epp:retention>
+            <epp:stated/>
+          </epp:retention>
+        </epp:statement>
+      </rdeEppParams:dcp>
+    </rdeEppParams:eppParams>
+  <rdePolicy:policy
+     scope="//rde:deposit/rde:contents/rdeDomain:domain"
+     element="rdeDom:registrant" />
+  </rde:contents>
+</rde:deposit>

--- a/core/src/test/resources/google/registry/rde/deposit_full_out_of_order.xml
+++ b/core/src/test/resources/google/registry/rde/deposit_full_out_of_order.xml
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rde:deposit type="FULL" id="20101017001" prevId="20101010001"
+  xmlns:domain="urn:ietf:params:xml:ns:domain-1.0"
+  xmlns:contact="urn:ietf:params:xml:ns:contact-1.0"
+  xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1"
+  xmlns:rde="urn:ietf:params:xml:ns:rde-1.0"
+  xmlns:rdeHeader="urn:ietf:params:xml:ns:rdeHeader-1.0"
+  xmlns:rdeDom="urn:ietf:params:xml:ns:rdeDomain-1.0"
+  xmlns:rdeHost="urn:ietf:params:xml:ns:rdeHost-1.0"
+  xmlns:rdeContact="urn:ietf:params:xml:ns:rdeContact-1.0"
+  xmlns:rdeRegistrar="urn:ietf:params:xml:ns:rdeRegistrar-1.0"
+  xmlns:rdeIDN="urn:ietf:params:xml:ns:rdeIDN-1.0"
+  xmlns:rdeNNDN="urn:ietf:params:xml:ns:rdeNNDN-1.0"
+  xmlns:rdeEppParams="urn:ietf:params:xml:ns:rdeEppParams-1.0"
+  xmlns:rdePolicy="urn:ietf:params:xml:ns:rdePolicy-1.0"
+  xmlns:epp="urn:ietf:params:xml:ns:epp-1.0">
+
+  <rde:watermark>2010-10-17T00:00:00Z</rde:watermark>
+  <rde:rdeMenu>
+    <rde:version>1.0</rde:version>
+    <rde:objURI>urn:ietf:params:xml:ns:rdeHeader-1.0</rde:objURI>
+    <rde:objURI>urn:ietf:params:xml:ns:rdeContact-1.0</rde:objURI>
+    <rde:objURI>urn:ietf:params:xml:ns:rdeHost-1.0</rde:objURI>
+    <rde:objURI>urn:ietf:params:xml:ns:rdeDomain-1.0</rde:objURI>
+    <rde:objURI>urn:ietf:params:xml:ns:rdeRegistrar-1.0</rde:objURI>
+    <rde:objURI>urn:ietf:params:xml:ns:rdeIDN-1.0</rde:objURI>
+    <rde:objURI>urn:ietf:params:xml:ns:rdeNNDN-1.0</rde:objURI>
+    <rde:objURI>urn:ietf:params:xml:ns:rdeEppParams-1.0</rde:objURI>
+  </rde:rdeMenu>
+
+  <!-- Contents -->
+  <rde:contents>
+    <!-- Header -->
+    <rdeHeader:header>
+      <rdeHeader:tld>test</rdeHeader:tld>
+      <rdeHeader:count
+        uri="urn:ietf:params:xml:ns:rdeDomain-1.0">2
+        </rdeHeader:count>
+      <rdeHeader:count
+        uri="urn:ietf:params:xml:ns:rdeHost-1.0">1
+        </rdeHeader:count>
+      <rdeHeader:count
+        uri="urn:ietf:params:xml:ns:rdeContact-1.0">1
+        </rdeHeader:count>
+      <rdeHeader:count
+        uri="urn:ietf:params:xml:ns:rdeRegistrar-1.0">1
+    </rdeHeader:count>
+      <rdeHeader:count
+        uri="urn:ietf:params:xml:ns:rdeIDN-1.0">1
+        </rdeHeader:count>
+      <rdeHeader:count
+        uri="urn:ietf:params:xml:ns:rdeNNDN-1.0">1
+        </rdeHeader:count>
+      <rdeHeader:count
+        uri="urn:ietf:params:xml:ns:rdeEppParams-1.0">1
+    </rdeHeader:count>
+    </rdeHeader:header>
+
+    <!-- Domain: example2.test -->
+    <rdeDom:domain>
+      <rdeDom:name>example2.test</rdeDom:name>
+      <rdeDom:roid>Dexample2-TEST</rdeDom:roid>
+      <rdeDom:status s="ok"/>
+      <rdeDom:status s="clientUpdateProhibited"/>
+      <rdeDom:registrant>jd1234</rdeDom:registrant>
+      <rdeDom:contact type="admin">sh8013</rdeDom:contact>
+      <rdeDom:contact type="tech">sh8013</rdeDom:contact>
+      <rdeDom:clID>RegistrarX</rdeDom:clID>
+      <rdeDom:crRr>RegistrarX</rdeDom:crRr>
+      <rdeDom:crDate>1999-04-03T22:00:00.0Z</rdeDom:crDate>
+      <rdeDom:exDate>2015-04-03T22:00:00.0Z</rdeDom:exDate>
+    </rdeDom:domain>
+
+    <!-- Domain: example1.test -->
+    <rdeDom:domain>
+      <rdeDom:name>example1.test</rdeDom:name>
+      <rdeDom:roid>Dexample1-TEST</rdeDom:roid>
+      <rdeDom:status s="ok"/>
+      <rdeDom:registrant>jd1234</rdeDom:registrant>
+      <rdeDom:contact type="admin">sh8013</rdeDom:contact>
+      <rdeDom:contact type="tech">sh8013</rdeDom:contact>
+      <rdeDom:ns>
+        <domain:hostObj>ns1.example.com</domain:hostObj>
+        <domain:hostObj>ns1.example1.test</domain:hostObj>
+      </rdeDom:ns>
+      <rdeDom:clID>RegistrarX</rdeDom:clID>
+      <rdeDom:crRr client="jdoe">RegistrarX</rdeDom:crRr>
+      <rdeDom:crDate>1999-04-03T22:00:00.0Z</rdeDom:crDate>
+      <rdeDom:exDate>2015-04-03T22:00:00.0Z</rdeDom:exDate>
+    </rdeDom:domain>
+
+
+
+    <!-- Host: ns1.example.com -->
+    <rdeHost:host>
+      <rdeHost:name>ns1.example.com</rdeHost:name>
+      <rdeHost:roid>Hns1_example_com-TEST</rdeHost:roid>
+      <rdeHost:status s="ok"/>
+      <rdeHost:status s="linked"/>
+      <rdeHost:addr ip="v4">192.0.2.2</rdeHost:addr>
+      <rdeHost:addr ip="v4">192.0.2.29</rdeHost:addr>
+      <rdeHost:addr ip="v6">1080:0:0:0:8:800:200C:417A
+      </rdeHost:addr>
+      <rdeHost:clID>RegistrarX</rdeHost:clID>
+      <rdeHost:crRr>RegistrarX</rdeHost:crRr>
+      <rdeHost:crDate>1999-05-08T12:10:00.0Z</rdeHost:crDate>
+      <rdeHost:upRr>RegistrarX</rdeHost:upRr>
+      <rdeHost:upDate>2009-10-03T09:34:00.0Z</rdeHost:upDate>
+    </rdeHost:host>
+
+    <!-- Host: ns1.example1.test -->
+    <rdeHost:host>
+      <rdeHost:name>ns1.example1.test</rdeHost:name>
+      <rdeHost:roid>Hns1_example1_test-TEST</rdeHost:roid>
+      <rdeHost:status s="ok"/>
+      <rdeHost:status s="linked"/>
+      <rdeHost:addr ip="v4">192.0.2.2</rdeHost:addr>
+      <rdeHost:addr ip="v4">192.0.2.29</rdeHost:addr>
+      <rdeHost:addr ip="v6">1080:0:0:0:8:800:200C:417A
+      </rdeHost:addr>
+      <rdeHost:clID>RegistrarX</rdeHost:clID>
+      <rdeHost:crRr>RegistrarX</rdeHost:crRr>
+      <rdeHost:crDate>1999-05-08T12:10:00.0Z</rdeHost:crDate>
+      <rdeHost:upRr>RegistrarX</rdeHost:upRr>
+      <rdeHost:upDate>2009-10-03T09:34:00.0Z</rdeHost:upDate>
+    </rdeHost:host>
+
+    <!-- Contact: sh8013 -->
+    <rdeContact:contact>
+      <rdeContact:id>sh8013</rdeContact:id>
+      <rdeContact:roid>Csh8013-TEST</rdeContact:roid>
+      <rdeContact:status s="linked"/>
+      <rdeContact:status s="clientDeleteProhibited"/>
+      <rdeContact:postalInfo type="int">
+        <contact:name>John Doe</contact:name>
+        <contact:org>Example Inc.</contact:org>
+        <contact:addr>
+          <contact:street>123 Example Dr.</contact:street>
+          <contact:street>Suite 100</contact:street>
+          <contact:city>Dulles</contact:city>
+          <contact:sp>VA</contact:sp>
+          <contact:pc>20166-6503</contact:pc>
+          <contact:cc>US</contact:cc>
+        </contact:addr>
+      </rdeContact:postalInfo>
+      <rdeContact:voice x="1234">+1.7035555555
+      </rdeContact:voice>
+      <rdeContact:fax>+1.7035555556
+      </rdeContact:fax>
+      <rdeContact:email>jdoe@example.test
+      </rdeContact:email>
+      <rdeContact:clID>RegistrarX</rdeContact:clID>
+      <rdeContact:crRr client="jdoe">RegistrarX
+      </rdeContact:crRr>
+      <rdeContact:crDate>2009-09-13T08:01:00.0Z</rdeContact:crDate>
+      <rdeContact:upRr client="jdoe">RegistrarX
+      </rdeContact:upRr>
+      <rdeContact:upDate>2009-11-26T09:10:00.0Z</rdeContact:upDate>
+      <rdeContact:trDate>2009-12-03T09:05:00.0Z</rdeContact:trDate>
+      <rdeContact:disclose flag="0">
+        <contact:voice/>
+        <contact:email/>
+      </rdeContact:disclose>
+    </rdeContact:contact>
+
+    <!-- Registrar: RegistrarX -->
+    <rdeRegistrar:registrar>
+      <rdeRegistrar:id>RegistrarX</rdeRegistrar:id>
+      <rdeRegistrar:name>Registrar X</rdeRegistrar:name>
+      <rdeRegistrar:gurid>123</rdeRegistrar:gurid>
+      <rdeRegistrar:status>ok</rdeRegistrar:status>
+      <rdeRegistrar:postalInfo type="int">
+        <rdeRegistrar:addr>
+          <rdeRegistrar:street>123 Example Dr.
+          </rdeRegistrar:street>
+          <rdeRegistrar:street>Suite 100
+          </rdeRegistrar:street>
+          <rdeRegistrar:city>Dulles</rdeRegistrar:city>
+          <rdeRegistrar:sp>VA</rdeRegistrar:sp>
+          <rdeRegistrar:pc>20166-6503</rdeRegistrar:pc>
+          <rdeRegistrar:cc>US</rdeRegistrar:cc>
+        </rdeRegistrar:addr>
+      </rdeRegistrar:postalInfo>
+      <rdeRegistrar:voice x="1234">+1.7035555555
+      </rdeRegistrar:voice>
+      <rdeRegistrar:fax>+1.7035555556
+      </rdeRegistrar:fax>
+      <rdeRegistrar:email>jdoe@example.test
+      </rdeRegistrar:email>
+      <rdeRegistrar:url>http://www.example.test
+      </rdeRegistrar:url>
+      <rdeRegistrar:whoisInfo>
+        <rdeRegistrar:name>whois.example.test
+        </rdeRegistrar:name>
+        <rdeRegistrar:url>http://whois.example.test
+        </rdeRegistrar:url>
+      </rdeRegistrar:whoisInfo>
+      <rdeRegistrar:crDate>2005-04-23T11:49:00.0Z</rdeRegistrar:crDate>
+      <rdeRegistrar:upDate>2009-02-17T17:51:00.0Z</rdeRegistrar:upDate>
+    </rdeRegistrar:registrar>
+
+    <!-- IDN Table -->
+    <rdeIDN:idnTableRef id="pt-BR">
+      <rdeIDN:url>
+http://www.iana.org/domains/idn-tables/tables/br_pt-br_1.0.html
+      </rdeIDN:url>
+      <rdeIDN:urlPolicy>
+        http://registro.br/dominio/regras.html
+      </rdeIDN:urlPolicy>
+    </rdeIDN:idnTableRef>
+
+    <!-- NNDN: pinguino.test -->
+    <rdeNNDN:NNDN>
+      <rdeNNDN:aName>xn--exampl-gva.test</rdeNNDN:aName>
+      <rdeNNDN:idnTableId>pt-BR</rdeNNDN:idnTableId>
+      <rdeNNDN:originalName>example1.test</rdeNNDN:originalName>
+      <rdeNNDN:nameState>withheld</rdeNNDN:nameState>
+      <rdeNNDN:crDate>2005-04-23T11:49:00.0Z</rdeNNDN:crDate>
+    </rdeNNDN:NNDN>
+
+    <!-- EppParams -->
+    <rdeEppParams:eppParams>
+      <rdeEppParams:version>1.0</rdeEppParams:version>
+      <rdeEppParams:lang>en</rdeEppParams:lang>
+      <rdeEppParams:objURI>
+        urn:ietf:params:xml:ns:domain-1.0
+      </rdeEppParams:objURI>
+      <rdeEppParams:objURI>
+        urn:ietf:params:xml:ns:contact-1.0
+      </rdeEppParams:objURI>
+      <rdeEppParams:objURI>
+        urn:ietf:params:xml:ns:host-1.0
+      </rdeEppParams:objURI>
+      <rdeEppParams:svcExtension>
+        <epp:extURI>urn:ietf:params:xml:ns:rgp-1.0
+        </epp:extURI>
+        <epp:extURI>urn:ietf:params:xml:ns:secDNS-1.1
+        </epp:extURI>
+      </rdeEppParams:svcExtension>
+      <rdeEppParams:dcp>
+      <epp:access><epp:all/></epp:access>
+        <epp:statement>
+          <epp:purpose>
+            <epp:admin/>
+            <epp:prov/>
+          </epp:purpose>
+          <epp:recipient>
+            <epp:ours/>
+            <epp:public/>
+          </epp:recipient>
+          <epp:retention>
+            <epp:stated/>
+          </epp:retention>
+        </epp:statement>
+      </rdeEppParams:dcp>
+    </rdeEppParams:eppParams>
+  <rdePolicy:policy
+     scope="//rde:deposit/rde:contents/rdeDomain:domain"
+     element="rdeDom:registrant" />
+  </rde:contents>
+</rde:deposit>


### PR DESCRIPTION
We already have ValidateEscrowDepositCommand to check for internal
reference consistency of two deposits, i. e. making sure that all
contacts and hosts referenced by domains exist in the same deposit.
Therefore to compare whether two deposits are equal we only need to make
sure that they contain the same domains and registrars, assuming they
both pass the validation. We don't compare their contents directly
because the MapReduce deposit contains all contacts and domains whereas
the Beam deposit only contains referenced ones, making a direct
comparison impossible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1476)
<!-- Reviewable:end -->
