### PR TITLE
Downgrade Caffeine to 2.9.3

### DIFF
--- a/core/gradle/dependency-locks/compile.lockfile
+++ b/core/gradle/dependency-locks/compile.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -244,7 +244,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/compileClasspath.lockfile
+++ b/core/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7

--- a/core/gradle/dependency-locks/default.lockfile
+++ b/core/gradle/dependency-locks/default.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -254,7 +254,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/deploy_jar.lockfile
+++ b/core/gradle/dependency-locks/deploy_jar.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/nonprodCompile.lockfile
+++ b/core/gradle/dependency-locks/nonprodCompile.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -244,7 +244,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/nonprodCompileClasspath.lockfile
+++ b/core/gradle/dependency-locks/nonprodCompileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -118,7 +118,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -237,7 +237,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/core/gradle/dependency-locks/nonprodRuntime.lockfile
+++ b/core/gradle/dependency-locks/nonprodRuntime.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +123,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/nonprodRuntimeClasspath.lockfile
+++ b/core/gradle/dependency-locks/nonprodRuntimeClasspath.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +123,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/runtime.lockfile
+++ b/core/gradle/dependency-locks/runtime.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -123,7 +123,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/core/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7

--- a/core/gradle/dependency-locks/testCompile.lockfile
+++ b/core/gradle/dependency-locks/testCompile.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -121,7 +121,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -265,7 +265,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/core/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -258,7 +258,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/core/gradle/dependency-locks/testRuntime.lockfile
+++ b/core/gradle/dependency-locks/testRuntime.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -126,7 +126,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -275,7 +275,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/core/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/core/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -126,7 +126,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -275,7 +275,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -18,7 +18,7 @@ ext {
     dependencyList = [
       'args4j:args4j:2.0.26',
       'com.beust:jcommander:1.60',
-      'com.github.ben-manes.caffeine:caffeine:3.0.6',
+      'com.github.ben-manes.caffeine:caffeine:2.9.3',
       'com.google.api:gax:1.66.0',
       'com.google.api.grpc:proto-google-cloud-secretmanager-v1:1.4.0',
       // The two below are needed only for Datastore bulk delete pipeline.

--- a/docs/gradle/dependency-locks/compile.lockfile
+++ b/docs/gradle/dependency-locks/compile.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -254,7 +254,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/docs/gradle/dependency-locks/compileClasspath.lockfile
+++ b/docs/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -118,7 +118,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -241,7 +241,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/docs/gradle/dependency-locks/default.lockfile
+++ b/docs/gradle/dependency-locks/default.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -254,7 +254,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/docs/gradle/dependency-locks/deploy_jar.lockfile
+++ b/docs/gradle/dependency-locks/deploy_jar.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/docs/gradle/dependency-locks/runtime.lockfile
+++ b/docs/gradle/dependency-locks/runtime.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -254,7 +254,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/docs/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/docs/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/docs/gradle/dependency-locks/testCompile.lockfile
+++ b/docs/gradle/dependency-locks/testCompile.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -257,7 +257,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/docs/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/docs/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -118,7 +118,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -245,7 +245,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/docs/gradle/dependency-locks/testRuntime.lockfile
+++ b/docs/gradle/dependency-locks/testRuntime.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -257,7 +257,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/docs/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/docs/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -257,7 +257,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/backend/gradle/dependency-locks/compile.lockfile
+++ b/services/backend/gradle/dependency-locks/compile.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/services/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -242,7 +242,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/services/backend/gradle/dependency-locks/default.lockfile
+++ b/services/backend/gradle/dependency-locks/default.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/backend/gradle/dependency-locks/runtime.lockfile
+++ b/services/backend/gradle/dependency-locks/runtime.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/services/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/backend/gradle/dependency-locks/testCompile.lockfile
+++ b/services/backend/gradle/dependency-locks/testCompile.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/backend/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/services/backend/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -242,7 +242,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/services/backend/gradle/dependency-locks/testRuntime.lockfile
+++ b/services/backend/gradle/dependency-locks/testRuntime.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/backend/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/services/backend/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/default/gradle/dependency-locks/compile.lockfile
+++ b/services/default/gradle/dependency-locks/compile.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/default/gradle/dependency-locks/compileClasspath.lockfile
+++ b/services/default/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -242,7 +242,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/services/default/gradle/dependency-locks/default.lockfile
+++ b/services/default/gradle/dependency-locks/default.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/default/gradle/dependency-locks/runtime.lockfile
+++ b/services/default/gradle/dependency-locks/runtime.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/default/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/services/default/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/default/gradle/dependency-locks/testCompile.lockfile
+++ b/services/default/gradle/dependency-locks/testCompile.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/default/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/services/default/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -242,7 +242,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/services/default/gradle/dependency-locks/testRuntime.lockfile
+++ b/services/default/gradle/dependency-locks/testRuntime.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/default/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/services/default/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/pubapi/gradle/dependency-locks/compile.lockfile
+++ b/services/pubapi/gradle/dependency-locks/compile.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/pubapi/gradle/dependency-locks/compileClasspath.lockfile
+++ b/services/pubapi/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -242,7 +242,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/services/pubapi/gradle/dependency-locks/default.lockfile
+++ b/services/pubapi/gradle/dependency-locks/default.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/pubapi/gradle/dependency-locks/runtime.lockfile
+++ b/services/pubapi/gradle/dependency-locks/runtime.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/pubapi/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/services/pubapi/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/pubapi/gradle/dependency-locks/testCompile.lockfile
+++ b/services/pubapi/gradle/dependency-locks/testCompile.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/pubapi/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/services/pubapi/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -242,7 +242,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/services/pubapi/gradle/dependency-locks/testRuntime.lockfile
+++ b/services/pubapi/gradle/dependency-locks/testRuntime.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/pubapi/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/services/pubapi/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/tools/gradle/dependency-locks/compile.lockfile
+++ b/services/tools/gradle/dependency-locks/compile.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/tools/gradle/dependency-locks/compileClasspath.lockfile
+++ b/services/tools/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -242,7 +242,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/services/tools/gradle/dependency-locks/default.lockfile
+++ b/services/tools/gradle/dependency-locks/default.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/tools/gradle/dependency-locks/runtime.lockfile
+++ b/services/tools/gradle/dependency-locks/runtime.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/tools/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/services/tools/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/tools/gradle/dependency-locks/testCompile.lockfile
+++ b/services/tools/gradle/dependency-locks/testCompile.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/tools/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/services/tools/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -242,7 +242,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.conscrypt:conscrypt-openjdk-uber:2.5.1

--- a/services/tools/gradle/dependency-locks/testRuntime.lockfile
+++ b/services/tools/gradle/dependency-locks/testRuntime.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20

--- a/services/tools/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/services/tools/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -17,7 +17,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.0
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0
 com.fasterxml.jackson:jackson-bom:2.13.0
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.0.6
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.7
 com.github.docker-java:docker-java-transport-zerodep:3.2.7
 com.github.docker-java:docker-java-transport:3.2.7
@@ -124,7 +124,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.8.9
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.33
-com.google.errorprone:error_prone_annotations:2.11.0
+com.google.errorprone:error_prone_annotations:2.10.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -253,7 +253,7 @@ org.bouncycastle:bcpg-jdk15on:1.67
 org.bouncycastle:bcpkix-jdk15on:1.67
 org.bouncycastle:bcprov-jdk15on:1.67
 org.checkerframework:checker-compat-qual:2.5.5
-org.checkerframework:checker-qual:3.21.3
+org.checkerframework:checker-qual:3.21.0
 org.codehaus.jackson:jackson-core-asl:1.9.13
 org.codehaus.jackson:jackson-mapper-asl:1.9.13
 org.codehaus.mojo:animal-sniffer-annotations:1.20


### PR DESCRIPTION
Apparently Caffeine >=3.* requires Java 11, and we're still stuck on Java 8
because of App Engine Standard.  Fortunately this doesn't affect the exposed
interface we're using, so we can simply go back to the newest Caffeine version
once Registry 3.0 Phase 3 (GKE migration) is completed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1600)
<!-- Reviewable:end -->
