### PR TITLE
Use the built-in replicaJpaTm() in RDAP

### DIFF
--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -1131,7 +1131,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
 
     private TypedQuery<T> buildQuery() {
       CriteriaQueryBuilder<T> queryBuilder =
-          CriteriaQueryBuilder.create(getEntityManager(), entityClass);
+          CriteriaQueryBuilder.create(JpaTransactionManagerImpl.this, entityClass);
       return addCriteria(queryBuilder);
     }
 
@@ -1178,7 +1178,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
     @Override
     public long count() {
       CriteriaQueryBuilder<Long> queryBuilder =
-          CriteriaQueryBuilder.createCount(getEntityManager(), entityClass);
+          CriteriaQueryBuilder.createCount(JpaTransactionManagerImpl.this, entityClass);
       return addCriteria(queryBuilder).getSingleResult();
     }
 

--- a/core/src/main/java/google/registry/rdap/RdapDomainSearchAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapDomainSearchAction.java
@@ -18,6 +18,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static google.registry.model.EppResourceUtils.loadByForeignKey;
 import static google.registry.model.index.ForeignKeyIndex.loadAndGetKey;
 import static google.registry.model.ofy.ObjectifyService.auditedOfy;
+import static google.registry.persistence.transaction.TransactionManagerFactory.replicaJpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.Action.Method.GET;
 import static google.registry.request.Action.Method.HEAD;
@@ -37,10 +38,8 @@ import com.google.common.primitives.Booleans;
 import com.googlecode.objectify.cmd.Query;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.host.HostResource;
-import google.registry.persistence.PersistenceModule.ReadOnlyReplicaJpaTm;
 import google.registry.persistence.VKey;
 import google.registry.persistence.transaction.CriteriaQueryBuilder;
-import google.registry.persistence.transaction.JpaTransactionManager;
 import google.registry.rdap.RdapJsonFormatter.OutputDataType;
 import google.registry.rdap.RdapMetrics.EndpointType;
 import google.registry.rdap.RdapMetrics.SearchType;
@@ -92,8 +91,6 @@ public class RdapDomainSearchAction extends RdapSearchActionBase {
   @Inject @Parameter("name") Optional<String> nameParam;
   @Inject @Parameter("nsLdhName") Optional<String> nsLdhNameParam;
   @Inject @Parameter("nsIp") Optional<String> nsIpParam;
-
-  @Inject @ReadOnlyReplicaJpaTm JpaTransactionManager readOnlyJpaTm;
 
   @Inject
   public RdapDomainSearchAction() {
@@ -228,31 +225,32 @@ public class RdapDomainSearchAction extends RdapSearchActionBase {
       resultSet = getMatchingResources(query, true, querySizeLimit);
     } else {
       resultSet =
-          readOnlyJpaTm.transact(
-              () -> {
-                CriteriaBuilder criteriaBuilder =
-                    readOnlyJpaTm.getEntityManager().getCriteriaBuilder();
-                CriteriaQueryBuilder<DomainBase> queryBuilder =
-                    CriteriaQueryBuilder.create(DomainBase.class)
-                        .where(
-                            "fullyQualifiedDomainName",
-                            criteriaBuilder::like,
-                            String.format("%s%%", partialStringQuery.getInitialString()))
-                        .orderByAsc("fullyQualifiedDomainName");
-                if (cursorString.isPresent()) {
-                  queryBuilder =
-                      queryBuilder.where(
-                          "fullyQualifiedDomainName",
-                          criteriaBuilder::greaterThan,
-                          cursorString.get());
-                }
-                if (partialStringQuery.getSuffix() != null) {
-                  queryBuilder =
-                      queryBuilder.where(
-                          "tld", criteriaBuilder::equal, partialStringQuery.getSuffix());
-                }
-                return getMatchingResourcesSql(queryBuilder, true, querySizeLimit);
-              });
+          replicaJpaTm()
+              .transact(
+                  () -> {
+                    CriteriaBuilder criteriaBuilder =
+                        replicaJpaTm().getEntityManager().getCriteriaBuilder();
+                    CriteriaQueryBuilder<DomainBase> queryBuilder =
+                        CriteriaQueryBuilder.create(replicaJpaTm(), DomainBase.class)
+                            .where(
+                                "fullyQualifiedDomainName",
+                                criteriaBuilder::like,
+                                String.format("%s%%", partialStringQuery.getInitialString()))
+                            .orderByAsc("fullyQualifiedDomainName");
+                    if (cursorString.isPresent()) {
+                      queryBuilder =
+                          queryBuilder.where(
+                              "fullyQualifiedDomainName",
+                              criteriaBuilder::greaterThan,
+                              cursorString.get());
+                    }
+                    if (partialStringQuery.getSuffix() != null) {
+                      queryBuilder =
+                          queryBuilder.where(
+                              "tld", criteriaBuilder::equal, partialStringQuery.getSuffix());
+                    }
+                    return getMatchingResourcesSql(queryBuilder, true, querySizeLimit);
+                  });
     }
     return makeSearchResults(resultSet);
   }
@@ -274,19 +272,20 @@ public class RdapDomainSearchAction extends RdapSearchActionBase {
       resultSet = getMatchingResources(query, true, querySizeLimit);
     } else {
       resultSet =
-          readOnlyJpaTm.transact(
-              () -> {
-                CriteriaQueryBuilder<DomainBase> builder =
-                    queryItemsSql(
-                            DomainBase.class,
-                            "tld",
-                            tld,
-                            Optional.of("fullyQualifiedDomainName"),
-                            cursorString,
-                            DeletedItemHandling.INCLUDE)
-                        .orderByAsc("fullyQualifiedDomainName");
-                return getMatchingResourcesSql(builder, true, querySizeLimit);
-              });
+          replicaJpaTm()
+              .transact(
+                  () -> {
+                    CriteriaQueryBuilder<DomainBase> builder =
+                        queryItemsSql(
+                                DomainBase.class,
+                                "tld",
+                                tld,
+                                Optional.of("fullyQualifiedDomainName"),
+                                cursorString,
+                                DeletedItemHandling.INCLUDE)
+                            .orderByAsc("fullyQualifiedDomainName");
+                    return getMatchingResourcesSql(builder, true, querySizeLimit);
+                  });
     }
     return makeSearchResults(resultSet);
   }
@@ -357,28 +356,29 @@ public class RdapDomainSearchAction extends RdapSearchActionBase {
           .map(VKey::from)
           .collect(toImmutableSet());
     } else {
-      return readOnlyJpaTm.transact(
-          () -> {
-            CriteriaQueryBuilder<HostResource> builder =
-                queryItemsSql(
-                    HostResource.class,
-                    "fullyQualifiedHostName",
-                    partialStringQuery,
-                    Optional.empty(),
-                    DeletedItemHandling.EXCLUDE);
-            if (desiredRegistrar.isPresent()) {
-              builder =
-                  builder.where(
-                      "currentSponsorClientId",
-                      readOnlyJpaTm.getEntityManager().getCriteriaBuilder()::equal,
-                      desiredRegistrar.get());
-            }
-            return getMatchingResourcesSql(builder, true, maxNameserversInFirstStage)
-                .resources()
-                .stream()
-                .map(HostResource::createVKey)
-                .collect(toImmutableSet());
-          });
+      return replicaJpaTm()
+          .transact(
+              () -> {
+                CriteriaQueryBuilder<HostResource> builder =
+                    queryItemsSql(
+                        HostResource.class,
+                        "fullyQualifiedHostName",
+                        partialStringQuery,
+                        Optional.empty(),
+                        DeletedItemHandling.EXCLUDE);
+                if (desiredRegistrar.isPresent()) {
+                  builder =
+                      builder.where(
+                          "currentSponsorClientId",
+                          replicaJpaTm().getEntityManager().getCriteriaBuilder()::equal,
+                          desiredRegistrar.get());
+                }
+                return getMatchingResourcesSql(builder, true, maxNameserversInFirstStage)
+                    .resources()
+                    .stream()
+                    .map(HostResource::createVKey)
+                    .collect(toImmutableSet());
+              });
     }
   }
 
@@ -512,20 +512,21 @@ public class RdapDomainSearchAction extends RdapSearchActionBase {
         parameters.put("desiredRegistrar", desiredRegistrar.get());
       }
       hostKeys =
-          readOnlyJpaTm.transact(
-              () -> {
-                javax.persistence.Query query =
-                    readOnlyJpaTm
-                        .getEntityManager()
-                        .createNativeQuery(queryBuilder.toString())
-                        .setMaxResults(maxNameserversInFirstStage);
-                parameters.build().forEach(query::setParameter);
-                @SuppressWarnings("unchecked")
-                Stream<String> resultStream = query.getResultStream();
-                return resultStream
-                    .map(repoId -> VKey.create(HostResource.class, repoId))
-                    .collect(toImmutableSet());
-              });
+          replicaJpaTm()
+              .transact(
+                  () -> {
+                    javax.persistence.Query query =
+                        replicaJpaTm()
+                            .getEntityManager()
+                            .createNativeQuery(queryBuilder.toString())
+                            .setMaxResults(maxNameserversInFirstStage);
+                    parameters.build().forEach(query::setParameter);
+                    @SuppressWarnings("unchecked")
+                    Stream<String> resultStream = query.getResultStream();
+                    return resultStream
+                        .map(repoId -> VKey.create(HostResource.class, repoId))
+                        .collect(toImmutableSet());
+                  });
     }
     return searchByNameserverRefs(hostKeys);
   }
@@ -570,38 +571,39 @@ public class RdapDomainSearchAction extends RdapSearchActionBase {
         }
         stream.forEach(domainSetBuilder::add);
       } else {
-        readOnlyJpaTm.transact(
-            () -> {
-              for (VKey<HostResource> hostKey : hostKeys) {
-                CriteriaQueryBuilder<DomainBase> queryBuilder =
-                    CriteriaQueryBuilder.create(DomainBase.class)
-                        .whereFieldContains("nsHosts", hostKey)
-                        .orderByAsc("fullyQualifiedDomainName");
-                CriteriaBuilder criteriaBuilder =
-                    readOnlyJpaTm.getEntityManager().getCriteriaBuilder();
-                if (!shouldIncludeDeleted()) {
-                  queryBuilder =
-                      queryBuilder.where(
-                          "deletionTime", criteriaBuilder::greaterThan, getRequestTime());
-                }
-                if (cursorString.isPresent()) {
-                  queryBuilder =
-                      queryBuilder.where(
-                          "fullyQualifiedDomainName",
-                          criteriaBuilder::greaterThan,
-                          cursorString.get());
-                }
-                readOnlyJpaTm
-                    .criteriaQuery(queryBuilder.build())
-                    .getResultStream()
-                    .filter(this::isAuthorized)
-                    .forEach(
-                        (domain) -> {
-                          Hibernate.initialize(domain.getDsData());
-                          domainSetBuilder.add(domain);
-                        });
-              }
-            });
+        replicaJpaTm()
+            .transact(
+                () -> {
+                  for (VKey<HostResource> hostKey : hostKeys) {
+                    CriteriaQueryBuilder<DomainBase> queryBuilder =
+                        CriteriaQueryBuilder.create(replicaJpaTm(), DomainBase.class)
+                            .whereFieldContains("nsHosts", hostKey)
+                            .orderByAsc("fullyQualifiedDomainName");
+                    CriteriaBuilder criteriaBuilder =
+                        replicaJpaTm().getEntityManager().getCriteriaBuilder();
+                    if (!shouldIncludeDeleted()) {
+                      queryBuilder =
+                          queryBuilder.where(
+                              "deletionTime", criteriaBuilder::greaterThan, getRequestTime());
+                    }
+                    if (cursorString.isPresent()) {
+                      queryBuilder =
+                          queryBuilder.where(
+                              "fullyQualifiedDomainName",
+                              criteriaBuilder::greaterThan,
+                              cursorString.get());
+                    }
+                    replicaJpaTm()
+                        .criteriaQuery(queryBuilder.build())
+                        .getResultStream()
+                        .filter(this::isAuthorized)
+                        .forEach(
+                            (domain) -> {
+                              Hibernate.initialize(domain.getDsData());
+                              domainSetBuilder.add(domain);
+                            });
+                  }
+                });
       }
     }
     List<DomainBase> domains = domainSetBuilder.build().asList();

--- a/core/src/main/java/google/registry/rdap/RdapEntitySearchAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapEntitySearchAction.java
@@ -15,7 +15,7 @@
 package google.registry.rdap;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.replicaJpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.persistence.transaction.TransactionManagerUtil.transactIfJpaTm;
 import static google.registry.rdap.RdapUtils.getRegistrarByIanaIdentifier;
@@ -277,7 +277,7 @@ public class RdapEntitySearchAction extends RdapSearchActionBase {
           resultSet = getMatchingResources(query, false, rdapResultSetMaxSize + 1);
         } else {
           resultSet =
-              jpaTm()
+              replicaJpaTm()
                   .transact(
                       () -> {
                         CriteriaQueryBuilder<ContactResource> builder =
@@ -399,7 +399,7 @@ public class RdapEntitySearchAction extends RdapSearchActionBase {
                   querySizeLimit);
         } else {
           contactResultSet =
-              jpaTm()
+              replicaJpaTm()
                   .transact(
                       () ->
                           getMatchingResourcesSql(

--- a/core/src/main/java/google/registry/rdap/RdapNameserverSearchAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapNameserverSearchAction.java
@@ -15,7 +15,7 @@
 package google.registry.rdap;
 
 import static google.registry.model.EppResourceUtils.loadByForeignKey;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.replicaJpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.Action.Method.GET;
 import static google.registry.request.Action.Method.HEAD;
@@ -233,7 +233,7 @@ public class RdapNameserverSearchAction extends RdapSearchActionBase {
       return makeSearchResults(
           getMatchingResources(query, shouldIncludeDeleted(), querySizeLimit), CursorType.NAME);
     } else {
-      return jpaTm()
+      return replicaJpaTm()
           .transact(
               () -> {
                 CriteriaQueryBuilder<HostResource> queryBuilder =
@@ -290,11 +290,11 @@ public class RdapNameserverSearchAction extends RdapSearchActionBase {
       }
       queryBuilder.append(" ORDER BY repo_id ASC");
       rdapResultSet =
-          jpaTm()
+          replicaJpaTm()
               .transact(
                   () -> {
                     javax.persistence.Query query =
-                        jpaTm()
+                        replicaJpaTm()
                             .getEntityManager()
                             .createNativeQuery(queryBuilder.toString(), HostResource.class)
                             .setMaxResults(querySizeLimit);

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerExtensionTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerExtensionTest.java
@@ -16,6 +16,7 @@ package google.registry.persistence.transaction;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.replicaJpaTm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -60,6 +61,17 @@ public class JpaTransactionManagerExtensionTest {
                       .getResultList();
               assertThat(results).isEmpty();
             });
+  }
+
+  @Test
+  void testReplicaJpaTm() {
+    TestEntity testEntity = new TestEntity("foo", "bar");
+    assertThat(
+            assertThrows(
+                PersistenceException.class,
+                () -> replicaJpaTm().transact(() -> replicaJpaTm().put(testEntity))))
+        .hasMessageThat()
+        .isEqualTo("Error while committing the transaction");
   }
 
   @Test


### PR DESCRIPTION
This includes a test for the replica-simulating transaction manager and
removal of any replica-specific code in RDAP tests, because it's
unnecessary due to the existing tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1506)
<!-- Reviewable:end -->
