### PR TITLE
Increase Nomulus build timeout

### DIFF
--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -144,6 +144,6 @@ artifacts:
     - 'release/cloudbuild-delete-*.yaml'
     - 'release/cloudbuild-schema-deploy-*.yaml'
 
-timeout: 3600s
+timeout: 7200s
 options:
   machineType: 'E2_HIGHCPU_32'


### PR DESCRIPTION
We have recently started to routinely breach the 1h timeout. Increasing
this value to 2h. We should also look into reusing the artifacts when
building RCs for different environments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1613)
<!-- Reviewable:end -->
