### PR TITLE
Add pending action extension to server update poll messages

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
@@ -43,6 +43,7 @@ import static google.registry.flows.domain.DomainFlowUtils.verifyNotInPendingDel
 import static google.registry.model.reporting.HistoryEntry.Type.DOMAIN_UPDATE;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
@@ -77,9 +78,11 @@ import google.registry.model.domain.secdns.SecDnsUpdateExtension;
 import google.registry.model.domain.superuser.DomainUpdateSuperuserExtension;
 import google.registry.model.eppcommon.AuthInfo;
 import google.registry.model.eppcommon.StatusValue;
+import google.registry.model.eppcommon.Trid;
 import google.registry.model.eppinput.EppInput;
 import google.registry.model.eppinput.ResourceCommand;
 import google.registry.model.eppoutput.EppResponse;
+import google.registry.model.poll.PendingActionNotificationResponse.DomainPendingActionNotificationResponse;
 import google.registry.model.poll.PollMessage;
 import google.registry.model.reporting.IcannReportingTypes.ActivityReportField;
 import google.registry.model.tld.Registry;
@@ -149,6 +152,7 @@ public final class DomainUpdateFlow implements TransactionalFlow {
   @Inject @RegistrarId String registrarId;
   @Inject @TargetId String targetId;
   @Inject @Superuser boolean isSuperuser;
+  @Inject Trid trid;
   @Inject DomainHistory.Builder historyBuilder;
   @Inject DnsQueue dnsQueue;
   @Inject EppResponse.Builder responseBuilder;
@@ -360,6 +364,10 @@ public final class DomainUpdateFlow implements TransactionalFlow {
             .setEventTime(now)
             .setRegistrarId(existingDomain.getCurrentSponsorRegistrarId())
             .setMsg(msg)
+            .setResponseData(
+                ImmutableList.of(
+                    DomainPendingActionNotificationResponse.create(
+                        existingDomain.getDomainName(), true, trid, now)))
             .build());
   }
 }

--- a/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
@@ -99,7 +99,9 @@ import google.registry.model.domain.DomainBase;
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.secdns.DelegationSignerData;
 import google.registry.model.eppcommon.StatusValue;
+import google.registry.model.eppcommon.Trid;
 import google.registry.model.host.HostResource;
+import google.registry.model.poll.PendingActionNotificationResponse.DomainPendingActionNotificationResponse;
 import google.registry.model.poll.PollMessage;
 import google.registry.model.tld.Registry;
 import google.registry.persistence.VKey;
@@ -949,6 +951,13 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .setParent(getOnlyHistoryEntryOfType(updatedDomain, DOMAIN_UPDATE))
             .setRegistrarId("NewRegistrar")
             .setMsg("The registry administrator has added the status(es) [serverHold].")
+            .setResponseData(
+                ImmutableList.of(
+                    DomainPendingActionNotificationResponse.create(
+                        "example.tld",
+                        true,
+                        Trid.create("ABC-12345", "server-trid"),
+                        clock.nowUtc())))
             .build());
   }
 
@@ -983,6 +992,13 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .setMsg(
                 "The registry administrator has removed the status(es) [serverHold,"
                     + " serverTransferProhibited, serverUpdateProhibited].")
+            .setResponseData(
+                ImmutableList.of(
+                    DomainPendingActionNotificationResponse.create(
+                        "example.tld",
+                        true,
+                        Trid.create("ABC-12345", "server-trid"),
+                        clock.nowUtc())))
             .build());
   }
 
@@ -1015,6 +1031,13 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
                 "The registry administrator has added the status(es) [serverHold,"
                     + " serverRenewProhibited] and removed the status(es)"
                     + " [serverTransferProhibited].")
+            .setResponseData(
+                ImmutableList.of(
+                    DomainPendingActionNotificationResponse.create(
+                        "example.tld",
+                        true,
+                        Trid.create("ABC-12345", "server-trid"),
+                        clock.nowUtc())))
             .build());
   }
 

--- a/core/src/test/resources/google/registry/flows/poll_response_server_hold.xml
+++ b/core/src/test/resources/google/registry/flows/poll_response_server_hold.xml
@@ -8,6 +8,16 @@
       <msg>The registry administrator has added the status(es) [serverHold].
       </msg>
     </msgQ>
+    <resData>
+      <domain:panData xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name paResult="1">example.tld</domain:name>
+        <domain:paTRID>
+          <clTRID>ABC-12345</clTRID>
+          <svTRID>server-trid</svTRID>
+        </domain:paTRID>
+        <domain:paDate>2000-06-02T13:00:00Z</domain:paDate>
+      </domain:panData>
+    </resData>
     <trID>
       <clTRID>ABC-12345</clTRID>
       <svTRID>server-trid</svTRID>


### PR DESCRIPTION
This is necessary for the poll messages to contain the necessary context
explaining what domain name the relevant statuses were being added/removed
to/from.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1478)
<!-- Reviewable:end -->
