### PR TITLE
Add renewal support for AT and internal registrations in DomainCreateFlow

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -14,6 +14,8 @@
 
 package google.registry.flows.domain;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static google.registry.flows.FlowUtils.persistEntityChanges;
 import static google.registry.flows.FlowUtils.validateRegistrarIsLoggedIn;
@@ -53,6 +55,7 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.DateTimeUtils.leapSafeAddYears;
 
+import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.InternetDomainName;
@@ -79,6 +82,7 @@ import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Flag;
 import google.registry.model.billing.BillingEvent.Reason;
 import google.registry.model.billing.BillingEvent.Recurring;
+import google.registry.model.billing.BillingEvent.RenewalPriceBehavior;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.domain.DomainCommand;
 import google.registry.model.domain.DomainCommand.Create;
@@ -114,7 +118,9 @@ import google.registry.model.tld.Registry.TldType;
 import google.registry.model.tld.label.ReservationType;
 import google.registry.tmch.LordnTaskUtils;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
+import org.joda.money.Money;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
@@ -302,6 +308,8 @@ public final class DomainCreateFlow implements TransactionalFlow {
     FeesAndCredits feesAndCredits =
         pricingLogic.getCreatePrice(
             registry, targetId, now, years, isAnchorTenant, allocationToken);
+    RenewalPriceInfo renewalPriceInfo =
+        getRenewalPriceInfo(isAnchorTenant, allocationToken, feesAndCredits.getCreateCost());
     validateFeeChallenge(targetId, now, feeCreate, feesAndCredits);
     Optional<SecDnsCreateExtension> secDnsCreate =
         validateSecDnsExtension(eppInput.getSingleExtension(SecDnsCreateExtension.class));
@@ -324,7 +332,7 @@ public final class DomainCreateFlow implements TransactionalFlow {
             now);
     // Create a new autorenew billing event and poll message starting at the expiration time.
     BillingEvent.Recurring autorenewBillingEvent =
-        createAutorenewBillingEvent(domainHistoryKey, registrationExpirationTime);
+        createAutorenewBillingEvent(domainHistoryKey, registrationExpirationTime, renewalPriceInfo);
     PollMessage.Autorenew autorenewPollMessage =
         createAutorenewPollMessage(domainHistoryKey, registrationExpirationTime);
     ImmutableSet.Builder<ImmutableObject> entitiesToSave = new ImmutableSet.Builder<>();
@@ -477,6 +485,7 @@ public final class DomainCreateFlow implements TransactionalFlow {
   private Optional<AllocationToken> verifyAllocationTokenIfPresent(
       DomainCommand.Create command, Registry registry, String registrarId, DateTime now)
       throws EppException {
+
     Optional<AllocationTokenExtension> extension =
         eppInput.getSingleExtension(AllocationTokenExtension.class);
     return Optional.ofNullable(
@@ -543,7 +552,9 @@ public final class DomainCreateFlow implements TransactionalFlow {
   }
 
   private Recurring createAutorenewBillingEvent(
-      Key<DomainHistory> domainHistoryKey, DateTime registrationExpirationTime) {
+      Key<DomainHistory> domainHistoryKey,
+      DateTime registrationExpirationTime,
+      RenewalPriceInfo renewalpriceInfo) {
     return new BillingEvent.Recurring.Builder()
         .setReason(Reason.RENEW)
         .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
@@ -552,6 +563,8 @@ public final class DomainCreateFlow implements TransactionalFlow {
         .setEventTime(registrationExpirationTime)
         .setRecurrenceEndTime(END_OF_TIME)
         .setParent(domainHistoryKey)
+        .setRenewalPriceBehavior(renewalpriceInfo.renewalPriceBehavior())
+        .setRenewalPrice(renewalpriceInfo.renewalPrice())
         .build();
   }
 
@@ -606,6 +619,46 @@ public final class DomainCreateFlow implements TransactionalFlow {
     if (hasClaimsNotice || hasSignedMarks) {
       LordnTaskUtils.enqueueDomainBaseTask(newDomain);
     }
+  }
+
+  /**
+   * Determines the {@link RenewalPriceBehavior} and the renewal price that needs be stored in the
+   * {@link Recurring} billing events.
+   *
+   * <p>By default, renewal price is calculated during the process of renewal. Renewal price should
+   * be the createCost if and only if the renewal price behavior in the {@link AllocationToken} is
+   * 'SPECIFIED'.
+   */
+  static RenewalPriceInfo getRenewalPriceInfo(
+      Boolean isAnchorTenant, Optional<AllocationToken> allocationToken, Money createCost) {
+    checkNotNull(createCost, "Create cost cannot be null");
+    if (isAnchorTenant) {
+      if (allocationToken.isPresent()) {
+        checkArgument(
+            allocationToken.get().getRenewalPriceBehavior() != RenewalPriceBehavior.SPECIFIED,
+            "Renewal price behavior cannot be SPECIFIED for anchor tenant");
+      }
+      return RenewalPriceInfo.create(RenewalPriceBehavior.NONPREMIUM, null);
+    } else if (allocationToken.isPresent()
+        && allocationToken.get().getRenewalPriceBehavior() == RenewalPriceBehavior.SPECIFIED) {
+      return RenewalPriceInfo.create(RenewalPriceBehavior.SPECIFIED, createCost);
+    } else {
+      return RenewalPriceInfo.create(RenewalPriceBehavior.DEFAULT, null);
+    }
+  }
+
+  /** A class to store renewal info used in {@link Recurring} billing events. */
+  @AutoValue
+  public abstract static class RenewalPriceInfo {
+    static DomainCreateFlow.RenewalPriceInfo create(
+        RenewalPriceBehavior renewalPriceBehavior, @Nullable Money renewalPrice) {
+      return new AutoValue_DomainCreateFlow_RenewalPriceInfo(renewalPriceBehavior, renewalPrice);
+    }
+
+    public abstract RenewalPriceBehavior renewalPriceBehavior();
+
+    @Nullable
+    public abstract Money renewalPrice();
   }
 
   private static ImmutableList<FeeTransformResponseExtension> createResponseExtensions(

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -82,6 +82,7 @@ import google.registry.flows.ResourceFlowTestCase;
 import google.registry.flows.domain.DomainCreateFlow.AnchorTenantCreatePeriodException;
 import google.registry.flows.domain.DomainCreateFlow.MustHaveSignedMarksInCurrentPhaseException;
 import google.registry.flows.domain.DomainCreateFlow.NoGeneralRegistrationsInCurrentPhaseException;
+import google.registry.flows.domain.DomainCreateFlow.RenewalPriceInfo;
 import google.registry.flows.domain.DomainCreateFlow.SignedMarksOnlyDuringSunriseException;
 import google.registry.flows.domain.DomainFlowTmchUtils.FoundMarkExpiredException;
 import google.registry.flows.domain.DomainFlowTmchUtils.FoundMarkNotYetValidException;
@@ -147,6 +148,7 @@ import google.registry.flows.exceptions.ResourceCreateContentionException;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Flag;
 import google.registry.model.billing.BillingEvent.Reason;
+import google.registry.model.billing.BillingEvent.RenewalPriceBehavior;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.GracePeriod;
@@ -175,7 +177,7 @@ import google.registry.testing.TestOfyAndSql;
 import google.registry.testing.TestOfyOnly;
 import java.math.BigDecimal;
 import java.util.Map;
-import javax.annotation.Nullable;
+import java.util.Optional;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
@@ -244,14 +246,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   }
 
   private void assertSuccessfulCreate(
-      String domainTld, ImmutableSet<BillingEvent.Flag> expectedBillingFlags) throws Exception {
-    assertSuccessfulCreate(domainTld, expectedBillingFlags, null);
-  }
-
-  private void assertSuccessfulCreate(
       String domainTld,
       ImmutableSet<BillingEvent.Flag> expectedBillingFlags,
-      @Nullable AllocationToken allocationToken)
+      Optional<AllocationToken> allocationToken)
       throws Exception {
     DomainBase domain = reloadResourceByForeignKey();
 
@@ -282,6 +279,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         .hasType(HistoryEntry.Type.DOMAIN_CREATE)
         .and()
         .hasPeriodYears(2);
+    RenewalPriceInfo renewalPriceInfo =
+        DomainCreateFlow.getRenewalPriceInfo(isAnchorTenant, allocationToken, creationCost);
     // There should be one bill for the create and one for the recurring autorenew event.
     BillingEvent.OneTime createBillingEvent =
         new BillingEvent.OneTime.Builder()
@@ -294,7 +293,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setBillingTime(billingTime)
             .setFlags(expectedBillingFlags)
             .setParent(historyEntry)
-            .setAllocationToken(allocationToken == null ? null : allocationToken.createVKey())
+            .setAllocationToken(
+                allocationToken.isPresent() ? allocationToken.get().createVKey() : null)
             .build();
 
     BillingEvent.Recurring renewBillingEvent =
@@ -306,6 +306,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setEventTime(domain.getRegistrationExpirationTime())
             .setRecurrenceEndTime(END_OF_TIME)
             .setParent(historyEntry)
+            .setRenewalPriceBehavior(renewalPriceInfo.renewalPriceBehavior())
+            .setRenewalPrice(renewalPriceInfo.renewalPrice())
             .build();
 
     ImmutableSet.Builder<BillingEvent> expectedBillingEvents =
@@ -406,7 +408,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     assertTransactionalFlow(true);
     runFlowAssertResponse(
         CommitMode.LIVE, userPrivileges, loadFile(responseXmlFile, substitutions));
-    assertSuccessfulCreate(domainTld, ImmutableSet.of());
+    assertSuccessfulCreate(domainTld, ImmutableSet.of(), Optional.empty());
     assertNoLordn();
   }
 
@@ -544,10 +546,14 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistContactsAndHosts();
     AllocationToken token =
         persistResource(
-            new AllocationToken.Builder().setToken("abc123").setTokenType(SINGLE_USE).build());
+            new AllocationToken.Builder()
+                .setToken("abc123")
+                .setTokenType(SINGLE_USE)
+                .setRenewalPriceBehavior(RenewalPriceBehavior.DEFAULT)
+                .build());
     clock.advanceOneMilli();
     runFlow();
-    assertSuccessfulCreate("tld", ImmutableSet.of(), token);
+    assertSuccessfulCreate("tld", ImmutableSet.of(), Optional.of(token));
     HistoryEntry historyEntry = getHistoryEntries(reloadResourceByForeignKey()).get(0);
     assertThat(transactIfJpaTm(() -> tm().loadByEntity(token)).getRedemptionHistoryEntry())
         .hasValue(HistoryEntry.createVKey(Key.create(historyEntry)));
@@ -574,7 +580,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 .build());
     clock.advanceOneMilli();
     runFlow();
-    assertSuccessfulCreate("tld", ImmutableSet.of(), allocationToken);
+    assertSuccessfulCreate("tld", ImmutableSet.of(), Optional.of(allocationToken));
     clock.advanceOneMilli();
     setEppInput(
         "domain_create_allocationtoken.xml",
@@ -593,7 +599,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     String expectedResponseXml =
         loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "example.foo.tld"));
     runFlowAssertResponse(CommitMode.LIVE, UserPrivileges.NORMAL, expectedResponseXml);
-    assertSuccessfulCreate("foo.tld", ImmutableSet.of());
+    assertSuccessfulCreate("foo.tld", ImmutableSet.of(), Optional.empty());
     assertNoLordn();
   }
 
@@ -884,7 +890,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     setEppInput("domain_create_idn_minna.xml");
     persistContactsAndHosts("net");
     runFlowAssertResponse(loadFile("domain_create_response_idn_minna.xml"));
-    assertSuccessfulCreate("xn--q9jyb4c", ImmutableSet.of());
+    assertSuccessfulCreate("xn--q9jyb4c", ImmutableSet.of(), Optional.empty());
     assertDnsTasksEnqueued("xn--abc-873b2e7eb1k8a4lpjvv.xn--q9jyb4c");
   }
 
@@ -924,7 +930,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     setEppInput("domain_create_claim_notice.xml");
     persistContactsAndHosts();
     runFlowAssertResponse(loadFile("domain_create_response_claims.xml"));
-    assertSuccessfulCreate("tld", ImmutableSet.of());
+    assertSuccessfulCreate("tld", ImmutableSet.of(), Optional.empty());
     assertDnsTasksEnqueued("example-one.tld");
     assertClaimsLordn();
   }
@@ -953,7 +959,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     setEppInput("domain_create_allocationtoken_claims.xml");
     persistContactsAndHosts();
     runFlowAssertResponse(loadFile("domain_create_response_claims.xml"));
-    assertSuccessfulCreate("tld", ImmutableSet.of(RESERVED), allocationToken);
+    assertSuccessfulCreate("tld", ImmutableSet.of(RESERVED), Optional.of(allocationToken));
     assertDnsTasksEnqueued("example-one.tld");
     assertClaimsLordn();
     assertAllocationTokenWasRedeemed("abcDEF23456");
@@ -966,7 +972,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(Registry.get("tld").asBuilder().setClaimsPeriodEnd(clock.nowUtc()).build());
     runFlowAssertResponse(
         loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "example.tld")));
-    assertSuccessfulCreate("tld", ImmutableSet.of());
+    assertSuccessfulCreate("tld", ImmutableSet.of(), Optional.empty());
     assertDnsTasksEnqueued("example.tld");
   }
 
@@ -1152,9 +1158,31 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     setEppInput("domain_create_anchor_allocationtoken.xml");
     persistContactsAndHosts();
     runFlowAssertResponse(loadFile("domain_create_anchor_response.xml"));
-    assertSuccessfulCreate("tld", ImmutableSet.of(ANCHOR_TENANT), allocationToken);
+    assertSuccessfulCreate("tld", ImmutableSet.of(ANCHOR_TENANT), Optional.of(allocationToken));
     assertNoLordn();
     assertAllocationTokenWasRedeemed("abcDEF23456");
+  }
+
+  @TestOfyAndSql
+  void testSuccess_internalRegistrationWithSpecifiedRenewalPrice() throws Exception {
+    allocationToken =
+        persistResource(
+            new AllocationToken.Builder()
+                .setToken("abc123")
+                .setTokenType(SINGLE_USE)
+                .setDomainName("resdom.tld")
+                .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
+                .build());
+    // Despite the domain being FULLY_BLOCKED, the non-superuser create succeeds the domain is also
+    // RESERVED_FOR_SPECIFIC_USE and the correct allocation token is passed.
+    setEppInput(
+        "domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "resdom.tld", "YEARS", "2"));
+    persistContactsAndHosts();
+    runFlowAssertResponse(
+        loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "resdom.tld")));
+    assertSuccessfulCreate("tld", ImmutableSet.of(RESERVED), Optional.of(allocationToken));
+    assertNoLordn();
+    assertAllocationTokenWasRedeemed("abc123");
   }
 
   @TestOfyAndSql
@@ -1172,7 +1200,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     setEppInput("domain_create_anchor_allocationtoken.xml");
     persistContactsAndHosts();
     runFlowAssertResponse(loadFile("domain_create_anchor_response.xml"));
-    assertSuccessfulCreate("tld", ImmutableSet.of(ANCHOR_TENANT), allocationToken);
+    assertSuccessfulCreate("tld", ImmutableSet.of(ANCHOR_TENANT), Optional.of(allocationToken));
     assertNoLordn();
     assertAllocationTokenWasRedeemed("abcDEF23456");
   }
@@ -1195,7 +1223,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     clock.setTo(DateTime.parse("2009-08-16T09:00:00.0Z"));
     persistContactsAndHosts();
     runFlowAssertResponse(loadFile("domain_create_response_claims.xml"));
-    assertSuccessfulCreate("tld", ImmutableSet.of(ANCHOR_TENANT), allocationToken);
+    assertSuccessfulCreate("tld", ImmutableSet.of(ANCHOR_TENANT), Optional.of(allocationToken));
     assertDnsTasksEnqueued("example-one.tld");
     assertClaimsLordn();
     assertAllocationTokenWasRedeemed("abcDEF23456");
@@ -1208,7 +1236,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistContactsAndHosts();
     runFlowAssertResponse(
         loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "example.tld")));
-    assertSuccessfulCreate("tld", ImmutableSet.of(ANCHOR_TENANT));
+    assertSuccessfulCreate("tld", ImmutableSet.of(ANCHOR_TENANT), Optional.empty());
     assertNoLordn();
   }
 
@@ -1220,7 +1248,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistContactsAndHosts();
     runFlowAssertResponse(
         loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "example.tld")));
-    assertSuccessfulCreate("tld", ImmutableSet.of(ANCHOR_TENANT));
+    assertSuccessfulCreate("tld", ImmutableSet.of(ANCHOR_TENANT), Optional.empty());
     assertNoLordn();
   }
 
@@ -1247,7 +1275,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         loadFile(
             "domain_create_response_encoded_signed_mark_name.xml",
             ImmutableMap.of("DOMAIN", "test-validate.tld")));
-    assertSuccessfulCreate("tld", ImmutableSet.of(ANCHOR_TENANT, SUNRISE), allocationToken);
+    assertSuccessfulCreate(
+        "tld", ImmutableSet.of(ANCHOR_TENANT, SUNRISE), Optional.of(allocationToken));
     assertDnsTasksEnqueued("test-validate.tld");
     assertSunriseLordn("test-validate.tld");
     assertAllocationTokenWasRedeemed("abcDEF23456");
@@ -1270,7 +1299,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     setEppInput("domain_create_anchor_allocationtoken.xml");
     persistContactsAndHosts();
     runFlowAssertResponse(loadFile("domain_create_anchor_response.xml"));
-    assertSuccessfulCreate("tld", ImmutableSet.of(ANCHOR_TENANT), allocationToken);
+    assertSuccessfulCreate("tld", ImmutableSet.of(ANCHOR_TENANT), Optional.of(allocationToken));
     assertNoLordn();
     assertAllocationTokenWasRedeemed("abcDEF23456");
   }
@@ -1291,7 +1320,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistContactsAndHosts();
     runFlowAssertResponse(
         loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "resdom.tld")));
-    assertSuccessfulCreate("tld", ImmutableSet.of(RESERVED), allocationToken);
+    assertSuccessfulCreate("tld", ImmutableSet.of(RESERVED), Optional.of(allocationToken));
     assertNoLordn();
     assertAllocationTokenWasRedeemed("abc123");
   }
@@ -1315,7 +1344,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistContactsAndHosts();
     runFlowAssertResponse(
         loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "resdom.tld")));
-    assertSuccessfulCreate("tld", ImmutableSet.of(RESERVED), allocationToken);
+    assertSuccessfulCreate("tld", ImmutableSet.of(RESERVED), Optional.of(allocationToken));
     assertNoLordn();
     assertAllocationTokenWasRedeemed("abc123");
   }
@@ -1585,7 +1614,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistContactsAndHosts();
     runFlowAssertResponse(
         CommitMode.LIVE, SUPERUSER, loadFile("domain_create_reserved_response.xml"));
-    assertSuccessfulCreate("tld", ImmutableSet.of(RESERVED));
+    assertSuccessfulCreate("tld", ImmutableSet.of(RESERVED), Optional.empty());
   }
 
   @TestOfyAndSql
@@ -1774,7 +1803,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         loadFile(
             "domain_create_response_premium.xml",
             ImmutableMap.of("EXDATE", "2001-04-03T22:00:00.0Z", "FEE", "200.00")));
-    assertSuccessfulCreate("example", ImmutableSet.of());
+    assertSuccessfulCreate("example", ImmutableSet.of(), Optional.empty());
   }
 
   @TestOfyAndSql
@@ -2141,7 +2170,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         loadFile(
             "domain_create_response_encoded_signed_mark_name.xml",
             ImmutableMap.of("DOMAIN", "test-validate.tld")));
-    assertSuccessfulCreate("tld", ImmutableSet.of(SUNRISE));
+    assertSuccessfulCreate("tld", ImmutableSet.of(SUNRISE), Optional.empty());
     assertSunriseLordn("test-validate.tld");
   }
 
@@ -2156,7 +2185,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         loadFile(
             "domain_create_response_encoded_signed_mark_name.xml",
             ImmutableMap.of("DOMAIN", "test-validate.tld")));
-    assertSuccessfulCreate("tld", ImmutableSet.of(SUNRISE));
+    assertSuccessfulCreate("tld", ImmutableSet.of(SUNRISE), Optional.empty());
     assertSunriseLordn("test-validate.tld");
   }
 
@@ -2572,5 +2601,85 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     EppException thrown = assertThrows(ReadOnlyModeEppException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
     DatabaseHelper.removeDatabaseMigrationSchedule();
+  }
+
+  @TestOfyAndSql
+  void testgetRenewalPriceInfo_isAnchorTenantWithoutToken_returnsNonPremiumAndNullPrice()
+      throws EppException {
+    assertThat(DomainCreateFlow.getRenewalPriceInfo(true, Optional.empty(), Money.of(USD, 123)))
+        .isEqualTo(RenewalPriceInfo.create(RenewalPriceBehavior.NONPREMIUM, null));
+  }
+
+  @TestOfyAndSql
+  void testgetRenewalPriceInfo_isAnchorTenantWithToken_returnsNonPremiumAndNullPrice()
+      throws EppException {
+    assertThat(
+            DomainCreateFlow.getRenewalPriceInfo(
+                true, Optional.of(allocationToken), Money.of(USD, 123)))
+        .isEqualTo(RenewalPriceInfo.create(RenewalPriceBehavior.NONPREMIUM, null));
+  }
+
+  @TestOfyAndSql
+  void testgetRenewalPriceInfo_isNotAnchorTenantWithToken_returnsDefaultAndNullPrice()
+      throws EppException {
+    assertThat(
+            DomainCreateFlow.getRenewalPriceInfo(
+                false, Optional.of(allocationToken), Money.of(USD, 123)))
+        .isEqualTo(RenewalPriceInfo.create(RenewalPriceBehavior.DEFAULT, null));
+  }
+
+  @TestOfyAndSql
+  void testgetRenewalPriceInfo_isNotAnchorTenantWithoutToken_returnsDefaultAndNullPrice()
+      throws EppException {
+    assertThat(DomainCreateFlow.getRenewalPriceInfo(false, Optional.empty(), Money.of(USD, 123)))
+        .isEqualTo(RenewalPriceInfo.create(RenewalPriceBehavior.DEFAULT, null));
+  }
+
+  @TestOfyAndSql
+  void testgetRenewalPriceInfo_isNotAnchorTenantWithoutToken_returnsSpecifiedAndCreatePrice()
+      throws EppException {
+    AllocationToken token =
+        persistResource(
+            new AllocationToken.Builder()
+                .setToken("abc123")
+                .setTokenType(SINGLE_USE)
+                .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
+                .build());
+    assertThat(DomainCreateFlow.getRenewalPriceInfo(false, Optional.of(token), Money.of(USD, 123)))
+        .isEqualTo(RenewalPriceInfo.create(RenewalPriceBehavior.SPECIFIED, Money.of(USD, 123)));
+  }
+
+  @TestOfyAndSql
+  void testgetRenewalPriceInfo_isAnchorTenantWithSpecifiedStateInToken_throwsError()
+      throws EppException {
+    AllocationToken token =
+        persistResource(
+            new AllocationToken.Builder()
+                .setToken("abc123")
+                .setTokenType(SINGLE_USE)
+                .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
+                .build());
+    assertThat(
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                  DomainCreateFlow.getRenewalPriceInfo(
+                      true, Optional.of(token), Money.of(USD, 123));
+                }))
+        .hasMessageThat()
+        .isEqualTo("Renewal price behavior cannot be SPECIFIED for anchor tenant");
+  }
+
+  @TestOfyAndSql
+  void testgetRenewalPriceInfo_isNotAnchorTenantWithoutTokenWithoutCreatePrice_throwsException()
+      throws EppException {
+    assertThat(
+            assertThrows(
+                NullPointerException.class,
+                () -> {
+                  DomainCreateFlow.getRenewalPriceInfo(false, Optional.empty(), null);
+                }))
+        .hasMessageThat()
+        .isEqualTo("Create cost cannot be null");
   }
 }


### PR DESCRIPTION
Renewal info will be added to recurring billing event when creating a domain (create flow). The code change mostly happens in `run()` which contains the logic of the flow. Since renewal price behavior needs to be set and that could be determined using existing boolean `isAnchorTenant` and `isValidReservedCreate`, a new helper method `getRenewalPriceBehavior` was created in this PR to determine the state of renewal price behavior, and this state replace the two existing booleans. As I was going through the flow, I noticed that some helper methods could be adjusted for minor improvements. For example, `isSunriseCreate` and `isReserved(domainName, isSunriseCreate) `were passed into `createOneTimeBillingEvent` and it could be `domainName` and `isSunriseCreate` and put the conditional in the helper method instead. 

tl;dr: this PR does the following: 
- Set the info for recurring billing event including renewal price behavior and renewal price 
- Replaced existing boolean `isAnchorTenant` and `isReserved` with `RenewalPriceBehavior.NONPREMIUM` and `RenewalPriceBehavior.SPECIFIED` 
- Modified existing testing set up to accommodate the renewal feature for AT and internal registrations.
- Rearranged parameters of some of the helper methods 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1591)
<!-- Reviewable:end -->
