### PR TITLE
Remove the BEAM RDE pipeline side job

### DIFF
--- a/core/src/main/java/google/registry/env/production/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/production/default/WEB-INF/cron.xml
@@ -37,19 +37,6 @@
   </cron>
 
   <cron>
-    <url>/_dr/task/rdeStaging?beam=true</url>
-    <description>
-      This job generates a full RDE escrow deposit as a single gigantic XML
-      document using the Beam pipeline regardless of the current TM
-      configuration and streams it to cloud storage. It does not trigger the
-      subsequent upload tasks and is meant to run parallel with the main cron
-      job in order to compare the results from both runs.
-    </description>
-    <schedule>every 8 hours from 00:07 to 20:00</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
     <url><![CDATA[/_dr/cron/fanout?queue=rde-upload&endpoint=/_dr/task/rdeUpload&forEachRealTld]]></url>
     <description>
       This job is a no-op unless RdeUploadCursor falls behind for some reason.


### PR DESCRIPTION
Now that SQL is the default, we do not need this side job to run
alongside the main one. Its purpose was to validate the BEAM pipeline
while Datastore was primary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1599)
<!-- Reviewable:end -->
