### PR TITLE
Use the service account credential to delete unused versions

### DIFF
--- a/release/cloudbuild-delete.yaml
+++ b/release/cloudbuild-delete.yaml
@@ -19,11 +19,20 @@
 # expanded in the copies sent to Spinnaker, we preserve the brackets around
 # them for safe pattern matching during release.
 # See https://github.com/spinnaker/spinnaker/issues/3028 for more information.
-steps:
 # Delete unused GAE versions.
 # GAE has a limit of ~250 versions per-project, including unused versions. We
 # therefore need to periodically delete old versions. This GCB job finds all
 # stopped versions and delete all but the last 3 (in case we need to rollback).
+steps:
+# Pull the credential for nomulus tool.
+- name: 'gcr.io/$PROJECT_ID/builder:latest'
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    gcloud secrets versions access latest \
+      --secret nomulus-tool-cloudbuild-credential > tool-credential.json
 - name: 'gcr.io/$PROJECT_ID/builder:latest'
   entrypoint: /bin/bash
   args:
@@ -35,6 +44,8 @@ steps:
     else
       project_id="domain-registry-${_ENV}"
     fi
+
+    gcloud auth activate-service-account --key-file=tool-credential.json
 
     for service in default pubapi backend tools
     do

--- a/release/cloudbuild-delete.yaml
+++ b/release/cloudbuild-delete.yaml
@@ -19,7 +19,7 @@
 # expanded in the copies sent to Spinnaker, we preserve the brackets around
 # them for safe pattern matching during release.
 # See https://github.com/spinnaker/spinnaker/issues/3028 for more information.
-# Delete unused GAE versions.
+#
 # GAE has a limit of ~250 versions per-project, including unused versions. We
 # therefore need to periodically delete old versions. This GCB job finds all
 # stopped versions and delete all but the last 3 (in case we need to rollback).
@@ -33,6 +33,7 @@ steps:
     set -e
     gcloud secrets versions access latest \
       --secret nomulus-tool-cloudbuild-credential > tool-credential.json
+# Delete unused GAE versions.
 - name: 'gcr.io/$PROJECT_ID/builder:latest'
   entrypoint: /bin/bash
   args:


### PR DESCRIPTION
Right now we are using the default credential of Cloud Build to run
gcloud, which does not have the necessary permission. By using the
service account credential (which is a GAE admin), we should be able to
delete unused versions as part of deployment.

Note: it looks like this never worked when it was added to the
deployment pipeline, not as a result of overground changes under our
feet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1484)
<!-- Reviewable:end -->
