### PR TITLE
Add support for delay of duration when scheduling a task

### DIFF
--- a/core/src/test/java/google/registry/backup/CommitLogCheckpointActionTest.java
+++ b/core/src/test/java/google/registry/backup/CommitLogCheckpointActionTest.java
@@ -83,6 +83,7 @@ public class CommitLogCheckpointActionTest {
         QUEUE_NAME,
         new TaskMatcher()
             .url(ExportCommitLogDiffAction.PATH)
+            .scheduleTime(null)
             .param(ExportCommitLogDiffAction.LOWER_CHECKPOINT_TIME_PARAM, oneMinuteAgo.toString())
             .param(ExportCommitLogDiffAction.UPPER_CHECKPOINT_TIME_PARAM, now.toString()));
     assertThat(loadRoot().getLastWrittenTime()).isEqualTo(now);

--- a/core/src/test/java/google/registry/backup/CommitLogCheckpointActionTest.java
+++ b/core/src/test/java/google/registry/backup/CommitLogCheckpointActionTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Timestamp;
 import google.registry.model.ofy.CommitLogCheckpoint;
 import google.registry.model.ofy.CommitLogCheckpointRoot;
 import google.registry.testing.AppEngineExtension;
@@ -67,6 +68,7 @@ public class CommitLogCheckpointActionTest {
         QUEUE_NAME,
         new TaskMatcher()
             .url(ExportCommitLogDiffAction.PATH)
+            .scheduleTime(Timestamp.getDefaultInstance())
             .param(ExportCommitLogDiffAction.LOWER_CHECKPOINT_TIME_PARAM, START_OF_TIME.toString())
             .param(ExportCommitLogDiffAction.UPPER_CHECKPOINT_TIME_PARAM, now.toString()));
     assertThat(loadRoot().getLastWrittenTime()).isEqualTo(now);

--- a/core/src/test/java/google/registry/backup/CommitLogCheckpointActionTest.java
+++ b/core/src/test/java/google/registry/backup/CommitLogCheckpointActionTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.protobuf.Timestamp;
 import google.registry.model.ofy.CommitLogCheckpoint;
 import google.registry.model.ofy.CommitLogCheckpointRoot;
 import google.registry.testing.AppEngineExtension;
@@ -68,7 +67,6 @@ public class CommitLogCheckpointActionTest {
         QUEUE_NAME,
         new TaskMatcher()
             .url(ExportCommitLogDiffAction.PATH)
-            .scheduleTime(Timestamp.getDefaultInstance())
             .param(ExportCommitLogDiffAction.LOWER_CHECKPOINT_TIME_PARAM, START_OF_TIME.toString())
             .param(ExportCommitLogDiffAction.UPPER_CHECKPOINT_TIME_PARAM, now.toString()));
     assertThat(loadRoot().getLastWrittenTime()).isEqualTo(now);
@@ -83,7 +81,6 @@ public class CommitLogCheckpointActionTest {
         QUEUE_NAME,
         new TaskMatcher()
             .url(ExportCommitLogDiffAction.PATH)
-            .scheduleTime(null)
             .param(ExportCommitLogDiffAction.LOWER_CHECKPOINT_TIME_PARAM, oneMinuteAgo.toString())
             .param(ExportCommitLogDiffAction.UPPER_CHECKPOINT_TIME_PARAM, now.toString()));
     assertThat(loadRoot().getLastWrittenTime()).isEqualTo(now);

--- a/core/src/test/java/google/registry/testing/CloudTasksHelper.java
+++ b/core/src/test/java/google/registry/testing/CloudTasksHelper.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Multimaps;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
 import com.google.common.truth.Truth8;
+import com.google.protobuf.Timestamp;
 import google.registry.model.ImmutableObject;
 import google.registry.util.CloudTasksUtils;
 import google.registry.util.Retrier;
@@ -195,6 +196,7 @@ public class CloudTasksHelper implements Serializable {
     // tests.
     HttpMethod method = HttpMethod.POST;
     String url;
+    Timestamp scheduleTime;
     Multimap<String, String> headers = ArrayListMultimap.create();
     Multimap<String, String> params = ArrayListMultimap.create();
 
@@ -216,6 +218,7 @@ public class CloudTasksHelper implements Serializable {
           Ascii.toLowerCase(task.getAppEngineHttpRequest().getAppEngineRouting().getService());
       method = task.getAppEngineHttpRequest().getHttpMethod();
       url = uri.getPath();
+      scheduleTime = task.getScheduleTime();
       ImmutableMultimap.Builder<String, String> headerBuilder = new ImmutableMultimap.Builder<>();
       task.getAppEngineHttpRequest()
           .getHeadersMap()
@@ -251,6 +254,7 @@ public class CloudTasksHelper implements Serializable {
       builder.put("url", url);
       builder.put("headers", headers);
       builder.put("params", params);
+      builder.put("scheduleTime", scheduleTime);
       return Maps.filterValues(builder, not(in(asList(null, "", Collections.EMPTY_MAP))));
     }
   }
@@ -293,6 +297,11 @@ public class CloudTasksHelper implements Serializable {
       return this;
     }
 
+    public TaskMatcher scheduleTime(Timestamp scheduleTime) {
+      expected.scheduleTime = scheduleTime;
+      return this;
+    }
+
     public TaskMatcher param(String key, String value) {
       checkNotNull(value, "Test error: A param can never have a null value, so don't assert it");
       expected.params.put(key, value);
@@ -324,6 +333,8 @@ public class CloudTasksHelper implements Serializable {
           && (expected.url == null || Objects.equals(expected.url, actual.url))
           && (expected.method == null || Objects.equals(expected.method, actual.method))
           && (expected.service == null || Objects.equals(expected.service, actual.service))
+          && (expected.scheduleTime == null
+              || Objects.equals(expected.scheduleTime, actual.scheduleTime))
           && containsEntries(actual.params, expected.params)
           && containsEntries(actual.headers, expected.headers);
     }

--- a/core/src/test/java/google/registry/testing/CloudTasksHelper.java
+++ b/core/src/test/java/google/registry/testing/CloudTasksHelper.java
@@ -325,6 +325,8 @@ public class CloudTasksHelper implements Serializable {
      *
      * <p>Match fails if any headers or params expected on the TaskMatcher are not found on the
      * Task. Note that the inverse is not true (i.e. there may be extra headers on the Task).
+     *
+     * <p>Schedule time by default is Timestamp.getDefaultInstance() or null.
      */
     @Override
     public boolean test(@Nonnull Task task) {

--- a/util/src/main/java/google/registry/util/CloudTasksUtils.java
+++ b/util/src/main/java/google/registry/util/CloudTasksUtils.java
@@ -202,6 +202,7 @@ public class CloudTasksUtils implements Serializable {
       Multimap<String, String> params,
       Clock clock,
       long duration) {
+    checkArgument(duration >= 0, "Negative duration is not supported.");
     if (duration == 0) {
       return createTask(path, method, service, params);
     }

--- a/util/src/main/java/google/registry/util/CloudTasksUtils.java
+++ b/util/src/main/java/google/registry/util/CloudTasksUtils.java
@@ -141,45 +141,6 @@ public class CloudTasksUtils implements Serializable {
   }
 
   /**
-   * Create a {@link Task} to be enqueued with delay up by {@code duration}.
-   *
-   * @param path the relative URI (staring with a slash and ending without one).
-   * @param method the HTTP method to be used for the request, only GET and POST are supported.
-   * @param service the App Engine service to route the request to. Note that with App Engine Task
-   *     Queue API if no service is specified, the service which enqueues the task will be used to
-   *     process the task. Cloud Tasks API does not support this feature so the service will always
-   *     needs to be explicitly specified.
-   * @param params a multi-map of URL query parameters. Duplicate keys are saved as is, and it is up
-   *     to the server to process the duplicate keys.
-   * @param clock a source of time.
-   * @param duration the amount of time that a task is randomly delayed by.
-   * @return the enqueued task.
-   * @see <a
-   *     href=ttps://cloud.google.com/appengine/docs/standard/java/taskqueue/push/creating-tasks#target>Specifyinig
-   *     the worker service</a>
-   */
-  private static Task createTask(
-      String path,
-      HttpMethod method,
-      String service,
-      Multimap<String, String> params,
-      Clock clock,
-      long duration) {
-    if (duration == 0) {
-      return createTask(path, method, service, params);
-    }
-    Instant scheduleTime =
-        Instant.ofEpochMilli(clock.nowUtc().plusMillis((int) duration).getMillis());
-    return Task.newBuilder(createTask(path, method, service, params))
-        .setScheduleTime(
-            Timestamp.newBuilder()
-                .setSeconds(scheduleTime.getEpochSecond())
-                .setNanos(scheduleTime.getNano())
-                .build())
-        .build();
-  }
-
-  /**
    * Create a {@link Task} to be enqueued with a random delay up to {@code jitterSeconds}.
    *
    * @param path the relative URI (staring with a slash and ending without one).
@@ -216,6 +177,45 @@ public class CloudTasksUtils implements Serializable {
         random.nextInt((int) SECONDS.toMillis(jitterSeconds.get())));
   }
 
+  /**
+   * Create a {@link Task} to be enqueued with delay of {@code duration}.
+   *
+   * @param path the relative URI (staring with a slash and ending without one).
+   * @param method the HTTP method to be used for the request, only GET and POST are supported.
+   * @param service the App Engine service to route the request to. Note that with App Engine Task
+   *     Queue API if no service is specified, the service which enqueues the task will be used to
+   *     process the task. Cloud Tasks API does not support this feature so the service will always
+   *     needs to be explicitly specified.
+   * @param params a multi-map of URL query parameters. Duplicate keys are saved as is, and it is up
+   *     to the server to process the duplicate keys.
+   * @param clock a source of time.
+   * @param duration the amount of time that a task needs to delayed for.
+   * @return the enqueued task.
+   * @see <a
+   *     href=ttps://cloud.google.com/appengine/docs/standard/java/taskqueue/push/creating-tasks#target>Specifyinig
+   *     the worker service</a>
+   */
+  private static Task createTask(
+      String path,
+      HttpMethod method,
+      String service,
+      Multimap<String, String> params,
+      Clock clock,
+      long duration) {
+    if (duration == 0) {
+      return createTask(path, method, service, params);
+    }
+    Instant scheduleTime =
+        Instant.ofEpochMilli(clock.nowUtc().plusMillis((int) duration).getMillis());
+    return Task.newBuilder(createTask(path, method, service, params))
+        .setScheduleTime(
+            Timestamp.newBuilder()
+                .setSeconds(scheduleTime.getEpochSecond())
+                .setNanos(scheduleTime.getNano())
+                .build())
+        .build();
+  }
+
   public static Task createPostTask(String path, String service, Multimap<String, String> params) {
     return createTask(path, HttpMethod.POST, service, params);
   }
@@ -248,7 +248,7 @@ public class CloudTasksUtils implements Serializable {
     return createTask(path, HttpMethod.GET, service, params, clock, jitterSeconds);
   }
 
-  /** Create a {@link Task} via HTTP.POST that will be delayed by {@code duration}. */
+  /** Create a {@link Task} via HTTP.POST that will be delayed for {@code duration}. */
   public static Task createPostTask(
       String path,
       String service,
@@ -258,7 +258,7 @@ public class CloudTasksUtils implements Serializable {
     return createTask(path, HttpMethod.POST, service, params, clock, duration.getMillis());
   }
 
-  /** Create a {@link Task} via HTTP.GET that will be delayed up by {@code duration}. */
+  /** Create a {@link Task} via HTTP.GET that will be delayed up for {@code duration}. */
   public static Task createGetTask(
       String path,
       String service,

--- a/util/src/test/java/google/registry/util/CloudTasksUtilsTest.java
+++ b/util/src/test/java/google/registry/util/CloudTasksUtilsTest.java
@@ -34,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Optional;
 import org.joda.time.DateTime;
+import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -211,6 +212,65 @@ public class CloudTasksUtilsTest {
   void testSuccess_createGetTasks_withZeroJitterSeconds() {
     Task task =
         CloudTasksUtils.createGetTask("/the/path", "myservice", params, clock, Optional.of(0));
+    assertThat(task.getAppEngineHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.GET);
+    assertThat(task.getAppEngineHttpRequest().getRelativeUri())
+        .isEqualTo("/the/path?key1=val1&key2=val2&key1=val3");
+    assertThat(task.getAppEngineHttpRequest().getAppEngineRouting().getService())
+        .isEqualTo("myservice");
+    assertThat(task.getScheduleTime().getSeconds()).isEqualTo(0);
+  }
+
+  @Test
+  void testSuccess_createGetTasks_withDelay() {
+    Task task =
+        CloudTasksUtils.createGetTask(
+            "/the/path", "myservice", params, clock, Duration.standardMinutes(10));
+    assertThat(task.getAppEngineHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.GET);
+    assertThat(task.getAppEngineHttpRequest().getRelativeUri())
+        .isEqualTo("/the/path?key1=val1&key2=val2&key1=val3");
+    assertThat(task.getAppEngineHttpRequest().getAppEngineRouting().getService())
+        .isEqualTo("myservice");
+    assertThat(Instant.ofEpochSecond(task.getScheduleTime().getSeconds()))
+        .isEqualTo(Instant.ofEpochMilli(clock.nowUtc().plusMinutes(10).getMillis()));
+  }
+
+  @Test
+  void testSuccess_createPostTasks_withDelay() {
+    Task task =
+        CloudTasksUtils.createPostTask(
+            "/the/path", "myservice", params, clock, Duration.standardMinutes(10));
+    assertThat(task.getAppEngineHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.POST);
+    assertThat(task.getAppEngineHttpRequest().getRelativeUri()).isEqualTo("/the/path");
+    assertThat(task.getAppEngineHttpRequest().getAppEngineRouting().getService())
+        .isEqualTo("myservice");
+    assertThat(task.getAppEngineHttpRequest().getHeadersMap().get("Content-Type"))
+        .isEqualTo("application/x-www-form-urlencoded");
+    assertThat(task.getAppEngineHttpRequest().getBody().toString(StandardCharsets.UTF_8))
+        .isEqualTo("key1=val1&key2=val2&key1=val3");
+    assertThat(task.getScheduleTime().getSeconds()).isNotEqualTo(0);
+    assertThat(Instant.ofEpochSecond(task.getScheduleTime().getSeconds()))
+        .isEqualTo(Instant.ofEpochMilli(clock.nowUtc().plusMinutes(10).getMillis()));
+  }
+
+  @Test
+  void testSuccess_createPostTasks_withZeroDelay() {
+    Task task =
+        CloudTasksUtils.createPostTask("/the/path", "myservice", params, clock, Duration.ZERO);
+    assertThat(task.getAppEngineHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.POST);
+    assertThat(task.getAppEngineHttpRequest().getRelativeUri()).isEqualTo("/the/path");
+    assertThat(task.getAppEngineHttpRequest().getAppEngineRouting().getService())
+        .isEqualTo("myservice");
+    assertThat(task.getAppEngineHttpRequest().getHeadersMap().get("Content-Type"))
+        .isEqualTo("application/x-www-form-urlencoded");
+    assertThat(task.getAppEngineHttpRequest().getBody().toString(StandardCharsets.UTF_8))
+        .isEqualTo("key1=val1&key2=val2&key1=val3");
+    assertThat(task.getScheduleTime().getSeconds()).isEqualTo(0);
+  }
+
+  @Test
+  void testSuccess_createGetTasks_withZeroDelay() {
+    Task task =
+        CloudTasksUtils.createGetTask("/the/path", "myservice", params, clock, Duration.ZERO);
     assertThat(task.getAppEngineHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.GET);
     assertThat(task.getAppEngineHttpRequest().getRelativeUri())
         .isEqualTo("/the/path?key1=val1&key2=val2&key1=val3");

--- a/util/src/test/java/google/registry/util/CloudTasksUtilsTest.java
+++ b/util/src/test/java/google/registry/util/CloudTasksUtilsTest.java
@@ -253,6 +253,28 @@ public class CloudTasksUtilsTest {
   }
 
   @Test
+  void testFailure_createGetTasks_withNegativeDelay() {
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                CloudTasksUtils.createGetTask(
+                    "/the/path", "myservice", params, clock, Duration.standardMinutes(-10)));
+    assertThat(thrown).hasMessageThat().isEqualTo("Negative duration is not supported.");
+  }
+
+  @Test
+  void testFailure_createPostTasks_withNegativeDelay() {
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                CloudTasksUtils.createGetTask(
+                    "/the/path", "myservice", params, clock, Duration.standardMinutes(-10)));
+    assertThat(thrown).hasMessageThat().isEqualTo("Negative duration is not supported.");
+  }
+
+  @Test
   void testSuccess_createPostTasks_withZeroDelay() {
     Task task =
         CloudTasksUtils.createPostTask("/the/path", "myservice", params, clock, Duration.ZERO);


### PR DESCRIPTION
Currently, there are two ways to create a task via `CloudTasksUtil`: one with no specific schedule time, and one with random delay. There needs to be a way to schedule a task by specifying the delay time.

Added `scheduleTime` as one of the matchers in `CloudTasksHelper`. `Instant` is used for time comparison since it allows us to create the time slightly easier by using millis. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1493)
<!-- Reviewable:end -->
