### PR TITLE
Use TLS v1.3 explicitly in RDE reporting

### DIFF
--- a/core/src/main/java/google/registry/request/Modules.java
+++ b/core/src/main/java/google/registry/request/Modules.java
@@ -29,6 +29,8 @@ import dagger.Module;
 import dagger.Provides;
 import java.net.HttpURLConnection;
 import javax.inject.Singleton;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
 
 /** Dagger modules for App Engine services and other vendor classes. */
 public final class Modules {
@@ -49,7 +51,16 @@ public final class Modules {
   public static final class UrlConnectionServiceModule {
     @Provides
     static UrlConnectionService provideUrlConnectionService() {
-      return url -> (HttpURLConnection) url.openConnection();
+      return url -> {
+        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        if (connection instanceof HttpsURLConnection) {
+          HttpsURLConnection httpsConnection = (HttpsURLConnection) connection;
+          SSLContext tls13Context = SSLContext.getInstance("TLSv1.3");
+          tls13Context.init(null, null, null);
+          httpsConnection.setSSLSocketFactory(tls13Context.getSocketFactory());
+        }
+        return connection;
+      };
     }
   }
 

--- a/core/src/main/java/google/registry/request/UrlConnectionService.java
+++ b/core/src/main/java/google/registry/request/UrlConnectionService.java
@@ -17,9 +17,10 @@ package google.registry.request;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.security.GeneralSecurityException;
 
 /** Functional interface for opening a connection from a URL, injectable for testing. */
 public interface UrlConnectionService {
 
-  HttpURLConnection createConnection(URL url) throws IOException;
+  HttpURLConnection createConnection(URL url) throws IOException, GeneralSecurityException;
 }

--- a/core/src/main/java/google/registry/tmch/Marksdb.java
+++ b/core/src/main/java/google/registry/tmch/Marksdb.java
@@ -32,6 +32,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.security.GeneralSecurityException;
 import java.security.Security;
 import java.security.SignatureException;
 import java.util.Arrays;
@@ -110,7 +111,8 @@ public final class Marksdb {
     }
   }
 
-  byte[] fetch(URL url, Optional<String> loginAndPassword) throws IOException {
+  byte[] fetch(URL url, Optional<String> loginAndPassword)
+      throws IOException, GeneralSecurityException {
     HttpURLConnection connection = urlConnectionService.createConnection(url);
     loginAndPassword.ifPresent(auth -> setBasicAuth(connection, auth));
     try {
@@ -124,7 +126,7 @@ public final class Marksdb {
   }
 
   List<String> fetchSignedCsv(Optional<String> loginAndPassword, String csvPath, String sigPath)
-      throws IOException, SignatureException, PGPException {
+      throws IOException, GeneralSecurityException, PGPException {
     checkArgument(
         loginAndPassword.isPresent(), "Cannot fetch from MarksDB without login credentials");
 

--- a/core/src/main/java/google/registry/tmch/NordnUploadAction.java
+++ b/core/src/main/java/google/registry/tmch/NordnUploadAction.java
@@ -54,6 +54,7 @@ import google.registry.util.UrlConnectionException;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 import java.util.List;
 import java.util.Random;
@@ -116,7 +117,7 @@ public final class NordnUploadAction implements Runnable {
   public void run() {
     try {
       processLordnTasks();
-    } catch (IOException e) {
+    } catch (IOException | GeneralSecurityException e) {
       throw new RuntimeException(e);
     }
   }
@@ -161,7 +162,7 @@ public final class NordnUploadAction implements Runnable {
     }
   }
 
-  private void processLordnTasks() throws IOException {
+  private void processLordnTasks() throws IOException, GeneralSecurityException {
     checkArgument(phase.equals(PARAM_LORDN_PHASE_SUNRISE)
         || phase.equals(PARAM_LORDN_PHASE_CLAIMS),
         "Invalid phase specified to Nordn servlet: %s.", phase);
@@ -194,7 +195,8 @@ public final class NordnUploadAction implements Runnable {
    * @see <a href="http://tools.ietf.org/html/draft-lozano-tmch-func-spec-08#section-6.3">TMCH
    *     functional specifications - LORDN File</a>
    */
-  private void uploadCsvToLordn(String urlPath, String csvData) throws IOException {
+  private void uploadCsvToLordn(String urlPath, String csvData)
+      throws IOException, GeneralSecurityException {
     String url = tmchMarksdbUrl + urlPath;
     logger.atInfo().log(
         "LORDN upload task %s: Sending to URL: %s ; data: %s", actionLogId, url, csvData);

--- a/core/src/main/java/google/registry/tmch/NordnVerifyAction.java
+++ b/core/src/main/java/google/registry/tmch/NordnVerifyAction.java
@@ -34,6 +34,7 @@ import google.registry.util.UrlConnectionException;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.security.GeneralSecurityException;
 import java.util.Map.Entry;
 import javax.inject.Inject;
 
@@ -77,7 +78,7 @@ public final class NordnVerifyAction implements Runnable {
   public void run() {
     try {
       verify();
-    } catch (IOException e) {
+    } catch (IOException | GeneralSecurityException e) {
       throw new RuntimeException(e);
     }
   }
@@ -89,11 +90,11 @@ public final class NordnVerifyAction implements Runnable {
    * available.
    *
    * @throws ConflictException if MarksDB has not yet finished processing the LORDN upload
-   * @see <a href="http://tools.ietf.org/html/draft-lozano-tmch-func-spec-08#section-6.3.1">
-   *     TMCH functional specifications LORDN Log File</a>
+   * @see <a href="http://tools.ietf.org/html/draft-lozano-tmch-func-spec-08#section-6.3.1">TMCH
+   *     functional specifications LORDN Log File</a>
    */
   @VisibleForTesting
-  LordnLog verify() throws IOException {
+  LordnLog verify() throws IOException, GeneralSecurityException {
     logger.atInfo().log("LORDN verify task %s: Sending request to URL %s", actionLogId, url);
     HttpURLConnection connection = urlConnectionService.createConnection(url);
     lordnRequestInitializer.initialize(connection, tld);

--- a/core/src/main/java/google/registry/tmch/TmchDnlAction.java
+++ b/core/src/main/java/google/registry/tmch/TmchDnlAction.java
@@ -23,7 +23,7 @@ import google.registry.model.tmch.ClaimsListDao;
 import google.registry.request.Action;
 import google.registry.request.auth.Auth;
 import java.io.IOException;
-import java.security.SignatureException;
+import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -52,7 +52,7 @@ public final class TmchDnlAction implements Runnable {
     List<String> lines;
     try {
       lines = marksdb.fetchSignedCsv(marksdbDnlLoginAndPassword, DNL_CSV_PATH, DNL_SIG_PATH);
-    } catch (SignatureException | IOException | PGPException e) {
+    } catch (GeneralSecurityException | IOException | PGPException e) {
       throw new RuntimeException(e);
     }
     ClaimsList claims = ClaimsListParser.parse(lines);

--- a/core/src/main/java/google/registry/tmch/TmchSmdrlAction.java
+++ b/core/src/main/java/google/registry/tmch/TmchSmdrlAction.java
@@ -22,7 +22,7 @@ import google.registry.model.smd.SignedMarkRevocationList;
 import google.registry.request.Action;
 import google.registry.request.auth.Auth;
 import java.io.IOException;
-import java.security.SignatureException;
+import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -51,7 +51,7 @@ public final class TmchSmdrlAction implements Runnable {
     List<String> lines;
     try {
       lines = marksdb.fetchSignedCsv(marksdbSmdrlLoginAndPassword, SMDRL_CSV_PATH, SMDRL_SIG_PATH);
-    } catch (SignatureException | IOException | PGPException e) {
+    } catch (GeneralSecurityException | IOException | PGPException e) {
       throw new RuntimeException(e);
     }
     SignedMarkRevocationList smdrl = SmdrlCsvParser.parse(lines);


### PR DESCRIPTION
The default Java 1.8 TLS version is 1.2 which isn't supported by the
ICANN upload site.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1564)
<!-- Reviewable:end -->
