### PR TITLE
Fix a in issue with RDE

### DIFF
--- a/core/src/main/java/google/registry/beam/rde/RdePipeline.java
+++ b/core/src/main/java/google/registry/beam/rde/RdePipeline.java
@@ -341,8 +341,8 @@ public class RdePipeline implements Serializable {
         .apply(
             String.format("Load most recent %s", historyClass.getSimpleName()),
             RegistryJpaIO.read(
-                ("SELECT %repoIdField%, id FROM %entity% WHERE (%repoIdField%, modificationTime) IN"
-                     + " (SELECT %repoIdField%, MAX(modificationTime) FROM %entity% WHERE"
+                ("SELECT %repoIdField%, id FROM %entity% WHERE (%repoIdField%, modificationTime)"
+                     + " IN (SELECT %repoIdField%, MAX(modificationTime) FROM %entity% WHERE"
                      + " modificationTime <= :watermark GROUP BY %repoIdField%) AND"
                      + " %resourceField%.deletionTime > :watermark AND"
                      + " COALESCE(%resourceField%.creationClientId, '') NOT LIKE 'prober-%' AND"

--- a/core/src/main/java/google/registry/beam/rde/RdePipeline.java
+++ b/core/src/main/java/google/registry/beam/rde/RdePipeline.java
@@ -378,13 +378,13 @@ public class RdePipeline implements Serializable {
       ImmutableSet<Long> dedupedIds = ImmutableSet.copyOf(ids);
       checkState(
           dedupedIds.size() == 1,
-          String.format(
-              "Multiple unique revision IDs detected for %s repo ID %s: %s",
-              EPP_RESOURCE_FIELD_NAME.get(historyEntryClazz), repoId, ids));
+          "Multiple unique revision IDs detected for %s repo ID %s: %s",
+          EPP_RESOURCE_FIELD_NAME.get(historyEntryClazz),
+          repoId,
+          ids);
       logger.atSevere().log(
-          String.format(
-              "Duplicate revision IDs detected for %s repo ID %s: %s",
-              EPP_RESOURCE_FIELD_NAME.get(historyEntryClazz), repoId, ids));
+          "Duplicate revision IDs detected for %s repo ID %s: %s",
+          EPP_RESOURCE_FIELD_NAME.get(historyEntryClazz), repoId, ids);
     }
     return loadResourceByHistoryEntryId(historyEntryClazz, repoId, ids.get(0));
   }

--- a/core/src/main/java/google/registry/beam/rde/RdePipeline.java
+++ b/core/src/main/java/google/registry/beam/rde/RdePipeline.java
@@ -15,7 +15,6 @@
 package google.registry.beam.rde;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static google.registry.beam.rde.RdePipeline.TupleTags.DOMAIN_FRAGMENTS;
 import static google.registry.beam.rde.RdePipeline.TupleTags.EXTERNAL_HOST_FRAGMENTS;
@@ -375,13 +374,17 @@ public class RdePipeline implements Serializable {
     // definitively only give us one revision ID per repo ID. In this case we have to abort and
     // require manual intervention.
     if (ids.size() != 1) {
-      ImmutableList<Long> dedupedIds = ids.stream().distinct().collect(toImmutableList());
+      ImmutableSet<Long> dedupedIds = ImmutableSet.copyOf(ids);
       if (dedupedIds.size() != 1) {
-        throw new RuntimeException(
-            String.format("Multiple unique revision IDs detected for repo ID %s: %s", repoId, ids));
+        throw new IllegalStateException(
+            String.format(
+                "Multiple unique revision IDs detected for %s repo ID %s: %s",
+                EPP_RESOURCE_FIELD_NAME.get(historyEntryClazz), repoId, ids));
       } else {
         logger.atSevere().log(
-            String.format("Duplicate revision IDs detected for repo ID %s: %s", repoId, ids));
+            String.format(
+                "Duplicate revision IDs detected for repo %s ID %s: %s",
+                EPP_RESOURCE_FIELD_NAME.get(historyEntryClazz), repoId, ids));
       }
     }
     return loadResourceByHistoryEntryId(historyEntryClazz, repoId, ids.get(0));


### PR DESCRIPTION
For some inexplicable reason, the RDE beam pipeline in both sandbox and
production has been broken for the past week or so. Our investigations
revealed that during the CoGropuByKey stage, some repo ID -> revision ID
pairs were duplicated. This may be a problem with the Dataflow runtime
which somehow introduced the duplicate during reshuffling.

This PR attempts to fix the symptom only by deduping the revision IDs. We
will do some more investigation and possibly follow up with the Dataflow
team if we determine it is an upstream issue.

TESTED=deployed the pipeline and successfully run sandbox RDE with it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1593)
<!-- Reviewable:end -->
