### PR TITLE
Fix protobuf-java-util dependency in gradle

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -319,6 +319,7 @@ dependencies {
   testCompile deps['com.google.appengine:appengine-testing']
   testCompile deps['com.google.guava:guava-testlib']
   testCompile deps['com.google.monitoring-client:contrib']
+  testCompile deps['com.google.protobuf:protobuf-java-util']
   testCompile deps['com.google.truth:truth']
   testCompile deps['com.google.truth.extensions:truth-java8-extension']
   testCompile deps['org.checkerframework:checker-qual']
@@ -367,8 +368,6 @@ dependencies {
   compile deps['org.flywaydb:flyway-core']
 
   closureCompiler deps['com.google.javascript:closure-compiler']
-  testCompile 'com.google.protobuf:protobuf-java-util:3.17.3'
-  testCompile 'com.google.protobuf:protobuf-java-util:3.17.3'
 }
 
 task jaxbToJava {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -89,6 +89,7 @@ ext {
       'com.google.oauth-client:google-oauth-client-jetty:1.31.4',
       'com.google.oauth-client:google-oauth-client-servlet:1.31.4',
       'com.google.protobuf:protobuf-java:3.13.0',
+      'com.google.protobuf:protobuf-java-util:3.17.3',
       'com.google.re2j:re2j:1.6',
       'com.google.template:soy:2021-02-01',
       'com.google.truth.extensions:truth-java8-extension:1.1.2',


### PR DESCRIPTION
In [#PR1491](https://github.com/google/nomulus/pull/1491/files), ```com.google.protobuf:protobuf-java-util:3.17.3``` was added to [build.gradle](https://github.com/rachelguan/nomulus/blob/e66f6caefd2f9bb4cd20f04b4add44bfb07fee00/core/build.gradle) via ```./gradlew fixGradleLint```. It fixed the dependency warnings but it was not the standard way to add it. 

The purpose of this PR is to fix the problem by adding the dependency to [dependencies.gradle](https://github.com/google/nomulus/blob/master/dependencies.gradle) and [build.gradle](https://github.com/rachelguan/nomulus/blob/e66f6caefd2f9bb4cd20f04b4add44bfb07fee00/core/build.gradle) following the same format as the other added dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1518)
<!-- Reviewable:end -->
