### PR TITLE
Add domainRepoId indexes to billing events

### DIFF
--- a/db/src/main/resources/sql/er_diagram/brief_er_diagram.html
+++ b/db/src/main/resources/sql/er_diagram/brief_er_diagram.html
@@ -261,11 +261,11 @@ td.section {
     </tr> 
     <tr> 
      <td class="property_name">generated on</td> 
-     <td class="property_value">2022-03-04 22:54:58.102534</td> 
+     <td class="property_value">2022-03-07 15:27:22.193205</td> 
     </tr> 
     <tr>
      <td class="property_name">last flyway file</td>
-     <td id="lastFlywayFile" class="property_value">V106__add_missing_indexes_from_query_analyzer.sql</td>
+     <td id="lastFlywayFile" class="property_value">V107__add_billingevent_domainrepoid_indexes.sql</td>
     </tr>
    </tbody>
   </table> 
@@ -284,7 +284,7 @@ td.section {
      generated on
     </text> 
     <text text-anchor="start" x="4055.5" y="-10.8" font-family="Helvetica,sans-Serif" font-size="14.00">
-     2022-03-04 22:54:58.102534
+     2022-03-07 15:27:22.193205
     </text> 
     <polygon fill="none" stroke="#888888" points="3968,-4 3968,-44 4233,-44 4233,-4 3968,-4" /> <!-- allocationtoken_a08ccbef --> 
     <g id="node1" class="node"> 

--- a/db/src/main/resources/sql/er_diagram/full_er_diagram.html
+++ b/db/src/main/resources/sql/er_diagram/full_er_diagram.html
@@ -261,11 +261,11 @@ td.section {
     </tr> 
     <tr> 
      <td class="property_name">generated on</td> 
-     <td class="property_value">2022-03-04 22:54:56.709583</td> 
+     <td class="property_value">2022-03-07 15:27:20.810747</td> 
     </tr> 
     <tr>
      <td class="property_name">last flyway file</td>
-     <td id="lastFlywayFile" class="property_value">V106__add_missing_indexes_from_query_analyzer.sql</td>
+     <td id="lastFlywayFile" class="property_value">V107__add_billingevent_domainrepoid_indexes.sql</td>
     </tr>
    </tbody>
   </table> 
@@ -284,7 +284,7 @@ td.section {
      generated on
     </text> 
     <text text-anchor="start" x="4755.52" y="-10.8" font-family="Helvetica,sans-Serif" font-size="14.00">
-     2022-03-04 22:54:56.709583
+     2022-03-07 15:27:20.810747
     </text> 
     <polygon fill="none" stroke="#888888" points="4668.02,-4 4668.02,-44 4933.02,-44 4933.02,-4 4668.02,-4" /> <!-- allocationtoken_a08ccbef --> 
     <g id="node1" class="node"> 
@@ -6924,6 +6924,18 @@ td.section {
      <td colspan="3"></td> 
     </tr> 
     <tr> 
+     <td colspan="2" class="name">idxl8vobbecsd32k4ksavdfx8st6</td> 
+     <td class="description right">[non-unique index]</td> 
+    </tr> 
+    <tr> 
+     <td class="spacer"></td> 
+     <td class="minwidth">domain_repo_id</td> 
+     <td class="minwidth">ascending</td> 
+    </tr> 
+    <tr> 
+     <td colspan="3"></td> 
+    </tr> 
+    <tr> 
      <td colspan="2" class="name">idxeokttmxtpq2hohcioe5t2242b</td> 
      <td class="description right">[non-unique index]</td> 
     </tr> 
@@ -7219,6 +7231,18 @@ td.section {
      <td colspan="3"></td> 
     </tr> 
     <tr> 
+     <td colspan="2" class="name">idxbgfmveqa7e5hn689koikwn70r</td> 
+     <td class="description right">[non-unique index]</td> 
+    </tr> 
+    <tr> 
+     <td class="spacer"></td> 
+     <td class="minwidth">domain_repo_id</td> 
+     <td class="minwidth">ascending</td> 
+    </tr> 
+    <tr> 
+     <td colspan="3"></td> 
+    </tr> 
+    <tr> 
      <td colspan="2" class="name">idx73l103vc5900ig3p4odf0cngt</td> 
      <td class="description right">[non-unique index]</td> 
     </tr> 
@@ -7449,6 +7473,18 @@ td.section {
     <tr> 
      <td class="spacer"></td> 
      <td class="minwidth">billing_recurrence_id</td> 
+     <td class="minwidth">ascending</td> 
+    </tr> 
+    <tr> 
+     <td colspan="3"></td> 
+    </tr> 
+    <tr> 
+     <td colspan="2" class="name">idxoqttafcywwdn41um6kwlt0n8b</td> 
+     <td class="description right">[non-unique index]</td> 
+    </tr> 
+    <tr> 
+     <td class="spacer"></td> 
+     <td class="minwidth">domain_repo_id</td> 
      <td class="minwidth">ascending</td> 
     </tr> 
     <tr> 

--- a/db/src/main/resources/sql/flyway.txt
+++ b/db/src/main/resources/sql/flyway.txt
@@ -104,3 +104,4 @@ V103__creation_time_not_null.sql
 V104__add_transfer_response_host_id_to_poll_message.sql
 V105__add_index_on_host_name_in_host_table.sql
 V106__add_missing_indexes_from_query_analyzer.sql
+V107__add_billingevent_domainrepoid_indexes.sql

--- a/db/src/main/resources/sql/flyway/V107__add_billingevent_domainrepoid_indexes.sql
+++ b/db/src/main/resources/sql/flyway/V107__add_billingevent_domainrepoid_indexes.sql
@@ -1,0 +1,18 @@
+-- Copyright 2022 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+
+CREATE INDEX IDXbgfmveqa7e5hn689koikwn70r ON "BillingEvent" (domain_repo_id);
+CREATE INDEX IDXoqttafcywwdn41um6kwlt0n8b ON "BillingRecurrence" (domain_repo_id);
+CREATE INDEX IDXl8vobbecsd32k4ksavdfx8st6 ON "BillingCancellation" (domain_repo_id);

--- a/db/src/main/resources/sql/schema/nomulus.golden.sql
+++ b/db/src/main/resources/sql/schema/nomulus.golden.sql
@@ -1666,6 +1666,13 @@ CREATE INDEX idxaydgox62uno9qx8cjlj5lauye ON public."PollMessage" USING btree (e
 
 
 --
+-- Name: idxbgfmveqa7e5hn689koikwn70r; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idxbgfmveqa7e5hn689koikwn70r ON public."BillingEvent" USING btree (domain_repo_id);
+
+
+--
 -- Name: idxbgssjudpm428mrv0xfpvgifps; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1792,6 +1799,13 @@ CREATE INDEX idxku0fopwyvd57ebo8bf0jg9xo2 ON public."BillingCancellation" USING 
 
 
 --
+-- Name: idxl8vobbecsd32k4ksavdfx8st6; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idxl8vobbecsd32k4ksavdfx8st6 ON public."BillingCancellation" USING btree (domain_repo_id);
+
+
+--
 -- Name: idxlrq7v63pc21uoh3auq6eybyhl; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1831,6 +1845,13 @@ CREATE INDEX idxo1xdtpij2yryh0skxe9v91sep ON public."ContactHistory" USING btree
 --
 
 CREATE INDEX idxoqd7n4hbx86hvlgkilq75olas ON public."Contact" USING btree (contact_id);
+
+
+--
+-- Name: idxoqttafcywwdn41um6kwlt0n8b; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idxoqttafcywwdn41um6kwlt0n8b ON public."BillingRecurrence" USING btree (domain_repo_id);
 
 
 --


### PR DESCRIPTION
The query analyzer identified this is a missing index on the BillingEvent table,
and I added it for recurrences and cancellations as well as it's likely to be a
problem for them too. "Give me all the billing events associated with a given
domain by its repo ID" seems like a pretty common use case for the DB (and does
appear to be used by our invoicing pipeline).

This is the first of two PRs that makes just the DB changes. The second PR
(#1544) will add the Java code changes, and will be committed after this one is
deployed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1545)
<!-- Reviewable:end -->
