### PR TITLE
Save db discrepancies to GCS

### DIFF
--- a/core/src/main/java/google/registry/beam/comparedb/ValidateDatabasePipelineOptions.java
+++ b/core/src/main/java/google/registry/beam/comparedb/ValidateDatabasePipelineOptions.java
@@ -46,4 +46,10 @@ public interface ValidateDatabasePipelineOptions extends RegistryPipelineOptions
   String getComparisonStartTimestamp();
 
   void setComparisonStartTimestamp(String comparisonStartTimestamp);
+
+  @Description("The GCS bucket where discrepancies found during comparison should be logged.")
+  @Nullable
+  String getDiffOutputGcsBucket();
+
+  void setDiffOutputGcsBucket(String gcsBucket);
 }

--- a/core/src/main/resources/google/registry/beam/validate_database_pipeline_metadata.json
+++ b/core/src/main/resources/google/registry/beam/validate_database_pipeline_metadata.json
@@ -24,7 +24,7 @@
       "name": "sqlSnapshotId",
       "label": "The ID of an exported Cloud SQL (Postgresql) snapshot.",
       "helpText": "The ID of an exported Cloud SQL (Postgresql) snapshot.",
-      "is_optional": true
+      "is_optional": false
     },
     {
       "name": "latestCommitLogTimestamp",
@@ -36,6 +36,12 @@
       "name": "comparisonStartTimestamp",
       "label": "Only entities updated at or after this time are included for validation.",
       "helpText": "The earliest entity update time allowed for inclusion in validation, in ISO8601 format.",
+      "is_optional": true
+    },
+    {
+      "name": "diffOutputGcsBucket",
+      "label": "The GCS bucket where data discrepancies should be output to.",
+      "helpText": "The GCS bucket where data discrepancies should be output to.",
       "is_optional": true
     }
   ]


### PR DESCRIPTION
Adds support for saving discrepancies in database comparison to a GCS bucket.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1527)
<!-- Reviewable:end -->
