### PR TITLE
Change check for root directory during rollback

### DIFF
--- a/release/rollback/common.py
+++ b/release/rollback/common.py
@@ -108,7 +108,7 @@ def get_nomulus_root() -> str:
         The absolute path to the Nomulus root directory.
     """
     for folder in pathlib.Path(__file__).parents:
-        if folder.name != 'nomulus':
+        if not folder.joinpath('rollback_tool').exists():
             continue
         if not folder.joinpath('settings.gradle').exists():
             continue


### PR DESCRIPTION
`rollback_tool` tries to infer the root of the nomulus tree by checking for a
directory named "nomulus".  This is potentially problematic (and, indeed, was
for me) since there is no guarantee what that directory will be named.

There are a number of features that characterize the root directory.  Check
for the presence of the `rollback_tool` wrapper script, as this is both at
root level and tightly coupled to the python code, so hopefully we won't
move it without testing that the script still works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1602)
<!-- Reviewable:end -->
