### PR TITLE
Correctly delete all stopped versions except for the most recent 3

### DIFF
--- a/release/cloudbuild-delete.yaml
+++ b/release/cloudbuild-delete.yaml
@@ -52,8 +52,8 @@ steps:
     do
       for version in $(gcloud app versions list \
         --filter="SERVICE:$service AND SERVING_STATUS:STOPPED" \
-        --sort-by=LAST_DEPLOYED --format="value(VERSION.ID)" \
-        --project=$project_id | head -n -3)
+        --format="value(VERSION.ID,LAST_DEPLOYED)" \
+        --project=$project_id | sort -k 2 | head -n -3)
       do
         gcloud app versions delete $version --service=$service \
           --project=$project_id --quiet;


### PR DESCRIPTION
The gcloud command does some weird stuff with sorting when custom format
is used. Here we instead rely on linux sort and head command to sort the
versions list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1511)
<!-- Reviewable:end -->
