### PR TITLE
Remove static methods in back up actions

### DIFF
--- a/core/src/main/java/google/registry/export/BackupDatastoreAction.java
+++ b/core/src/main/java/google/registry/export/BackupDatastoreAction.java
@@ -14,9 +14,10 @@
 
 package google.registry.export;
 
-import static google.registry.export.CheckBackupAction.enqueuePollTask;
 import static google.registry.request.Action.Method.POST;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.flogger.FluentLogger;
 import google.registry.config.RegistryConfig;
 import google.registry.export.datastore.DatastoreAdmin;
@@ -26,6 +27,9 @@ import google.registry.request.Action;
 import google.registry.request.HttpException.InternalServerErrorException;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
+import google.registry.util.Clock;
+import google.registry.util.CloudTasksUtils;
+import java.util.Optional;
 import javax.inject.Inject;
 
 /**
@@ -59,6 +63,8 @@ public class BackupDatastoreAction implements Runnable {
 
   @Inject DatastoreAdmin datastoreAdmin;
   @Inject Response response;
+  @Inject Clock clock;
+  @Inject CloudTasksUtils cloudTasksUtils;
 
   @Inject
   BackupDatastoreAction() {}
@@ -73,8 +79,22 @@ public class BackupDatastoreAction implements Runnable {
               .execute();
 
       String backupName = backup.getName();
-      // Enqueue a poll task to monitor the backup and load REPORTING-related kinds into bigquery.
-      enqueuePollTask(backupName, AnnotatedEntities.getReportingKinds());
+
+      // Enqueue a poll task to monitor the backup for completion and load REPORTING-related kinds
+      // into bigquery.
+      cloudTasksUtils.enqueue(
+          CheckBackupAction.QUEUE,
+          CloudTasksUtils.createPostTask(
+              CheckBackupAction.PATH,
+              CheckBackupAction.SERVICE,
+              ImmutableMultimap.of(
+                  CheckBackupAction.CHECK_BACKUP_NAME_PARAM,
+                  backupName,
+                  CheckBackupAction.CHECK_BACKUP_KINDS_TO_LOAD_PARAM,
+                  Joiner.on(',').join(AnnotatedEntities.getReportingKinds())),
+              clock,
+              Optional.of((int) CheckBackupAction.POLL_COUNTDOWN.getMillis())));
+
       String message =
           String.format(
               "Datastore backup started with name: %s\nSaving to %s",

--- a/core/src/main/java/google/registry/export/BackupDatastoreAction.java
+++ b/core/src/main/java/google/registry/export/BackupDatastoreAction.java
@@ -16,9 +16,11 @@ package google.registry.export;
 
 import static google.registry.request.Action.Method.POST;
 
+import com.google.cloud.tasks.v2.Task;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.flogger.FluentLogger;
+import com.google.protobuf.Timestamp;
 import google.registry.config.RegistryConfig;
 import google.registry.export.datastore.DatastoreAdmin;
 import google.registry.export.datastore.Operation;
@@ -29,7 +31,7 @@ import google.registry.request.Response;
 import google.registry.request.auth.Auth;
 import google.registry.util.Clock;
 import google.registry.util.CloudTasksUtils;
-import java.util.Optional;
+import java.time.Instant;
 import javax.inject.Inject;
 
 /**
@@ -82,18 +84,30 @@ public class BackupDatastoreAction implements Runnable {
 
       // Enqueue a poll task to monitor the backup for completion and load REPORTING-related kinds
       // into bigquery.
+      // TODO(rachelguan): replace it with schedule time helper once that PR gets merged
+      Instant scheduleTime =
+          Instant.ofEpochMilli(
+              clock
+                  .nowUtc()
+                  .plusMillis((int) CheckBackupAction.POLL_COUNTDOWN.getMillis())
+                  .getMillis());
       cloudTasksUtils.enqueue(
           CheckBackupAction.QUEUE,
-          CloudTasksUtils.createPostTask(
-              CheckBackupAction.PATH,
-              CheckBackupAction.SERVICE,
-              ImmutableMultimap.of(
-                  CheckBackupAction.CHECK_BACKUP_NAME_PARAM,
-                  backupName,
-                  CheckBackupAction.CHECK_BACKUP_KINDS_TO_LOAD_PARAM,
-                  Joiner.on(',').join(AnnotatedEntities.getReportingKinds())),
-              clock,
-              Optional.of((int) CheckBackupAction.POLL_COUNTDOWN.getMillis())));
+          Task.newBuilder(
+                  CloudTasksUtils.createPostTask(
+                      CheckBackupAction.PATH,
+                      CheckBackupAction.SERVICE,
+                      ImmutableMultimap.of(
+                          CheckBackupAction.CHECK_BACKUP_NAME_PARAM,
+                          backupName,
+                          CheckBackupAction.CHECK_BACKUP_KINDS_TO_LOAD_PARAM,
+                          Joiner.on(',').join(AnnotatedEntities.getReportingKinds()))))
+              .setScheduleTime(
+                  Timestamp.newBuilder()
+                      .setSeconds(scheduleTime.getEpochSecond())
+                      .setNanos(scheduleTime.getNano())
+                      .build())
+              .build());
 
       String message =
           String.format(

--- a/core/src/main/java/google/registry/export/BigqueryPollJobAction.java
+++ b/core/src/main/java/google/registry/export/BigqueryPollJobAction.java
@@ -65,9 +65,7 @@ public class BigqueryPollJobAction implements Runnable {
   @Inject @Header(CHAINED_TASK_QUEUE_HEADER) Lazy<String> chainedQueueName;
   @Inject @Header(PROJECT_ID_HEADER) String projectId;
   @Inject @Header(JOB_ID_HEADER) String jobId;
-
   @Inject @Payload byte[] payload;
-
   @Inject BigqueryPollJobAction() {}
 
   @Override

--- a/core/src/main/java/google/registry/export/UpdateSnapshotViewAction.java
+++ b/core/src/main/java/google/registry/export/UpdateSnapshotViewAction.java
@@ -21,13 +21,12 @@ import com.google.api.services.bigquery.Bigquery;
 import com.google.api.services.bigquery.model.Table;
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.ViewDefinition;
-import com.google.appengine.api.taskqueue.TaskOptions;
-import com.google.appengine.api.taskqueue.TaskOptions.Method;
 import com.google.common.flogger.FluentLogger;
 import google.registry.bigquery.CheckedBigquery;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.model.annotations.DeleteAfterMigration;
 import google.registry.request.Action;
+import google.registry.request.Action.Service;
 import google.registry.request.HttpException.InternalServerErrorException;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
@@ -58,6 +57,8 @@ public class UpdateSnapshotViewAction implements Runnable {
 
   static final String PATH = "/_dr/task/updateSnapshotView"; // See web.xml.
 
+  static final String SERVICE = Service.BACKEND.toString();
+
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   @Inject
@@ -84,17 +85,6 @@ public class UpdateSnapshotViewAction implements Runnable {
 
   @Inject
   UpdateSnapshotViewAction() {}
-
-  /** Create a task for updating a snapshot view. */
-  static TaskOptions createViewUpdateTask(
-      String datasetId, String tableId, String kindName, String viewName) {
-    return TaskOptions.Builder.withUrl(PATH)
-        .method(Method.POST)
-        .param(UPDATE_SNAPSHOT_DATASET_ID_PARAM, datasetId)
-        .param(UPDATE_SNAPSHOT_TABLE_ID_PARAM, tableId)
-        .param(UPDATE_SNAPSHOT_KIND_PARAM, kindName)
-        .param(UPDATE_SNAPSHOT_VIEWNAME_PARAM, viewName);
-  }
 
   @Override
   public void run() {

--- a/core/src/main/java/google/registry/export/UpdateSnapshotViewAction.java
+++ b/core/src/main/java/google/registry/export/UpdateSnapshotViewAction.java
@@ -26,7 +26,6 @@ import google.registry.bigquery.CheckedBigquery;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.model.annotations.DeleteAfterMigration;
 import google.registry.request.Action;
-import google.registry.request.Action.Service;
 import google.registry.request.HttpException.InternalServerErrorException;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
@@ -56,8 +55,6 @@ public class UpdateSnapshotViewAction implements Runnable {
   static final String QUEUE = "export-snapshot-update-view"; // See queue.xml.
 
   static final String PATH = "/_dr/task/updateSnapshotView"; // See web.xml.
-
-  static final String SERVICE = Service.BACKEND.toString();
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 

--- a/core/src/main/java/google/registry/export/UploadDatastoreBackupAction.java
+++ b/core/src/main/java/google/registry/export/UploadDatastoreBackupAction.java
@@ -33,7 +33,7 @@ import com.google.common.flogger.FluentLogger;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
 import com.google.protobuf.ByteString;
-import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
 import google.registry.bigquery.BigqueryUtils.SourceFormat;
 import google.registry.bigquery.BigqueryUtils.WriteDisposition;
 import google.registry.bigquery.CheckedBigquery;
@@ -50,7 +50,6 @@ import google.registry.util.CloudTasksUtils;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
-import java.time.Instant;
 import javax.inject.Inject;
 
 /** Action to load a Datastore backup from Google Cloud Storage into BigQuery. */
@@ -77,13 +76,11 @@ public class UploadDatastoreBackupAction implements Runnable {
 
   static final String PATH = "/_dr/task/uploadDatastoreBackup"; // See web.xml.
 
-  static final String SERVICE = Service.BACKEND.toString();
-
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   @Inject CheckedBigquery checkedBigquery;
-
   @Inject CloudTasksUtils cloudTasksUtils;
+  @Inject Clock clock;
 
   @Inject @Config("projectId") String projectId;
 
@@ -98,8 +95,6 @@ public class UploadDatastoreBackupAction implements Runnable {
   @Inject
   @Parameter(UPLOAD_BACKUP_KINDS_PARAM)
   String backupKinds;
-
-  @Inject Clock clock;
 
   @Inject
   UploadDatastoreBackupAction() {}
@@ -145,9 +140,9 @@ public class UploadDatastoreBackupAction implements Runnable {
       ByteArrayOutputStream taskBytes = new ByteArrayOutputStream();
       new ObjectOutputStream(taskBytes)
           .writeObject(
-              CloudTasksUtils.createPostTask(
+              cloudTasksUtils.createPostTask(
                   UpdateSnapshotViewAction.PATH,
-                  UpdateSnapshotViewAction.SERVICE,
+                  Service.BACKEND.toString(),
                   ImmutableMultimap.of(
                       UpdateSnapshotViewAction.UPDATE_SNAPSHOT_DATASET_ID_PARAM,
                       BACKUP_DATASET,
@@ -158,20 +153,14 @@ public class UploadDatastoreBackupAction implements Runnable {
                       UpdateSnapshotViewAction.UPDATE_SNAPSHOT_VIEWNAME_PARAM,
                       LATEST_BACKUP_VIEW_NAME)));
 
-      Instant scheduleTime =
-          Instant.ofEpochMilli(
-              clock
-                  .nowUtc()
-                  .plusMillis((int) BigqueryPollJobAction.POLL_COUNTDOWN.getMillis())
-                  .getMillis());
       // Enqueues a task to poll for the success or failure of the referenced BigQuery job and to
       // launch the provided task in the specified queue if the job succeeds.
       cloudTasksUtils.enqueue(
           BigqueryPollJobAction.QUEUE,
           Task.newBuilder()
               .setAppEngineHttpRequest(
-                  CloudTasksUtils.createPostTask(
-                          BigqueryPollJobAction.PATH, Service.BACKEND.toString(), null)
+                  cloudTasksUtils
+                      .createPostTask(BigqueryPollJobAction.PATH, Service.BACKEND.toString(), null)
                       .getAppEngineHttpRequest()
                       .toBuilder()
                       .putHeaders(BigqueryPollJobAction.PROJECT_ID_HEADER, jobRef.getProjectId())
@@ -184,10 +173,8 @@ public class UploadDatastoreBackupAction implements Runnable {
                       .setBody(ByteString.copyFrom(taskBytes.toByteArray()))
                       .build())
               .setScheduleTime(
-                  Timestamp.newBuilder()
-                      .setSeconds(scheduleTime.getEpochSecond())
-                      .setNanos(scheduleTime.getNano())
-                      .build())
+                  Timestamps.fromMillis(
+                      clock.nowUtc().plus(BigqueryPollJobAction.POLL_COUNTDOWN).getMillis()))
               .build());
 
       builder.append(String.format(" - %s:%s\n", projectId, jobId));

--- a/core/src/main/java/google/registry/export/UploadDatastoreBackupAction.java
+++ b/core/src/main/java/google/registry/export/UploadDatastoreBackupAction.java
@@ -158,14 +158,12 @@ public class UploadDatastoreBackupAction implements Runnable {
                       UpdateSnapshotViewAction.UPDATE_SNAPSHOT_VIEWNAME_PARAM,
                       LATEST_BACKUP_VIEW_NAME)));
 
-      // TODO(rachelguan): replace it with schedule time helper once that PR gets merged
       Instant scheduleTime =
           Instant.ofEpochMilli(
               clock
                   .nowUtc()
                   .plusMillis((int) BigqueryPollJobAction.POLL_COUNTDOWN.getMillis())
                   .getMillis());
-
       // Enqueues a task to poll for the success or failure of the referenced BigQuery job and to
       // launch the provided task in the specified queue if the job succeeds.
       cloudTasksUtils.enqueue(

--- a/core/src/main/java/google/registry/export/UploadDatastoreBackupAction.java
+++ b/core/src/main/java/google/registry/export/UploadDatastoreBackupAction.java
@@ -25,14 +25,10 @@ import com.google.api.services.bigquery.model.JobConfiguration;
 import com.google.api.services.bigquery.model.JobConfigurationLoad;
 import com.google.api.services.bigquery.model.JobReference;
 import com.google.api.services.bigquery.model.TableReference;
-import com.google.appengine.api.taskqueue.TaskHandle;
-import com.google.appengine.api.taskqueue.TaskOptions;
-import com.google.appengine.api.taskqueue.TaskOptions.Method;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.FluentLogger;
 import google.registry.bigquery.BigqueryUtils.SourceFormat;
 import google.registry.bigquery.BigqueryUtils.WriteDisposition;
@@ -41,6 +37,7 @@ import google.registry.config.RegistryConfig.Config;
 import google.registry.export.BigqueryPollJobAction.BigqueryPollJobEnqueuer;
 import google.registry.model.annotations.DeleteAfterMigration;
 import google.registry.request.Action;
+import google.registry.request.Action.Service;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.HttpException.InternalServerErrorException;
 import google.registry.request.Parameter;
@@ -72,6 +69,8 @@ public class UploadDatastoreBackupAction implements Runnable {
 
   static final String PATH = "/_dr/task/uploadDatastoreBackup"; // See web.xml.
 
+  static final String SERVICE = Service.BACKEND.toString();
+
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   @Inject CheckedBigquery checkedBigquery;
@@ -92,18 +91,6 @@ public class UploadDatastoreBackupAction implements Runnable {
 
   @Inject
   UploadDatastoreBackupAction() {}
-
-  /** Enqueue a task for starting a backup load. */
-  public static TaskHandle enqueueUploadBackupTask(
-      String backupId, String gcsFile, ImmutableSet<String> kinds) {
-    return getQueue(QUEUE)
-        .add(
-            TaskOptions.Builder.withUrl(PATH)
-                .method(Method.POST)
-                .param(UPLOAD_BACKUP_ID_PARAM, backupId)
-                .param(UPLOAD_BACKUP_FOLDER_PARAM, gcsFile)
-                .param(UPLOAD_BACKUP_KINDS_PARAM, Joiner.on(',').join(kinds)));
-  }
 
   @Override
   public void run() {

--- a/core/src/main/java/google/registry/request/RequestModule.java
+++ b/core/src/main/java/google/registry/request/RequestModule.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CharStreams;
 import com.google.common.net.MediaType;
+import com.google.protobuf.ByteString;
 import dagger.Module;
 import dagger.Provides;
 import google.registry.model.common.DatabaseMigrationStateSchedule.PrimaryDatabase;
@@ -179,6 +180,16 @@ public final class RequestModule {
   static byte[] providePayloadAsBytes(HttpServletRequest req) {
     try {
       return ByteStreams.toByteArray(req.getInputStream());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Provides
+  @Payload
+  static ByteString providePayloadAsByteString(HttpServletRequest req) {
+    try {
+      return ByteString.copyFrom(ByteStreams.toByteArray(req.getInputStream()));
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/core/src/test/java/google/registry/export/BackupDatastoreActionTest.java
+++ b/core/src/test/java/google/registry/export/BackupDatastoreActionTest.java
@@ -27,6 +27,7 @@ import google.registry.export.datastore.Operation;
 import google.registry.testing.AppEngineExtension;
 import google.registry.testing.CloudTasksHelper;
 import google.registry.testing.CloudTasksHelper.TaskMatcher;
+import google.registry.testing.FakeClock;
 import google.registry.testing.FakeResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,7 @@ public class BackupDatastoreActionTest {
     action.datastoreAdmin = datastoreAdmin;
     action.response = response;
     action.cloudTasksUtils = cloudTasksHelper.getTestCloudTasksUtils();
+    action.clock = new FakeClock();
     when(datastoreAdmin.export(
             "gs://registry-project-id-datastore-backups", AnnotatedEntities.getBackupKinds()))
         .thenReturn(exportRequest);

--- a/core/src/test/java/google/registry/export/BackupDatastoreActionTest.java
+++ b/core/src/test/java/google/registry/export/BackupDatastoreActionTest.java
@@ -17,16 +17,17 @@ package google.registry.export;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.export.CheckBackupAction.CHECK_BACKUP_KINDS_TO_LOAD_PARAM;
 import static google.registry.export.CheckBackupAction.CHECK_BACKUP_NAME_PARAM;
-import static google.registry.testing.TaskQueueHelper.assertTasksEnqueued;
 import static org.mockito.Mockito.when;
 
+import com.google.cloud.tasks.v2.HttpMethod;
 import com.google.common.base.Joiner;
 import google.registry.export.datastore.DatastoreAdmin;
 import google.registry.export.datastore.DatastoreAdmin.Export;
 import google.registry.export.datastore.Operation;
 import google.registry.testing.AppEngineExtension;
+import google.registry.testing.CloudTasksHelper;
+import google.registry.testing.CloudTasksHelper.TaskMatcher;
 import google.registry.testing.FakeResponse;
-import google.registry.testing.TaskQueueHelper.TaskMatcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,13 +47,14 @@ public class BackupDatastoreActionTest {
   @Mock private Operation backupOperation;
 
   private final FakeResponse response = new FakeResponse();
+  private CloudTasksHelper cloudTasksHelper = new CloudTasksHelper();
   private final BackupDatastoreAction action = new BackupDatastoreAction();
 
   @BeforeEach
   void beforeEach() throws Exception {
     action.datastoreAdmin = datastoreAdmin;
     action.response = response;
-
+    action.cloudTasksUtils = cloudTasksHelper.getTestCloudTasksUtils();
     when(datastoreAdmin.export(
             "gs://registry-project-id-datastore-backups", AnnotatedEntities.getBackupKinds()))
         .thenReturn(exportRequest);
@@ -66,7 +68,7 @@ public class BackupDatastoreActionTest {
   @Test
   void testBackup_enqueuesPollTask() {
     action.run();
-    assertTasksEnqueued(
+    cloudTasksHelper.assertTasksEnqueued(
         CheckBackupAction.QUEUE,
         new TaskMatcher()
             .url(CheckBackupAction.PATH)
@@ -74,7 +76,7 @@ public class BackupDatastoreActionTest {
             .param(
                 CHECK_BACKUP_KINDS_TO_LOAD_PARAM,
                 Joiner.on(",").join(AnnotatedEntities.getReportingKinds()))
-            .method("POST"));
+            .method(HttpMethod.POST));
     assertThat(response.getPayload())
         .isEqualTo(
             "Datastore backup started with name: "

--- a/core/src/test/java/google/registry/export/BackupDatastoreActionTest.java
+++ b/core/src/test/java/google/registry/export/BackupDatastoreActionTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.tasks.v2.HttpMethod;
 import com.google.common.base.Joiner;
+import com.google.protobuf.util.Timestamps;
 import google.registry.export.datastore.DatastoreAdmin;
 import google.registry.export.datastore.DatastoreAdmin.Export;
 import google.registry.export.datastore.Operation;
@@ -78,7 +79,10 @@ public class BackupDatastoreActionTest {
             .param(
                 CHECK_BACKUP_KINDS_TO_LOAD_PARAM,
                 Joiner.on(",").join(AnnotatedEntities.getReportingKinds()))
-            .method(HttpMethod.POST));
+            .method(HttpMethod.POST)
+            .scheduleTime(
+                Timestamps.fromMillis(
+                    action.clock.nowUtc().plus(CheckBackupAction.POLL_COUNTDOWN).getMillis())));
     assertThat(response.getPayload())
         .isEqualTo(
             "Datastore backup started with name: "

--- a/core/src/test/java/google/registry/export/BigqueryPollJobActionTest.java
+++ b/core/src/test/java/google/registry/export/BigqueryPollJobActionTest.java
@@ -105,7 +105,7 @@ public class BigqueryPollJobActionTest {
             .build();
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     new ObjectOutputStream(bytes).writeObject(chainedTask);
-    action.payload = bytes.toByteArray();
+    action.payload = ByteString.copyFrom(bytes.toByteArray());
 
     action.run();
     assertLogMessage(
@@ -154,7 +154,7 @@ public class BigqueryPollJobActionTest {
   void testFailure_badChainedTaskPayload() throws Exception {
     when(bigqueryJobsGet.execute()).thenReturn(
         new Job().setStatus(new JobStatus().setState("DONE")));
-    action.payload = "payload".getBytes(UTF_8);
+    action.payload = ByteString.copyFrom("payload".getBytes(UTF_8));
     BadRequestException thrown = assertThrows(BadRequestException.class, action::run);
     assertThat(thrown).hasMessageThat().contains("Cannot deserialize task from payload");
   }

--- a/core/src/test/java/google/registry/export/BigqueryPollJobActionTest.java
+++ b/core/src/test/java/google/registry/export/BigqueryPollJobActionTest.java
@@ -14,13 +14,8 @@
 
 package google.registry.export;
 
-import static com.google.appengine.api.taskqueue.QueueFactory.getQueue;
-import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.testing.TaskQueueHelper.assertNoTasksEnqueued;
-import static google.registry.testing.TaskQueueHelper.assertTasksEnqueued;
 import static google.registry.testing.TestLogHandlerUtils.assertLogMessage;
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.logging.Level.INFO;
 import static java.util.logging.Level.SEVERE;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -32,26 +27,25 @@ import com.google.api.services.bigquery.model.ErrorProto;
 import com.google.api.services.bigquery.model.Job;
 import com.google.api.services.bigquery.model.JobReference;
 import com.google.api.services.bigquery.model.JobStatus;
-import com.google.appengine.api.taskqueue.TaskOptions;
-import com.google.appengine.api.taskqueue.TaskOptions.Method;
-import com.google.appengine.api.taskqueue.dev.QueueStateInfo.TaskStateInfo;
-import google.registry.export.BigqueryPollJobAction.BigqueryPollJobEnqueuer;
+import com.google.cloud.tasks.v2.AppEngineHttpRequest;
+import com.google.cloud.tasks.v2.AppEngineRouting;
+import com.google.cloud.tasks.v2.HttpMethod;
+import com.google.cloud.tasks.v2.Task;
+import com.google.common.net.HttpHeaders;
+import com.google.common.net.MediaType;
+import com.google.protobuf.ByteString;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.HttpException.NotModifiedException;
 import google.registry.testing.AppEngineExtension;
+import google.registry.testing.CloudTasksHelper;
+import google.registry.testing.CloudTasksHelper.TaskMatcher;
 import google.registry.testing.FakeClock;
-import google.registry.testing.FakeSleeper;
-import google.registry.testing.TaskQueueHelper;
-import google.registry.testing.TaskQueueHelper.TaskMatcher;
 import google.registry.util.CapturingLogHandler;
 import google.registry.util.JdkLoggerConfig;
-import google.registry.util.Retrier;
-import google.registry.util.TaskQueueUtils;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -66,8 +60,7 @@ public class BigqueryPollJobActionTest {
   private static final String PROJECT_ID = "project_id";
   private static final String JOB_ID = "job_id";
   private static final String CHAINED_QUEUE_NAME = UpdateSnapshotViewAction.QUEUE;
-  private static final TaskQueueUtils TASK_QUEUE_UTILS =
-      new TaskQueueUtils(new Retrier(new FakeSleeper(new FakeClock()), 1));
+
 
   private final Bigquery bigquery = mock(Bigquery.class);
   private final Bigquery.Jobs bigqueryJobs = mock(Bigquery.Jobs.class);
@@ -76,19 +69,22 @@ public class BigqueryPollJobActionTest {
   private final CapturingLogHandler logHandler = new CapturingLogHandler();
   private BigqueryPollJobAction action = new BigqueryPollJobAction();
 
+  private CloudTasksHelper cloudTasksHelper = new CloudTasksHelper();
+
   @BeforeEach
   void beforeEach() throws Exception {
     action.bigquery = bigquery;
     when(bigquery.jobs()).thenReturn(bigqueryJobs);
     when(bigqueryJobs.get(PROJECT_ID, JOB_ID)).thenReturn(bigqueryJobsGet);
-    action.taskQueueUtils = TASK_QUEUE_UTILS;
+    action.cloudTasksUtils = cloudTasksHelper.getTestCloudTasksUtils();
     action.projectId = PROJECT_ID;
     action.jobId = JOB_ID;
+    action.clock = new FakeClock();
     action.chainedQueueName = () -> CHAINED_QUEUE_NAME;
     JdkLoggerConfig.getConfig(BigqueryPollJobAction.class).addHandler(logHandler);
   }
 
-  private static TaskMatcher newPollJobTaskMatcher(String method) {
+  private static TaskMatcher newPollJobTaskMatcher(HttpMethod method) {
     return new TaskMatcher()
         .method(method)
         .url(BigqueryPollJobAction.PATH)
@@ -98,28 +94,39 @@ public class BigqueryPollJobActionTest {
 
   @Test
   void testSuccess_enqueuePollTask() {
-    new BigqueryPollJobEnqueuer(TASK_QUEUE_UTILS).enqueuePollTask(
-        new JobReference().setProjectId(PROJECT_ID).setJobId(JOB_ID));
-    assertTasksEnqueued(BigqueryPollJobAction.QUEUE, newPollJobTaskMatcher("GET"));
+    action.cloudTasksUtils.enqueue(
+        BigqueryPollJobAction.QUEUE,
+        BigqueryPollJobAction.BigqueryPollJob.createGetTask(
+            new JobReference().setProjectId(PROJECT_ID).setJobId(JOB_ID), action.clock));
+    cloudTasksHelper.assertTasksEnqueued(
+        BigqueryPollJobAction.QUEUE, newPollJobTaskMatcher(HttpMethod.GET));
   }
 
   @Test
   void testSuccess_enqueuePollTask_withChainedTask() throws Exception {
-    TaskOptions chainedTask = TaskOptions.Builder
-        .withUrl("/_dr/something")
-        .method(Method.POST)
-        .header("X-Testing", "foo")
-        .param("testing", "bar");
-    new BigqueryPollJobEnqueuer(TASK_QUEUE_UTILS).enqueuePollTask(
-        new JobReference().setProjectId(PROJECT_ID).setJobId(JOB_ID),
-        chainedTask,
-        getQueue(CHAINED_QUEUE_NAME));
-    assertTasksEnqueued(BigqueryPollJobAction.QUEUE, newPollJobTaskMatcher("POST"));
-    TaskStateInfo taskInfo = getOnlyElement(
-        TaskQueueHelper.getQueueInfo(BigqueryPollJobAction.QUEUE).getTaskInfo());
-    ByteArrayInputStream taskBodyBytes = new ByteArrayInputStream(taskInfo.getBodyAsBytes());
-    TaskOptions taskOptions = (TaskOptions) new ObjectInputStream(taskBodyBytes).readObject();
-    assertThat(taskOptions).isEqualTo(chainedTask);
+    Task chainedTask =
+        Task.newBuilder()
+            .setAppEngineHttpRequest(
+                AppEngineHttpRequest.newBuilder()
+                    .setHttpMethod(HttpMethod.POST)
+                    .setRelativeUri("/_dr/something")
+                    .setAppEngineRouting(
+                        AppEngineRouting.newBuilder().setService("SERVICE").build())
+                    .build())
+            .build();
+
+    action.cloudTasksUtils.enqueue(
+        BigqueryPollJobAction.QUEUE,
+        BigqueryPollJobAction.BigqueryPollJob.createPostTask(
+            new JobReference().setProjectId(PROJECT_ID).setJobId(JOB_ID),
+            chainedTask,
+            CHAINED_QUEUE_NAME));
+
+    cloudTasksHelper.assertTasksEnqueued(
+        BigqueryPollJobAction.QUEUE, new TaskMatcher().method(HttpMethod.POST));
+
+    // assertThat(cloudTasksHelper.getTestTasksFor(BigqueryPollJobAction.QUEUE).get(0))
+    //     .isEqualTo(chainedTask);
   }
 
   @Test
@@ -136,12 +143,17 @@ public class BigqueryPollJobActionTest {
     when(bigqueryJobsGet.execute()).thenReturn(
         new Job().setStatus(new JobStatus().setState("DONE")));
 
-    TaskOptions chainedTask =
-        TaskOptions.Builder.withUrl("/_dr/something")
-            .method(Method.POST)
-            .header("X-Testing", "foo")
-            .param("testing", "bar")
-            .taskName("my_task_name");
+    AppEngineHttpRequest.Builder requestBuilder =
+        AppEngineHttpRequest.newBuilder()
+            .setHttpMethod(HttpMethod.POST)
+            .setRelativeUri("/_dr/something")
+            .putHeaders("X-Test", "foo")
+            .putHeaders(HttpHeaders.CONTENT_TYPE, MediaType.FORM_DATA.toString())
+            .setBody(ByteString.copyFromUtf8("testing=bar"));
+
+    Task chainedTask =
+        Task.newBuilder().setName("my_task_name").setAppEngineHttpRequest(requestBuilder).build();
+
     ByteArrayOutputStream bytes = new ByteArrayOutputStream();
     new ObjectOutputStream(bytes).writeObject(chainedTask);
     action.payload = bytes.toByteArray();
@@ -153,14 +165,15 @@ public class BigqueryPollJobActionTest {
         logHandler,
         INFO,
         "Added chained task my_task_name for /_dr/something to queue " + CHAINED_QUEUE_NAME);
-    assertTasksEnqueued(
+    cloudTasksHelper.assertTasksEnqueued(
         CHAINED_QUEUE_NAME,
         new TaskMatcher()
             .url("/_dr/something")
-            .method("POST")
-            .header("X-Testing", "foo")
+            .header("X-Test", "foo")
+            .header(HttpHeaders.CONTENT_TYPE, MediaType.FORM_DATA.toString())
             .param("testing", "bar")
-            .taskName("my_task_name"));
+            .taskName("my_task_name")
+            .method(HttpMethod.POST));
   }
 
   @Test
@@ -172,7 +185,7 @@ public class BigqueryPollJobActionTest {
     action.run();
     assertLogMessage(
         logHandler, SEVERE, String.format("Bigquery job failed - %s:%s", PROJECT_ID, JOB_ID));
-    assertNoTasksEnqueued(CHAINED_QUEUE_NAME);
+    cloudTasksHelper.assertNoTasksEnqueued(CHAINED_QUEUE_NAME);
   }
 
   @Test
@@ -192,7 +205,7 @@ public class BigqueryPollJobActionTest {
   void testFailure_badChainedTaskPayload() throws Exception {
     when(bigqueryJobsGet.execute()).thenReturn(
         new Job().setStatus(new JobStatus().setState("DONE")));
-    action.payload = "payload".getBytes(UTF_8);
+    action.payload = "payload".getBytes(StandardCharsets.UTF_8);
     BadRequestException thrown = assertThrows(BadRequestException.class, action::run);
     assertThat(thrown).hasMessageThat().contains("Cannot deserialize task from payload");
   }

--- a/core/src/test/java/google/registry/export/CheckBackupActionTest.java
+++ b/core/src/test/java/google/registry/export/CheckBackupActionTest.java
@@ -15,10 +15,6 @@
 package google.registry.export;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.export.CheckBackupAction.CHECK_BACKUP_KINDS_TO_LOAD_PARAM;
-import static google.registry.export.CheckBackupAction.CHECK_BACKUP_NAME_PARAM;
-import static google.registry.testing.TaskQueueHelper.assertNoTasksEnqueued;
-import static google.registry.testing.TaskQueueHelper.assertTasksEnqueued;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -27,7 +23,7 @@ import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
-import com.google.common.collect.ImmutableSet;
+import com.google.cloud.tasks.v2.HttpMethod;
 import google.registry.export.datastore.DatastoreAdmin;
 import google.registry.export.datastore.DatastoreAdmin.Get;
 import google.registry.export.datastore.Operation;
@@ -36,9 +32,10 @@ import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.HttpException.NoContentException;
 import google.registry.request.HttpException.NotModifiedException;
 import google.registry.testing.AppEngineExtension;
+import google.registry.testing.CloudTasksHelper;
+import google.registry.testing.CloudTasksHelper.TaskMatcher;
 import google.registry.testing.FakeClock;
 import google.registry.testing.FakeResponse;
-import google.registry.testing.TaskQueueHelper.TaskMatcher;
 import google.registry.testing.TestDataHelper;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
@@ -57,7 +54,7 @@ public class CheckBackupActionTest {
 
   private static final DateTime START_TIME = DateTime.parse("2014-08-01T01:02:03Z");
   private static final DateTime COMPLETE_TIME = START_TIME.plus(Duration.standardMinutes(30));
-
+  private final CloudTasksHelper cloudTasksHelper = new CloudTasksHelper();
   private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
 
   @RegisterExtension
@@ -80,6 +77,7 @@ public class CheckBackupActionTest {
     action.backupName = "some_backup";
     action.kindsToLoadParam = "one,two";
     action.response = response;
+    action.cloudTasksUtils = cloudTasksHelper.getTestCloudTasksUtils();
 
     when(datastoreAdmin.get(anyString())).thenReturn(getBackupProgressRequest);
     when(getBackupProgressRequest.execute()).thenAnswer(arg -> backupOperation);
@@ -110,28 +108,15 @@ public class CheckBackupActionTest {
                 null));
   }
 
-  private static void assertLoadTaskEnqueued(String id, String folder, String kinds) {
-    assertTasksEnqueued(
+  private void assertLoadTaskEnqueued(String id, String folder, String kinds) {
+    cloudTasksHelper.assertTasksEnqueued(
         "export-snapshot",
         new TaskMatcher()
             .url("/_dr/task/uploadDatastoreBackup")
-            .method("POST")
+            .method(HttpMethod.POST)
             .param("id", id)
             .param("folder", folder)
             .param("kinds", kinds));
-  }
-
-  @MockitoSettings(strictness = Strictness.LENIENT)
-  @Test
-  void testSuccess_enqueuePollTask() {
-    CheckBackupAction.enqueuePollTask("some_backup_name", ImmutableSet.of("one", "two", "three"));
-    assertTasksEnqueued(
-        CheckBackupAction.QUEUE,
-        new TaskMatcher()
-            .url(CheckBackupAction.PATH)
-            .param(CHECK_BACKUP_NAME_PARAM, "some_backup_name")
-            .param(CHECK_BACKUP_KINDS_TO_LOAD_PARAM, "one,two,three")
-            .method("POST"));
   }
 
   @Test
@@ -189,7 +174,7 @@ public class CheckBackupActionTest {
     action.kindsToLoadParam = "";
 
     action.run();
-    assertNoTasksEnqueued("export-snapshot");
+    cloudTasksHelper.assertNoTasksEnqueued("export-snapshot");
   }
 
   @MockitoSettings(strictness = Strictness.LENIENT)

--- a/core/src/test/java/google/registry/export/CheckBackupActionTest.java
+++ b/core/src/test/java/google/registry/export/CheckBackupActionTest.java
@@ -54,7 +54,6 @@ public class CheckBackupActionTest {
 
   private static final DateTime START_TIME = DateTime.parse("2014-08-01T01:02:03Z");
   private static final DateTime COMPLETE_TIME = START_TIME.plus(Duration.standardMinutes(30));
-  private final CloudTasksHelper cloudTasksHelper = new CloudTasksHelper();
   private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
 
   @RegisterExtension
@@ -68,6 +67,7 @@ public class CheckBackupActionTest {
   private final FakeResponse response = new FakeResponse();
   private final FakeClock clock = new FakeClock(COMPLETE_TIME.plusMillis(1000));
   private final CheckBackupAction action = new CheckBackupAction();
+  private final CloudTasksHelper cloudTasksHelper = new CloudTasksHelper();
 
   @BeforeEach
   void beforeEach() throws Exception {

--- a/core/src/test/java/google/registry/export/UpdateSnapshotViewActionTest.java
+++ b/core/src/test/java/google/registry/export/UpdateSnapshotViewActionTest.java
@@ -14,15 +14,7 @@
 
 package google.registry.export;
 
-import static com.google.appengine.api.taskqueue.QueueFactory.getQueue;
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.export.UpdateSnapshotViewAction.QUEUE;
-import static google.registry.export.UpdateSnapshotViewAction.UPDATE_SNAPSHOT_DATASET_ID_PARAM;
-import static google.registry.export.UpdateSnapshotViewAction.UPDATE_SNAPSHOT_KIND_PARAM;
-import static google.registry.export.UpdateSnapshotViewAction.UPDATE_SNAPSHOT_TABLE_ID_PARAM;
-import static google.registry.export.UpdateSnapshotViewAction.UPDATE_SNAPSHOT_VIEWNAME_PARAM;
-import static google.registry.export.UpdateSnapshotViewAction.createViewUpdateTask;
-import static google.registry.testing.TaskQueueHelper.assertTasksEnqueued;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -38,7 +30,6 @@ import com.google.common.collect.Iterables;
 import google.registry.bigquery.CheckedBigquery;
 import google.registry.request.HttpException.InternalServerErrorException;
 import google.registry.testing.AppEngineExtension;
-import google.registry.testing.TaskQueueHelper.TaskMatcher;
 import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -79,23 +70,6 @@ public class UpdateSnapshotViewActionTest {
     action.viewName = "latest_datastore_export";
     action.projectId = "myproject";
     action.tableId = "12345_fookind";
-  }
-
-  @Test
-  void testSuccess_createViewUpdateTask() {
-    getQueue(QUEUE)
-        .add(
-            createViewUpdateTask(
-                "some_dataset", "12345_fookind", "fookind", "latest_datastore_export"));
-    assertTasksEnqueued(
-        QUEUE,
-        new TaskMatcher()
-            .url(UpdateSnapshotViewAction.PATH)
-            .method("POST")
-            .param(UPDATE_SNAPSHOT_DATASET_ID_PARAM, "some_dataset")
-            .param(UPDATE_SNAPSHOT_TABLE_ID_PARAM, "12345_fookind")
-            .param(UPDATE_SNAPSHOT_KIND_PARAM, "fookind")
-            .param(UPDATE_SNAPSHOT_VIEWNAME_PARAM, "latest_datastore_export"));
   }
 
   @Test

--- a/core/src/test/java/google/registry/export/UploadDatastoreBackupActionTest.java
+++ b/core/src/test/java/google/registry/export/UploadDatastoreBackupActionTest.java
@@ -35,6 +35,7 @@ import com.google.api.services.bigquery.model.Job;
 import com.google.api.services.bigquery.model.JobConfigurationLoad;
 import com.google.cloud.tasks.v2.HttpMethod;
 import com.google.common.collect.Iterables;
+import com.google.protobuf.util.Timestamps;
 import google.registry.bigquery.CheckedBigquery;
 import google.registry.request.HttpException.InternalServerErrorException;
 import google.registry.testing.AppEngineExtension;
@@ -142,17 +143,26 @@ public class UploadDatastoreBackupActionTest {
             .method(HttpMethod.POST)
             .header(PROJECT_ID_HEADER, "Project-Id")
             .header(JOB_ID_HEADER, "load-backup-2018_12_05T17_46_39_92612-one")
-            .header(CHAINED_TASK_QUEUE_HEADER, UpdateSnapshotViewAction.QUEUE),
+            .header(CHAINED_TASK_QUEUE_HEADER, UpdateSnapshotViewAction.QUEUE)
+            .scheduleTime(
+                Timestamps.fromMillis(
+                    action.clock.nowUtc().plus(BigqueryPollJobAction.POLL_COUNTDOWN).getMillis())),
         new TaskMatcher()
             .method(HttpMethod.POST)
             .header(PROJECT_ID_HEADER, "Project-Id")
             .header(JOB_ID_HEADER, "load-backup-2018_12_05T17_46_39_92612-two")
-            .header(CHAINED_TASK_QUEUE_HEADER, UpdateSnapshotViewAction.QUEUE),
+            .header(CHAINED_TASK_QUEUE_HEADER, UpdateSnapshotViewAction.QUEUE)
+            .scheduleTime(
+                Timestamps.fromMillis(
+                    action.clock.nowUtc().plus(BigqueryPollJobAction.POLL_COUNTDOWN).getMillis())),
         new TaskMatcher()
             .method(HttpMethod.POST)
             .header(PROJECT_ID_HEADER, "Project-Id")
             .header(JOB_ID_HEADER, "load-backup-2018_12_05T17_46_39_92612-three")
-            .header(CHAINED_TASK_QUEUE_HEADER, UpdateSnapshotViewAction.QUEUE));
+            .header(CHAINED_TASK_QUEUE_HEADER, UpdateSnapshotViewAction.QUEUE)
+            .scheduleTime(
+                Timestamps.fromMillis(
+                    action.clock.nowUtc().plus(BigqueryPollJobAction.POLL_COUNTDOWN).getMillis())));
   }
 
   @Test

--- a/core/src/test/java/google/registry/export/UploadDatastoreBackupActionTest.java
+++ b/core/src/test/java/google/registry/export/UploadDatastoreBackupActionTest.java
@@ -18,14 +18,7 @@ import static com.google.common.collect.Iterables.transform;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.export.UploadDatastoreBackupAction.BACKUP_DATASET;
 import static google.registry.export.UploadDatastoreBackupAction.LATEST_BACKUP_VIEW_NAME;
-import static google.registry.export.UploadDatastoreBackupAction.PATH;
-import static google.registry.export.UploadDatastoreBackupAction.QUEUE;
-import static google.registry.export.UploadDatastoreBackupAction.UPLOAD_BACKUP_FOLDER_PARAM;
-import static google.registry.export.UploadDatastoreBackupAction.UPLOAD_BACKUP_ID_PARAM;
-import static google.registry.export.UploadDatastoreBackupAction.UPLOAD_BACKUP_KINDS_PARAM;
-import static google.registry.export.UploadDatastoreBackupAction.enqueueUploadBackupTask;
 import static google.registry.export.UploadDatastoreBackupAction.getBackupInfoFileForKind;
-import static google.registry.testing.TaskQueueHelper.assertTasksEnqueued;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -40,13 +33,11 @@ import com.google.api.services.bigquery.model.Job;
 import com.google.api.services.bigquery.model.JobConfigurationLoad;
 import com.google.api.services.bigquery.model.JobReference;
 import com.google.appengine.api.taskqueue.QueueFactory;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import google.registry.bigquery.CheckedBigquery;
 import google.registry.export.BigqueryPollJobAction.BigqueryPollJobEnqueuer;
 import google.registry.request.HttpException.InternalServerErrorException;
 import google.registry.testing.AppEngineExtension;
-import google.registry.testing.TaskQueueHelper.TaskMatcher;
 import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -87,18 +78,6 @@ public class UploadDatastoreBackupActionTest {
     action.backupKinds = "one,two,three";
   }
 
-  @Test
-  void testSuccess_enqueueLoadTask() {
-    enqueueUploadBackupTask("id12345", "gs://bucket/path", ImmutableSet.of("one", "two", "three"));
-    assertTasksEnqueued(
-        QUEUE,
-        new TaskMatcher()
-            .url(PATH)
-            .method("POST")
-            .param(UPLOAD_BACKUP_ID_PARAM, "id12345")
-            .param(UPLOAD_BACKUP_FOLDER_PARAM, "gs://bucket/path")
-            .param(UPLOAD_BACKUP_KINDS_PARAM, "one,two,three"));
-  }
 
   @Test
   void testSuccess_doPost() throws Exception {

--- a/core/src/test/java/google/registry/export/UploadDatastoreBackupActionTest.java
+++ b/core/src/test/java/google/registry/export/UploadDatastoreBackupActionTest.java
@@ -40,6 +40,7 @@ import google.registry.request.HttpException.InternalServerErrorException;
 import google.registry.testing.AppEngineExtension;
 import google.registry.testing.CloudTasksHelper;
 import google.registry.testing.CloudTasksHelper.TaskMatcher;
+import google.registry.testing.FakeClock;
 import java.io.IOException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -78,6 +79,7 @@ public class UploadDatastoreBackupActionTest {
     action.backupId = "2018-12-05T17:46:39_92612";
     action.backupKinds = "one,two,three";
     action.cloudTasksUtils = cloudTasksHelper.getTestCloudTasksUtils();
+    action.clock = new FakeClock();
   }
 
 


### PR DESCRIPTION
The main goal of this PR was to move the static methods for enqueueing tasks to where the method was called. Since a `CloudTasksUtil` instance needs to be injected at where the task is enqueued, those static methods were replaced with `cloudTasksUtil.enqueue(queueName, task)`. 

These static methods were created in those backup action files. In order to completely remove the dependency of `TaskOptions` and related libraries from those action files, `BigqueryPollJobAction` and related files need to be modified as well. There is a static class BigqueryPollJobEnqueuer` in `BigqueryPollJobAction` that contains two methods of enqueueing tasks. Those two methods were called in multiple files. The easiest way to modify this class was to have the methods return `Task` and they can be enqueued inside the file where the method is called. 

Some tasks require adding headers and payload for `POST` tasks. The purpose of this PR was to replace `TaskQueueUtils` with `CloudTasksUtil`. It's debatable to put those key-values into `params`. For now, `CloudTasksUtil` does not have support for those but it can be done after; payload and headers can be added on top of the tasks created via the helpers in `CloudTasksUtil`. 

Note: the changes made in `CloudTasksUtil` are temporary. A separate [PR](https://github.com/google/nomulus/pull/1448) was made to support null/empty `params` 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1481)
<!-- Reviewable:end -->
