### PR TITLE
Change to hasSize() for assertions

### DIFF
--- a/core/src/test/java/google/registry/backup/DeleteOldCommitLogsActionTest.java
+++ b/core/src/test/java/google/registry/backup/DeleteOldCommitLogsActionTest.java
@@ -92,7 +92,7 @@ public class DeleteOldCommitLogsActionTest
     contact = auditedOfy().load().type(ContactResource.class).first().now();
 
     // The following value might change if {@link CommitLogRevisionsTranslatorFactory} changes.
-    assertThat(contact.getRevisions().size()).isEqualTo(6);
+    assertThat(contact.getRevisions()).hasSize(6);
 
     // Before deleting the unneeded manifests - we have 11 of them (one for the first
     // creation, and 10 more for the mutateContacts)

--- a/core/src/test/java/google/registry/batch/SendExpiringCertificateNotificationEmailActionTest.java
+++ b/core/src/test/java/google/registry/batch/SendExpiringCertificateNotificationEmailActionTest.java
@@ -15,6 +15,7 @@
 package google.registry.batch;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 import static google.registry.testing.AppEngineExtension.makeRegistrar1;
 import static google.registry.testing.DatabaseHelper.loadByEntity;
 import static google.registry.testing.DatabaseHelper.persistResource;
@@ -430,7 +431,7 @@ class SendExpiringCertificateNotificationEmailActionTest {
     }
 
     ImmutableList<RegistrarInfo> results = action.getRegistrarsWithExpiringCertificates();
-    assertThat(results.size()).isEqualTo(numOfRegistrarsWithExpiringCertificates);
+    assertThat(results).hasSize(numOfRegistrarsWithExpiringCertificates);
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
+++ b/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
@@ -282,7 +282,7 @@ class Spec11PipelineTest {
         ImmutableList.copyOf(
             ResourceUtils.readResourceUtf8(this.getClass(), "test_output.txt").split("\n"));
     ImmutableList<String> resultFileContents = resultFileContents();
-    assertThat(resultFileContents.size()).isEqualTo(expectedFileContents.size());
+    assertThat(resultFileContents).hasSize(expectedFileContents.size());
     assertThat(resultFileContents.get(0)).isEqualTo(expectedFileContents.get(0));
     assertThat(resultFileContents.subList(1, resultFileContents.size()))
         .comparingElementsUsing(

--- a/core/src/test/java/google/registry/model/replay/ReplicateToDatastoreActionTest.java
+++ b/core/src/test/java/google/registry/model/replay/ReplicateToDatastoreActionTest.java
@@ -302,13 +302,13 @@ public class ReplicateToDatastoreActionTest {
     // records.
     action.run();
     Truth8.assertThat(ofyTm().transact(() -> ofyTm().loadByKeyIfPresent(bar.key()))).isPresent();
-    assertThat(ofyTm().loadAllOf(ReplayGap.class).size()).isEqualTo(30);
+    assertThat(ofyTm().loadAllOf(ReplayGap.class)).hasSize(30);
 
     // Verify that we can clean up this many gap records after expiration.
     fakeClock.advanceBy(Duration.millis(ReplicateToDatastoreAction.MAX_GAP_RETENTION_MILLIS + 1));
     resetAction();
     action.run();
-    assertThat(ofyTm().loadAllOf(ReplayGap.class).size()).isEqualTo(0);
+    assertThat(ofyTm().loadAllOf(ReplayGap.class)).isEmpty();
   }
 
   @Test

--- a/core/src/test/java/google/registry/rde/BouncyCastleTest.java
+++ b/core/src/test/java/google/registry/rde/BouncyCastleTest.java
@@ -170,7 +170,7 @@ public class BouncyCastleTest {
     try (ByteArrayInputStream input = new ByteArrayInputStream(signatureFileData)) {
       PGPObjectFactory pgpFact = new BcPGPObjectFactory(input);
       PGPSignatureList sigList = (PGPSignatureList) pgpFact.nextObject();
-      assertThat(sigList.size()).isEqualTo(1);
+      assertThat(sigList).hasSize(1);
       sig = sigList.get(0);
     }
 
@@ -212,8 +212,8 @@ public class BouncyCastleTest {
       PGPObjectFactory pgpFact = new BcPGPObjectFactory(input);
       PGPOnePassSignatureList onePassList = (PGPOnePassSignatureList) pgpFact.nextObject();
       PGPSignatureList sigList = (PGPSignatureList) pgpFact.nextObject();
-      assertThat(onePassList.size()).isEqualTo(1);
-      assertThat(sigList.size()).isEqualTo(1);
+      assertThat(onePassList).hasSize(1);
+      assertThat(sigList).hasSize(1);
       onePass = onePassList.get(0);
       sig = sigList.get(0);
     }
@@ -258,7 +258,7 @@ public class BouncyCastleTest {
     try (ByteArrayInputStream input = new ByteArrayInputStream(encryptedData)) {
       PGPObjectFactory pgpFact = new BcPGPObjectFactory(input);
       PGPEncryptedDataList encDataList = (PGPEncryptedDataList) pgpFact.nextObject();
-      assertThat(encDataList.size()).isEqualTo(1);
+      assertThat(encDataList).hasSize(1);
       PGPPublicKeyEncryptedData encData = (PGPPublicKeyEncryptedData) encDataList.get(0);
       assertThat(encData.getKeyID()).isEqualTo(publicKey.getKeyID());
       assertThat(encData.getKeyID()).isEqualTo(privateKey.getKeyID());
@@ -302,7 +302,7 @@ public class BouncyCastleTest {
     try (ByteArrayInputStream input = new ByteArrayInputStream(encryptedData)) {
       PGPObjectFactory pgpFact = new BcPGPObjectFactory(input);
       PGPEncryptedDataList encDataList = (PGPEncryptedDataList) pgpFact.nextObject();
-      assertThat(encDataList.size()).isEqualTo(1);
+      assertThat(encDataList).hasSize(1);
       PGPPublicKeyEncryptedData encData = (PGPPublicKeyEncryptedData) encDataList.get(0);
       // Bob loads the private key to which the message is addressed.
       PGPPrivateKey privateKey =
@@ -350,7 +350,7 @@ public class BouncyCastleTest {
     try (ByteArrayInputStream input = new ByteArrayInputStream(encryptedData)) {
       PGPObjectFactory pgpFact = new BcPGPObjectFactory(input);
       PGPEncryptedDataList encDataList = (PGPEncryptedDataList) pgpFact.nextObject();
-      assertThat(encDataList.size()).isEqualTo(1);
+      assertThat(encDataList).hasSize(1);
       PGPPublicKeyEncryptedData encData = (PGPPublicKeyEncryptedData) encDataList.get(0);
       // Bob loads the private key to which the message is addressed.
       PGPPrivateKey privateKey =

--- a/core/src/test/java/google/registry/request/JsonResponseTest.java
+++ b/core/src/test/java/google/registry/request/JsonResponseTest.java
@@ -53,7 +53,7 @@ class JsonResponseTest {
   void testSetHeader() {
     jsonResponse.setHeader("header", "value");
     Map<String, Object> headerMap = fakeResponse.getHeaders();
-    assertThat(headerMap.size()).isEqualTo(1);
+    assertThat(headerMap).hasSize(1);
     assertThat(headerMap.get("header")).isEqualTo("value");
   }
 }

--- a/core/src/test/java/google/registry/testing/CloudTasksHelper.java
+++ b/core/src/test/java/google/registry/testing/CloudTasksHelper.java
@@ -158,7 +158,7 @@ public class CloudTasksHelper implements Serializable {
    */
   public void assertTasksEnqueued(String queueName, Collection<TaskMatcher> taskMatchers) {
     List<Task> tasks = getTestTasksFor(queueName);
-    assertThat(tasks.size()).isEqualTo(taskMatchers.size());
+    assertThat(tasks).hasSize(taskMatchers.size());
     for (final TaskMatcher taskMatcher : taskMatchers) {
       try {
         tasks.remove(tasks.stream().filter(taskMatcher).findFirst().get());

--- a/core/src/test/java/google/registry/tools/DomainLockUtilsTest.java
+++ b/core/src/test/java/google/registry/tools/DomainLockUtilsTest.java
@@ -15,6 +15,7 @@
 package google.registry.tools;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 import static google.registry.batch.AsyncTaskEnqueuer.QUEUE_ASYNC_ACTIONS;
 import static google.registry.testing.DatabaseHelper.assertNoBillingEvents;
 import static google.registry.testing.DatabaseHelper.createTlds;
@@ -546,7 +547,7 @@ public final class DomainLockUtilsTest {
     assertThat(loadByEntity(domain).getStatusValues()).containsNoneIn(REGISTRY_LOCK_STATUSES);
     ImmutableList<DomainHistory> historyEntries =
         getHistoryEntriesOfType(domain, HistoryEntry.Type.DOMAIN_UPDATE, DomainHistory.class);
-    assertThat(historyEntries.size()).isEqualTo(2);
+    assertThat(historyEntries).hasSize(2);
     historyEntries.forEach(
         entry -> {
           assertThat(entry.getRequestedByRegistrar()).isEqualTo(!isAdmin);

--- a/core/src/test/java/google/registry/tools/GenerateAllocationTokensCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateAllocationTokensCommandTest.java
@@ -133,7 +133,7 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
     runCommand("--prefix", "ooo", "--number", "100", "--length", "16");
     // The deterministic string generator makes it too much hassle to assert about each token, so
     // just assert total number.
-    assertThat(loadAllOf(AllocationToken.class).size()).isEqualTo(100);
+    assertThat(loadAllOf(AllocationToken.class)).hasSize(100);
   }
 
   @TestOfyAndSql
@@ -200,7 +200,7 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
     Collection<String> sampleTokens = command.stringGenerator.createStrings(13, 100);
     runCommand("--tokens", Joiner.on(",").join(sampleTokens));
     assertInStdout(Iterables.toArray(sampleTokens, String.class));
-    assertThat(loadAllOf(AllocationToken.class).size()).isEqualTo(100);
+    assertThat(loadAllOf(AllocationToken.class)).hasSize(100);
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/tools/javascrap/CreateSyntheticHistoryEntriesPipelineTest.java
+++ b/core/src/test/java/google/registry/tools/javascrap/CreateSyntheticHistoryEntriesPipelineTest.java
@@ -98,7 +98,7 @@ public class CreateSyntheticHistoryEntriesPipelineTest {
       Class<? extends HistoryEntry> historyClazz, T resource) {
     ImmutableList<? extends HistoryEntry> historyEntries =
         jpaTm().transact(() -> jpaTm().loadAllOf(historyClazz));
-    assertThat(historyEntries.size()).isEqualTo(1);
+    assertThat(historyEntries).hasSize(1);
     HistoryEntry historyEntry = historyEntries.get(0);
     assertThat(historyEntry.getType()).isEqualTo(HistoryEntry.Type.SYNTHETIC);
     assertThat(historyEntry.getRegistrarId()).isEqualTo("NewRegistrar");


### PR DESCRIPTION
There are different ways to verify the size of a list and `hasSize()` is the preferred way because it produces a more meaningful failure message. [Search for Java Readability Snippets in MOMA for more details] 
The purpose of the PR is to replace size comparison assertions in existing size comparison cases with `hasSize()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1588)
<!-- Reviewable:end -->
