### PR TITLE
Terminate with exit code of 1 on format check fail

### DIFF
--- a/java-format/google-java-format-git-diff.sh
+++ b/java-format/google-java-format-git-diff.sh
@@ -139,10 +139,11 @@ function isJavaFormatNeededOnDiffs() {
 
   if [[ ${modifiedLineCount} -ne 0 ]]; then
     echo "true"
+    exit 1
   else
     echo "false"
+    exit 0
   fi
-  exit 0
 }
 
 # The main function of this script:


### PR DESCRIPTION
The format check script currently outputs "true" if there were files that need
reformatting and "false" if not, which is useful for gradle but less so for
other applications (notably commit hooks).  Terminate with an exit code of 1
if the format check fails.

TESTED: Tried this from both a pre-commit hook and from the gradle build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1570)
<!-- Reviewable:end -->
