### PR TITLE
Make code change for AllocationToken schema change

### DIFF
--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -351,12 +351,18 @@ class google.registry.model.domain.token.AllocationToken {
   google.registry.model.CreateAutoTimestamp creationTime;
   google.registry.model.UpdateAutoTimestamp updateTimestamp;
   google.registry.model.common.TimedTransitionProperty<google.registry.model.domain.token.AllocationToken$TokenStatus, google.registry.model.domain.token.AllocationToken$TokenStatusTransition> tokenStatusTransitions;
+  google.registry.model.domain.token.AllocationToken$RenewalPriceBehavior renewalPriceBehavior;
   google.registry.model.domain.token.AllocationToken$TokenType tokenType;
   google.registry.persistence.DomainHistoryVKey redemptionHistoryEntry;
   int discountYears;
   java.lang.String domainName;
   java.util.Set<java.lang.String> allowedClientIds;
   java.util.Set<java.lang.String> allowedTlds;
+}
+enum google.registry.model.domain.token.AllocationToken$RenewalPriceBehavior {
+  DEFAULT;
+  NONPREMIUM;
+  SPECIFIED;
 }
 enum google.registry.model.domain.token.AllocationToken$TokenStatus {
   CANCELLED;

--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -350,19 +350,14 @@ class google.registry.model.domain.token.AllocationToken {
   double discountFraction;
   google.registry.model.CreateAutoTimestamp creationTime;
   google.registry.model.UpdateAutoTimestamp updateTimestamp;
+  google.registry.model.billing.BillingEvent$RenewalPriceBehavior renewalPriceBehavior;
   google.registry.model.common.TimedTransitionProperty<google.registry.model.domain.token.AllocationToken$TokenStatus, google.registry.model.domain.token.AllocationToken$TokenStatusTransition> tokenStatusTransitions;
-  google.registry.model.domain.token.AllocationToken$RenewalPriceBehavior renewalPriceBehavior;
   google.registry.model.domain.token.AllocationToken$TokenType tokenType;
   google.registry.persistence.DomainHistoryVKey redemptionHistoryEntry;
   int discountYears;
   java.lang.String domainName;
   java.util.Set<java.lang.String> allowedClientIds;
   java.util.Set<java.lang.String> allowedTlds;
-}
-enum google.registry.model.domain.token.AllocationToken$RenewalPriceBehavior {
-  DEFAULT;
-  NONPREMIUM;
-  SPECIFIED;
 }
 enum google.registry.model.domain.token.AllocationToken$TokenStatus {
   CANCELLED;

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -24,6 +24,7 @@
         domain_name text,
         redemption_domain_history_id int8,
         redemption_domain_repo_id text,
+        renewal_price_behavior int4,
         token_status_transitions hstore,
         token_type text,
         primary key (token)

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -24,7 +24,7 @@
         domain_name text,
         redemption_domain_history_id int8,
         redemption_domain_repo_id text,
-        renewal_price_behavior int4,
+        renewal_price_behavior text not null,
         token_status_transitions hstore,
         token_type text,
         primary key (token)


### PR DESCRIPTION
This is the corresponding code change to [PR#1580: Add renewal price behavior to AllocationToken](https://github.com/google/nomulus/pull/1580). 

The enum used here is called `RenewalPriceBehavior`, which will be introduced by [PR#1573](https://github.com/google/nomulus/pull/1573). The use cases for `AllocationToken` are `DEFAULT` and `SPECIFIED`. Once PR#1573 goes in, the enum will be coming from `BillingEvent.java`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1581)
<!-- Reviewable:end -->
