### PR TITLE
Remove cron entries for Datastore-specific jobs

### DIFF
--- a/core/src/main/java/google/registry/batch/RefreshDnsOnHostRenameAction.java
+++ b/core/src/main/java/google/registry/batch/RefreshDnsOnHostRenameAction.java
@@ -49,6 +49,7 @@ import google.registry.batch.AsyncTaskMetrics.OperationResult;
 import google.registry.dns.DnsQueue;
 import google.registry.mapreduce.MapreduceRunner;
 import google.registry.mapreduce.inputs.NullInput;
+import google.registry.model.annotations.DeleteAfterMigration;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.host.HostResource;
 import google.registry.model.server.Lock;
@@ -79,6 +80,8 @@ import org.joda.time.Duration;
     service = Action.Service.BACKEND,
     path = "/_dr/task/refreshDnsOnHostRename",
     auth = Auth.AUTH_INTERNAL_OR_ADMIN)
+@DeleteAfterMigration
+@Deprecated
 public class RefreshDnsOnHostRenameAction implements Runnable {
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();

--- a/core/src/main/java/google/registry/env/alpha/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/alpha/default/WEB-INF/cron.xml
@@ -80,54 +80,12 @@
   </cron>
 
   <cron>
-    <url><![CDATA[/_dr/task/resaveAllEppResources?fast=true]]></url>
+    <url><![CDATA[/_dr/task/resaveAllEppResourcesPipeline?fast=true]]></url>
     <description>
       This job resaves all our resources, projected in time to "now".
       It is needed for "deleteOldCommitLogs" to work correctly.
     </description>
     <schedule>1st monday of month 09:00</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/task/deleteOldCommitLogs]]></url>
-    <description>
-      This job deletes unreferenced commit logs from Datastore that are older than thirty days.
-      Since references are only updated on save, if we want to delete "unneeded" commit logs, we
-      also need "resaveAllEppResources" to run periodically.
-    </description>
-    <schedule>3rd monday of month 09:00</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/cron/commitLogCheckpoint]]></url>
-    <description>
-      This job checkpoints the commit log buckets and exports the diff since last checkpoint to GCS.
-    </description>
-    <schedule>every 3 minutes synchronized</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/task/deleteContactsAndHosts]]></url>
-    <description>
-      This job runs a mapreduce that processes batch asynchronous deletions of
-      contact and host resources by mapping over all EppResources and checking
-      for any references to the contacts/hosts in pending deletion.
-    </description>
-    <schedule>every 5 minutes synchronized</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/task/refreshDnsOnHostRename]]></url>
-    <description>
-      This job runs a mapreduce that asynchronously handles DNS refreshes for
-      host renames by mapping over all domains and creating DNS refresh tasks
-      for any domains that reference a renamed host.
-    </description>
-    <schedule>every 5 minutes synchronized</schedule>
     <target>backend</target>
   </cron>
 
@@ -153,23 +111,6 @@
   </cron>
 
   <cron>
-    <url><![CDATA[/_dr/cron/fanout?queue=export-snapshot&endpoint=/_dr/task/backupDatastore&runInEmpty]]></url>
-    <description>
-      This job fires off a Datastore managed-export job that generates snapshot files in GCS.
-      It also enqueues a new task to wait on the completion of that job and then load the resulting
-      snapshot into bigquery.
-    </description>
-    <!--
-      Keep google.registry.export.CheckBackupAction.MAXIMUM_BACKUP_RUNNING_TIME less than
-      this interval. -->
-    <schedule>every day 06:00</schedule>
-    <target>backend</target>
-  </cron>
-
-  <!--
-    Removed for the duration of load testing
-    TODO(b/71607184): Restore after loadtesting is done
-  <cron>
     <url><![CDATA[/_dr/cron/fanout?queue=retryable-cron-tasks&endpoint=/_dr/task/deleteProberData&runInEmpty]]></url>
     <description>
       This job clears out data from probers and runs once a week.
@@ -178,7 +119,6 @@
     <timezone>UTC</timezone>
     <target>backend</target>
   </cron>
-  -->
 
   <!-- TODO: Add borgmon job to check that these files are created and updated successfully. -->
   <cron>
@@ -196,24 +136,6 @@
       Premium terms export to Google Drive job for creating once-daily exports.
     </description>
     <schedule>every day 05:00</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/cron/fanout?queue=replay-commit-logs-to-sql&endpoint=/_dr/task/replayCommitLogsToSql&runInEmpty]]></url>
-    <description>
-      Replays recent commit logs from Datastore to the SQL secondary backend.
-    </description>
-    <schedule>every 3 minutes</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/cron/replicateToDatastore]]></url>
-    <description>
-      Replays recent transactions from SQL to the Datastore secondary backend.
-    </description>
-    <schedule>every 3 minutes</schedule>
     <target>backend</target>
   </cron>
 

--- a/core/src/main/java/google/registry/env/crash/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/crash/default/WEB-INF/cron.xml
@@ -102,55 +102,6 @@
     <target>backend</target>
   </cron>
 
-  <!-- Disabled for sql-only tests.
-  <cron>
-    <url><![CDATA[/_dr/cron/commitLogCheckpoint]]></url>
-    <description>
-      This job checkpoints the commit log buckets and exports the diff since last checkpoint to GCS.
-    </description>
-    <schedule>every 3 minutes synchronized</schedule>
-    <target>backend</target>
-  </cron>
-  -->
-
-  <cron>
-    <url><![CDATA[/_dr/task/deleteContactsAndHosts]]></url>
-    <description>
-      This job runs a mapreduce that processes batch asynchronous deletions of
-      contact and host resources by mapping over all EppResources and checking
-      for any references to the contacts/hosts in pending deletion.
-    </description>
-    <schedule>every 5 minutes synchronized</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/task/refreshDnsOnHostRename]]></url>
-    <description>
-      This job runs a mapreduce that asynchronously handles DNS refreshes for
-      host renames by mapping over all domains and creating DNS refresh tasks
-      for any domains that reference a renamed host.
-    </description>
-    <schedule>every 5 minutes synchronized</schedule>
-    <target>backend</target>
-  </cron>
-
-  <!-- Disabled for sql-only tests
-  <cron>
-    <url><![CDATA[/_dr/cron/fanout?queue=export-snapshot&endpoint=/_dr/task/backupDatastore&runInEmpty]]></url>
-    <description>
-      This job fires off a Datastore managed-export job that generates snapshot files in GCS.
-      It also enqueues a new task to wait on the completion of that job and then load the resulting
-      snapshot into bigquery.
-    </description>
-    <!- -
-      Keep google.registry.export.CheckBackupAction.MAXIMUM_BACKUP_RUNNING_TIME less than
-      this interval. - ->
-    <schedule>every day 06:00</schedule>
-    <target>backend</target>
-  </cron>
-  -->
-
   <cron>
     <url><![CDATA[/_dr/cron/fanout?queue=retryable-cron-tasks&endpoint=/_dr/task/deleteProberData&runInEmpty]]></url>
     <description>
@@ -200,26 +151,6 @@
     <target>backend</target>
   </cron>
 
-  <!-- Disabled for sql-only tests.
-  <cron>
-    <url><![CDATA[/_dr/cron/fanout?queue=replay-commit-logs-to-sql&endpoint=/_dr/task/replayCommitLogsToSql&runInEmpty]]></url>
-    <description>
-      Replays recent commit logs from Datastore to the SQL secondary backend.
-    </description>
-    <schedule>every 3 minutes</schedule>
-    <target>backend</target>
-  </cron>
-  -->
-
-  <cron>
-    <url><![CDATA[/_dr/cron/replicateToDatastore]]></url>
-    <description>
-      Replays recent transactions from SQL to the Datastore secondary backend.
-    </description>
-    <schedule>every 3 minutes</schedule>
-    <target>backend</target>
-  </cron>
-
   <!--
     The next two wipeout jobs are required when crash has production data.
    -->
@@ -227,15 +158,6 @@
     <url><![CDATA[/_dr/task/wipeOutCloudSql]]></url>
     <description>
       This job runs an action that deletes all data in Cloud SQL.
-    </description>
-    <schedule>every saturday 03:07</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/task/wipeOutDatastore]]></url>
-    <description>
-      This job runs an action that deletes all data in Cloud Datastore.
     </description>
     <schedule>every saturday 03:07</schedule>
     <target>backend</target>

--- a/core/src/main/java/google/registry/env/production/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/production/default/WEB-INF/cron.xml
@@ -103,7 +103,7 @@
   </cron>
 
   <cron>
-    <url><![CDATA[/_dr/task/resaveAllEppResources?fast=true]]></url>
+    <url><![CDATA[/_dr/task/resaveAllEppResourcesPipeline?fast=true]]></url>
     <description>
       This job resaves all our resources, projected in time to "now".
       It is needed for "deleteOldCommitLogs" to work correctly.
@@ -122,53 +122,11 @@
   </cron>
 
   <cron>
-    <url><![CDATA[/_dr/task/deleteOldCommitLogs]]></url>
-    <description>
-      This job deletes unreferenced commit logs from Datastore that are older than thirty days.
-      Since references are only updated on save, if we want to delete "unneeded" commit logs, we
-      also need "resaveAllEppResources" to run periodically.
-    </description>
-    <schedule>3rd monday of month 09:00</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/cron/commitLogCheckpoint]]></url>
-    <description>
-      This job checkpoints the commit log buckets and exports the diff since last checkpoint to GCS.
-    </description>
-    <schedule>every 3 minutes synchronized</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
     <url><![CDATA[/_dr/cron/fanout?queue=retryable-cron-tasks&endpoint=/_dr/task/exportDomainLists&runInEmpty]]></url>
     <description>
       This job exports lists of all active domain names to Google Drive and Google Cloud Storage.
     </description>
     <schedule>every 12 hours synchronized</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/task/deleteContactsAndHosts]]></url>
-    <description>
-      This job runs a mapreduce that processes batch asynchronous deletions of
-      contact and host resources by mapping over all EppResources and checking
-      for any references to the contacts/hosts in pending deletion.
-    </description>
-    <schedule>every 5 minutes synchronized</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/task/refreshDnsOnHostRename]]></url>
-    <description>
-      This job runs a mapreduce that asynchronously handles DNS refreshes for
-      host renames by mapping over all domains and creating DNS refresh tasks
-      for any domains that reference a renamed host.
-    </description>
-    <schedule>every 5 minutes synchronized</schedule>
     <target>backend</target>
   </cron>
 
@@ -199,20 +157,6 @@
       This job runs an action that sends emails to partners if their certificates are expiring soon.
     </description>
     <schedule>every day 04:30</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/cron/fanout?queue=export-snapshot&endpoint=/_dr/task/backupDatastore&runInEmpty]]></url>
-    <description>
-      This job fires off a Datastore managed-export job that generates snapshot files in GCS.
-      It also enqueues a new task to wait on the completion of that job and then load the resulting
-      snapshot into bigquery.
-    </description>
-    <!--
-      Keep google.registry.export.CheckBackupAction.MAXIMUM_BACKUP_RUNNING_TIME less than
-      this interval. -->
-    <schedule>every day 06:00</schedule>
     <target>backend</target>
   </cron>
 
@@ -337,24 +281,6 @@
       See GenerateSpec11ReportAction for more details.
     </description>
     <schedule>every day 15:00</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/cron/fanout?queue=replay-commit-logs-to-sql&endpoint=/_dr/task/replayCommitLogsToSql&runInEmpty]]></url>
-    <description>
-      Replays recent commit logs from Datastore to the SQL secondary backend.
-    </description>
-    <schedule>every 3 minutes</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/cron/replicateToDatastore]]></url>
-    <description>
-      Replays recent transactions from SQL to the Datastore secondary backend.
-    </description>
-    <schedule>every 3 minutes</schedule>
     <target>backend</target>
   </cron>
 

--- a/core/src/main/java/google/registry/env/qa/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/qa/default/WEB-INF/cron.xml
@@ -32,45 +32,12 @@
   </cron>
 
   <cron>
-    <url><![CDATA[/_dr/task/resaveAllEppResources?fast=true]]></url>
+    <url><![CDATA[/_dr/task/resaveAllEppResourcesPipeline?fast=true]]></url>
     <description>
       This job resaves all our resources, projected in time to "now".
       It is needed for "deleteOldCommitLogs" to work correctly.
     </description>
     <schedule>1st monday of month 09:00</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/task/deleteOldCommitLogs]]></url>
-    <description>
-      This job deletes unreferenced commit logs from Datastore that are older than thirty days.
-      Since references are only updated on save, if we want to delete "unneeded" commit logs, we
-      also need "resaveAllEppResources" to run periodically.
-    </description>
-    <schedule>3rd monday of month 09:00</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/task/deleteContactsAndHosts]]></url>
-    <description>
-      This job runs a mapreduce that processes batch asynchronous deletions of
-      contact and host resources by mapping over all EppResources and checking
-      for any references to the contacts/hosts in pending deletion.
-    </description>
-    <schedule>every 5 minutes synchronized</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/task/refreshDnsOnHostRename]]></url>
-    <description>
-      This job runs a mapreduce that asynchronously handles DNS refreshes for
-      host renames by mapping over all domains and creating DNS refresh tasks
-      for any domains that reference a renamed host.
-    </description>
-    <schedule>every 5 minutes synchronized</schedule>
     <target>backend</target>
   </cron>
 
@@ -99,42 +66,6 @@
       This job runs an action that deletes all data in Cloud SQL.
     </description>
     <schedule>every saturday 03:07</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/task/wipeOutDatastore]]></url>
-    <description>
-      This job runs an action that deletes all data in Cloud Datastore.
-    </description>
-    <schedule>every saturday 03:07</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/cron/fanout?queue=replay-commit-logs-to-sql&endpoint=/_dr/task/replayCommitLogsToSql&runInEmpty]]></url>
-    <description>
-      Replays recent commit logs from Datastore to the SQL secondary backend.
-    </description>
-    <schedule>every 3 minutes</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/cron/replicateToDatastore]]></url>
-    <description>
-      Replays recent transactions from SQL to the Datastore secondary backend.
-    </description>
-    <schedule>every 3 minutes</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/cron/commitLogCheckpoint]]></url>
-    <description>
-      This job checkpoints the commit log buckets and exports the diff since last checkpoint to GCS.
-    </description>
-    <schedule>every 3 minutes synchronized</schedule>
     <target>backend</target>
   </cron>
 </cronentries>

--- a/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/cron.xml
+++ b/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/cron.xml
@@ -87,7 +87,7 @@
   </cron>
 
   <cron>
-    <url><![CDATA[/_dr/task/resaveAllEppResources?fast=true]]></url>
+    <url><![CDATA[/_dr/task/resaveAllEppResourcesPipeline?fast=true]]></url>
     <description>
       This job resaves all our resources, projected in time to "now".
       It is needed for "deleteOldCommitLogs" to work correctly.
@@ -97,53 +97,11 @@
   </cron>
 
   <cron>
-    <url><![CDATA[/_dr/task/deleteOldCommitLogs]]></url>
-    <description>
-      This job deletes unreferenced commit logs from Datastore that are older than thirty days.
-      Since references are only updated on save, if we want to delete "unneeded" commit logs, we
-      also need "resaveAllEppResources" to run periodically.
-    </description>
-    <schedule>3rd monday of month 09:00</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/cron/commitLogCheckpoint]]></url>
-    <description>
-      This job checkpoints the commit log buckets and exports the diff since last checkpoint to GCS.
-    </description>
-    <schedule>every 3 minutes synchronized</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
     <url><![CDATA[/_dr/cron/fanout?queue=retryable-cron-tasks&endpoint=/_dr/task/exportDomainLists&runInEmpty]]></url>
     <description>
       This job exports lists of all active domain names to Google Drive and Google Cloud Storage.
     </description>
     <schedule>every 12 hours synchronized</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/task/deleteContactsAndHosts]]></url>
-    <description>
-      This job runs a mapreduce that processes batch asynchronous deletions of
-      contact and host resources by mapping over all EppResources and checking
-      for any references to the contacts/hosts in pending deletion.
-    </description>
-    <schedule>every 5 minutes synchronized</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/task/refreshDnsOnHostRename]]></url>
-    <description>
-      This job runs a mapreduce that asynchronously handles DNS refreshes for
-      host renames by mapping over all domains and creating DNS refresh tasks
-      for any domains that reference a renamed host.
-    </description>
-    <schedule>every 5 minutes synchronized</schedule>
     <target>backend</target>
   </cron>
 
@@ -165,20 +123,6 @@
       autorenew end date.
     </description>
     <schedule>every day 03:07</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/cron/fanout?queue=export-snapshot&endpoint=/_dr/task/backupDatastore&runInEmpty]]></url>
-    <description>
-      This job fires off a Datastore managed-export job that generates snapshot files in GCS.
-      It also enqueues a new task to wait on the completion of that job and then load the resulting
-      snapshot into bigquery.
-    </description>
-    <!--
-      Keep google.registry.export.CheckBackupAction.MAXIMUM_BACKUP_RUNNING_TIME less than
-      this interval. -->
-    <schedule>every day 06:00</schedule>
     <target>backend</target>
   </cron>
 
@@ -226,24 +170,6 @@
       Delete up to 100 expired _ah_SESSION entities from Datastore.
     </description>
     <schedule>every 15 minutes</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/cron/fanout?queue=replay-commit-logs-to-sql&endpoint=/_dr/task/replayCommitLogsToSql&runInEmpty]]></url>
-    <description>
-      Replays recent commit logs from Datastore to the SQL secondary backend.
-    </description>
-    <schedule>every 3 minutes</schedule>
-    <target>backend</target>
-  </cron>
-
-  <cron>
-    <url><![CDATA[/_dr/cron/replicateToDatastore]]></url>
-    <description>
-      Replays recent transactions from SQL to the Datastore secondary backend.
-    </description>
-    <schedule>every 3 minutes</schedule>
     <target>backend</target>
   </cron>
 


### PR DESCRIPTION
We'll delete the associated code soon enough too, but it's safer to delete the
cron jobs first and run in that state for a week, so we can still run them
manually if need be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1615)
<!-- Reviewable:end -->
