### PR TITLE
Fix create/update timestamp replay problems

### DIFF
--- a/core/src/main/java/google/registry/model/translators/UpdateAutoTimestampTranslatorFactory.java
+++ b/core/src/main/java/google/registry/model/translators/UpdateAutoTimestampTranslatorFactory.java
@@ -14,6 +14,8 @@
 
 package google.registry.model.translators;
 
+import static com.google.common.base.Preconditions.checkState;
+import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.ofyTm;
 import static org.joda.time.DateTimeZone.UTC;
 
@@ -48,9 +50,16 @@ public class UpdateAutoTimestampTranslatorFactory
       @Override
       public Date saveValue(UpdateAutoTimestamp pojoValue) {
 
-        // Don't do this if we're in the course of transaction serialization.
+        // If we're in the course of Transaction serialization, we have to use the transaction time
+        // here and the JPA transaction manager which is what will ultimately be saved during the
+        // commit.
+        // Note that this branch doesn't respect "auto update disabled", as this state is
+        // specifically to address replay, so we add a runtime check for this.
         if (Transaction.inSerializationMode()) {
-          return pojoValue.getTimestamp() == null ? null : pojoValue.getTimestamp().toDate();
+          checkState(
+              UpdateAutoTimestamp.autoUpdateEnabled(),
+              "Auto-update disabled during transaction serialization.");
+          return jpaTm().getTransactionTime();
         }
 
         return UpdateAutoTimestamp.autoUpdateEnabled()

--- a/core/src/main/java/google/registry/model/translators/UpdateAutoTimestampTranslatorFactory.java
+++ b/core/src/main/java/google/registry/model/translators/UpdateAutoTimestampTranslatorFactory.java
@@ -59,7 +59,7 @@ public class UpdateAutoTimestampTranslatorFactory
           checkState(
               UpdateAutoTimestamp.autoUpdateEnabled(),
               "Auto-update disabled during transaction serialization.");
-          return jpaTm().getTransactionTime();
+          return jpaTm().getTransactionTime().toDate();
         }
 
         return UpdateAutoTimestamp.autoUpdateEnabled()

--- a/core/src/test/java/google/registry/batch/ExpandRecurringBillingEventsActionTest.java
+++ b/core/src/test/java/google/registry/batch/ExpandRecurringBillingEventsActionTest.java
@@ -48,7 +48,6 @@ import google.registry.model.common.Cursor;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.Period;
-import google.registry.model.ofy.Ofy;
 import google.registry.model.reporting.DomainTransactionRecord;
 import google.registry.model.reporting.DomainTransactionRecord.TransactionReportField;
 import google.registry.model.reporting.HistoryEntry;
@@ -56,7 +55,6 @@ import google.registry.model.tld.Registry;
 import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.FakeClock;
 import google.registry.testing.FakeResponse;
-import google.registry.testing.InjectExtension;
 import google.registry.testing.ReplayExtension;
 import google.registry.testing.TestOfyAndSql;
 import google.registry.testing.TestOfyOnly;
@@ -77,11 +75,6 @@ public class ExpandRecurringBillingEventsActionTest
 
   private DateTime currentTestTime = DateTime.parse("1999-01-05T00:00:00Z");
   private final FakeClock clock = new FakeClock(currentTestTime);
-
-  @Order(Order.DEFAULT - 1)
-  @RegisterExtension
-  public final InjectExtension inject =
-      new InjectExtension().withStaticFieldOverride(Ofy.class, "clock", clock);
 
   @Order(Order.DEFAULT - 2)
   @RegisterExtension

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -174,8 +174,6 @@ import google.registry.testing.TaskQueueHelper.TaskMatcher;
 import google.registry.testing.TestOfyAndSql;
 import google.registry.testing.TestOfyOnly;
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.joda.money.Money;
@@ -192,7 +190,6 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   private static final String CLAIMS_KEY = "2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001";
 
   private AllocationToken allocationToken;
-  List<DomainBase> expectedUpdates = new ArrayList<>();
 
   @Order(value = Order.DEFAULT - 2)
   @RegisterExtension
@@ -351,20 +348,11 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     assertDnsTasksEnqueued(getUniqueIdFromCommand());
     assertEppResourceIndexEntityFor(domain);
 
-    expectUpdateFor(domain);
+    replayExtension.expectUpdateFor(domain);
 
     // Verify that all timestamps are correct after SQL -> DS replay.
     // Added to confirm that timestamps get updated correctly.
-    replayExtension.setEntityCheck(
-        entity -> {
-          if (entity instanceof DomainBase) {
-            DomainBase expectedDomain = expectedUpdates.remove(0);
-            DomainBase domainEntity = (DomainBase) entity;
-            assertThat(domainEntity.getCreationTime()).isEqualTo(expectedDomain.getCreationTime());
-            assertThat(domainEntity.getUpdateTimestamp())
-                .isEqualTo(expectedDomain.getUpdateTimestamp());
-          }
-        });
+    replayExtension.enableDomainTimestampChecks();
   }
 
   private void assertNoLordn() throws Exception {
@@ -407,10 +395,6 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                     + ",example-one.tld,370d0b7c9223372036854775807,1,"
                     + "2009-08-16T09:00:00.016Z,2009-08-16T09:00:00.000Z");
     assertTasksEnqueued(QUEUE_CLAIMS, task);
-  }
-
-  void expectUpdateFor(DomainBase domain) {
-    expectedUpdates.add(domain);
   }
 
   private void doSuccessfulTest(
@@ -596,7 +580,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         ImmutableMap.of("DOMAIN", "otherexample.tld", "YEARS", "2"));
     runFlowAssertResponse(
         loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "otherexample.tld")));
-    expectUpdateFor(reloadResourceByForeignKey());
+    replayExtension.expectUpdateFor(reloadResourceByForeignKey());
   }
 
   @TestOfyAndSql
@@ -849,7 +833,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   @TestOfyAndSql
   void testSuccess_existedButWasDeleted() throws Exception {
     persistContactsAndHosts();
-    expectUpdateFor(persistDeletedDomain(getUniqueIdFromCommand(), clock.nowUtc().minusDays(1)));
+    replayExtension.expectUpdateFor(
+        persistDeletedDomain(getUniqueIdFromCommand(), clock.nowUtc().minusDays(1)));
     clock.advanceOneMilli();
     doSuccessfulTest();
   }

--- a/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
@@ -111,8 +111,6 @@ import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.ReplayExtension;
 import google.registry.testing.TestOfyAndSql;
 import google.registry.testing.TestOfyOnly;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
@@ -136,7 +134,6 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
   private ContactResource sh8013Contact;
   private ContactResource mak21Contact;
   private ContactResource unusedContact;
-  List<DomainBase> expectedUpdates = new ArrayList<>();
 
   @Order(value = Order.DEFAULT - 2)
   @RegisterExtension
@@ -205,12 +202,8 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .setDomain(domain)
             .build());
     clock.advanceOneMilli();
-    expectUpdateFor(domain);
+    replayExtension.expectUpdateFor(domain);
     return domain;
-  }
-
-  void expectUpdateFor(DomainBase domain) {
-    expectedUpdates.add(domain);
   }
 
   private void doSuccessfulTest() throws Exception {
@@ -221,7 +214,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     assertTransactionalFlow(true);
     runFlowAssertResponse(loadFile(expectedXmlFilename));
     DomainBase domain = reloadResourceByForeignKey();
-    expectUpdateFor(domain);
+    replayExtension.expectUpdateFor(domain);
     // Check that the domain was updated. These values came from the xml.
     assertAboutDomains()
         .that(domain)
@@ -242,21 +235,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
 
     // Verify that all timestamps are correct after SQL -> DS replay.
     // Added to confirm that timestamps get updated correctly.
-    replayExtension.setEntityCheck(
-        entity -> {
-          if (entity instanceof DomainBase) {
-            DomainBase expectedDomain = expectedUpdates.remove(0);
-
-            // Ignore it if we enqueued a null, these are for dealing with known issues.
-            if (expectedDomain == null) {
-              return;
-            }
-            DomainBase domainEntity = (DomainBase) entity;
-            assertThat(domainEntity.getCreationTime()).isEqualTo(expectedDomain.getCreationTime());
-            assertThat(domainEntity.getUpdateTimestamp())
-                .isEqualTo(expectedDomain.getUpdateTimestamp());
-          }
-        });
+    replayExtension.enableDomainTimestampChecks();
   }
 
   @TestOfyAndSql
@@ -337,7 +316,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     persistResource(
         reloadResourceByForeignKey().asBuilder().setNameservers(nameservers.build()).build());
     // Add a null update here so we don't compare.
-    expectUpdateFor(null);
+    replayExtension.expectUpdateFor(null);
     clock.advanceOneMilli();
   }
 

--- a/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
@@ -671,4 +671,30 @@ public class DomainBaseSqlTest {
         .that(domain.getTransferData())
         .isEqualExceptFields(thatDomain.getTransferData(), "serverApproveEntities");
   }
+
+  // @TestSqlOnly
+  // void testUpdateTimeAfterNameserverUpdate() {
+  //   persistDomain();
+  //   DomainBase persisted = loadByKey(domain.createVKey());
+  //   DateTime originalUpdateTime = persisted.getUpdateTimestamp().getTimestamp();
+  //   fakeClock.advanceOneMilli();
+  //   DateTime transactionTime =
+  //       jpaTm().transact(
+  //           () -> {
+  //             HostResource host2 =
+  //                 new HostResource.Builder()
+  //                     .setRepoId("host2")
+  //                     .setHostName("ns2.example.com")
+  //                     .setCreationRegistrarId("registrar1")
+  //                     .setPersistedCurrentSponsorRegistrarId("registrar2")
+  //                     .build();
+  //             insertInDb(host2);
+  //             domain = persisted.asBuilder().addNameserver(host2.createVKey()).build();
+  //             updateInDb(domain);
+  //             return jpaTm().getTransactionTime();
+  //           });
+  //   domain = loadByKey(domain.createVKey());
+  //   assertThat(domain.getUpdateTimestamp().getTimestamp()).isEqualTo(transactionTime);
+  //   assertThat(domain.getUpdateTimestamp().getTimestamp()).isNotEqualTo(originalUpdateTime);
+  // }
 }

--- a/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainBaseSqlTest.java
@@ -671,30 +671,4 @@ public class DomainBaseSqlTest {
         .that(domain.getTransferData())
         .isEqualExceptFields(thatDomain.getTransferData(), "serverApproveEntities");
   }
-
-  // @TestSqlOnly
-  // void testUpdateTimeAfterNameserverUpdate() {
-  //   persistDomain();
-  //   DomainBase persisted = loadByKey(domain.createVKey());
-  //   DateTime originalUpdateTime = persisted.getUpdateTimestamp().getTimestamp();
-  //   fakeClock.advanceOneMilli();
-  //   DateTime transactionTime =
-  //       jpaTm().transact(
-  //           () -> {
-  //             HostResource host2 =
-  //                 new HostResource.Builder()
-  //                     .setRepoId("host2")
-  //                     .setHostName("ns2.example.com")
-  //                     .setCreationRegistrarId("registrar1")
-  //                     .setPersistedCurrentSponsorRegistrarId("registrar2")
-  //                     .build();
-  //             insertInDb(host2);
-  //             domain = persisted.asBuilder().addNameserver(host2.createVKey()).build();
-  //             updateInDb(domain);
-  //             return jpaTm().getTransactionTime();
-  //           });
-  //   domain = loadByKey(domain.createVKey());
-  //   assertThat(domain.getUpdateTimestamp().getTimestamp()).isEqualTo(transactionTime);
-  //   assertThat(domain.getUpdateTimestamp().getTimestamp()).isNotEqualTo(originalUpdateTime);
-  // }
 }


### PR DESCRIPTION
When CreateAutoTimestamp and UpdateAutoTimestamp are inserted into a
Transaction, their values are not populated in the same way as when they are
stored in the course of an SQL commit.  This results in different timestamp
values between SQL and datastore during the SQL -> DS replay.

Fix this by providing these values from the JPA transaction time when we're
doing transaction serialization.

This change also removes the initialization of the Ofy clock in
ExpandRecurringBillingEventsActionTest.  It's not necessary as the
ReplayExtension already takes care of this and doing it after the
ReplayExtension as we were breaks a test now that the update timestamps are
correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1515)
<!-- Reviewable:end -->
