### PR TITLE
Build Java8-compatible release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -331,6 +331,18 @@ subprojects {
 
   apply from: "${rootDir.path}/java_common.gradle"
 
+  if (project.name == 'docs') {
+    compileJava {
+      // TODO: Remove this once we are on Java 11 across the board.
+      options.release = 11
+    }
+  } else {
+    compileJava {
+      // TODO: Remove this once we migrate off AppEngine.
+      options.release = 8
+    }
+  }
+
   if (project.name == 'third_party') return
 
   project.tasks.test.dependsOn runPresubmits

--- a/build.gradle
+++ b/build.gradle
@@ -331,12 +331,7 @@ subprojects {
 
   apply from: "${rootDir.path}/java_common.gradle"
 
-  if (project.name == 'docs') {
-    compileJava {
-      // TODO: Remove this once we are on Java 11 across the board.
-      options.release = 11
-    }
-  } else {
+  if (project.name != 'docs') {
     compileJava {
       // TODO: Remove this once we migrate off AppEngine.
       options.release = 8

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -37,9 +37,6 @@ test {
   useJUnitPlatform()
 }
 
-sourceCompatibility = '11'
-targetCompatibility = '11'
-
 task flowDocsTool(type: JavaExec) {
   systemProperty 'test.projectRoot', rootProject.projectRootDir
   jvmArgs = ['--add-exports', 'jdk.javadoc/jdk.javadoc.internal.tool=ALL-UNNAMED']

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -128,13 +128,6 @@ tasks.withType(JavaCompile).configureEach {
     }
 }
 
-// TODO: Change source version to 11 after target version is changed to 11 and
-// once we figure out what's wrong with Dagger compilation with source version
-// >8.
-sourceCompatibility = '8'
-// TODO: Change target version to 11. Source version can stay at 8.
-targetCompatibility = '8'
-
 compileJava { options.encoding = "UTF-8" }
 compileTestJava { options.encoding = "UTF-8" }
 


### PR DESCRIPTION
Use the new options.release Gradle property to make sure builds are
compatible with Java 8, which is the runtime on Appengine.

This new property replaces sourceCompatibility, targetCompatibility, and
bootclasspath (wasn't previously set, which is the reason why we
couldn't detect Java9 api usage when building).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1586)
<!-- Reviewable:end -->
