### PR TITLE
Begin migration from Guava Cache to Caffeine

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -172,6 +172,7 @@ dependencies {
   testRuntime files(sourceSets.test.resources.srcDirs)
 
   compile deps['com.beust:jcommander']
+  compile deps['com.github.ben-manes.caffeine:caffeine']
   compile deps['com.google.api:gax']
   compile deps['com.google.api.grpc:proto-google-cloud-datastore-v1']
   compile deps['com.google.api.grpc:proto-google-common-protos']

--- a/core/gradle/dependency-locks/compile.lockfile
+++ b/core/gradle/dependency-locks/compile.lockfile
@@ -13,6 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -118,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -243,7 +244,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/compileClasspath.lockfile
+++ b/core/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,6 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7

--- a/core/gradle/dependency-locks/default.lockfile
+++ b/core/gradle/dependency-locks/default.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +254,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/deploy_jar.lockfile
+++ b/core/gradle/dependency-locks/deploy_jar.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/nonprodCompile.lockfile
+++ b/core/gradle/dependency-locks/nonprodCompile.lockfile
@@ -13,6 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -118,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -243,7 +244,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/nonprodCompileClasspath.lockfile
+++ b/core/gradle/dependency-locks/nonprodCompileClasspath.lockfile
@@ -13,6 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -117,7 +118,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -236,7 +237,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/core/gradle/dependency-locks/nonprodRuntime.lockfile
+++ b/core/gradle/dependency-locks/nonprodRuntime.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -122,7 +123,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/nonprodRuntimeClasspath.lockfile
+++ b/core/gradle/dependency-locks/nonprodRuntimeClasspath.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -122,7 +123,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/runtime.lockfile
+++ b/core/gradle/dependency-locks/runtime.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -122,7 +123,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/core/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7

--- a/core/gradle/dependency-locks/testCompile.lockfile
+++ b/core/gradle/dependency-locks/testCompile.lockfile
@@ -13,6 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -120,7 +121,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -264,7 +265,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/core/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,6 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -119,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -257,7 +258,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/core/gradle/dependency-locks/testRuntime.lockfile
+++ b/core/gradle/dependency-locks/testRuntime.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -125,7 +126,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -274,7 +275,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/core/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -125,7 +126,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -274,7 +275,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -1438,8 +1438,8 @@ public final class RegistryConfig {
   }
 
   /** Returns the amount of time a singleton should be cached, before expiring. */
-  public static Duration getSingletonCacheRefreshDuration() {
-    return Duration.standardSeconds(CONFIG_SETTINGS.get().caching.singletonCacheRefreshSeconds);
+  public static java.time.Duration getSingletonCacheRefreshDuration() {
+    return java.time.Duration.ofSeconds(CONFIG_SETTINGS.get().caching.singletonCacheRefreshSeconds);
   }
 
   /**

--- a/core/src/main/java/google/registry/model/tld/Registry.java
+++ b/core/src/main/java/google/registry/model/tld/Registry.java
@@ -264,8 +264,7 @@ public class Registry extends ImmutableObject
   /** A cache that loads the {@link Registry} for a given tld. */
   private static final LoadingCache<String, Optional<Registry>> CACHE =
       CacheBuilder.newBuilder()
-          .expireAfterWrite(
-              java.time.Duration.ofMillis(getSingletonCacheRefreshDuration().getMillis()))
+          .expireAfterWrite(getSingletonCacheRefreshDuration())
           .build(
               new CacheLoader<String, Optional<Registry>>() {
                 @Override

--- a/core/src/main/java/google/registry/tmch/TmchCertificateAuthority.java
+++ b/core/src/main/java/google/registry/tmch/TmchCertificateAuthority.java
@@ -17,11 +17,11 @@ package google.registry.tmch;
 import static google.registry.config.RegistryConfig.ConfigModule.TmchCaMode.PILOT;
 import static google.registry.config.RegistryConfig.ConfigModule.TmchCaMode.PRODUCTION;
 import static google.registry.config.RegistryConfig.getSingletonCacheRefreshDuration;
+import static google.registry.model.CacheUtils.newCacheBuilder;
 import static google.registry.util.ResourceUtils.readResourceUtf8;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.config.RegistryConfig.ConfigModule.TmchCaMode;
@@ -76,9 +76,7 @@ public final class TmchCertificateAuthority {
    * persist the correct one for this given environment.
    */
   private static final LoadingCache<TmchCaMode, X509CRL> CRL_CACHE =
-      CacheBuilder.newBuilder()
-          .expireAfterWrite(
-              java.time.Duration.ofMillis(getSingletonCacheRefreshDuration().getMillis()))
+      newCacheBuilder(getSingletonCacheRefreshDuration())
           .build(
               new CacheLoader<TmchCaMode, X509CRL>() {
                 @Override

--- a/core/src/test/java/google/registry/flows/host/HostInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostInfoFlowTest.java
@@ -54,13 +54,10 @@ class HostInfoFlowTest extends ResourceFlowTestCase<HostInfoFlow, HostResource> 
   @RegisterExtension
   final ReplayExtension replayExtension = ReplayExtension.createWithDoubleReplay(clock);
 
-  HostInfoFlowTest() {
-    setEppInput("host_info.xml", ImmutableMap.of("HOSTNAME", "ns1.example.tld"));
-  }
-
   @BeforeEach
   void initHostTest() {
     createTld("foobar");
+    setEppInput("host_info.xml", ImmutableMap.of("HOSTNAME", "ns1.example.tld"));
   }
 
   private HostResource persistHostResource() throws Exception {

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -18,6 +18,7 @@ ext {
     dependencyList = [
       'args4j:args4j:2.0.26',
       'com.beust:jcommander:1.60',
+      'com.github.ben-manes.caffeine:caffeine:3.0.6',
       'com.google.api:gax:1.66.0',
       'com.google.api.grpc:proto-google-cloud-secretmanager-v1:1.4.0',
       // The two below are needed only for Datastore bulk delete pipeline.

--- a/docs/gradle/dependency-locks/compile.lockfile
+++ b/docs/gradle/dependency-locks/compile.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +254,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/docs/gradle/dependency-locks/compileClasspath.lockfile
+++ b/docs/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,6 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -117,7 +118,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -240,7 +241,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/docs/gradle/dependency-locks/default.lockfile
+++ b/docs/gradle/dependency-locks/default.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +254,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/docs/gradle/dependency-locks/deploy_jar.lockfile
+++ b/docs/gradle/dependency-locks/deploy_jar.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/docs/gradle/dependency-locks/runtime.lockfile
+++ b/docs/gradle/dependency-locks/runtime.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +254,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/docs/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/docs/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/docs/gradle/dependency-locks/testCompile.lockfile
+++ b/docs/gradle/dependency-locks/testCompile.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -256,7 +257,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/docs/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/docs/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,6 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -117,7 +118,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -244,7 +245,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/docs/gradle/dependency-locks/testRuntime.lockfile
+++ b/docs/gradle/dependency-locks/testRuntime.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -256,7 +257,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/docs/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/docs/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -256,7 +257,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/backend/gradle/dependency-locks/compile.lockfile
+++ b/services/backend/gradle/dependency-locks/compile.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/services/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,6 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -118,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -241,7 +242,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/services/backend/gradle/dependency-locks/default.lockfile
+++ b/services/backend/gradle/dependency-locks/default.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/backend/gradle/dependency-locks/runtime.lockfile
+++ b/services/backend/gradle/dependency-locks/runtime.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/services/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/backend/gradle/dependency-locks/testCompile.lockfile
+++ b/services/backend/gradle/dependency-locks/testCompile.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/backend/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/services/backend/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,6 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -118,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -241,7 +242,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/services/backend/gradle/dependency-locks/testRuntime.lockfile
+++ b/services/backend/gradle/dependency-locks/testRuntime.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/backend/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/services/backend/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/default/gradle/dependency-locks/compile.lockfile
+++ b/services/default/gradle/dependency-locks/compile.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/default/gradle/dependency-locks/compileClasspath.lockfile
+++ b/services/default/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,6 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -118,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -241,7 +242,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/services/default/gradle/dependency-locks/default.lockfile
+++ b/services/default/gradle/dependency-locks/default.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/default/gradle/dependency-locks/runtime.lockfile
+++ b/services/default/gradle/dependency-locks/runtime.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/default/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/services/default/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/default/gradle/dependency-locks/testCompile.lockfile
+++ b/services/default/gradle/dependency-locks/testCompile.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/default/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/services/default/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,6 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -118,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -241,7 +242,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/services/default/gradle/dependency-locks/testRuntime.lockfile
+++ b/services/default/gradle/dependency-locks/testRuntime.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/default/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/services/default/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/pubapi/gradle/dependency-locks/compile.lockfile
+++ b/services/pubapi/gradle/dependency-locks/compile.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/pubapi/gradle/dependency-locks/compileClasspath.lockfile
+++ b/services/pubapi/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,6 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -118,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -241,7 +242,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/services/pubapi/gradle/dependency-locks/default.lockfile
+++ b/services/pubapi/gradle/dependency-locks/default.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/pubapi/gradle/dependency-locks/runtime.lockfile
+++ b/services/pubapi/gradle/dependency-locks/runtime.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/pubapi/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/services/pubapi/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/pubapi/gradle/dependency-locks/testCompile.lockfile
+++ b/services/pubapi/gradle/dependency-locks/testCompile.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/pubapi/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/services/pubapi/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,6 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -118,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -241,7 +242,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/services/pubapi/gradle/dependency-locks/testRuntime.lockfile
+++ b/services/pubapi/gradle/dependency-locks/testRuntime.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/pubapi/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/services/pubapi/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/tools/gradle/dependency-locks/compile.lockfile
+++ b/services/tools/gradle/dependency-locks/compile.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/tools/gradle/dependency-locks/compileClasspath.lockfile
+++ b/services/tools/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,6 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -118,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -241,7 +242,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/services/tools/gradle/dependency-locks/default.lockfile
+++ b/services/tools/gradle/dependency-locks/default.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/tools/gradle/dependency-locks/runtime.lockfile
+++ b/services/tools/gradle/dependency-locks/runtime.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/tools/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/services/tools/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/tools/gradle/dependency-locks/testCompile.lockfile
+++ b/services/tools/gradle/dependency-locks/testCompile.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/tools/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/services/tools/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,6 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -118,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -241,7 +242,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/services/tools/gradle/dependency-locks/testRuntime.lockfile
+++ b/services/tools/gradle/dependency-locks/testRuntime.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/tools/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/services/tools/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -17,6 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
+com.github.ben-manes.caffeine:caffeine:3.0.6
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.10.0
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -252,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.0
+org.checkerframework:checker-qual:3.21.3
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20


### PR DESCRIPTION
Caffeine is apparently strictly superior to the older Guava Cache (and is even
recommended in lieu of Guava Cache on Guava Cache's own documentation).

This adds the relevant dependencies and switch over just a single call site to
use the new Caffeine cache. It also implements a new pattern, asynchronously
refreshing the cache value starting from half of our configuration time. For
frequently accessed entities this will allow us to NEVER block on a load, as it
will be asynchronously refreshed in the background long before it ever expires
synchronously during a read operation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1590)
<!-- Reviewable:end -->
