### PR TITLE
Ignore version UIDs during txn deserialization

### DIFF
--- a/core/src/main/java/google/registry/tools/RegistryTool.java
+++ b/core/src/main/java/google/registry/tools/RegistryTool.java
@@ -104,6 +104,7 @@ public final class RegistryTool {
           .put("registrar_contact", RegistrarContactCommand.class)
           .put("remove_registry_one_key", RemoveRegistryOneKeyCommand.class)
           .put("renew_domain", RenewDomainCommand.class)
+          .put("replay_txns", ReplayTxnsCommand.class)
           .put("resave_entities", ResaveEntitiesCommand.class)
           .put("resave_environment_entities", ResaveEnvironmentEntitiesCommand.class)
           .put("resave_epp_resource", ResaveEppResourceCommand.class)

--- a/core/src/main/java/google/registry/tools/ReplayTxnsCommand.java
+++ b/core/src/main/java/google/registry/tools/ReplayTxnsCommand.java
@@ -1,0 +1,54 @@
+// Copyright 2022 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.tools;
+
+import static google.registry.persistence.transaction.TransactionManagerFactory.replicaJpaTm;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import google.registry.persistence.transaction.Transaction;
+import google.registry.persistence.transaction.TransactionEntity;
+import java.util.List;
+
+@Parameters(separators = " =", commandDescription = "Replay a range of transactions.")
+public class ReplayTxnsCommand implements CommandWithRemoteApi {
+
+  private static final int BATCH_SIZE = 200;
+
+  @Parameter(
+      names = {"-s", "--start-txn-id"},
+      description = "Transaction id to start replaying at.",
+      required = true)
+  long startTxnId;
+
+  @Override
+  public void run() throws Exception {
+    List<TransactionEntity> txns;
+    do {
+      txns = replicaJpaTm().transact(() ->
+          replicaJpaTm().query(
+                  "SELECT txn FROM TransactionEntity txn where id >= :startTxn ORDER BY id",
+              TransactionEntity.class)
+              .setParameter("startTxn", startTxnId)
+              .setMaxResults(BATCH_SIZE)
+              .getResultList());
+      for (TransactionEntity txn : txns) {
+        System.out.println("Replaying transaction " + txn.getId());
+        Transaction.deserialize(txn.getContents());
+        startTxnId = txn.getId() + 1;
+      }
+    } while (txns.size() > 0);
+  }
+}

--- a/core/src/main/java/google/registry/tools/ReplayTxnsCommand.java
+++ b/core/src/main/java/google/registry/tools/ReplayTxnsCommand.java
@@ -37,13 +37,18 @@ public class ReplayTxnsCommand implements CommandWithRemoteApi {
   public void run() throws Exception {
     List<TransactionEntity> txns;
     do {
-      txns = replicaJpaTm().transact(() ->
-          replicaJpaTm().query(
-                  "SELECT txn FROM TransactionEntity txn where id >= :startTxn ORDER BY id",
-              TransactionEntity.class)
-              .setParameter("startTxn", startTxnId)
-              .setMaxResults(BATCH_SIZE)
-              .getResultList());
+      txns =
+          replicaJpaTm()
+              .transact(
+                  () ->
+                      replicaJpaTm()
+                          .query(
+                              "SELECT txn FROM TransactionEntity txn where id >= :startTxn ORDER"
+                                  + " BY id",
+                              TransactionEntity.class)
+                          .setParameter("startTxn", startTxnId)
+                          .setMaxResults(BATCH_SIZE)
+                          .getResultList());
       for (TransactionEntity txn : txns) {
         System.out.println("Replaying transaction " + txn.getId());
         Transaction.deserialize(txn.getContents());


### PR DESCRIPTION
When deserializing transactions for replay to datastore, ignore class version
UIDs that don't match those of the local classes and just use the local class
descriptors instead.  This is a simple solution for the problem of persisted
VKeys containing references to classes where the class has been updated and
the serial version UID has changed.

Also add a "replay_txns" command that replays the transactions from a given
start point so we can verify all transactions are deserializable.

TESTED:
    Ran replay_txns against all transactions on sandbox beginning with
    transaction id 1828385, which includes Recurring billing events containing
    both the old and the new serial version UIDs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1607)
<!-- Reviewable:end -->
