### PR TITLE
Remove AppEngineServiceUtils dependency

### DIFF
--- a/core/src/main/java/google/registry/tools/GenerateEscrowDepositCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateEscrowDepositCommand.java
@@ -33,7 +33,6 @@ import google.registry.model.rde.RdeMode;
 import google.registry.rde.RdeStagingAction;
 import google.registry.request.Action.Service;
 import google.registry.tools.params.DateTimeParameter;
-import google.registry.util.AppEngineServiceUtils;
 import google.registry.util.CloudTasksUtils;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -89,8 +88,6 @@ final class GenerateEscrowDepositCommand implements CommandWithRemoteApi {
       description = "Specify output subdirectory (under GCS RDE bucket, directory manual).",
       required = true)
   private String outdir;
-
-  @Inject AppEngineServiceUtils appEngineServiceUtils;
 
   @Inject CloudTasksUtils cloudTasksUtils;
 

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
@@ -59,7 +59,6 @@ import google.registry.ui.forms.FormException;
 import google.registry.ui.forms.FormFieldException;
 import google.registry.ui.server.RegistrarFormFields;
 import google.registry.ui.server.SendEmailUtils;
-import google.registry.util.AppEngineServiceUtils;
 import google.registry.util.CloudTasksUtils;
 import google.registry.util.CollectionUtils;
 import google.registry.util.DiffUtils;
@@ -108,7 +107,6 @@ public class RegistrarSettingsAction implements Runnable, JsonActionRunner.JsonA
   private static ThreadLocal<Boolean> isInTestDriver = ThreadLocal.withInitial(() -> false);
 
   @Inject JsonActionRunner jsonActionRunner;
-  @Inject AppEngineServiceUtils appEngineServiceUtils;
   @Inject RegistrarConsoleMetrics registrarConsoleMetrics;
   @Inject SendEmailUtils sendEmailUtils;
   @Inject AuthenticatedRegistrarAccessor registrarAccessor;

--- a/core/src/test/java/google/registry/batch/RelockDomainActionTest.java
+++ b/core/src/test/java/google/registry/batch/RelockDomainActionTest.java
@@ -31,8 +31,6 @@ import static google.registry.testing.SqlHelper.saveRegistryLock;
 import static google.registry.tools.LockOrUnlockDomainCommand.REGISTRY_LOCK_STATUSES;
 import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT;
 import static javax.servlet.http.HttpServletResponse.SC_OK;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -51,7 +49,6 @@ import google.registry.testing.FakeResponse;
 import google.registry.testing.TestOfyAndSql;
 import google.registry.testing.UserInfo;
 import google.registry.tools.DomainLockUtils;
-import google.registry.util.AppEngineServiceUtils;
 import google.registry.util.EmailMessage;
 import google.registry.util.SendEmailService;
 import google.registry.util.StringGenerator.Alphabets;
@@ -110,11 +107,6 @@ public class RelockDomainActionTest {
         domainLockUtils.administrativelyApplyUnlock(
             DOMAIN_NAME, CLIENT_ID, false, Optional.empty());
     assertThat(loadByEntity(domain).getStatusValues()).containsNoneIn(REGISTRY_LOCK_STATUSES);
-
-    AppEngineServiceUtils appEngineServiceUtils = mock(AppEngineServiceUtils.class);
-    lenient()
-        .when(appEngineServiceUtils.getServiceHostname("backend"))
-        .thenReturn("backend.hostname.fake");
 
     action = createAction(oldLock.getRevisionId());
   }

--- a/core/src/test/java/google/registry/batch/ResaveEntityActionTest.java
+++ b/core/src/test/java/google/registry/batch/ResaveEntityActionTest.java
@@ -44,7 +44,6 @@ import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.FakeClock;
 import google.registry.testing.InjectExtension;
 import google.registry.testing.TestOfyAndSql;
-import google.registry.util.AppEngineServiceUtils;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
@@ -66,7 +65,6 @@ public class ResaveEntityActionTest {
 
   @RegisterExtension public final InjectExtension inject = new InjectExtension();
 
-  @Mock private AppEngineServiceUtils appEngineServiceUtils;
   @Mock private Response response;
   private final FakeClock clock = new FakeClock(DateTime.parse("2016-02-11T10:00:00Z"));
   private AsyncTaskEnqueuer asyncTaskEnqueuer;

--- a/core/src/test/java/google/registry/tools/DomainLockUtilsTest.java
+++ b/core/src/test/java/google/registry/tools/DomainLockUtilsTest.java
@@ -31,8 +31,6 @@ import static google.registry.tools.LockOrUnlockDomainCommand.REGISTRY_LOCK_STAT
 import static org.joda.time.Duration.standardDays;
 import static org.joda.time.Duration.standardHours;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.google.cloud.tasks.v2.HttpMethod;
 import com.google.common.collect.ImmutableList;
@@ -55,7 +53,6 @@ import google.registry.testing.FakeClock;
 import google.registry.testing.SqlHelper;
 import google.registry.testing.TestOfyAndSql;
 import google.registry.testing.UserInfo;
-import google.registry.util.AppEngineServiceUtils;
 import google.registry.util.StringGenerator.Alphabets;
 import java.util.Optional;
 import java.util.Set;
@@ -96,8 +93,6 @@ public final class DomainLockUtilsTest {
     HostResource host = persistActiveHost("ns1.example.net");
     domain = persistResource(newDomainBase(DOMAIN_NAME, host));
 
-    AppEngineServiceUtils appEngineServiceUtils = mock(AppEngineServiceUtils.class);
-    when(appEngineServiceUtils.getServiceHostname("backend")).thenReturn("backend.hostname.fake");
     domainLockUtils =
         new DomainLockUtils(
             new DeterministicStringGenerator(Alphabets.BASE_58),

--- a/core/src/test/java/google/registry/tools/GenerateEscrowDepositCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateEscrowDepositCommandTest.java
@@ -17,17 +17,14 @@ package google.registry.tools;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
 
 import com.beust.jcommander.ParameterException;
 import google.registry.testing.CloudTasksHelper;
 import google.registry.testing.CloudTasksHelper.TaskMatcher;
 import google.registry.testing.InjectExtension;
-import google.registry.util.AppEngineServiceUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
@@ -38,8 +35,6 @@ public class GenerateEscrowDepositCommandTest
 
   @RegisterExtension public final InjectExtension inject = new InjectExtension();
 
-  @Mock AppEngineServiceUtils appEngineServiceUtils;
-
   CloudTasksHelper cloudTasksHelper = new CloudTasksHelper();
 
   @BeforeEach
@@ -47,10 +42,7 @@ public class GenerateEscrowDepositCommandTest
     createTld("tld");
     createTld("anothertld");
     command = new GenerateEscrowDepositCommand();
-    command.appEngineServiceUtils = appEngineServiceUtils;
     command.cloudTasksUtils = cloudTasksHelper.getTestCloudTasksUtils();
-    when(appEngineServiceUtils.getCurrentVersionHostname("backend"))
-        .thenReturn("backend.test.localhost");
   }
 
   @Test

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistrarSettingsActionTestCase.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistrarSettingsActionTestCase.java
@@ -50,7 +50,6 @@ import google.registry.testing.CloudTasksHelper;
 import google.registry.testing.FakeClock;
 import google.registry.testing.InjectExtension;
 import google.registry.ui.server.SendEmailUtils;
-import google.registry.util.AppEngineServiceUtils;
 import google.registry.util.EmailMessage;
 import google.registry.util.SendEmailService;
 import java.io.PrintWriter;
@@ -88,7 +87,6 @@ public abstract class RegistrarSettingsActionTestCase {
 
   @RegisterExtension public final InjectExtension inject = new InjectExtension();
 
-  @Mock AppEngineServiceUtils appEngineServiceUtils;
   @Mock HttpServletRequest req;
   @Mock HttpServletResponse rsp;
   @Mock SendEmailService emailService;
@@ -112,8 +110,6 @@ public abstract class RegistrarSettingsActionTestCase {
         getOnlyElement(loadRegistrar(CLIENT_ID).getContactsOfType(RegistrarContact.Type.TECH));
 
     action.registrarAccessor = null;
-    action.appEngineServiceUtils = appEngineServiceUtils;
-    when(appEngineServiceUtils.getCurrentVersionHostname("backend")).thenReturn("backend.hostname");
     action.jsonActionRunner =
         new JsonActionRunner(ImmutableMap.of(), new JsonResponse(new ResponseImpl(rsp)));
     action.sendEmailUtils =


### PR DESCRIPTION
The ```AppEngineServiceUtils ``` instance is no longer required in some of the existing code after the conversion of task queue API to ```Cloud Task``` API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1534)
<!-- Reviewable:end -->
