### PR TITLE
Add a a delay to task in CommitLogCheckpointAction 

### DIFF
--- a/core/src/test/java/google/registry/backup/CommitLogCheckpointActionTest.java
+++ b/core/src/test/java/google/registry/backup/CommitLogCheckpointActionTest.java
@@ -47,11 +47,10 @@ public class CommitLogCheckpointActionTest {
 
   private DateTime now = DateTime.now(UTC);
   private CommitLogCheckpointAction task = new CommitLogCheckpointAction();
-  private final CloudTasksHelper cloudTasksHelper = new CloudTasksHelper();
+  private final CloudTasksHelper cloudTasksHelper = new CloudTasksHelper(new FakeClock(now));
 
   @BeforeEach
   void beforeEach() {
-    task.clock = new FakeClock(now);
     task.strategy = strategy;
     task.cloudTasksUtils = cloudTasksHelper.getTestCloudTasksUtils();
     when(strategy.computeCheckpoint())
@@ -68,7 +67,8 @@ public class CommitLogCheckpointActionTest {
         new TaskMatcher()
             .url(ExportCommitLogDiffAction.PATH)
             .param(ExportCommitLogDiffAction.LOWER_CHECKPOINT_TIME_PARAM, START_OF_TIME.toString())
-            .param(ExportCommitLogDiffAction.UPPER_CHECKPOINT_TIME_PARAM, now.toString()));
+            .param(ExportCommitLogDiffAction.UPPER_CHECKPOINT_TIME_PARAM, now.toString())
+            .scheduleTime(now.plus(CommitLogCheckpointAction.ENQUEUE_DELAY_SECONDS)));
     assertThat(loadRoot().getLastWrittenTime()).isEqualTo(now);
   }
 
@@ -82,7 +82,8 @@ public class CommitLogCheckpointActionTest {
         new TaskMatcher()
             .url(ExportCommitLogDiffAction.PATH)
             .param(ExportCommitLogDiffAction.LOWER_CHECKPOINT_TIME_PARAM, oneMinuteAgo.toString())
-            .param(ExportCommitLogDiffAction.UPPER_CHECKPOINT_TIME_PARAM, now.toString()));
+            .param(ExportCommitLogDiffAction.UPPER_CHECKPOINT_TIME_PARAM, now.toString())
+            .scheduleTime(now.plus(CommitLogCheckpointAction.ENQUEUE_DELAY_SECONDS)));
     assertThat(loadRoot().getLastWrittenTime()).isEqualTo(now);
   }
 


### PR DESCRIPTION
There is an significant increase of `VerifyException` at at `ExportCommitLogDiffAction.run`. After the switch to `Cloud Task` API, there's a chance that the task gets invoked before the `Datastore` transaction commits. Adding a delay to each submitted task could prevent a task gets invoked before the the transaction is committed. 