### PR TITLE
Fix a subtle issue in BRDA copy caused by Cloud Tasks

### DIFF
--- a/core/src/main/java/google/registry/beam/rde/RdeIO.java
+++ b/core/src/main/java/google/registry/beam/rde/RdeIO.java
@@ -68,6 +68,7 @@ import org.apache.beam.sdk.values.PDone;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.joda.time.DateTime;
+import org.joda.time.Duration;
 
 public class RdeIO {
 
@@ -261,6 +262,7 @@ public class RdeIO {
 
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
     private static final long serialVersionUID = 5822176227753327224L;
+    private static final Duration ENQUEUE_DELAY = Duration.standardMinutes(1);
 
     private final CloudTasksUtils cloudTasksUtils;
 
@@ -271,19 +273,11 @@ public class RdeIO {
     @ProcessElement
     public void processElement(
         @Element KV<PendingDeposit, Integer> input, PipelineOptions options) {
-      PendingDeposit key = input.getKey();
-      // We need to save the revision in a separate transaction because the subsequent upload/copy
-      // action reads the most current revision from the database. If it is done in the same
-      // transaction with the enqueueing, the action might start running before the transaction is
-      // committed, due to Cloud Tasks not being transaction aware. The downside is that if for some
-      // reason the second transaction is rolled back, the revision update is not undone. But this
-      // should be fine since the next run will just increment the revision and start over.
-      tm().transact(
-              () ->
-                  RdeRevision.saveRevision(
-                      key.tld(), key.watermark(), key.mode(), input.getValue()));
+
       tm().transact(
               () -> {
+                PendingDeposit key = input.getKey();
+                int revision = input.getValue();
                 Registry registry = Registry.get(key.tld());
                 Optional<Cursor> cursor =
                     transactIfJpaTm(
@@ -305,25 +299,30 @@ public class RdeIO {
                 tm().put(Cursor.create(key.cursor(), newPosition, registry));
                 logger.atInfo().log(
                     "Rolled forward %s on %s cursor to %s.", key.cursor(), key.tld(), newPosition);
+                RdeRevision.saveRevision(key.tld(), key.watermark(), key.mode(), input.getValue());
                 // Enqueueing a task is a side effect that is not undone if the transaction rolls
                 // back. So this may result in multiple copies of the same task being processed.
                 // This is fine because the RdeUploadAction is guarded by a lock and tracks progress
-                // by cursor. The BrdaCopyAction writes a file to GCS, which is an atomic action.
+                // by cursor. The BrdaCopyAction writes a file to GCS, which is an atomic action. It
+                // is also guarded by a cursor to not run before the cursor is updated. We also
+                // include a delay to minimize the chance that the enqueued job executes before the
+                // transaction is committed, which triggers a retry.
                 if (key.mode() == RdeMode.FULL) {
                   cloudTasksUtils.enqueue(
                       RDE_UPLOAD_QUEUE,
-                      cloudTasksUtils.createPostTask(
+                      cloudTasksUtils.createPostTaskWithDelay(
                           RdeUploadAction.PATH,
                           Service.BACKEND.getServiceId(),
                           ImmutableMultimap.of(
                               RequestParameters.PARAM_TLD,
                               key.tld(),
                               RdeModule.PARAM_PREFIX,
-                              options.getJobName() + '/')));
+                              options.getJobName() + '/'),
+                          ENQUEUE_DELAY));
                 } else {
                   cloudTasksUtils.enqueue(
                       BRDA_QUEUE,
-                      cloudTasksUtils.createPostTask(
+                      cloudTasksUtils.createPostTaskWithDelay(
                           BrdaCopyAction.PATH,
                           Service.BACKEND.getServiceId(),
                           ImmutableMultimap.of(
@@ -332,7 +331,8 @@ public class RdeIO {
                               RdeModule.PARAM_WATERMARK,
                               key.watermark().toString(),
                               RdeModule.PARAM_PREFIX,
-                              options.getJobName() + '/')));
+                              options.getJobName() + '/'),
+                          ENQUEUE_DELAY));
                 }
               });
     }

--- a/core/src/main/java/google/registry/rde/RdeStagingReducer.java
+++ b/core/src/main/java/google/registry/rde/RdeStagingReducer.java
@@ -233,7 +233,6 @@ public final class RdeStagingReducer extends Reducer<PendingDeposit, DepositFrag
               tm().put(Cursor.create(key.cursor(), newPosition, registry));
               logger.atInfo().log(
                   "Rolled forward %s on %s cursor to %s.", key.cursor(), tld, newPosition);
-              RdeRevision.saveRevision(tld, watermark, mode, revision);
               // Enqueueing a task is a side effect that is not undone if the transaction rolls
               // back. So this may result in multiple copies of the same task being processed. This
               // is fine because the RdeUploadAction is guarded by a lock and tracks progress by

--- a/core/src/main/java/google/registry/rde/RdeUploadAction.java
+++ b/core/src/main/java/google/registry/rde/RdeUploadAction.java
@@ -148,7 +148,7 @@ public final class RdeUploadAction implements Runnable, EscrowTask {
       throw new NoContentException(
           String.format(
               "Waiting on RdeStagingAction for TLD %s to send %s upload; "
-                  + "last RDE staging completion was at %s",
+                  + "last RDE staging completion was before %s",
               tld, watermark, stagingCursorTime));
     }
     DateTime sftpCursorTime =

--- a/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
+++ b/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
@@ -420,7 +420,7 @@ public class RdeUploadActionTest {
         .hasMessageThat()
         .isEqualTo(
             "Waiting on RdeStagingAction for TLD tld to send 2010-10-17T00:00:00.000Z upload; "
-                + "last RDE staging completion was at 2010-10-17T00:00:00.000Z");
+                + "last RDE staging completion was before 2010-10-17T00:00:00.000Z");
   }
 
   @TestOfyAndSql
@@ -437,8 +437,9 @@ public class RdeUploadActionTest {
     assertThat(thrown)
         .hasMessageThat()
         .isEqualTo(
-            "Waiting on 120 minute SFTP cooldown for TLD tld to send 2010-10-17T00:00:00.000Z "
-                + "upload; last upload attempt was at 2010-10-16T22:23:00.000Z (97 minutes ago)");
+            "Waiting on 120 minute SFTP cooldown for TLD tld to send 2010-10-17T00:00:00.000Z"
+                + " upload; last upload attempt was at 2010-10-16T22:23:00.000Z (97 minutes"
+                + " ago)");
   }
 
   private String slurp(InputStream is) throws IOException {

--- a/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
+++ b/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
@@ -403,7 +403,7 @@ public class RdeUploadActionTest {
         .hasMessageThat()
         .isEqualTo(
             "Waiting on RdeStagingAction for TLD tld to send 2010-10-17T00:00:00.000Z upload; last"
-                + " RDE staging completion was at 1970-01-01T00:00:00.000Z");
+                + " RDE staging completion was before 1970-01-01T00:00:00.000Z");
     cloudTasksHelper.assertNoTasksEnqueued("rde-upload");
     assertThat(folder.list()).isEmpty();
   }


### PR DESCRIPTION
After the Cloud Tasks migration and #1508, the BRDA copy job now
routinely fail on the first try because the revision update is not
commited by the time the Cloud Tasks job enqueued in the same
transaction runs for  the first time. This is because the enqueueing is
a side effect and not part of the transaction. The job eventually
succeeds because of retries.

This PR attempts to mitigate the initial failure by saving the revisions
in a separate transaction before the enqueueing happens, insuring that
it is updated by the time the job runs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1556)
<!-- Reviewable:end -->
