### PR TITLE
Some code health fixes

### DIFF
--- a/core/src/test/java/google/registry/export/UploadDatastoreBackupActionTest.java
+++ b/core/src/test/java/google/registry/export/UploadDatastoreBackupActionTest.java
@@ -48,7 +48,6 @@ import google.registry.testing.AppEngineExtension;
 import google.registry.testing.CloudTasksHelper;
 import google.registry.testing.CloudTasksHelper.TaskMatcher;
 import google.registry.testing.FakeClock;
-import google.registry.util.CloudTasksUtils;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;

--- a/core/src/test/java/google/registry/export/UploadDatastoreBackupActionTest.java
+++ b/core/src/test/java/google/registry/export/UploadDatastoreBackupActionTest.java
@@ -73,7 +73,6 @@ public class UploadDatastoreBackupActionTest {
       mock(Bigquery.Datasets.Insert.class);
   private UploadDatastoreBackupAction action;
   private CloudTasksHelper cloudTasksHelper = new CloudTasksHelper();
-  private CloudTasksUtils cloudTasksUtils = cloudTasksHelper.getTestCloudTasksUtils();
 
   @BeforeEach
   void beforeEach() throws Exception {

--- a/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
+++ b/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
@@ -234,15 +234,6 @@ public class RdeUploadActionTest {
     RdeUploadAction action = createAction(null);
     action.prefix = Optional.of("job-name/");
     action.tld = "lol";
-    gcsUtils.delete(GHOSTRYDE_FILE);
-    gcsUtils.createFromBytes(
-        GHOSTRYDE_FILE_WITH_PREFIX, Ghostryde.encode(DEPOSIT_XML.read(), encryptKey));
-    gcsUtils.delete(LENGTH_FILE);
-    gcsUtils.createFromBytes(
-        LENGTH_FILE_WITH_PREFIX, Long.toString(DEPOSIT_XML.size()).getBytes(UTF_8));
-    gcsUtils.delete(REPORT_FILE);
-    gcsUtils.createFromBytes(
-        REPORT_FILE_WITH_PREFIX, Ghostryde.encode(REPORT_XML.read(), encryptKey));
     action.run();
     verify(runner)
         .lockRunAndRollForward(


### PR DESCRIPTION
1. testRun_withPrefix() in RdeUploadActionTest does calls a mock lock
   handler and does not actually try to read from the fake GCS
   implementation. Therefore there's no point settig it up.

2. Remove an unused field in UploadDatastoreBackupActionTest.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1563)
<!-- Reviewable:end -->
