### PR TITLE
Replace .get()).isEqualTo() with hasValue()

### DIFF
--- a/core/src/test/java/google/registry/model/tld/RegistryLockDaoTest.java
+++ b/core/src/test/java/google/registry/model/tld/RegistryLockDaoTest.java
@@ -16,6 +16,7 @@ package google.registry.model.tld;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.testing.SqlHelper.getMostRecentRegistryLockByRepoId;
 import static google.registry.testing.SqlHelper.getMostRecentUnlockedRegistryLockByRepoId;
@@ -67,7 +68,7 @@ public final class RegistryLockDaoTest extends EntityTestCase {
             () -> {
               RegistryLock fromDatabase =
                   RegistryLockDao.getByVerificationCode(lock.getVerificationCode()).get();
-              assertThat(fromDatabase.getLockCompletionTime().get()).isEqualTo(fakeClock.nowUtc());
+              assertThat(fromDatabase.getLockCompletionTime()).hasValue(fakeClock.nowUtc());
               assertThat(fromDatabase.getLastUpdateTime()).isEqualTo(fakeClock.nowUtc());
             });
   }
@@ -87,7 +88,7 @@ public final class RegistryLockDaoTest extends EntityTestCase {
     assertThat(fromDatabase.getUnlockRequestTime()).isEqualTo(Optional.of(fakeClock.nowUtc()));
     assertThat(fromDatabase.getUnlockCompletionTime()).isEqualTo(Optional.of(fakeClock.nowUtc()));
     assertThat(fromDatabase.isLocked()).isFalse();
-    assertThat(fromDatabase.getRelockDuration().get()).isEqualTo(Duration.standardHours(6));
+    assertThat(fromDatabase.getRelockDuration()).hasValue(Duration.standardHours(6));
   }
 
   @Test

--- a/core/src/test/java/google/registry/model/tld/RegistryTest.java
+++ b/core/src/test/java/google/registry/model/tld/RegistryTest.java
@@ -261,8 +261,8 @@ public final class RegistryTest extends EntityTestCase {
     Registry registry = Registry.get("tld").asBuilder().setPremiumList(pl2).build();
     Optional<String> pl = registry.getPremiumListName();
     assertThat(pl).hasValue("tld2");
-    PremiumList stored = PremiumListDao.getLatestRevision(pl.get()).get();
-    assertThat(stored.getName()).isEqualTo("tld2");
+    assertThat(PremiumListDao.getLatestRevision("tld2")).isPresent();
+    assertThat(PremiumListDao.getLatestRevision("tld2").get().getName()).isEqualTo("tld2");
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/model/tld/label/PremiumListDaoTest.java
+++ b/core/src/test/java/google/registry/model/tld/label/PremiumListDaoTest.java
@@ -261,7 +261,7 @@ public class PremiumListDaoTest {
     assertThat(PremiumListDao.premiumListCache.getIfPresent("testname")).isNull();
     PremiumListDao.save(testList);
     PremiumList pl = PremiumListDao.getLatestRevision("testname").get();
-    assertThat(PremiumListDao.premiumListCache.getIfPresent("testname").get()).isEqualTo(pl);
+    assertThat(PremiumListDao.premiumListCache.getIfPresent("testname")).hasValue(pl);
     TransactionManagerUtil.transactIfJpaTm(
         () -> PremiumListDao.save("testname", USD, ImmutableList.of("test,USD 1")));
     assertThat(PremiumListDao.premiumListCache.getIfPresent("testname")).isNull();

--- a/core/src/test/java/google/registry/model/tld/label/PremiumListTest.java
+++ b/core/src/test/java/google/registry/model/tld/label/PremiumListTest.java
@@ -16,6 +16,7 @@ package google.registry.model.tld.label;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static com.google.common.truth.Truth8.assertThat;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistPremiumList;
 import static google.registry.testing.DatabaseHelper.persistReservedList;
@@ -100,8 +101,8 @@ public class PremiumListTest {
   @Test
   void testParse_canIncludeOrNotIncludeCurrencyUnit() {
     PremiumListDao.save("tld", USD, ImmutableList.of("rofl,USD 90", "paper, 80"));
-    assertThat(PremiumListDao.getPremiumPrice("tld", "rofl").get()).isEqualTo(Money.of(USD, 90));
-    assertThat(PremiumListDao.getPremiumPrice("tld", "paper").get()).isEqualTo(Money.of(USD, 80));
+    assertThat(PremiumListDao.getPremiumPrice("tld", "rofl")).hasValue(Money.of(USD, 90));
+    assertThat(PremiumListDao.getPremiumPrice("tld", "paper")).hasValue(Money.of(USD, 80));
   }
 
   @Test

--- a/core/src/test/java/google/registry/model/tmch/TmchCrlTest.java
+++ b/core/src/test/java/google/registry/model/tmch/TmchCrlTest.java
@@ -15,9 +15,9 @@
 package google.registry.model.tmch;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 
 import google.registry.model.EntityTestCase;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link TmchCrl}. */
@@ -29,7 +29,7 @@ public class TmchCrlTest extends EntityTestCase {
 
   @Test
   void testSuccess() {
-    assertThat(TmchCrl.get()).isEqualTo(Optional.empty());
+    assertThat(TmchCrl.get()).isEmpty();
     TmchCrl.set("lolcat", "https://lol.cat");
     assertThat(TmchCrl.get().get().getCrl()).isEqualTo("lolcat");
   }

--- a/core/src/test/java/google/registry/ui/forms/FormFieldTest.java
+++ b/core/src/test/java/google/registry/ui/forms/FormFieldTest.java
@@ -51,7 +51,7 @@ class FormFieldTest {
 
   @Test
   void testConvert_emptyString_returnsEmpty() {
-    assertThat(FormField.named("lol").build().convert("").get()).isEmpty();
+    assertThat(FormField.named("lol").build().convert("")).hasValue("");
   }
 
   @Test
@@ -249,7 +249,8 @@ class FormFieldTest {
 
   @Test
   void testAsList_empty_returnsEmpty() {
-    assertThat(FormField.named("lol").asList().build().convert(ImmutableList.of()).get()).isEmpty();
+    assertThat(FormField.named("lol").asList().build().convert(ImmutableList.of()))
+        .hasValue(ImmutableList.of());
   }
 
   @Test
@@ -277,16 +278,16 @@ class FormFieldTest {
   void testAsEnum() {
     FormField<String, ICanHazEnum> omgField =
         FormField.named("omg").asEnum(ICanHazEnum.class).build();
-    assertThat(omgField.convert("LOL").get()).isEqualTo(ICanHazEnum.LOL);
-    assertThat(omgField.convert("CAT").get()).isEqualTo(ICanHazEnum.CAT);
+    assertThat(omgField.convert("LOL")).hasValue(ICanHazEnum.LOL);
+    assertThat(omgField.convert("CAT")).hasValue(ICanHazEnum.CAT);
   }
 
   @Test
   void testAsEnum_lowercase_works() {
     FormField<String, ICanHazEnum> omgField =
         FormField.named("omg").asEnum(ICanHazEnum.class).build();
-    assertThat(omgField.convert("lol").get()).isEqualTo(ICanHazEnum.LOL);
-    assertThat(omgField.convert("cat").get()).isEqualTo(ICanHazEnum.CAT);
+    assertThat(omgField.convert("lol")).hasValue(ICanHazEnum.LOL);
+    assertThat(omgField.convert("cat")).hasValue(ICanHazEnum.CAT);
   }
 
   @Test
@@ -305,8 +306,8 @@ class FormFieldTest {
   void testSplitList() {
     FormField<String, List<String>> field =
         FormField.named("lol").asList(Splitter.on(',').omitEmptyStrings()).build();
-    assertThat(field.convert("oh,my,goth").get()).containsExactly("oh", "my", "goth").inOrder();
-    assertThat(field.convert("").get()).isEmpty();
+    assertThat(field.convert("oh,my,goth")).hasValue(ImmutableList.of("oh", "my", "goth"));
+    assertThat(field.convert("")).hasValue(ImmutableList.of());
     assertThat(field.convert(null)).isEmpty();
   }
 
@@ -314,21 +315,15 @@ class FormFieldTest {
   void testSplitSet() {
     FormField<String, Set<String>> field =
         FormField.named("lol").uppercased().asSet(Splitter.on(',').omitEmptyStrings()).build();
-    assertThat(field.convert("oh,my,goth").get()).containsExactly("OH", "MY", "GOTH").inOrder();
-    assertThat(field.convert("").get()).isEmpty();
+    assertThat(field.convert("oh,my,goth")).hasValue(ImmutableSet.of("OH", "MY", "GOTH"));
+    assertThat(field.convert("")).hasValue(ImmutableSet.of());
     assertThat(field.convert(null)).isEmpty();
   }
 
   @Test
   void testAsList() {
-    assertThat(
-            FormField.named("lol")
-                .asList()
-                .build()
-                .convert(ImmutableList.of("lol", "cat", ""))
-                .get())
-        .containsExactly("lol", "cat", "")
-        .inOrder();
+    assertThat(FormField.named("lol").asList().build().convert(ImmutableList.of("lol", "cat", "")))
+        .hasValue(ImmutableList.of("lol", "cat", ""));
   }
 
   @Test
@@ -341,10 +336,8 @@ class FormFieldTest {
                 .asList()
                 .range(closed(1, 2))
                 .build()
-                .convert(ImmutableList.of("lol\n", "\tcat "))
-                .get())
-        .containsExactly("lol", "cat")
-        .inOrder();
+                .convert(ImmutableList.of("lol\n", "\tcat ")))
+        .hasValue(ImmutableList.of("lol", "cat"));
   }
 
   @Test
@@ -354,9 +347,8 @@ class FormFieldTest {
                 .emptyToNull()
                 .asList()
                 .build()
-                .convert(ImmutableList.of("omg", ""))
-                .get())
-        .containsExactly("omg");
+                .convert(ImmutableList.of("omg", "")))
+        .hasValue(ImmutableList.of("omg"));
   }
 
   @Test
@@ -420,25 +412,20 @@ class FormFieldTest {
                 .build()
                 .convert(
                     Lists.cartesianProduct(
-                        ImmutableList.of(ImmutableList.of(1, 2), ImmutableList.of(3, 4))))
-                .get())
-        .containsExactly(
-            ImmutableList.of(2, 6),
-            ImmutableList.of(2, 8),
-            ImmutableList.of(4, 6),
-            ImmutableList.of(4, 8))
-        .inOrder();
+                        ImmutableList.of(ImmutableList.of(1, 2), ImmutableList.of(3, 4)))))
+        .hasValue(
+            ImmutableList.of(
+                ImmutableList.of(2, 6),
+                ImmutableList.of(2, 8),
+                ImmutableList.of(4, 6),
+                ImmutableList.of(4, 8)));
   }
 
   @Test
   void testAsSet() {
     assertThat(
-            FormField.named("lol")
-                .asSet()
-                .build()
-                .convert(ImmutableList.of("lol", "cat", "cat"))
-                .get())
-        .containsExactly("lol", "cat");
+            FormField.named("lol").asSet().build().convert(ImmutableList.of("lol", "cat", "cat")))
+        .hasValue(ImmutableSet.of("lol", "cat"));
   }
 
   @Test

--- a/core/src/test/java/google/registry/ui/forms/FormFieldTest.java
+++ b/core/src/test/java/google/registry/ui/forms/FormFieldTest.java
@@ -441,7 +441,7 @@ class FormFieldTest {
                 .get())
         .containsExactly("lol", "cat");
   }
-  
+
   @Test
   void testTrimmed() {
     assertThat(FormField.named("lol").trimmed().build().convert(" \thello \t\n")).hasValue("hello");

--- a/core/src/test/java/google/registry/ui/forms/FormFieldTest.java
+++ b/core/src/test/java/google/registry/ui/forms/FormFieldTest.java
@@ -306,8 +306,8 @@ class FormFieldTest {
   void testSplitList() {
     FormField<String, List<String>> field =
         FormField.named("lol").asList(Splitter.on(',').omitEmptyStrings()).build();
-    assertThat(field.convert("oh,my,goth")).hasValue(ImmutableList.of("oh", "my", "goth"));
-    assertThat(field.convert("")).hasValue(ImmutableList.of());
+    assertThat(field.convert("oh,my,goth").get()).containsExactly("oh", "my", "goth").inOrder();
+    assertThat(field.convert("").get()).isEmpty();
     assertThat(field.convert(null)).isEmpty();
   }
 
@@ -315,15 +315,21 @@ class FormFieldTest {
   void testSplitSet() {
     FormField<String, Set<String>> field =
         FormField.named("lol").uppercased().asSet(Splitter.on(',').omitEmptyStrings()).build();
-    assertThat(field.convert("oh,my,goth")).hasValue(ImmutableSet.of("OH", "MY", "GOTH"));
-    assertThat(field.convert("")).hasValue(ImmutableSet.of());
+    assertThat(field.convert("oh,my,goth").get()).containsExactly("OH", "MY", "GOTH").inOrder();
+    assertThat(field.convert("").get()).isEmpty();
     assertThat(field.convert(null)).isEmpty();
   }
 
   @Test
   void testAsList() {
-    assertThat(FormField.named("lol").asList().build().convert(ImmutableList.of("lol", "cat", "")))
-        .hasValue(ImmutableList.of("lol", "cat", ""));
+    assertThat(
+            FormField.named("lol")
+                .asList()
+                .build()
+                .convert(ImmutableList.of("lol", "cat", ""))
+                .get())
+        .containsExactly("lol", "cat", "")
+        .inOrder();
   }
 
   @Test
@@ -336,8 +342,10 @@ class FormFieldTest {
                 .asList()
                 .range(closed(1, 2))
                 .build()
-                .convert(ImmutableList.of("lol\n", "\tcat ")))
-        .hasValue(ImmutableList.of("lol", "cat"));
+                .convert(ImmutableList.of("lol\n", "\tcat "))
+                .get())
+        .containsExactly("lol", "cat")
+        .inOrder();
   }
 
   @Test
@@ -347,8 +355,9 @@ class FormFieldTest {
                 .emptyToNull()
                 .asList()
                 .build()
-                .convert(ImmutableList.of("omg", "")))
-        .hasValue(ImmutableList.of("omg"));
+                .convert(ImmutableList.of("omg", ""))
+                .get())
+        .containsExactly("omg");
   }
 
   @Test
@@ -412,22 +421,27 @@ class FormFieldTest {
                 .build()
                 .convert(
                     Lists.cartesianProduct(
-                        ImmutableList.of(ImmutableList.of(1, 2), ImmutableList.of(3, 4)))))
-        .hasValue(
-            ImmutableList.of(
-                ImmutableList.of(2, 6),
-                ImmutableList.of(2, 8),
-                ImmutableList.of(4, 6),
-                ImmutableList.of(4, 8)));
+                        ImmutableList.of(ImmutableList.of(1, 2), ImmutableList.of(3, 4))))
+                .get())
+        .containsExactly(
+            ImmutableList.of(2, 6),
+            ImmutableList.of(2, 8),
+            ImmutableList.of(4, 6),
+            ImmutableList.of(4, 8))
+        .inOrder();
   }
 
   @Test
   void testAsSet() {
     assertThat(
-            FormField.named("lol").asSet().build().convert(ImmutableList.of("lol", "cat", "cat")))
-        .hasValue(ImmutableSet.of("lol", "cat"));
+            FormField.named("lol")
+                .asSet()
+                .build()
+                .convert(ImmutableList.of("lol", "cat", "cat"))
+                .get())
+        .containsExactly("lol", "cat");
   }
-
+  
   @Test
   void testTrimmed() {
     assertThat(FormField.named("lol").trimmed().build().convert(" \thello \t\n")).hasValue("hello");


### PR DESCRIPTION
When verifying the value in `Optional<?>` variables, the most intuitive way seems to be using `get()` to get the value then comparing the value by calling `isEqualTo()`. However, this way is not preferred way since manually calling `get()`returns a worse error message and might potentially throw `NullPointerException`. We can use `hasValue()` from `Truth8.assertThat` for value comparison.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1589)
<!-- Reviewable:end -->
