### PR TITLE
Add renewal logic in allocation token related commands 

### DIFF
--- a/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
+++ b/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
@@ -373,6 +373,9 @@ public class AllocationToken extends BackupGroupRoot implements Buildable, Datas
     }
 
     public Builder setRenewalPriceBehavior(RenewalPriceBehavior renewalPriceBehavior) {
+      checkArgument(
+          renewalPriceBehavior != RenewalPriceBehavior.NONPREMIUM,
+          "NONPREMIUM is not a supported renewal price behavior in allocation token");
       getInstance().renewalPriceBehavior = renewalPriceBehavior;
       return this;
     }

--- a/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
+++ b/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
@@ -373,9 +373,6 @@ public class AllocationToken extends BackupGroupRoot implements Buildable, Datas
     }
 
     public Builder setRenewalPriceBehavior(RenewalPriceBehavior renewalPriceBehavior) {
-      checkArgument(
-          renewalPriceBehavior != RenewalPriceBehavior.NONPREMIUM,
-          "NONPREMIUM is not a supported renewal price behavior in allocation token");
       getInstance().renewalPriceBehavior = renewalPriceBehavior;
       return this;
     }

--- a/core/src/main/java/google/registry/tools/GenerateAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateAllocationTokensCommand.java
@@ -25,7 +25,6 @@ import static google.registry.util.CollectionUtils.nullToEmpty;
 import static google.registry.util.StringGenerator.DEFAULT_PASSWORD_LENGTH;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import avro.shaded.com.google.common.base.Ascii;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.appengine.tools.remoteapi.RemoteApiException;
@@ -146,9 +145,9 @@ class GenerateAllocationTokensCommand implements CommandWithRemoteApi {
   @Parameter(
       names = {"--renewal_price_behavior"},
       description =
-          "Type of renewal price behavior, either DEFAULT (default) or SPECIFIED. This indicates"
-              + " how a domain should be charged for renewal.")
-  private String renewalPriceBehavior;
+          "Type of renewal price behavior, either DEFAULT (default), NONPREMIUM, or SPECIFIED."
+              + " This indicates how a domain should be charged for renewal.")
+  private RenewalPriceBehavior renewalPriceBehavior = RenewalPriceBehavior.DEFAULT;
 
   @Parameter(
       names = {"--dry_run"},
@@ -183,6 +182,7 @@ class GenerateAllocationTokensCommand implements CommandWithRemoteApi {
               .collect(Collectors.toCollection(ArrayDeque::new));
       numTokens = domainNames.size();
     }
+
     int tokensSaved = 0;
     do {
       ImmutableSet<AllocationToken> tokens =
@@ -192,7 +192,7 @@ class GenerateAllocationTokensCommand implements CommandWithRemoteApi {
                     AllocationToken.Builder token =
                         new AllocationToken.Builder()
                             .setToken(t)
-                            .setRenewalPriceBehavior(getRenewalPriceBehavior(renewalPriceBehavior))
+                            .setRenewalPriceBehavior(renewalPriceBehavior)
                             .setTokenType(tokenType == null ? SINGLE_USE : tokenType)
                             .setAllowedRegistrarIds(
                                 ImmutableSet.copyOf(nullToEmpty(allowedClientIds)))
@@ -308,18 +308,5 @@ class GenerateAllocationTokensCommand implements CommandWithRemoteApi {
             tm().loadByKeysIfPresent(existingTokenKeys).values().stream()
                 .map(AllocationToken::getToken)
                 .collect(toImmutableSet()));
-  }
-
-  private RenewalPriceBehavior getRenewalPriceBehavior(String renewalPriceBehaviorStr) {
-    if (renewalPriceBehaviorStr == null) {
-      return RenewalPriceBehavior.DEFAULT;
-    } else {
-      try {
-        return RenewalPriceBehavior.valueOf(Ascii.toUpperCase(renewalPriceBehaviorStr));
-      } catch (IllegalArgumentException e) {
-        throw new IllegalArgumentException(
-            String.format("Invalid renewal price behavior: '%s'", renewalPriceBehaviorStr));
-      }
-    }
   }
 }

--- a/core/src/main/java/google/registry/tools/GenerateAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateAllocationTokensCommand.java
@@ -17,6 +17,7 @@ package google.registry.tools;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Sets.difference;
+import static google.registry.model.billing.BillingEvent.RenewalPriceBehavior.DEFAULT;
 import static google.registry.model.domain.token.AllocationToken.TokenType.SINGLE_USE;
 import static google.registry.model.domain.token.AllocationToken.TokenType.UNLIMITED_USE;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
@@ -145,9 +146,12 @@ class GenerateAllocationTokensCommand implements CommandWithRemoteApi {
   @Parameter(
       names = {"--renewal_price_behavior"},
       description =
-          "Type of renewal price behavior, either DEFAULT (default), NONPREMIUM, or SPECIFIED."
-              + " This indicates how a domain should be charged for renewal.")
-  private RenewalPriceBehavior renewalPriceBehavior = RenewalPriceBehavior.DEFAULT;
+          "The type of renewal price behavior, either DEFAULT (default), NONPREMIUM, or SPECIFIED."
+              + " This indicates how a domain should be charged for renewal. By default, a domain"
+              + " will be renewed at the renewal price from the pricing engine. If the renewal"
+              + " price behavior is set to SPECIFIED, it means that the renewal cost will be the"
+              + " same as the domain's calculated create price.")
+  private RenewalPriceBehavior renewalPriceBehavior = DEFAULT;
 
   @Parameter(
       names = {"--dry_run"},

--- a/core/src/main/java/google/registry/tools/UpdateAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdateAllocationTokensCommand.java
@@ -21,9 +21,9 @@ import static com.google.common.collect.Streams.stream;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.persistence.transaction.TransactionManagerUtil.transactIfJpaTm;
 
-import avro.shaded.com.google.common.base.Ascii;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.beust.jcommander.internal.Nullable;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -93,9 +93,10 @@ final class UpdateAllocationTokensCommand extends UpdateOrDeleteAllocationTokens
   @Parameter(
       names = {"--renewal_price_behavior"},
       description =
-          "Type of renewal price behavior, either DEFAULT (default) or SPECIFIED. This indicates"
-              + " how a domain should be charged for renewal.")
-  private String renewalPriceBehavior;
+          "Type of renewal price behavior, either DEFAULT (default), NONPREMIUM, or SPECIFIED."
+              + " This indicates how a domain should be charged for renewal.")
+  @Nullable
+  private RenewalPriceBehavior renewalPriceBehavior;
 
   private static final int BATCH_SIZE = 20;
   private static final Joiner JOINER = Joiner.on(", ");
@@ -152,17 +153,8 @@ final class UpdateAllocationTokensCommand extends UpdateOrDeleteAllocationTokens
     Optional.ofNullable(discountYears).ifPresent(builder::setDiscountYears);
     Optional.ofNullable(tokenStatusTransitions).ifPresent(builder::setTokenStatusTransitions);
     Optional.ofNullable(renewalPriceBehavior)
-        .ifPresent(behavior -> builder.setRenewalPriceBehavior(getRenewalPriceBehavior(behavior)));
+        .ifPresent(behavior -> builder.setRenewalPriceBehavior(renewalPriceBehavior));
     return builder.build();
-  }
-
-  private RenewalPriceBehavior getRenewalPriceBehavior(String renewalPriceBehaviorStr) {
-    try {
-      return RenewalPriceBehavior.valueOf(Ascii.toUpperCase(renewalPriceBehaviorStr));
-    } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException(
-          String.format("Invalid renewal price behavior: '%s'", renewalPriceBehaviorStr));
-    }
   }
 
   private long saveBatch(ImmutableList<AllocationToken> batch) {

--- a/core/src/main/java/google/registry/tools/UpdateAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdateAllocationTokensCommand.java
@@ -93,8 +93,11 @@ final class UpdateAllocationTokensCommand extends UpdateOrDeleteAllocationTokens
   @Parameter(
       names = {"--renewal_price_behavior"},
       description =
-          "Type of renewal price behavior, either DEFAULT (default), NONPREMIUM, or SPECIFIED."
-              + " This indicates how a domain should be charged for renewal.")
+          "The type of renewal price behavior, either DEFAULT (default), NONPREMIUM, or SPECIFIED."
+              + " This indicates how a domain should be charged for renewal. By default, a domain"
+              + " will be renewed at the renewal price from the pricing engine. If the renewal"
+              + " price behavior is set to SPECIFIED, it means that the renewal cost will be the"
+              + " same as the domain's calculated create price.")
   @Nullable
   private RenewalPriceBehavior renewalPriceBehavior;
 

--- a/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
+++ b/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
@@ -162,7 +162,7 @@ public class AllocationTokenTest extends EntityTestCase {
   }
 
   @TestOfyAndSql
-  void testgetRenewalBehavior_returnsDefaultRenewBehavior() {
+  void testGetRenewalBehavior_returnsDefaultRenewBehavior() {
     assertThat(
             persistResource(
                     new AllocationToken.Builder()
@@ -174,7 +174,7 @@ public class AllocationTokenTest extends EntityTestCase {
   }
 
   @TestOfyAndSql
-  void testsetRenewalBehavior_assertsRenewalBehaviorIsNotDefault() {
+  void testSetRenewalBehavior_assertsRenewalBehaviorIsNotDefault() {
     assertThat(
             persistResource(
                     new AllocationToken.Builder()
@@ -187,55 +187,20 @@ public class AllocationTokenTest extends EntityTestCase {
   }
 
   @TestOfyAndSql
-  void testsetRenewalBehavior_assertsRenewalBehaviorIsModified() {
-    AllocationToken allocationToken =
+  void testSetRenewalBehavior_assertRenewalBehaviorIsModified() {
+    AllocationToken token =
         persistResource(
             new AllocationToken.Builder()
                 .setToken("abc123")
                 .setTokenType(SINGLE_USE)
-                .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
+                .setRenewalPriceBehavior(RenewalPriceBehavior.NONPREMIUM)
                 .build());
+    AllocationToken loadedToken = loadByEntity(token);
+    assertThat(token).isEqualTo(loadedToken);
     persistResource(
-        loadByEntity(allocationToken)
-            .asBuilder()
-            .setRenewalPriceBehavior(RenewalPriceBehavior.DEFAULT)
-            .build());
-    assertThat(loadByEntity(allocationToken).getRenewalPriceBehavior())
-        .isEqualTo(RenewalPriceBehavior.DEFAULT);
-  }
-
-  @TestOfyAndSql
-  void testsetRenewalBehavior_UnsupportedBehaviorThrowsUnsupportedRenewalPriceBehavior() {
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> {
-                  new AllocationToken.Builder()
-                      .setToken("abc123")
-                      .setTokenType(SINGLE_USE)
-                      .setRenewalPriceBehavior(RenewalPriceBehavior.NONPREMIUM)
-                      .build();
-                }))
-        .hasMessageThat()
-        .isEqualTo("NONPREMIUM is not a supported renewal price behavior in allocation token");
-  }
-
-  @TestOfyAndSql
-  void testsetRenewalBehavior_InvalidBehaviorThrowsUnsupportedRenewalPriceBehavior() {
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> {
-                  new AllocationToken.Builder()
-                      .setToken("abc123")
-                      .setTokenType(SINGLE_USE)
-                      .setRenewalPriceBehavior(RenewalPriceBehavior.valueOf("TEST"))
-                      .build();
-                }))
-        .hasMessageThat()
-        .isEqualTo(
-            "No enum constant"
-                + " google.registry.model.billing.BillingEvent.RenewalPriceBehavior.TEST");
+        loadedToken.asBuilder().setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED).build());
+    assertThat(loadByEntity(token).getRenewalPriceBehavior())
+        .isEqualTo(RenewalPriceBehavior.SPECIFIED);
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
+++ b/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
@@ -187,20 +187,55 @@ public class AllocationTokenTest extends EntityTestCase {
   }
 
   @TestOfyAndSql
-  void testsetRenewalBehavior_assertRenewalBehaviorIsModified() {
-    AllocationToken token =
+  void testsetRenewalBehavior_assertsRenewalBehaviorIsModified() {
+    AllocationToken allocationToken =
         persistResource(
             new AllocationToken.Builder()
                 .setToken("abc123")
                 .setTokenType(SINGLE_USE)
-                .setRenewalPriceBehavior(RenewalPriceBehavior.NONPREMIUM)
+                .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
                 .build());
-    AllocationToken loadedToken = loadByEntity(token);
-    assertThat(token).isEqualTo(loadedToken);
     persistResource(
-        loadedToken.asBuilder().setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED).build());
-    assertThat(loadByEntity(token).getRenewalPriceBehavior())
-        .isEqualTo(RenewalPriceBehavior.SPECIFIED);
+        loadByEntity(allocationToken)
+            .asBuilder()
+            .setRenewalPriceBehavior(RenewalPriceBehavior.DEFAULT)
+            .build());
+    assertThat(loadByEntity(allocationToken).getRenewalPriceBehavior())
+        .isEqualTo(RenewalPriceBehavior.DEFAULT);
+  }
+
+  @TestOfyAndSql
+  void testsetRenewalBehavior_UnsupportedBehaviorThrowsUnsupportedRenewalPriceBehavior() {
+    assertThat(
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                  new AllocationToken.Builder()
+                      .setToken("abc123")
+                      .setTokenType(SINGLE_USE)
+                      .setRenewalPriceBehavior(RenewalPriceBehavior.NONPREMIUM)
+                      .build();
+                }))
+        .hasMessageThat()
+        .isEqualTo("NONPREMIUM is not a supported renewal price behavior in allocation token");
+  }
+
+  @TestOfyAndSql
+  void testsetRenewalBehavior_InvalidBehaviorThrowsUnsupportedRenewalPriceBehavior() {
+    assertThat(
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                  new AllocationToken.Builder()
+                      .setToken("abc123")
+                      .setTokenType(SINGLE_USE)
+                      .setRenewalPriceBehavior(RenewalPriceBehavior.valueOf("TEST"))
+                      .build();
+                }))
+        .hasMessageThat()
+        .isEqualTo(
+            "No enum constant"
+                + " google.registry.model.billing.BillingEvent.RenewalPriceBehavior.TEST");
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/tools/GenerateAllocationTokensCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateAllocationTokensCommandTest.java
@@ -15,6 +15,8 @@
 package google.registry.tools;
 
 import static com.google.common.truth.Truth.assertThat;
+import static google.registry.model.billing.BillingEvent.RenewalPriceBehavior.DEFAULT;
+import static google.registry.model.billing.BillingEvent.RenewalPriceBehavior.SPECIFIED;
 import static google.registry.model.domain.token.AllocationToken.TokenType.SINGLE_USE;
 import static google.registry.model.domain.token.AllocationToken.TokenType.UNLIMITED_USE;
 import static google.registry.testing.DatabaseHelper.assertAllocationTokens;
@@ -37,6 +39,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import com.google.common.io.Files;
+import google.registry.model.billing.BillingEvent.RenewalPriceBehavior;
 import google.registry.model.domain.token.AllocationToken;
 import google.registry.model.domain.token.AllocationToken.TokenStatus;
 import google.registry.model.reporting.HistoryEntry;
@@ -70,7 +73,7 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
   @TestOfyAndSql
   void testSuccess_oneToken() throws Exception {
     runCommand("--prefix", "blah", "--number", "1", "--length", "9");
-    assertAllocationTokens(createToken("blah123456789", null, null));
+    assertAllocationTokens(createToken("blah123456789", DEFAULT, null, null));
     assertInStdout("blah123456789");
   }
 
@@ -78,16 +81,16 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
   void testSuccess_threeTokens() throws Exception {
     runCommand("--prefix", "foo", "--number", "3", "--length", "10");
     assertAllocationTokens(
-        createToken("foo123456789A", null, null),
-        createToken("fooBCDEFGHJKL", null, null),
-        createToken("fooMNPQRSTUVW", null, null));
+        createToken("foo123456789A", DEFAULT, null, null),
+        createToken("fooBCDEFGHJKL", DEFAULT, null, null),
+        createToken("fooMNPQRSTUVW", DEFAULT, null, null));
     assertInStdout("foo123456789A\nfooBCDEFGHJKL\nfooMNPQRSTUVW");
   }
 
   @TestOfyAndSql
   void testSuccess_defaults() throws Exception {
     runCommand("--number", "1");
-    assertAllocationTokens(createToken("123456789ABCDEFG", null, null));
+    assertAllocationTokens(createToken("123456789ABCDEFG", DEFAULT, null, null));
     assertInStdout("123456789ABCDEFG");
   }
 
@@ -101,7 +104,7 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
         .when(command)
         .saveTokens(ArgumentMatchers.any());
     runCommand("--number", "1");
-    assertAllocationTokens(createToken("123456789ABCDEFG", null, null));
+    assertAllocationTokens(createToken("123456789ABCDEFG", DEFAULT, null, null));
     assertInStdout("123456789ABCDEFG");
     verify(command, times(3)).saveTokens(ArgumentMatchers.any());
   }
@@ -115,7 +118,7 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
                 .setTokenType(SINGLE_USE)
                 .build());
     runCommand("--number", "1", "--prefix", "DEADBEEF", "--length", "12");
-    assertAllocationTokens(existingToken, createToken("DEADBEEFDEFGHJKLMNPQ", null, null));
+    assertAllocationTokens(existingToken, createToken("DEADBEEFDEFGHJKLMNPQ", DEFAULT, null, null));
     assertInStdout("DEADBEEFDEFGHJKLMNPQ");
   }
 
@@ -143,9 +146,9 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
     Files.asCharSink(domainNamesFile, UTF_8).write("foo1.tld\nboo2.tld\nçauçalito.みんな\n");
     runCommand("--domain_names_file", domainNamesFile.getPath());
     assertAllocationTokens(
-        createToken("123456789ABCDEFG", null, "foo1.tld"),
-        createToken("HJKLMNPQRSTUVWXY", null, "boo2.tld"),
-        createToken("Zabcdefghijkmnop", null, "xn--aualito-txac.xn--q9jyb4c"));
+        createToken("123456789ABCDEFG", DEFAULT, null, "foo1.tld"),
+        createToken("HJKLMNPQRSTUVWXY", DEFAULT, null, "boo2.tld"),
+        createToken("Zabcdefghijkmnop", DEFAULT, null, "xn--aualito-txac.xn--q9jyb4c"));
     assertInStdout(
         "foo1.tld,123456789ABCDEFG",
         "boo2.tld,HJKLMNPQRSTUVWXY",
@@ -189,8 +192,77 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
   @TestOfyAndSql
   void testSuccess_specifyTokens() throws Exception {
     runCommand("--tokens", "foobar,foobaz");
-    assertAllocationTokens(createToken("foobar", null, null), createToken("foobaz", null, null));
+    assertAllocationTokens(
+        createToken("foobar", DEFAULT, null, null), createToken("foobaz", DEFAULT, null, null));
     assertInStdout("foobar", "foobaz");
+  }
+
+  @TestOfyAndSql
+  void testSuccess_renewalPriceBehaviorIsDefault() throws Exception {
+    runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", "DEFAULT");
+    assertAllocationTokens(
+        createToken("foobar", DEFAULT, null, null), createToken("foobaz", DEFAULT, null, null));
+    assertInStdout("foobar", "foobaz");
+  }
+
+  @TestOfyAndSql
+  void testSuccess_renewalPriceBehaviorIsSpecified() throws Exception {
+    runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", "SPECIFIED");
+    assertAllocationTokens(
+        createToken("foobar", SPECIFIED, null, null), createToken("foobaz", SPECIFIED, null, null));
+    assertInStdout("foobar", "foobaz");
+  }
+
+  @TestOfyAndSql
+  void testSuccess_renewalPriceBehaviorIsInAllLowerCase() throws Exception {
+    runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", "specified");
+    assertAllocationTokens(
+        createToken("foobar", SPECIFIED, null, null), createToken("foobaz", SPECIFIED, null, null));
+    assertInStdout("foobar", "foobaz");
+  }
+
+  @TestOfyAndSql
+  void testSuccess_renewalPriceBehaviorIsInMixedrCases() throws Exception {
+    runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", "deFault");
+    assertAllocationTokens(
+        createToken("foobar", DEFAULT, null, null), createToken("foobaz", DEFAULT, null, null));
+    assertInStdout("foobar", "foobaz");
+  }
+
+  @TestOfyAndSql
+  void testFailure_renewalPriceBehaviorIsSpecifiedIsInvalid() {
+    assertThat(
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                  runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", "SPEXIFIED");
+                }))
+        .hasMessageThat()
+        .isEqualTo("Invalid renewal price behavior: 'SPEXIFIED'");
+  }
+
+  @TestOfyAndSql
+  void testFailure_renewalPriceBehaviorIsNonpremium() {
+    assertThat(
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                  runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", "NONPREMIUM");
+                }))
+        .hasMessageThat()
+        .isEqualTo("NONPREMIUM is not a supported renewal price behavior in allocation token");
+  }
+
+  @TestOfyAndSql
+  void testFailure_renewalPriceBehaviorIsEmptyString() {
+    assertThat(
+            assertThrows(
+                IllegalArgumentException.class,
+                () -> {
+                  runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", "");
+                }))
+        .hasMessageThat()
+        .isEqualTo("Invalid renewal price behavior: ''");
   }
 
   @TestOfyAndSql
@@ -318,10 +390,14 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
 
   private AllocationToken createToken(
       String token,
+      RenewalPriceBehavior renewalPriceBehavior,
       @Nullable VKey<? extends HistoryEntry> redemptionHistoryEntry,
       @Nullable String domainName) {
     AllocationToken.Builder builder =
-        new AllocationToken.Builder().setToken(token).setTokenType(SINGLE_USE);
+        new AllocationToken.Builder()
+            .setToken(token)
+            .setTokenType(SINGLE_USE)
+            .setRenewalPriceBehavior(renewalPriceBehavior);
     if (redemptionHistoryEntry != null) {
       builder.setRedemptionHistoryEntry(redemptionHistoryEntry);
     }

--- a/core/src/test/java/google/registry/tools/GenerateAllocationTokensCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateAllocationTokensCommandTest.java
@@ -15,7 +15,7 @@
 package google.registry.tools;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.model.billing.BillingEvent.RenewalPriceBehavior.DEFAULT;
+import static google.registry.model.billing.BillingEvent.RenewalPriceBehavior.NONPREMIUM;
 import static google.registry.model.billing.BillingEvent.RenewalPriceBehavior.SPECIFIED;
 import static google.registry.model.domain.token.AllocationToken.TokenType.SINGLE_USE;
 import static google.registry.model.domain.token.AllocationToken.TokenType.UNLIMITED_USE;
@@ -39,7 +39,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import com.google.common.io.Files;
-import google.registry.model.billing.BillingEvent.RenewalPriceBehavior;
 import google.registry.model.domain.token.AllocationToken;
 import google.registry.model.domain.token.AllocationToken.TokenStatus;
 import google.registry.model.reporting.HistoryEntry;
@@ -73,7 +72,7 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
   @TestOfyAndSql
   void testSuccess_oneToken() throws Exception {
     runCommand("--prefix", "blah", "--number", "1", "--length", "9");
-    assertAllocationTokens(createToken("blah123456789", DEFAULT, null, null));
+    assertAllocationTokens(createToken("blah123456789", null, null));
     assertInStdout("blah123456789");
   }
 
@@ -81,16 +80,16 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
   void testSuccess_threeTokens() throws Exception {
     runCommand("--prefix", "foo", "--number", "3", "--length", "10");
     assertAllocationTokens(
-        createToken("foo123456789A", DEFAULT, null, null),
-        createToken("fooBCDEFGHJKL", DEFAULT, null, null),
-        createToken("fooMNPQRSTUVW", DEFAULT, null, null));
+        createToken("foo123456789A", null, null),
+        createToken("fooBCDEFGHJKL", null, null),
+        createToken("fooMNPQRSTUVW", null, null));
     assertInStdout("foo123456789A\nfooBCDEFGHJKL\nfooMNPQRSTUVW");
   }
 
   @TestOfyAndSql
   void testSuccess_defaults() throws Exception {
     runCommand("--number", "1");
-    assertAllocationTokens(createToken("123456789ABCDEFG", DEFAULT, null, null));
+    assertAllocationTokens(createToken("123456789ABCDEFG", null, null));
     assertInStdout("123456789ABCDEFG");
   }
 
@@ -104,7 +103,7 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
         .when(command)
         .saveTokens(ArgumentMatchers.any());
     runCommand("--number", "1");
-    assertAllocationTokens(createToken("123456789ABCDEFG", DEFAULT, null, null));
+    assertAllocationTokens(createToken("123456789ABCDEFG", null, null));
     assertInStdout("123456789ABCDEFG");
     verify(command, times(3)).saveTokens(ArgumentMatchers.any());
   }
@@ -118,7 +117,7 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
                 .setTokenType(SINGLE_USE)
                 .build());
     runCommand("--number", "1", "--prefix", "DEADBEEF", "--length", "12");
-    assertAllocationTokens(existingToken, createToken("DEADBEEFDEFGHJKLMNPQ", DEFAULT, null, null));
+    assertAllocationTokens(existingToken, createToken("DEADBEEFDEFGHJKLMNPQ", null, null));
     assertInStdout("DEADBEEFDEFGHJKLMNPQ");
   }
 
@@ -146,9 +145,9 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
     Files.asCharSink(domainNamesFile, UTF_8).write("foo1.tld\nboo2.tld\nçauçalito.みんな\n");
     runCommand("--domain_names_file", domainNamesFile.getPath());
     assertAllocationTokens(
-        createToken("123456789ABCDEFG", DEFAULT, null, "foo1.tld"),
-        createToken("HJKLMNPQRSTUVWXY", DEFAULT, null, "boo2.tld"),
-        createToken("Zabcdefghijkmnop", DEFAULT, null, "xn--aualito-txac.xn--q9jyb4c"));
+        createToken("123456789ABCDEFG", null, "foo1.tld"),
+        createToken("HJKLMNPQRSTUVWXY", null, "boo2.tld"),
+        createToken("Zabcdefghijkmnop", null, "xn--aualito-txac.xn--q9jyb4c"));
     assertInStdout(
         "foo1.tld,123456789ABCDEFG",
         "boo2.tld,HJKLMNPQRSTUVWXY",
@@ -192,16 +191,30 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
   @TestOfyAndSql
   void testSuccess_specifyTokens() throws Exception {
     runCommand("--tokens", "foobar,foobaz");
-    assertAllocationTokens(
-        createToken("foobar", DEFAULT, null, null), createToken("foobaz", DEFAULT, null, null));
+    assertAllocationTokens(createToken("foobar", null, null), createToken("foobaz", null, null));
     assertInStdout("foobar", "foobaz");
   }
 
   @TestOfyAndSql
   void testSuccess_renewalPriceBehaviorIsDefault() throws Exception {
     runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", "DEFAULT");
+    assertAllocationTokens(createToken("foobar", null, null), createToken("foobaz", null, null));
+    assertInStdout("foobar", "foobaz");
+  }
+
+  @TestOfyAndSql
+  void testSuccess_renewalPriceBehaviorIsSetToDefaultByDefault() throws Exception {
+    runCommand("--tokens", "foobar,foobaz");
+    assertAllocationTokens(createToken("foobar", null, null), createToken("foobaz", null, null));
+    assertInStdout("foobar", "foobaz");
+  }
+
+  @TestOfyAndSql
+  void testSuccess_renewalPriceBehaviorIsNonPremium() throws Exception {
+    runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", "NONPREMIUM");
     assertAllocationTokens(
-        createToken("foobar", DEFAULT, null, null), createToken("foobaz", DEFAULT, null, null));
+        createToken("foobar", null, null).asBuilder().setRenewalPriceBehavior(NONPREMIUM).build(),
+        createToken("foobaz", null, null).asBuilder().setRenewalPriceBehavior(NONPREMIUM).build());
     assertInStdout("foobar", "foobaz");
   }
 
@@ -209,60 +222,44 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
   void testSuccess_renewalPriceBehaviorIsSpecified() throws Exception {
     runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", "SPECIFIED");
     assertAllocationTokens(
-        createToken("foobar", SPECIFIED, null, null), createToken("foobaz", SPECIFIED, null, null));
+        createToken("foobar", null, null).asBuilder().setRenewalPriceBehavior(SPECIFIED).build(),
+        createToken("foobaz", null, null).asBuilder().setRenewalPriceBehavior(SPECIFIED).build());
     assertInStdout("foobar", "foobaz");
   }
 
   @TestOfyAndSql
-  void testSuccess_renewalPriceBehaviorIsInAllLowerCase() throws Exception {
-    runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", "specified");
+  void testSuccess_renewalPriceBehaviorIsSpecifiedButMixedCase() throws Exception {
+    runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", "speCIFied");
     assertAllocationTokens(
-        createToken("foobar", SPECIFIED, null, null), createToken("foobaz", SPECIFIED, null, null));
+        createToken("foobar", null, null).asBuilder().setRenewalPriceBehavior(SPECIFIED).build(),
+        createToken("foobaz", null, null).asBuilder().setRenewalPriceBehavior(SPECIFIED).build());
     assertInStdout("foobar", "foobaz");
   }
 
   @TestOfyAndSql
-  void testSuccess_renewalPriceBehaviorIsInMixedrCases() throws Exception {
-    runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", "deFault");
-    assertAllocationTokens(
-        createToken("foobar", DEFAULT, null, null), createToken("foobaz", DEFAULT, null, null));
-    assertInStdout("foobar", "foobaz");
-  }
-
-  @TestOfyAndSql
-  void testFailure_renewalPriceBehaviorIsSpecifiedIsInvalid() {
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> {
-                  runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", "SPEXIFIED");
-                }))
+  void testFailure_renewalPriceBehaviorIsInvalid() {
+    ParameterException thrown =
+        assertThrows(
+            ParameterException.class,
+            () -> runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", "SPEXIFIED"));
+    assertThat(thrown)
         .hasMessageThat()
-        .isEqualTo("Invalid renewal price behavior: 'SPEXIFIED'");
-  }
-
-  @TestOfyAndSql
-  void testFailure_renewalPriceBehaviorIsNonpremium() {
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> {
-                  runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", "NONPREMIUM");
-                }))
-        .hasMessageThat()
-        .isEqualTo("NONPREMIUM is not a supported renewal price behavior in allocation token");
+        .isEqualTo(
+            "Invalid value for --renewal_price_behavior parameter. Allowed values:[DEFAULT,"
+                + " NONPREMIUM, SPECIFIED]");
   }
 
   @TestOfyAndSql
   void testFailure_renewalPriceBehaviorIsEmptyString() {
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> {
-                  runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", "");
-                }))
+    ParameterException thrown =
+        assertThrows(
+            ParameterException.class,
+            () -> runCommand("--tokens", "foobar,foobaz", "--renewal_price_behavior", ""));
+    assertThat(thrown)
         .hasMessageThat()
-        .isEqualTo("Invalid renewal price behavior: ''");
+        .isEqualTo(
+            "Invalid value for --renewal_price_behavior parameter. Allowed values:[DEFAULT,"
+                + " NONPREMIUM, SPECIFIED]");
   }
 
   @TestOfyAndSql
@@ -390,14 +387,10 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
 
   private AllocationToken createToken(
       String token,
-      RenewalPriceBehavior renewalPriceBehavior,
       @Nullable VKey<? extends HistoryEntry> redemptionHistoryEntry,
       @Nullable String domainName) {
     AllocationToken.Builder builder =
-        new AllocationToken.Builder()
-            .setToken(token)
-            .setTokenType(SINGLE_USE)
-            .setRenewalPriceBehavior(renewalPriceBehavior);
+        new AllocationToken.Builder().setToken(token).setTokenType(SINGLE_USE);
     if (redemptionHistoryEntry != null) {
       builder.setRedemptionHistoryEntry(redemptionHistoryEntry);
     }

--- a/core/src/test/java/google/registry/tools/UpdateAllocationTokensCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateAllocationTokensCommandTest.java
@@ -15,6 +15,9 @@
 package google.registry.tools;
 
 import static com.google.common.truth.Truth.assertThat;
+import static google.registry.model.billing.BillingEvent.RenewalPriceBehavior.DEFAULT;
+import static google.registry.model.billing.BillingEvent.RenewalPriceBehavior.NONPREMIUM;
+import static google.registry.model.billing.BillingEvent.RenewalPriceBehavior.SPECIFIED;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.CANCELLED;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.ENDED;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.NOT_STARTED;
@@ -26,25 +29,23 @@ import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.beust.jcommander.ParameterException;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
-import google.registry.model.billing.BillingEvent.RenewalPriceBehavior;
 import google.registry.model.domain.token.AllocationToken;
 import google.registry.model.domain.token.AllocationToken.TokenStatus;
 import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.TestOfyAndSql;
 import org.joda.time.DateTime;
 
+/** Unit tests for {@link UpdateAllocationTokensCommand}. */
 @DualDatabaseTest
 class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocationTokensCommand> {
 
   @TestOfyAndSql
   void testUpdateTlds_setTlds() throws Exception {
     AllocationToken token =
-        persistResource(
-            builderWithPromo(RenewalPriceBehavior.DEFAULT)
-                .setAllowedTlds(ImmutableSet.of("toRemove"))
-                .build());
+        persistResource(builderWithPromo().setAllowedTlds(ImmutableSet.of("toRemove")).build());
     runCommandForced("--prefix", "token", "--allowed_tlds", "tld,example");
     assertThat(reloadResource(token).getAllowedTlds()).containsExactly("tld", "example");
   }
@@ -52,10 +53,7 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
   @TestOfyAndSql
   void testUpdateTlds_clearTlds() throws Exception {
     AllocationToken token =
-        persistResource(
-            builderWithPromo(RenewalPriceBehavior.DEFAULT)
-                .setAllowedTlds(ImmutableSet.of("toRemove"))
-                .build());
+        persistResource(builderWithPromo().setAllowedTlds(ImmutableSet.of("toRemove")).build());
     runCommandForced("--prefix", "token", "--allowed_tlds", "");
     assertThat(reloadResource(token).getAllowedTlds()).isEmpty();
   }
@@ -64,9 +62,7 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
   void testUpdateClientIds_setClientIds() throws Exception {
     AllocationToken token =
         persistResource(
-            builderWithPromo(RenewalPriceBehavior.DEFAULT)
-                .setAllowedRegistrarIds(ImmutableSet.of("toRemove"))
-                .build());
+            builderWithPromo().setAllowedRegistrarIds(ImmutableSet.of("toRemove")).build());
     runCommandForced("--prefix", "token", "--allowed_client_ids", "clientone,clienttwo");
     assertThat(reloadResource(token).getAllowedRegistrarIds())
         .containsExactly("clientone", "clienttwo");
@@ -76,18 +72,14 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
   void testUpdateClientIds_clearClientIds() throws Exception {
     AllocationToken token =
         persistResource(
-            builderWithPromo(RenewalPriceBehavior.DEFAULT)
-                .setAllowedRegistrarIds(ImmutableSet.of("toRemove"))
-                .build());
+            builderWithPromo().setAllowedRegistrarIds(ImmutableSet.of("toRemove")).build());
     runCommandForced("--prefix", "token", "--allowed_client_ids", "");
     assertThat(reloadResource(token).getAllowedRegistrarIds()).isEmpty();
   }
 
   @TestOfyAndSql
   void testUpdateDiscountFraction() throws Exception {
-    AllocationToken token =
-        persistResource(
-            builderWithPromo(RenewalPriceBehavior.DEFAULT).setDiscountFraction(0.5).build());
+    AllocationToken token = persistResource(builderWithPromo().setDiscountFraction(0.5).build());
     runCommandForced("--prefix", "token", "--discount_fraction", "0.15");
     assertThat(reloadResource(token).getDiscountFraction()).isEqualTo(0.15);
   }
@@ -96,10 +88,7 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
   void testUpdateDiscountPremiums() throws Exception {
     AllocationToken token =
         persistResource(
-            builderWithPromo(RenewalPriceBehavior.DEFAULT)
-                .setDiscountFraction(0.5)
-                .setDiscountPremiums(false)
-                .build());
+            builderWithPromo().setDiscountFraction(0.5).setDiscountPremiums(false).build());
     runCommandForced("--prefix", "token", "--discount_premiums", "true");
     assertThat(reloadResource(token).shouldDiscountPremiums()).isTrue();
     runCommandForced("--prefix", "token", "--discount_premiums", "false");
@@ -108,105 +97,105 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
 
   @TestOfyAndSql
   void testUpdateDiscountYears() throws Exception {
-    AllocationToken token =
-        persistResource(
-            builderWithPromo(RenewalPriceBehavior.DEFAULT).setDiscountFraction(0.5).build());
+    AllocationToken token = persistResource(builderWithPromo().setDiscountFraction(0.5).build());
     runCommandForced("--prefix", "token", "--discount_years", "4");
     assertThat(reloadResource(token).getDiscountYears()).isEqualTo(4);
   }
 
   @TestOfyAndSql
   void testUpdateRenewalPriceBehavior_setToSpecified() throws Exception {
-    AllocationToken token =
-        persistResource(
-            builderWithPromo(RenewalPriceBehavior.DEFAULT).setDiscountFraction(0.5).build());
+    AllocationToken token = persistResource(builderWithPromo().setDiscountFraction(0.5).build());
     runCommandForced("--prefix", "token", "--renewal_price_behavior", "SPECIFIED");
-    assertThat(reloadResource(token).getRenewalPriceBehavior())
-        .isEqualTo(RenewalPriceBehavior.SPECIFIED);
+    assertThat(reloadResource(token).getRenewalPriceBehavior()).isEqualTo(SPECIFIED);
   }
 
   @TestOfyAndSql
   void testUpdateRenewalPriceBehavior_setToDefault() throws Exception {
     AllocationToken token =
         persistResource(
-            builderWithPromo(RenewalPriceBehavior.SPECIFIED).setDiscountFraction(0.5).build());
+            builderWithPromo().setRenewalPriceBehavior(SPECIFIED).setDiscountFraction(0.5).build());
     runCommandForced("--prefix", "token", "--renewal_price_behavior", "default");
-    assertThat(reloadResource(token).getRenewalPriceBehavior())
-        .isEqualTo(RenewalPriceBehavior.DEFAULT);
+    assertThat(reloadResource(token).getRenewalPriceBehavior()).isEqualTo(DEFAULT);
+  }
+
+  @TestOfyAndSql
+  void testUpdateRenewalPriceBehavior_setToNonPremium() throws Exception {
+    AllocationToken token =
+        persistResource(
+            builderWithPromo().setRenewalPriceBehavior(SPECIFIED).setDiscountFraction(0.5).build());
+    runCommandForced("--prefix", "token", "--renewal_price_behavior", "NONpremium");
+    assertThat(reloadResource(token).getRenewalPriceBehavior()).isEqualTo(NONPREMIUM);
   }
 
   @TestOfyAndSql
   void testUpdateRenewalPriceBehavior_setFromDefaultToDefault() throws Exception {
-    AllocationToken token =
-        persistResource(
-            builderWithPromo(RenewalPriceBehavior.DEFAULT).setDiscountFraction(0.5).build());
+    AllocationToken token = persistResource(builderWithPromo().setDiscountFraction(0.5).build());
     runCommandForced("--prefix", "token", "--renewal_price_behavior", "defauLT");
-    assertThat(reloadResource(token).getRenewalPriceBehavior())
-        .isEqualTo(RenewalPriceBehavior.DEFAULT);
+    assertThat(reloadResource(token).getRenewalPriceBehavior()).isEqualTo(DEFAULT);
   }
 
   @TestOfyAndSql
   void testUpdateRenewalPriceBehavior_setFromSpecifiedToSpecified() throws Exception {
     AllocationToken token =
         persistResource(
-            builderWithPromo(RenewalPriceBehavior.SPECIFIED).setDiscountFraction(0.5).build());
+            builderWithPromo().setRenewalPriceBehavior(SPECIFIED).setDiscountFraction(0.5).build());
     runCommandForced("--prefix", "token", "--renewal_price_behavior", "SPecified");
-    assertThat(reloadResource(token).getRenewalPriceBehavior())
-        .isEqualTo(RenewalPriceBehavior.SPECIFIED);
+    assertThat(reloadResource(token).getRenewalPriceBehavior()).isEqualTo(SPECIFIED);
   }
 
   @TestOfyAndSql
-  void testUpdateRenewalPriceBehavior_setToLowercaseSpecified() throws Exception {
+  void testUpdateRenewalPriceBehavior_setFromNonPremiumToDefault() throws Exception {
     AllocationToken token =
         persistResource(
-            builderWithPromo(RenewalPriceBehavior.DEFAULT).setDiscountFraction(0.5).build());
-    runCommandForced("--prefix", "token", "--renewal_price_behavior", "specified");
-    assertThat(reloadResource(token).getRenewalPriceBehavior())
-        .isEqualTo(RenewalPriceBehavior.SPECIFIED);
+            builderWithPromo()
+                .setRenewalPriceBehavior(NONPREMIUM)
+                .setDiscountFraction(0.5)
+                .build());
+    runCommandForced("--prefix", "token", "--renewal_price_behavior", "defauLT");
+    assertThat(reloadResource(token).getRenewalPriceBehavior()).isEqualTo(DEFAULT);
   }
 
   @TestOfyAndSql
   void testUpdateRenewalPriceBehavior_setToMixedCaseDefault() throws Exception {
     AllocationToken token =
         persistResource(
-            builderWithPromo(RenewalPriceBehavior.SPECIFIED).setDiscountFraction(0.5).build());
+            builderWithPromo().setRenewalPriceBehavior(SPECIFIED).setDiscountFraction(0.5).build());
     runCommandForced("--prefix", "token", "--renewal_price_behavior", "deFauLt");
-    assertThat(reloadResource(token).getRenewalPriceBehavior())
-        .isEqualTo(RenewalPriceBehavior.DEFAULT);
+    assertThat(reloadResource(token).getRenewalPriceBehavior()).isEqualTo(DEFAULT);
   }
 
   @TestOfyAndSql
   void testUpdateRenewalPriceBehavior_setToInvalidBehavior_throwsException() {
-    persistResource(
-        builderWithPromo(RenewalPriceBehavior.DEFAULT).setDiscountFraction(0.5).build());
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> {
-                  runCommandForced("--prefix", "token", "--renewal_price_behavior", "premium");
-                }))
+    ParameterException thrown =
+        assertThrows(
+            ParameterException.class,
+            () -> runCommandForced("--prefix", "token", "--renewal_price_behavior", "premium"));
+    persistResource(builderWithPromo().setDiscountFraction(0.5).build());
+    assertThat(thrown)
         .hasMessageThat()
-        .isEqualTo("Invalid renewal price behavior: 'premium'");
+        .isEqualTo(
+            "Invalid value for --renewal_price_behavior parameter. Allowed values:[DEFAULT,"
+                + " NONPREMIUM, SPECIFIED]");
   }
 
   @TestOfyAndSql
-  void testUpdateRenewalPriceBehavior_setToNonPremium_throwsException() {
-    persistResource(
-        builderWithPromo(RenewalPriceBehavior.SPECIFIED).setDiscountFraction(0.5).build());
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> {
-                  runCommandForced("--prefix", "token", "--renewal_price_behavior", "nonpremium");
-                }))
+  void testUpdateRenewalPriceBehavior_setToEmptyString_throwsException() {
+    ParameterException thrown =
+        assertThrows(
+            ParameterException.class,
+            () -> runCommandForced("--prefix", "token", "--renewal_price_behavior", ""));
+    persistResource(builderWithPromo().setDiscountFraction(0.5).build());
+    assertThat(thrown)
         .hasMessageThat()
-        .isEqualTo("NONPREMIUM is not a supported renewal price behavior in allocation token");
+        .isEqualTo(
+            "Invalid value for --renewal_price_behavior parameter. Allowed values:[DEFAULT,"
+                + " NONPREMIUM, SPECIFIED]");
   }
 
   @TestOfyAndSql
   void testUpdateStatusTransitions() throws Exception {
     DateTime now = DateTime.now(UTC);
-    AllocationToken token = persistResource(builderWithPromo(RenewalPriceBehavior.DEFAULT).build());
+    AllocationToken token = persistResource(builderWithPromo().build());
     runCommandForced(
         "--prefix",
         "token",
@@ -221,7 +210,7 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
   @TestOfyAndSql
   void testUpdateStatusTransitions_badTransitions() {
     DateTime now = DateTime.now(UTC);
-    persistResource(builderWithPromo(RenewalPriceBehavior.DEFAULT).build());
+    persistResource(builderWithPromo().build());
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,
@@ -241,10 +230,7 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
   @TestOfyAndSql
   void testUpdate_onlyWithPrefix() throws Exception {
     AllocationToken token =
-        persistResource(
-            builderWithPromo(RenewalPriceBehavior.DEFAULT)
-                .setAllowedTlds(ImmutableSet.of("tld"))
-                .build());
+        persistResource(builderWithPromo().setAllowedTlds(ImmutableSet.of("tld")).build());
     AllocationToken otherToken =
         persistResource(
             new AllocationToken.Builder()
@@ -260,10 +246,7 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
   @TestOfyAndSql
   void testUpdate_onlyTokensProvided() throws Exception {
     AllocationToken firstToken =
-        persistResource(
-            builderWithPromo(RenewalPriceBehavior.DEFAULT)
-                .setAllowedTlds(ImmutableSet.of("tld"))
-                .build());
+        persistResource(builderWithPromo().setAllowedTlds(ImmutableSet.of("tld")).build());
     AllocationToken secondToken =
         persistResource(
             new AllocationToken.Builder()
@@ -288,7 +271,7 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
   void testDoNothing() throws Exception {
     AllocationToken token =
         persistResource(
-            builderWithPromo(RenewalPriceBehavior.DEFAULT)
+            builderWithPromo()
                 .setAllowedRegistrarIds(ImmutableSet.of("clientid"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .setDiscountFraction(0.15)
@@ -326,13 +309,11 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
     assertThat(thrown).hasMessageThat().isEqualTo("Provided prefix should not be blank");
   }
 
-  private static AllocationToken.Builder builderWithPromo(
-      RenewalPriceBehavior renewalPriceBehavior) {
+  private static AllocationToken.Builder builderWithPromo() {
     DateTime now = DateTime.now(UTC);
     return new AllocationToken.Builder()
         .setToken("token")
         .setTokenType(UNLIMITED_USE)
-        .setRenewalPriceBehavior(renewalPriceBehavior)
         .setTokenStatusTransitions(
             ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
                 .put(START_OF_TIME, NOT_STARTED)


### PR DESCRIPTION
The purpose of this PR is to set up the renewal behavior in allocation token related commands, which will be used in domain create flow. 

The changes to `GenerateAllocationTokensCommand` and `UpdateAllocationTokensCommand` are in this PR since they are very similar. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1596)
<!-- Reviewable:end -->
