### PR TITLE
Add missing transaction for whois lookups

### DIFF
--- a/core/src/main/java/google/registry/whois/NameserverWhoisResponse.java
+++ b/core/src/main/java/google/registry/whois/NameserverWhoisResponse.java
@@ -49,9 +49,11 @@ final class NameserverWhoisResponse extends WhoisResponseImpl {
       HostResource host = hosts.get(i);
       String registrarId =
           host.isSubordinate()
-              ? tm().loadByKey(host.getSuperordinateDomain())
-                  .cloneProjectedAtTime(getTimestamp())
-                  .getCurrentSponsorRegistrarId()
+              ? tm().transact(
+                      () ->
+                          tm().loadByKey(host.getSuperordinateDomain())
+                              .cloneProjectedAtTime(getTimestamp())
+                              .getCurrentSponsorRegistrarId())
               : host.getPersistedCurrentSponsorRegistrarId();
       Optional<Registrar> registrar = Registrar.loadByRegistrarIdCached(registrarId);
       checkState(registrar.isPresent(), "Could not load registrar %s", registrarId);

--- a/core/src/main/java/google/registry/whois/NameserverWhoisResponse.java
+++ b/core/src/main/java/google/registry/whois/NameserverWhoisResponse.java
@@ -16,9 +16,12 @@ package google.registry.whois;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.net.InetAddresses;
 import google.registry.model.host.HostResource;
 import google.registry.model.registrar.Registrar;
@@ -44,16 +47,29 @@ final class NameserverWhoisResponse extends WhoisResponseImpl {
 
   @Override
   public WhoisResponseResults getResponse(boolean preferUnicode, String disclaimer) {
+    // If we have subordinate hosts, load their registrar ids in a single transaction up-front.
+    ImmutableList<HostResource> subordinateHosts =
+        hosts.stream().filter(HostResource::isSubordinate).collect(toImmutableList());
+    ImmutableMap<HostResource, String> hostRegistrars =
+        subordinateHosts.isEmpty()
+            ? ImmutableMap.of()
+            : tm().transact(
+                    () ->
+                        subordinateHosts.stream()
+                            .collect(
+                                toImmutableMap(
+                                    k -> k,
+                                    host ->
+                                        tm().loadByKey(host.getSuperordinateDomain())
+                                            .cloneProjectedAtTime(getTimestamp())
+                                            .getCurrentSponsorRegistrarId())));
+
     BasicEmitter emitter = new BasicEmitter();
     for (int i = 0; i < hosts.size(); i++) {
       HostResource host = hosts.get(i);
       String registrarId =
           host.isSubordinate()
-              ? tm().transact(
-                      () ->
-                          tm().loadByKey(host.getSuperordinateDomain())
-                              .cloneProjectedAtTime(getTimestamp())
-                              .getCurrentSponsorRegistrarId())
+              ? hostRegistrars.get(host)
               : host.getPersistedCurrentSponsorRegistrarId();
       Optional<Registrar> registrar = Registrar.loadByRegistrarIdCached(registrarId);
       checkState(registrar.isPresent(), "Could not load registrar %s", registrarId);

--- a/core/src/main/java/google/registry/whois/NameserverWhoisResponse.java
+++ b/core/src/main/java/google/registry/whois/NameserverWhoisResponse.java
@@ -17,11 +17,11 @@ package google.registry.whois;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import com.google.common.net.InetAddresses;
 import google.registry.model.host.HostResource;
 import google.registry.model.registrar.Registrar;
@@ -55,14 +55,12 @@ final class NameserverWhoisResponse extends WhoisResponseImpl {
             ? ImmutableMap.of()
             : tm().transact(
                     () ->
-                        subordinateHosts.stream()
-                            .collect(
-                                toImmutableMap(
-                                    k -> k,
-                                    host ->
-                                        tm().loadByKey(host.getSuperordinateDomain())
-                                            .cloneProjectedAtTime(getTimestamp())
-                                            .getCurrentSponsorRegistrarId())));
+                        Maps.toMap(
+                            subordinateHosts.iterator(),
+                            host ->
+                                tm().loadByKey(host.getSuperordinateDomain())
+                                    .cloneProjectedAtTime(getTimestamp())
+                                    .getCurrentSponsorRegistrarId()));
 
     BasicEmitter emitter = new BasicEmitter();
     for (int i = 0; i < hosts.size(); i++) {

--- a/core/src/test/resources/google/registry/whois/whois_subord_nameserver.txt
+++ b/core/src/test/resources/google/registry/whois/whois_subord_nameserver.txt
@@ -1,0 +1,11 @@
+Server Name: ns1.zobo.tld
+IP Address: 192.0.2.123
+IP Address: 2001:db8::1
+Registrar: The Registrar
+Registrar WHOIS Server: whois.nic.fakewhois.example
+Registrar URL: http://my.fake.url
+>>> Last update of WHOIS database: 2009-05-29T20:15:00Z <<<
+
+Doodle Disclaimer
+I exist so that carriage return
+in disclaimer can be tested.


### PR DESCRIPTION
Nameserver whois lookups are failing under SQL for hosts with superordinate
domains because the query in this case is not done in a transaction.  We
missed this during testing because a) we didn't have a test for lookups of
hosts with superordinate domains and b) we missed converting
NameserverWhoisResponseTest to a DualDatabaseTest.

This PR fixes the problem and adds the requisite testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1614)
<!-- Reviewable:end -->
