### PR TITLE
Don't reset the update time for TLD updates

### DIFF
--- a/core/src/main/java/google/registry/model/registrar/Registrar.java
+++ b/core/src/main/java/google/registry/model/registrar/Registrar.java
@@ -825,7 +825,6 @@ public class Registrar extends ImmutableObject
 
     public Builder setAllowedTlds(Set<String> allowedTlds) {
       getInstance().allowedTlds = ImmutableSortedSet.copyOf(assertTldsExist(allowedTlds));
-      getInstance().lastUpdateTime = UpdateAutoTimestamp.create(null);
       return this;
     }
 

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -472,8 +472,10 @@ public class DatabaseHelper {
 
   public static void allowRegistrarAccess(String registrarId, String tld) {
     Registrar registrar = loadRegistrar(registrarId);
-    persistResource(
-        registrar.asBuilder().setAllowedTlds(union(registrar.getAllowedTlds(), tld)).build());
+    if (!registrar.getAllowedTlds().contains(tld)) {
+      persistResource(
+          registrar.asBuilder().setAllowedTlds(union(registrar.getAllowedTlds(), tld)).build());
+    }
   }
 
   public static void disallowRegistrarAccess(String registrarId, String tld) {


### PR DESCRIPTION
It turns out that the reason that the Registrar update timestamp isn't updated
for some of the tests is because the record is updated unchanged.  We can
avoid this problem by not trying to update the registrar to the same value.
So in this case, if the registrar alreay contains the TLD we're adding, don't
try to add it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1532)
<!-- Reviewable:end -->
