### PR TITLE
Validate that a registrar has billing accounts for all its allowed TLDs

### DIFF
--- a/core/src/main/java/google/registry/model/OteAccountBuilder.java
+++ b/core/src/main/java/google/registry/model/OteAccountBuilder.java
@@ -38,6 +38,7 @@ import google.registry.model.registrar.RegistrarAddress;
 import google.registry.model.registrar.RegistrarContact;
 import google.registry.model.tld.Registry;
 import google.registry.model.tld.Registry.TldState;
+import google.registry.model.tld.Registry.TldType;
 import google.registry.model.tld.label.PremiumList;
 import google.registry.model.tld.label.PremiumListDao;
 import google.registry.persistence.VKey;
@@ -110,6 +111,17 @@ public final class OteAccountBuilder {
           Money.of(CurrencyUnit.USD, 100),
           DateTime.parse("2030-03-01T00:00:00Z"),
           Money.of(CurrencyUnit.USD, 0));
+
+  /**
+   * The default billing account map applied to all OT&amp;E registrars.
+   *
+   * <p>This contains dummy values for USD and JPY so that OT&amp;E registrars can be granted access
+   * to all existing TLDs in sandbox. Note that OT&amp;E is only on sandbox and thus these dummy
+   * values will never be used in production (the only environment where real invoicing takes
+   * place).
+   */
+  public static final ImmutableMap<CurrencyUnit, String> DEFAULT_BILLING_ACCOUNT_MAP =
+      ImmutableMap.of(CurrencyUnit.USD, "123", CurrencyUnit.JPY, "456");
 
   private final ImmutableMap<String, String> registrarIdToTld;
   private final Registry sunriseTld;
@@ -305,6 +317,7 @@ public final class OteAccountBuilder {
             .setTldStateTransitions(ImmutableSortedMap.of(START_OF_TIME, initialTldState))
             .setDnsWriters(ImmutableSet.of("VoidDnsWriter"))
             .setPremiumList(premiumList.get())
+            .setTldType(TldType.TEST)
             .setRoidSuffix(
                 String.format(
                     "%S%X",
@@ -334,6 +347,7 @@ public final class OteAccountBuilder {
         .setPhoneNumber("+1.2125550100")
         .setIcannReferralEmail("nightmare@registrar.test")
         .setState(Registrar.State.ACTIVE)
+        .setBillingAccountMap(DEFAULT_BILLING_ACCOUNT_MAP)
         .build();
   }
 

--- a/core/src/main/java/google/registry/model/tld/Registries.java
+++ b/core/src/main/java/google/registry/model/tld/Registries.java
@@ -72,7 +72,7 @@ public final class Registries {
                                 .stream()
                                 .map(Key::getName)
                                 .collect(toImmutableSet());
-                        return Registry.getAll(tlds).stream()
+                        return Registry.get(tlds).stream()
                             .map(e -> Maps.immutableEntry(e.getTldStr(), e.getTldType()))
                             .collect(entriesToImmutableMap());
                       } else {
@@ -105,7 +105,7 @@ public final class Registries {
 
   /** Returns the Registry entities themselves of the given type loaded fresh from Datastore. */
   public static ImmutableSet<Registry> getTldEntitiesOfType(TldType type) {
-    return Registry.getAll(filterValues(cache.get(), equalTo(type)).keySet());
+    return Registry.get(filterValues(cache.get(), equalTo(type)).keySet());
   }
 
   /** Pass-through check that the specified TLD exists, otherwise throw an IAE. */

--- a/core/src/main/java/google/registry/tools/CreateOrUpdateRegistrarCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdateRegistrarCommand.java
@@ -24,14 +24,11 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.joda.time.DateTimeZone.UTC;
 
 import com.beust.jcommander.Parameter;
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import google.registry.flows.certs.CertificateChecker;
 import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.RegistrarAddress;
-import google.registry.model.tld.Registry;
 import google.registry.tools.params.KeyValueMapParameter.CurrencyUnitToStringMap;
 import google.registry.tools.params.OptionalLongParameter;
 import google.registry.tools.params.OptionalPhoneNumberParameter;
@@ -46,7 +43,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import org.joda.money.CurrencyUnit;
@@ -433,22 +429,6 @@ abstract class CreateOrUpdateRegistrarCommand extends MutatingCommand {
         // Require a phone passcode.
         checkArgument(
             newRegistrar.getPhonePasscode() != null, "--passcode is required for REAL registrars.");
-        // Check if registrar has billing account IDs for the currency of the TLDs that it is
-        // allowed to register.
-        ImmutableSet<CurrencyUnit> tldCurrencies =
-            newRegistrar
-                .getAllowedTlds()
-                .stream()
-                .map(tld -> Registry.get(tld).getCurrency())
-                .collect(toImmutableSet());
-        Set<CurrencyUnit> currenciesWithoutBillingAccountId =
-            newRegistrar.getBillingAccountMap() == null
-                ? tldCurrencies
-                : Sets.difference(tldCurrencies, newRegistrar.getBillingAccountMap().keySet());
-        checkArgument(
-            currenciesWithoutBillingAccountId.isEmpty(),
-            "Need billing account map entries for currencies: %s",
-            Joiner.on(' ').join(currenciesWithoutBillingAccountId));
       }
 
       stageEntityChange(oldRegistrar, newRegistrar);

--- a/core/src/main/java/google/registry/tools/RegistryTool.java
+++ b/core/src/main/java/google/registry/tools/RegistryTool.java
@@ -15,6 +15,7 @@
 package google.registry.tools;
 
 import com.google.common.collect.ImmutableMap;
+import google.registry.tools.javascrap.BackfillRegistrarBillingAccountsCommand;
 import google.registry.tools.javascrap.CompareEscrowDepositsCommand;
 import google.registry.tools.javascrap.HardDeleteHostCommand;
 
@@ -30,6 +31,7 @@ public final class RegistryTool {
   public static final ImmutableMap<String, Class<? extends Command>> COMMAND_MAP =
       new ImmutableMap.Builder<String, Class<? extends Command>>()
           .put("ack_poll_messages", AckPollMessagesCommand.class)
+          .put("backfill_registrar_billing_accounts", BackfillRegistrarBillingAccountsCommand.class)
           .put("canonicalize_labels", CanonicalizeLabelsCommand.class)
           .put("check_domain", CheckDomainCommand.class)
           .put("check_domain_claims", CheckDomainClaimsCommand.class)

--- a/core/src/main/java/google/registry/tools/RegistryToolComponent.java
+++ b/core/src/main/java/google/registry/tools/RegistryToolComponent.java
@@ -43,6 +43,7 @@ import google.registry.request.Modules.UrlConnectionServiceModule;
 import google.registry.request.Modules.UrlFetchServiceModule;
 import google.registry.request.Modules.UserServiceModule;
 import google.registry.tools.AuthModule.LocalCredentialModule;
+import google.registry.tools.javascrap.BackfillRegistrarBillingAccountsCommand;
 import google.registry.tools.javascrap.CompareEscrowDepositsCommand;
 import google.registry.tools.javascrap.HardDeleteHostCommand;
 import google.registry.util.UtilsModule;
@@ -89,6 +90,8 @@ import javax.inject.Singleton;
     })
 interface RegistryToolComponent {
   void inject(AckPollMessagesCommand command);
+
+  void inject(BackfillRegistrarBillingAccountsCommand command);
 
   void inject(CheckDomainClaimsCommand command);
 

--- a/core/src/main/java/google/registry/tools/javascrap/BackfillRegistrarBillingAccountsCommand.java
+++ b/core/src/main/java/google/registry/tools/javascrap/BackfillRegistrarBillingAccountsCommand.java
@@ -1,0 +1,56 @@
+// Copyright 2021 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.tools.javascrap;
+
+import static com.google.common.base.Preconditions.checkState;
+import static google.registry.model.OteAccountBuilder.DEFAULT_BILLING_ACCOUNT_MAP;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+
+import com.beust.jcommander.Parameters;
+import google.registry.config.RegistryEnvironment;
+import google.registry.model.registrar.Registrar;
+import google.registry.tools.CommandWithRemoteApi;
+
+/**
+ * Backfills the billing account maps on all Registrars that don't have any set.
+ *
+ * <p>This should not (and cannot) be used on production. Its purpose is to backfill these values on
+ * sandbox, where most registrars have an empty billing account map, including all that were created
+ * for OT&amp;E. The same default billing account map is used for all registrars, and includes
+ * values for USD and JPY. The actual values here don't matter as we don't do invoicing on sandbox
+ * anyway.
+ */
+@Parameters(separators = " =", commandDescription = "Backfill registrar billing account maps.")
+public class BackfillRegistrarBillingAccountsCommand implements CommandWithRemoteApi {
+
+  @Override
+  public void run() throws Exception {
+    checkState(
+        RegistryEnvironment.get() != RegistryEnvironment.PRODUCTION,
+        "Do not run this on production");
+    System.out.println("Populating billing account maps on all registrars missing them ...");
+    tm().transact(
+            () ->
+                tm().loadAllOfStream(Registrar.class)
+                    .filter(r -> r.getBillingAccountMap().isEmpty())
+                    .forEach(
+                        r ->
+                            tm().update(
+                                    r.asBuilder()
+                                        .setBillingAccountMap(DEFAULT_BILLING_ACCOUNT_MAP)
+                                        .build())));
+    System.out.println("Done!");
+  }
+}

--- a/core/src/test/java/google/registry/export/sheet/SyncRegistrarsSheetTest.java
+++ b/core/src/test/java/google/registry/export/sheet/SyncRegistrarsSheetTest.java
@@ -336,7 +336,11 @@ public class SyncRegistrarsSheetTest {
 
   @TestOfyAndSql
   void testRun_missingValues_stillWorks() throws Exception {
-    persistNewRegistrar("SomeRegistrar", "Some Registrar", Registrar.Type.REAL, 8L);
+    persistResource(
+        persistNewRegistrar("SomeRegistrar", "Some Registrar", Registrar.Type.REAL, 8L)
+            .asBuilder()
+            .setBillingAccountMap(ImmutableMap.of())
+            .build());
 
     newSyncRegistrarsSheet().run("foobar");
 

--- a/core/src/test/java/google/registry/model/tld/RegistryTest.java
+++ b/core/src/test/java/google/registry/model/tld/RegistryTest.java
@@ -190,7 +190,7 @@ public final class RegistryTest extends EntityTestCase {
   @TestOfyAndSql
   void testGetAll() {
     createTld("foo");
-    assertThat(Registry.getAll(ImmutableSet.of("foo", "tld")))
+    assertThat(Registry.get(ImmutableSet.of("foo", "tld")))
         .containsExactlyElementsIn(
             tm().transact(
                     () ->

--- a/core/src/test/java/google/registry/testing/AppEngineExtension.java
+++ b/core/src/test/java/google/registry/testing/AppEngineExtension.java
@@ -66,6 +66,7 @@ import java.util.Set;
 import java.util.logging.LogManager;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.joda.money.CurrencyUnit;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -289,6 +290,7 @@ public final class AppEngineExtension implements BeforeEachCallback, AfterEachCa
                 .build())
         .setPhoneNumber("+1.3334445555")
         .setPhonePasscode("12345")
+        .setBillingAccountMap(ImmutableMap.of(CurrencyUnit.USD, "abc123"))
         .setContactsRequireSyncing(true);
   }
 

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -762,6 +762,7 @@ public class DatabaseHelper {
             .setType(type)
             .setState(State.ACTIVE)
             .setIanaIdentifier(ianaIdentifier)
+            .setBillingAccountMap(ImmutableMap.of(USD, "abc123"))
             .setLocalizedAddress(
                 new RegistrarAddress.Builder()
                     .setStreet(ImmutableList.of("123 Fake St"))


### PR DESCRIPTION
This will require edits to a substantial number of registrars on sandbox (nearly
all of them) because almost all of them have access to at least one TLD, but
almost none of them have any billing accounts set. Until this is set, any updates
to the existing registrars that aren't adding the billing accounts will cause
failures.

Unfortunately, there wasn't any less invasive foolproof way to implement this
change, and we already had one attempt to implement it on create registrar
command that wasn't working (because allowed TLDs tend not to be added on
initial registrar creation, but rather, afterwards as an update).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1601)
<!-- Reviewable:end -->
