### PR TITLE
Ignore read-only when saving commit logs

### DIFF
--- a/core/src/main/java/google/registry/model/ofy/CommitLogMutation.java
+++ b/core/src/main/java/google/registry/model/ofy/CommitLogMutation.java
@@ -69,7 +69,7 @@ public class CommitLogMutation extends ImmutableObject implements DatastoreOnlyE
    * converted to a raw Datastore Entity, serialized to bytes, and stored within the mutation.
    */
   public static CommitLogMutation create(Key<CommitLogManifest> parent, Object entity) {
-    return createFromRaw(parent, auditedOfy().save().toEntity(entity));
+    return createFromRaw(parent, auditedOfy().saveIgnoringReadOnlyWithBackup().toEntity(entity));
   }
 
   /**

--- a/core/src/main/java/google/registry/model/ofy/CommitLoggedWork.java
+++ b/core/src/main/java/google/registry/model/ofy/CommitLoggedWork.java
@@ -156,7 +156,7 @@ public class CommitLoggedWork<R> implements Runnable {
             .map(entity -> (ImmutableObject) CommitLogMutation.create(manifestKey, entity))
             .collect(toImmutableSet());
     auditedOfy()
-        .saveWithoutBackup()
+        .saveIgnoringReadOnlyWithoutBackup()
         .entities(
             new ImmutableSet.Builder<>()
                 .add(manifest)

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionManagerFactory.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionManagerFactory.java
@@ -17,7 +17,6 @@ package google.registry.persistence.transaction;
 import static com.google.common.base.Preconditions.checkState;
 import static google.registry.model.common.DatabaseMigrationStateSchedule.MigrationState.DATASTORE_PRIMARY_NO_ASYNC;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
-import static org.joda.time.DateTimeZone.UTC;
 
 import com.google.appengine.api.utils.SystemProperty;
 import com.google.appengine.api.utils.SystemProperty.Environment.Value;
@@ -30,10 +29,11 @@ import google.registry.model.common.DatabaseMigrationStateSchedule.PrimaryDataba
 import google.registry.model.ofy.DatastoreTransactionManager;
 import google.registry.persistence.DaggerPersistenceComponent;
 import google.registry.tools.RegistryToolEnvironment;
+import google.registry.util.Clock;
 import google.registry.util.NonFinalForTesting;
+import google.registry.util.SystemClock;
 import java.util.Optional;
 import java.util.function.Supplier;
-import org.joda.time.DateTime;
 
 /** Factory class to create {@link TransactionManager} instance. */
 // TODO: Rename this to PersistenceFactory and move to persistence package.
@@ -43,6 +43,9 @@ public final class TransactionManagerFactory {
 
   /** Optional override to manually set the transaction manager per-test. */
   private static Optional<TransactionManager> tmForTest = Optional.empty();
+
+  /** The current clock (defined as a variable so we can override it in tests) */
+  private static Clock clock = new SystemClock();
 
   /** Supplier for jpaTm so that it is initialized only once, upon first usage. */
   @NonFinalForTesting
@@ -105,7 +108,7 @@ public final class TransactionManagerFactory {
     if (onBeam) {
       return jpaTm();
     }
-    return DatabaseMigrationStateSchedule.getValueAtTime(DateTime.now(UTC))
+    return DatabaseMigrationStateSchedule.getValueAtTime(clock.nowUtc())
             .getPrimaryDatabase()
             .equals(PrimaryDatabase.DATASTORE)
         ? ofyTm()
@@ -195,7 +198,7 @@ public final class TransactionManagerFactory {
   }
 
   public static void assertNotReadOnlyMode() {
-    if (DatabaseMigrationStateSchedule.getValueAtTime(DateTime.now(UTC)).isReadOnly()) {
+    if (DatabaseMigrationStateSchedule.getValueAtTime(clock.nowUtc()).isReadOnly()) {
       throw new ReadOnlyModeException();
     }
   }
@@ -214,6 +217,12 @@ public final class TransactionManagerFactory {
         .equals(DATASTORE_PRIMARY_NO_ASYNC)) {
       throw new ReadOnlyModeException();
     }
+  }
+
+  /** Allows us to set the clock used by the factory in unit tests. */
+  @VisibleForTesting
+  public static void setClock(Clock clock) {
+    TransactionManagerFactory.clock = clock;
   }
 
   /** Registry is currently undergoing maintenance and is in read-only mode. */

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionManagerFactory.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionManagerFactory.java
@@ -213,7 +213,7 @@ public final class TransactionManagerFactory {
    */
   @DeleteAfterMigration
   public static void assertAsyncActionsAreAllowed() {
-    if (DatabaseMigrationStateSchedule.getValueAtTime(DateTime.now(UTC))
+    if (DatabaseMigrationStateSchedule.getValueAtTime(clock.nowUtc())
         .equals(DATASTORE_PRIMARY_NO_ASYNC)) {
       throw new ReadOnlyModeException();
     }
@@ -221,7 +221,7 @@ public final class TransactionManagerFactory {
 
   /** Allows us to set the clock used by the factory in unit tests. */
   @VisibleForTesting
-  public static void setClock(Clock clock) {
+  public static void setClockForTesting(Clock clock) {
     TransactionManagerFactory.clock = clock;
   }
 

--- a/core/src/test/java/google/registry/model/replay/ReplicateToDatastoreActionTest.java
+++ b/core/src/test/java/google/registry/model/replay/ReplicateToDatastoreActionTest.java
@@ -53,6 +53,7 @@ import google.registry.testing.InjectExtension;
 import google.registry.testing.ReplayExtension;
 import google.registry.testing.TestObject;
 import google.registry.util.RequestStatusChecker;
+import google.registry.util.SystemClock;
 import java.lang.reflect.Proxy;
 import java.util.List;
 import java.util.logging.Level;
@@ -106,6 +107,7 @@ public class ReplicateToDatastoreActionTest {
   void tearDown() {
     DatabaseHelper.removeDatabaseMigrationSchedule();
     fakeClock.disableAutoIncrement();
+    TransactionManagerFactory.setClockForTesting(new SystemClock());
   }
 
   @RetryingTest(4)
@@ -367,8 +369,9 @@ public class ReplicateToDatastoreActionTest {
                     ImmutableSortedMap.<DateTime, MigrationState>naturalOrder()
                         .put(START_OF_TIME, MigrationState.DATASTORE_ONLY)
                         .put(START_OF_TIME.plusHours(1), MigrationState.DATASTORE_PRIMARY)
-                        .put(START_OF_TIME.plusHours(2), MigrationState.DATASTORE_PRIMARY_READ_ONLY)
-                        .put(START_OF_TIME.plusHours(3), MigrationState.SQL_PRIMARY)
+                        .put(START_OF_TIME.plusHours(2), MigrationState.DATASTORE_PRIMARY_NO_ASYNC)
+                        .put(START_OF_TIME.plusHours(3), MigrationState.DATASTORE_PRIMARY_READ_ONLY)
+                        .put(START_OF_TIME.plusHours(4), MigrationState.SQL_PRIMARY)
                         .put(now.plusHours(1), MigrationState.SQL_PRIMARY_READ_ONLY)
                         .put(now.plusHours(2), MigrationState.DATASTORE_PRIMARY_READ_ONLY)
                         .put(now.plusHours(3), MigrationState.DATASTORE_PRIMARY)

--- a/core/src/test/java/google/registry/model/replay/ReplicateToDatastoreActionTest.java
+++ b/core/src/test/java/google/registry/model/replay/ReplicateToDatastoreActionTest.java
@@ -367,9 +367,8 @@ public class ReplicateToDatastoreActionTest {
                     ImmutableSortedMap.<DateTime, MigrationState>naturalOrder()
                         .put(START_OF_TIME, MigrationState.DATASTORE_ONLY)
                         .put(START_OF_TIME.plusHours(1), MigrationState.DATASTORE_PRIMARY)
-                        .put(START_OF_TIME.plusHours(2), MigrationState.DATASTORE_PRIMARY_NO_ASYNC)
-                        .put(START_OF_TIME.plusHours(3), MigrationState.DATASTORE_PRIMARY_READ_ONLY)
-                        .put(START_OF_TIME.plusHours(4), MigrationState.SQL_PRIMARY)
+                        .put(START_OF_TIME.plusHours(2), MigrationState.DATASTORE_PRIMARY_READ_ONLY)
+                        .put(START_OF_TIME.plusHours(3), MigrationState.SQL_PRIMARY)
                         .put(now.plusHours(1), MigrationState.SQL_PRIMARY_READ_ONLY)
                         .put(now.plusHours(2), MigrationState.DATASTORE_PRIMARY_READ_ONLY)
                         .put(now.plusHours(3), MigrationState.DATASTORE_PRIMARY)
@@ -399,7 +398,7 @@ public class ReplicateToDatastoreActionTest {
     // Put us in SQL primary now, readonly in an hour, then in datastore primary after 25 hours.
     // And we'll need the TransactionManagerFactory to use the fake clock.
     DateTime now = fakeClock.nowUtc();
-    TransactionManagerFactory.setClock(fakeClock);
+    TransactionManagerFactory.setClockForTesting(fakeClock);
     jpaTm()
         .transact(
             () ->
@@ -407,9 +406,10 @@ public class ReplicateToDatastoreActionTest {
                     ImmutableSortedMap.<DateTime, MigrationState>naturalOrder()
                         .put(START_OF_TIME, MigrationState.DATASTORE_ONLY)
                         .put(START_OF_TIME.plusHours(1), MigrationState.DATASTORE_PRIMARY)
-                        .put(START_OF_TIME.plusHours(2), MigrationState.DATASTORE_PRIMARY_READ_ONLY)
-                        .put(START_OF_TIME.plusHours(3), MigrationState.SQL_PRIMARY_READ_ONLY)
-                        .put(START_OF_TIME.plusHours(4), MigrationState.SQL_PRIMARY)
+                        .put(START_OF_TIME.plusHours(2), MigrationState.DATASTORE_PRIMARY_NO_ASYNC)
+                        .put(START_OF_TIME.plusHours(3), MigrationState.DATASTORE_PRIMARY_READ_ONLY)
+                        .put(START_OF_TIME.plusHours(4), MigrationState.SQL_PRIMARY_READ_ONLY)
+                        .put(START_OF_TIME.plusHours(5), MigrationState.SQL_PRIMARY)
                         .put(now.plusHours(1), MigrationState.SQL_PRIMARY_READ_ONLY)
                         .put(now.plusHours(25), MigrationState.DATASTORE_PRIMARY_READ_ONLY)
                         .put(now.plusHours(26), MigrationState.DATASTORE_PRIMARY_READ_ONLY)


### PR DESCRIPTION
Ignore read-only when saving commit logs and commit log mutations so that we
can safely replicate in read-only mode.  This should be safe, as we only ever
to the situation of saving commit logs and mutations when something has
already actually been modified in a transaction, meaning that we should have hit
the "read only" sentinel already.

This also introduces the ability to set the Clock in the
TransactionManagerFactory so that we can test this functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1584)
<!-- Reviewable:end -->
