### PR TITLE
Change to thrown = assertThrows() then assertThat(thrown)

### DIFF
--- a/core/src/test/java/google/registry/model/OteAccountBuilderTest.java
+++ b/core/src/test/java/google/registry/model/OteAccountBuilderTest.java
@@ -225,7 +225,9 @@ public final class OteAccountBuilderTest {
 
     OteAccountBuilder oteSetupHelper = OteAccountBuilder.forRegistrarId("myclientid");
 
-    assertThat(assertThrows(IllegalStateException.class, () -> oteSetupHelper.buildAndPersist()))
+    IllegalStateException thrown =
+        assertThrows(IllegalStateException.class, () -> oteSetupHelper.buildAndPersist());
+    assertThat(thrown)
         .hasMessageThat()
         .contains("Found existing object(s) conflicting with OT&E objects");
   }
@@ -236,7 +238,9 @@ public final class OteAccountBuilderTest {
 
     OteAccountBuilder oteSetupHelper = OteAccountBuilder.forRegistrarId("myclientid");
 
-    assertThat(assertThrows(IllegalStateException.class, () -> oteSetupHelper.buildAndPersist()))
+    IllegalStateException thrown =
+        assertThrows(IllegalStateException.class, () -> oteSetupHelper.buildAndPersist());
+    assertThat(thrown)
         .hasMessageThat()
         .contains("Found existing object(s) conflicting with OT&E objects");
   }

--- a/core/src/test/java/google/registry/model/common/DatabaseMigrationStateScheduleTest.java
+++ b/core/src/test/java/google/registry/model/common/DatabaseMigrationStateScheduleTest.java
@@ -131,10 +131,11 @@ public class DatabaseMigrationStateScheduleTest extends EntityTestCase {
             .put(startTime.plusHours(2), DATASTORE_PRIMARY_NO_ASYNC)
             .put(startTime.plusHours(3), DATASTORE_PRIMARY_READ_ONLY)
             .build();
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> jpaTm().transact(() -> DatabaseMigrationStateSchedule.set(nowInvalidMap))))
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> jpaTm().transact(() -> DatabaseMigrationStateSchedule.set(nowInvalidMap)));
+    assertThat(thrown)
         .hasMessageThat()
         .isEqualTo(
             "Cannot transition from current state-as-of-now DATASTORE_ONLY "
@@ -143,14 +144,13 @@ public class DatabaseMigrationStateScheduleTest extends EntityTestCase {
 
   @Test
   void testFailure_notInTransaction() {
-    assertThat(
-            assertThrows(
-                IllegalStateException.class,
-                () ->
-                    DatabaseMigrationStateSchedule.set(
-                        DatabaseMigrationStateSchedule.DEFAULT_TRANSITION_MAP.toValueMap())))
-        .hasMessageThat()
-        .isEqualTo("Not in a transaction");
+    IllegalStateException thrown =
+        assertThrows(
+            IllegalStateException.class,
+            () ->
+                DatabaseMigrationStateSchedule.set(
+                    DatabaseMigrationStateSchedule.DEFAULT_TRANSITION_MAP.toValueMap()));
+    assertThat(thrown).hasMessageThat().isEqualTo("Not in a transaction");
   }
 
   @Test
@@ -188,10 +188,11 @@ public class DatabaseMigrationStateScheduleTest extends EntityTestCase {
   private void runInvalidTransition(MigrationState from, MigrationState to) {
     ImmutableSortedMap<DateTime, MigrationState> transitions =
         createMapEndingWithTransition(from, to);
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> jpaTm().transact(() -> DatabaseMigrationStateSchedule.set(transitions))))
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> jpaTm().transact(() -> DatabaseMigrationStateSchedule.set(transitions)));
+    assertThat(thrown)
         .hasMessageThat()
         .isEqualTo(
             String.format("validStateTransitions map cannot transition from %s to %s.", from, to));

--- a/core/src/test/java/google/registry/rdap/AbstractJsonableObjectTest.java
+++ b/core/src/test/java/google/registry/rdap/AbstractJsonableObjectTest.java
@@ -73,8 +73,10 @@ final class AbstractJsonableObjectTest {
       @JsonableElement String myString = "A";
       @JsonableElement("myString") String anotherString = "B";
     };
-    assertThat(assertThrows(JsonableException.class, () -> jsonable.toJson()))
-        .hasMessageThat().contains("Encountered the same field name 'myString' multiple times");
+    JsonableException thrown = assertThrows(JsonableException.class, () -> jsonable.toJson());
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains("Encountered the same field name 'myString' multiple times");
   }
 
   @Test
@@ -96,8 +98,8 @@ final class AbstractJsonableObjectTest {
             return in;
           }
         };
-    assertThat(assertThrows(JsonableException.class, () -> jsonable.toJson()))
-        .hasMessageThat().contains("must have no arguments");
+    JsonableException thrown = assertThrows(JsonableException.class, () -> jsonable.toJson());
+    assertThat(thrown).hasMessageThat().contains("must have no arguments");
   }
 
   @Test
@@ -186,8 +188,10 @@ final class AbstractJsonableObjectTest {
       @JsonableElement("myList[]")
       Optional<Integer> myListMeaningOfLife = Optional.of(42);
     };
-    assertThat(assertThrows(JsonableException.class, () -> jsonable.toJson()))
-        .hasMessageThat().contains("Encountered the same field name 'myList' multiple times");
+    JsonableException thrown = assertThrows(JsonableException.class, () -> jsonable.toJson());
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains("Encountered the same field name 'myList' multiple times");
   }
 
   @RestrictJsonNames({"allowed", "allowedList[]"})
@@ -226,7 +230,8 @@ final class AbstractJsonableObjectTest {
       @JsonableElement
       JsonableWithNameRestrictions wrong = new JsonableWithNameRestrictions();
     };
-    assertThat(assertThrows(JsonableException.class, () -> jsonable.toJson()))
+    JsonableException thrown = assertThrows(JsonableException.class, () -> jsonable.toJson());
+    assertThat(thrown)
         .hasMessageThat()
         .contains("must be named one of ['allowed', 'allowedList[]'], but is named 'wrong'");
   }
@@ -237,9 +242,8 @@ final class AbstractJsonableObjectTest {
       @JsonableElement
       JsonableWithNoAllowedNames wrong = new JsonableWithNoAllowedNames();
     };
-    assertThat(assertThrows(JsonableException.class, () -> jsonable.toJson()))
-        .hasMessageThat()
-        .contains("is annotated with an empty RestrictJsonNames");
+    JsonableException thrown = assertThrows(JsonableException.class, () -> jsonable.toJson());
+    assertThat(thrown).hasMessageThat().contains("is annotated with an empty RestrictJsonNames");
   }
 
   @RestrictJsonNames({})

--- a/core/src/test/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsActionTest.java
+++ b/core/src/test/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsActionTest.java
@@ -232,17 +232,15 @@ public final class UpdateRegistrarRdapBaseUrlsActionTest {
   @TestOfyAndSql
   void testNoTlds() {
     deleteTld("tld");
-    assertThat(assertThrows(IllegalArgumentException.class, action::run))
-        .hasMessageThat()
-        .isEqualTo("There must exist at least one REAL TLD.");
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, action::run);
+    assertThat(thrown).hasMessageThat().isEqualTo("There must exist at least one REAL TLD.");
   }
 
   @TestOfyAndSql
   void testOnlyTestTlds() {
     persistResource(Registry.get("tld").asBuilder().setTldType(TldType.TEST).build());
-    assertThat(assertThrows(IllegalArgumentException.class, action::run))
-        .hasMessageThat()
-        .isEqualTo("There must exist at least one REAL TLD.");
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, action::run);
+    assertThat(thrown).hasMessageThat().isEqualTo("There must exist at least one REAL TLD.");
   }
 
   @TestOfyAndSql
@@ -278,7 +276,8 @@ public final class UpdateRegistrarRdapBaseUrlsActionTest {
     httpTransport.addNextResponse(badLoginResponse);
     httpTransport.addNextResponse(badLoginResponse);
 
-    assertThat(assertThrows(RuntimeException.class, action::run))
+    RuntimeException thrown = assertThrows(RuntimeException.class, action::run);
+    assertThat(thrown)
         .hasMessageThat()
         .isEqualTo("Error contacting MosAPI server. Tried TLDs [secondtld, tld]");
   }
@@ -316,9 +315,8 @@ public final class UpdateRegistrarRdapBaseUrlsActionTest {
     httpTransport.addNextResponse(logoutResponse);
     httpTransport.addNextResponse(badLoginResponse);
 
-    assertThat(assertThrows(RuntimeException.class, action::run))
-        .hasCauseThat()
-        .isInstanceOf(JsonSyntaxException.class);
+    RuntimeException thrown = assertThrows(RuntimeException.class, action::run);
+    assertThat(thrown).hasCauseThat().isInstanceOf(JsonSyntaxException.class);
   }
 
   private static void addValidResponses(TestHttpTransport httpTransport) {

--- a/core/src/test/java/google/registry/request/auth/AuthenticatedRegistrarAccessorTest.java
+++ b/core/src/test/java/google/registry/request/auth/AuthenticatedRegistrarAccessorTest.java
@@ -403,9 +403,9 @@ class AuthenticatedRegistrarAccessorTest {
     AuthenticatedRegistrarAccessor registrarAccessor =
         AuthenticatedRegistrarAccessor.createForTesting(ImmutableSetMultimap.of());
 
-    assertThat(assertThrows(RegistrarAccessDeniedException.class, registrarAccessor::guessClientId))
-        .hasMessageThat()
-        .isEqualTo("TestUserId isn't associated with any registrar");
+    RegistrarAccessDeniedException thrown =
+        assertThrows(RegistrarAccessDeniedException.class, registrarAccessor::guessClientId);
+    assertThat(thrown).hasMessageThat().isEqualTo("TestUserId isn't associated with any registrar");
   }
 
   @TestOfyAndSql

--- a/core/src/test/java/google/registry/tools/CreateOrUpdateReservedListCommandTestCase.java
+++ b/core/src/test/java/google/registry/tools/CreateOrUpdateReservedListCommandTestCase.java
@@ -61,41 +61,38 @@ abstract class CreateOrUpdateReservedListCommandTestCase<
 
   @Test
   void testFailure_fileDoesntExist() {
-    assertThat(
-            assertThrows(
-                ParameterException.class,
-                () ->
-                    runCommandForced(
-                        "--name=xn--q9jyb4c_common-reserved",
-                        "--input=" + reservedTermsPath + "-nonexistent")))
-        .hasMessageThat()
-        .contains("-i not found");
+    ParameterException thrown =
+        assertThrows(
+            ParameterException.class,
+            () ->
+                runCommandForced(
+                    "--name=xn--q9jyb4c_common-reserved",
+                    "--input=" + reservedTermsPath + "-nonexistent"));
+    assertThat(thrown).hasMessageThat().contains("-i not found");
   }
 
   @Test
   void testFailure_fileDoesntParse() {
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                    runCommandForced(
-                        "--name=xn--q9jyb4c_common-reserved",
-                        "--input=" + invalidReservedTermsPath)))
-        .hasMessageThat()
-        .contains("No enum constant");
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                runCommandForced(
+                    "--name=xn--q9jyb4c_common-reserved", "--input=" + invalidReservedTermsPath));
+    assertThat(thrown).hasMessageThat().contains("No enum constant");
   }
 
   @Test
   void testFailure_invalidLabel_includesFullDomainName() throws Exception {
     Files.asCharSink(new File(invalidReservedTermsPath), UTF_8)
         .write("example.tld,FULLY_BLOCKED\n\n");
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                    runCommandForced(
-                        "--name=xn--q9jyb4c_common-reserved",
-                        "--input=" + invalidReservedTermsPath)))
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                runCommandForced(
+                    "--name=xn--q9jyb4c_common-reserved", "--input=" + invalidReservedTermsPath));
+    assertThat(thrown)
         .hasMessageThat()
         .isEqualTo("Label example.tld must not be a multi-level domain name");
   }

--- a/core/src/test/java/google/registry/tools/DomainLockUtilsTest.java
+++ b/core/src/test/java/google/registry/tools/DomainLockUtilsTest.java
@@ -60,7 +60,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -317,12 +316,13 @@ public final class DomainLockUtilsTest {
     domainLockUtils.saveNewRegistryUnlockRequest(
         DOMAIN_NAME, "TheRegistrar", false, Optional.empty());
 
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                    domainLockUtils.saveNewRegistryUnlockRequest(
-                        DOMAIN_NAME, "TheRegistrar", false, Optional.empty())))
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                domainLockUtils.saveNewRegistryUnlockRequest(
+                    DOMAIN_NAME, "TheRegistrar", false, Optional.empty()));
+    assertThat(thrown)
         .hasMessageThat()
         .isEqualTo("A pending unlock action already exists for example.tld");
   }
@@ -332,37 +332,38 @@ public final class DomainLockUtilsTest {
     RegistryLock lock =
         domainLockUtils.saveNewRegistryLockRequest(DOMAIN_NAME, "TheRegistrar", null, true);
     domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), true);
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                    domainLockUtils.saveNewRegistryUnlockRequest(
-                        DOMAIN_NAME, "TheRegistrar", false, Optional.empty())))
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                domainLockUtils.saveNewRegistryUnlockRequest(
+                    DOMAIN_NAME, "TheRegistrar", false, Optional.empty()));
+    assertThat(thrown)
         .hasMessageThat()
         .isEqualTo("Non-admin user cannot unlock admin-locked domain example.tld");
   }
 
   @TestOfyAndSql
   void testFailure_createLock_unknownDomain() {
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                    domainLockUtils.saveNewRegistryLockRequest(
-                        "asdf.tld", "TheRegistrar", POC_ID, false)))
-        .hasMessageThat()
-        .isEqualTo("Domain doesn't exist");
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                domainLockUtils.saveNewRegistryLockRequest(
+                    "asdf.tld", "TheRegistrar", POC_ID, false));
+    assertThat(thrown).hasMessageThat().isEqualTo("Domain doesn't exist");
   }
 
   @TestOfyAndSql
   void testFailure_createLock_alreadyPendingLock() {
     domainLockUtils.saveNewRegistryLockRequest(DOMAIN_NAME, "TheRegistrar", POC_ID, false);
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                    domainLockUtils.saveNewRegistryLockRequest(
-                        DOMAIN_NAME, "TheRegistrar", POC_ID, false)))
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                domainLockUtils.saveNewRegistryLockRequest(
+                    DOMAIN_NAME, "TheRegistrar", POC_ID, false));
+    assertThat(thrown)
         .hasMessageThat()
         .isEqualTo("A pending or completed lock action already exists for example.tld");
   }
@@ -370,26 +371,24 @@ public final class DomainLockUtilsTest {
   @TestOfyAndSql
   void testFailure_createLock_alreadyLocked() {
     persistResource(domain.asBuilder().setStatusValues(REGISTRY_LOCK_STATUSES).build());
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                    domainLockUtils.saveNewRegistryLockRequest(
-                        DOMAIN_NAME, "TheRegistrar", POC_ID, false)))
-        .hasMessageThat()
-        .isEqualTo("Domain example.tld is already locked");
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                domainLockUtils.saveNewRegistryLockRequest(
+                    DOMAIN_NAME, "TheRegistrar", POC_ID, false));
+    assertThat(thrown).hasMessageThat().isEqualTo("Domain example.tld is already locked");
   }
 
   @TestOfyAndSql
   void testFailure_createUnlock_alreadyUnlocked() {
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                    domainLockUtils.saveNewRegistryUnlockRequest(
-                        DOMAIN_NAME, "TheRegistrar", false, Optional.empty())))
-        .hasMessageThat()
-        .isEqualTo("Domain example.tld is already unlocked");
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                domainLockUtils.saveNewRegistryUnlockRequest(
+                    DOMAIN_NAME, "TheRegistrar", false, Optional.empty()));
+    assertThat(thrown).hasMessageThat().isEqualTo("Domain example.tld is already unlocked");
   }
 
   @TestOfyAndSql
@@ -398,12 +397,11 @@ public final class DomainLockUtilsTest {
         domainLockUtils.saveNewRegistryLockRequest(DOMAIN_NAME, "TheRegistrar", POC_ID, false);
     domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), false);
     domain = loadByEntity(domain);
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), false)))
-        .hasMessageThat()
-        .isEqualTo("Domain example.tld is already locked");
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), false));
+    assertThat(thrown).hasMessageThat().isEqualTo("Domain example.tld is already locked");
     assertNoDomainChanges();
   }
 
@@ -412,12 +410,11 @@ public final class DomainLockUtilsTest {
     RegistryLock lock =
         domainLockUtils.saveNewRegistryLockRequest(DOMAIN_NAME, "TheRegistrar", POC_ID, false);
     clock.advanceBy(standardDays(1));
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), true)))
-        .hasMessageThat()
-        .isEqualTo("The pending lock has expired; please try again");
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), true));
+    assertThat(thrown).hasMessageThat().isEqualTo("The pending lock has expired; please try again");
     assertNoDomainChanges();
   }
 
@@ -425,12 +422,11 @@ public final class DomainLockUtilsTest {
   void testFailure_applyLock_nonAdmin_applyAdminLock() {
     RegistryLock lock =
         domainLockUtils.saveNewRegistryLockRequest(DOMAIN_NAME, "TheRegistrar", null, true);
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), false)))
-        .hasMessageThat()
-        .isEqualTo("Non-admin user cannot complete admin lock");
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), false));
+    assertThat(thrown).hasMessageThat().isEqualTo("Non-admin user cannot complete admin lock");
     assertNoDomainChanges();
   }
 
@@ -444,12 +440,11 @@ public final class DomainLockUtilsTest {
             DOMAIN_NAME, "TheRegistrar", false, Optional.empty());
     domainLockUtils.verifyAndApplyUnlock(unlock.getVerificationCode(), false);
 
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> domainLockUtils.verifyAndApplyUnlock(unlock.getVerificationCode(), false)))
-        .hasMessageThat()
-        .isEqualTo("Domain example.tld is already unlocked");
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> domainLockUtils.verifyAndApplyUnlock(unlock.getVerificationCode(), false));
+    assertThat(thrown).hasMessageThat().isEqualTo("Domain example.tld is already unlocked");
     assertNoDomainChanges();
   }
 
@@ -461,12 +456,11 @@ public final class DomainLockUtilsTest {
     // reload to pick up modification times, etc
     lock = getRegistryLockByVerificationCode(verificationCode).get();
     domain = persistResource(domain.asBuilder().setStatusValues(REGISTRY_LOCK_STATUSES).build());
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> domainLockUtils.verifyAndApplyLock(verificationCode, false)))
-        .hasMessageThat()
-        .isEqualTo("Domain example.tld is already locked");
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> domainLockUtils.verifyAndApplyLock(verificationCode, false));
+    assertThat(thrown).hasMessageThat().isEqualTo("Domain example.tld is already locked");
 
     // Failure during Datastore portion shouldn't affect the SQL object
     RegistryLock afterAction = getRegistryLockByVerificationCode(lock.getVerificationCode()).get();
@@ -517,10 +511,11 @@ public final class DomainLockUtilsTest {
                 .setRegistrarPocId("someone@example.com")
                 .setVerificationCode("hi")
                 .build());
-    assertThat(
-            Assert.assertThrows(
-                IllegalArgumentException.class,
-                () -> domainLockUtils.enqueueDomainRelock(lockWithoutDuration)))
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> domainLockUtils.enqueueDomainRelock(lockWithoutDuration));
+    assertThat(thrown)
         .hasMessageThat()
         .isEqualTo(
             String.format(

--- a/core/src/test/java/google/registry/tools/SetDatabaseMigrationStateCommandTest.java
+++ b/core/src/test/java/google/registry/tools/SetDatabaseMigrationStateCommandTest.java
@@ -139,14 +139,15 @@ public class SetDatabaseMigrationStateCommandTest
 
   @TestOfyAndSql
   void testFailure_invalidTransition() {
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                    runCommandForced(
-                        String.format(
-                            "--migration_schedule=%s=DATASTORE_ONLY,%s=DATASTORE_PRIMARY_READ_ONLY",
-                            START_OF_TIME, START_OF_TIME.plusHours(1)))))
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                runCommandForced(
+                    String.format(
+                        "--migration_schedule=%s=DATASTORE_ONLY,%s=DATASTORE_PRIMARY_READ_ONLY",
+                        START_OF_TIME, START_OF_TIME.plusHours(1))));
+    assertThat(thrown)
         .hasMessageThat()
         .isEqualTo(
             "validStateTransitions map cannot transition from DATASTORE_ONLY "
@@ -158,18 +159,16 @@ public class SetDatabaseMigrationStateCommandTest
     // The map we pass in is valid by itself, but we can't go from DATASTORE_ONLY now to
     // DATASTORE_PRIMARY_READ_ONLY now
     DateTime now = fakeClock.nowUtc();
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                    runCommandForced(
-                        String.format(
-                            "--migration_schedule=%s=DATASTORE_ONLY,%s=DATASTORE_PRIMARY,"
-                                + "%s=DATASTORE_PRIMARY_NO_ASYNC,%s=DATASTORE_PRIMARY_READ_ONLY",
-                            START_OF_TIME,
-                            now.minusHours(3),
-                            now.minusHours(2),
-                            now.minusHours(1)))))
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                runCommandForced(
+                    String.format(
+                        "--migration_schedule=%s=DATASTORE_ONLY,%s=DATASTORE_PRIMARY,"
+                            + "%s=DATASTORE_PRIMARY_NO_ASYNC,%s=DATASTORE_PRIMARY_READ_ONLY",
+                        START_OF_TIME, now.minusHours(3), now.minusHours(2), now.minusHours(1))));
+    assertThat(thrown)
         .hasMessageThat()
         .isEqualTo(
             "Cannot transition from current state-as-of-now DATASTORE_ONLY "

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistryLockGetActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistryLockGetActionTest.java
@@ -226,25 +226,22 @@ final class RegistryLockGetActionTest {
   @Test
   void testFailure_invalidMethod() {
     action.method = Method.POST;
-    assertThat(assertThrows(IllegalArgumentException.class, action::run))
-        .hasMessageThat()
-        .isEqualTo("Only GET requests allowed");
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, action::run);
+    assertThat(thrown).hasMessageThat().isEqualTo("Only GET requests allowed");
   }
 
   @Test
   void testFailure_noAuthInfo() {
     action.authResult = AuthResult.NOT_AUTHENTICATED;
-    assertThat(assertThrows(IllegalArgumentException.class, action::run))
-        .hasMessageThat()
-        .isEqualTo("User auth info must be present");
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, action::run);
+    assertThat(thrown).hasMessageThat().isEqualTo("User auth info must be present");
   }
 
   @Test
   void testFailure_noClientId() {
     action.paramClientId = Optional.empty();
-    assertThat(assertThrows(IllegalArgumentException.class, action::run))
-        .hasMessageThat()
-        .isEqualTo("clientId must be present");
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, action::run);
+    assertThat(thrown).hasMessageThat().isEqualTo("clientId must be present");
   }
 
   @Test


### PR DESCRIPTION
We usually inline our code to avoid a variable being declared then used only once. However, for test cases, it's actually preferred (at least on our team) to have `assertThrows()` being in a different line from `assertThat()` for readability. There are still places in the codebase with `assertThat(assertThrows())` in test cases and the purpose of this PR is to make the assertions for failure cases more consistent. 

For failure cases, we would like to use `assertThrows()` to first statement the failure, then use `assertThat()` to verify the error message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1606)
<!-- Reviewable:end -->
