### PR TITLE
Don't throw errors when existing premium list is empty

### DIFF
--- a/core/src/main/java/google/registry/model/tld/label/PremiumListDao.java
+++ b/core/src/main/java/google/registry/model/tld/label/PremiumListDao.java
@@ -14,6 +14,7 @@
 
 package google.registry.model.tld.label;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static google.registry.config.RegistryConfig.getDomainLabelListCacheDuration;
 import static google.registry.config.RegistryConfig.getSingletonCachePersistDuration;
@@ -153,6 +154,7 @@ public class PremiumListDao {
   }
 
   public static PremiumList save(String name, CurrencyUnit currencyUnit, List<String> inputData) {
+    checkArgument(!inputData.isEmpty(), "New premium list data cannot be empty");
     return save(PremiumListUtils.parseToPremiumList(name, currencyUnit, inputData));
   }
 

--- a/core/src/main/java/google/registry/model/tld/label/PremiumListUtils.java
+++ b/core/src/main/java/google/registry/model/tld/label/PremiumListUtils.java
@@ -14,7 +14,6 @@
 
 package google.registry.model.tld.label;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static org.joda.time.DateTimeZone.UTC;
 
 import com.google.common.collect.ImmutableMap;
@@ -38,7 +37,6 @@ public class PremiumListUtils {
             .setCreationTimestamp(DateTime.now(UTC))
             .build();
     ImmutableMap<String, PremiumEntry> prices = partialPremiumList.parse(inputData);
-    checkArgument(inputData.size() > 0, "Input cannot be empty");
     Map<String, BigDecimal> priceAmounts = Maps.transformValues(prices, PremiumEntry::getValue);
     return partialPremiumList.asBuilder().setLabelsToPrices(priceAmounts).build();
   }

--- a/core/src/main/java/google/registry/tools/UpdatePremiumListCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdatePremiumListCommand.java
@@ -16,6 +16,7 @@ package google.registry.tools;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static google.registry.model.tld.label.PremiumListUtils.parseToPremiumList;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.util.ListNamingUtils.convertFilePathToName;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -27,7 +28,6 @@ import com.google.common.collect.Streams;
 import google.registry.model.tld.label.PremiumList;
 import google.registry.model.tld.label.PremiumList.PremiumEntry;
 import google.registry.model.tld.label.PremiumListDao;
-import google.registry.model.tld.label.PremiumListUtils;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Optional;
@@ -45,11 +45,11 @@ class UpdatePremiumListCommand extends CreateOrUpdatePremiumListCommand {
         String.format("Could not update premium list %s because it doesn't exist.", name));
     List<String> existingEntry = getExistingPremiumEntry(list.get()).asList();
     inputData = Files.readAllLines(inputFile, UTF_8);
+    checkArgument(!inputData.isEmpty(), "New premium list data cannot be empty");
     currency = list.get().getCurrency();
     // reconstructing existing premium list to bypass Hibernate lazy initialization exception
-    PremiumList existingPremiumList =
-        PremiumListUtils.parseToPremiumList(name, currency, existingEntry);
-    PremiumList updatedPremiumList = PremiumListUtils.parseToPremiumList(name, currency, inputData);
+    PremiumList existingPremiumList = parseToPremiumList(name, currency, existingEntry);
+    PremiumList updatedPremiumList = parseToPremiumList(name, currency, inputData);
 
     return String.format(
         "Update premium list for %s?\n Old List: %s\n New List: %s",

--- a/core/src/test/java/google/registry/model/tld/label/PremiumListDaoTest.java
+++ b/core/src/test/java/google/registry/model/tld/label/PremiumListDaoTest.java
@@ -22,6 +22,7 @@ import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.joda.money.CurrencyUnit.JPY;
 import static org.joda.money.CurrencyUnit.USD;
 import static org.joda.time.Duration.standardDays;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -237,6 +238,15 @@ public class PremiumListDaoTest {
     assertThat(PremiumListDao.getPremiumPrice("premlist", "gold")).hasValue(moneyOf(JPY, 1000));
     assertThat(PremiumListDao.getPremiumPrice("premlist", "palladium"))
         .hasValue(moneyOf(JPY, 15000));
+  }
+
+  @Test
+  void testSave_throwsOnEmptyInputData() {
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> PremiumListDao.save("test-list", CurrencyUnit.GBP, ImmutableList.of()));
+    assertThat(thrown).hasMessageThat().isEqualTo("New premium list data cannot be empty");
   }
 
   @Test


### PR DESCRIPTION
This state is possible to get into when things go wrong and it shouldn't prevent
saving new revisions of the list. Note that it will continue to throw errors if
you attempt to save a new revision that is blank (which is usually a mistake).

See http://b/211774375

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1479)
<!-- Reviewable:end -->
