### PR TITLE
Disable sending cert expiration emails on sandbox

### DIFF
--- a/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/cron.xml
@@ -169,15 +169,6 @@
   </cron>
 
   <cron>
-    <url><![CDATA[/_dr/task/sendExpiringCertificateNotificationEmail]]></url>
-    <description>
-      This job runs an action that sends emails to partners if their certificates are expiring soon.
-    </description>
-    <schedule>every day 04:30</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
     <url><![CDATA[/_dr/cron/fanout?queue=export-snapshot&endpoint=/_dr/task/backupDatastore&runInEmpty]]></url>
     <description>
       This job fires off a Datastore managed-export job that generates snapshot files in GCS.


### PR DESCRIPTION
This has caused some confusion for a registrar. Disable it for now while
we figure out how to re-word the email for sandbox, or if we should
leave it disabled permanently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1528)
<!-- Reviewable:end -->
