### PR TITLE
Fix a few references to "Datastore" in comments

### DIFF
--- a/core/src/main/java/google/registry/model/tmch/ClaimsList.java
+++ b/core/src/main/java/google/registry/model/tmch/ClaimsList.java
@@ -70,8 +70,7 @@ public class ClaimsList extends ImmutableObject implements SqlOnlyEntity {
    *
    * <p>Note that the value of this field is parsed from the claims list file(See this <a
    * href="https://tools.ietf.org/html/draft-lozano-tmch-func-spec-08#section-6.1">RFC</>), it is
-   * the DNL List creation datetime from the rfc. Since this field has been used by Datastore, we
-   * cannot change its name until we finish the migration.
+   * the DNL List creation datetime from the rfc.
    *
    * <p>TODO(b/177567432): Rename this field to tmdbGenerationTime.
    */

--- a/core/src/main/java/google/registry/model/tmch/TmchCrl.java
+++ b/core/src/main/java/google/registry/model/tmch/TmchCrl.java
@@ -47,7 +47,7 @@ public final class TmchCrl extends CrossTldSingleton implements SqlOnlyEntity {
    * Change the singleton to a new ASCII-armored X.509 CRL.
    *
    * <p>Please do not call this function unless your CRL is properly formatted, signed by the root,
-   * and actually newer than the one currently in Datastore.
+   * and actually newer than the one currently in the database.
    */
   public static void set(final String crl, final String url) {
     jpaTm()

--- a/core/src/main/java/google/registry/tmch/TmchCertificateAuthority.java
+++ b/core/src/main/java/google/registry/tmch/TmchCertificateAuthority.java
@@ -41,8 +41,8 @@ import javax.inject.Inject;
  * Helper methods for accessing ICANN's TMCH root certificate and revocation list.
  *
  * <p>There are two CRLs, a real one for the production environment and a pilot one for
- * non-production environments. The Datastore singleton {@link TmchCrl} entity is used to cache this
- * CRL once loaded and will always contain the proper one corresponding to the environment.
+ * non-production environments. The singleton {@link TmchCrl} entity is used to cache this CRL once
+ * loaded and will always contain the proper one corresponding to the environment.
  *
  * <p>The CRTs do not change and are included as files in the codebase that are not refreshed. They
  * were downloaded from https://ca.icann.org/tmch.crt and https://ca.icann.org/tmch_pilot.crt
@@ -66,7 +66,7 @@ public final class TmchCertificateAuthority {
   }
 
   /**
-   * A cached supplier that loads the CRL from Datastore or chooses a default value.
+   * A cached supplier that loads the CRL from the database or chooses a default value.
    *
    * <p>We keep the cache here rather than caching TmchCrl in the model, because loading the CRL
    * string into an X509CRL instance is expensive and should itself be cached.
@@ -132,7 +132,7 @@ public final class TmchCertificateAuthority {
   }
 
   /**
-   * Update to the latest TMCH X.509 certificate revocation list and save it to Datastore.
+   * Update to the latest TMCH X.509 certificate revocation list and save it to the database.
    *
    * <p>Your ASCII-armored CRL must be signed by the current ICANN root certificate.
    *

--- a/core/src/main/java/google/registry/tmch/TmchCrlAction.java
+++ b/core/src/main/java/google/registry/tmch/TmchCrlAction.java
@@ -40,7 +40,7 @@ public final class TmchCrlAction implements Runnable {
   @Inject TmchCertificateAuthority tmchCertificateAuthority;
   @Inject TmchCrlAction() {}
 
-  /** Synchronously fetches latest ICANN TMCH CRL and saves it to Datastore. */
+  /** Synchronously fetches latest ICANN TMCH CRL and saves it to the database. */
   @Override
   public void run() {
     try {


### PR DESCRIPTION
Fix references to Datastore in the comments of classes that are now SQL-only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1576)
<!-- Reviewable:end -->
