### PR TITLE
Make sql-based lock more robust

### DIFF
--- a/core/src/main/java/google/registry/persistence/transaction/ReadOnlyCheckingQuery.java
+++ b/core/src/main/java/google/registry/persistence/transaction/ReadOnlyCheckingQuery.java
@@ -31,7 +31,7 @@ import javax.persistence.TemporalType;
 
 /** A {@link Query} that throws exceptions on write actions if in read-only mode. */
 @DeleteAfterMigration
-class ReadOnlyCheckingQuery implements Query {
+public class ReadOnlyCheckingQuery implements Query {
 
   private final Query delegate;
 


### PR DESCRIPTION
Currently lock/unlock transactions for SQL-based locks use the the
SERIALIZABLE isolation level. This is an overkill since locking involves
only a single table row. Using SERIALIZABLE level may cause the
transactions to rollback for irrelevant database operations.

In this PR we set lock transactions' isolation level to REPEATABLE_READ.
This is a temporary, ad hoc solution. A better transaction API being
planned will address this more elegantly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1496)
<!-- Reviewable:end -->
