### PR TITLE
Fix build warning for unused variable

### DIFF
--- a/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
+++ b/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
@@ -197,12 +197,8 @@ public class AllocationTokenTest extends EntityTestCase {
                 .build());
     AllocationToken loadedToken = loadByEntity(token);
     assertThat(token).isEqualTo(loadedToken);
-    AllocationToken modifiedToken =
-        persistResource(
-            loadedToken
-                .asBuilder()
-                .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
-                .build());
+    persistResource(
+        loadedToken.asBuilder().setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED).build());
     assertThat(loadByEntity(token).getRenewalPriceBehavior())
         .isEqualTo(RenewalPriceBehavior.SPECIFIED);
   }


### PR DESCRIPTION
`modifiedToken` was originally create for token comparison but it wasn't necessary since the assertion only requires the `RenewalPriceBehavior` enum.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1594)
<!-- Reviewable:end -->
