### PR TITLE
Downgrade dependencies that no longer support Java8

### DIFF
--- a/common/gradle/dependency-locks/compile.lockfile
+++ b/common/gradle/dependency-locks/compile.lockfile
@@ -1,13 +1,13 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:31.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.3
 javax.inject:javax.inject:1
 joda-time:joda-time:2.10.14
-org.checkerframework:checker-qual:3.21.4
+org.checkerframework:checker-qual:3.19.0

--- a/common/gradle/dependency-locks/compileClasspath.lockfile
+++ b/common/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.code.findbugs:jsr305:3.0.2
 com.google.errorprone:error_prone_annotations:2.11.0
 com.google.guava:failureaccess:1.0.1
@@ -10,4 +10,4 @@ com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.3
 javax.inject:javax.inject:1
 joda-time:joda-time:2.10.14
-org.checkerframework:checker-qual:3.12.0
+org.checkerframework:checker-qual:3.19.0

--- a/common/gradle/dependency-locks/default.lockfile
+++ b/common/gradle/dependency-locks/default.lockfile
@@ -1,13 +1,13 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:31.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.3
 javax.inject:javax.inject:1
 joda-time:joda-time:2.10.14
-org.checkerframework:checker-qual:3.21.4
+org.checkerframework:checker-qual:3.19.0

--- a/common/gradle/dependency-locks/deploy_jar.lockfile
+++ b/common/gradle/dependency-locks/deploy_jar.lockfile
@@ -1,13 +1,13 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:31.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.3
 javax.inject:javax.inject:1
 joda-time:joda-time:2.10.14
-org.checkerframework:checker-qual:3.21.4
+org.checkerframework:checker-qual:3.19.0

--- a/common/gradle/dependency-locks/runtime.lockfile
+++ b/common/gradle/dependency-locks/runtime.lockfile
@@ -1,13 +1,13 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:31.1-jre
 com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.3
 javax.inject:javax.inject:1
 joda-time:joda-time:2.10.14
-org.checkerframework:checker-qual:3.21.4
+org.checkerframework:checker-qual:3.19.0

--- a/common/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/common/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.code.findbugs:jsr305:3.0.2
 com.google.errorprone:error_prone_annotations:2.11.0
 com.google.guava:failureaccess:1.0.1
@@ -10,4 +10,4 @@ com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 com.google.j2objc:j2objc-annotations:1.3
 javax.inject:javax.inject:1
 joda-time:joda-time:2.10.14
-org.checkerframework:checker-qual:3.12.0
+org.checkerframework:checker-qual:3.19.0

--- a/common/gradle/dependency-locks/testCompile.lockfile
+++ b/common/gradle/dependency-locks/testCompile.lockfile
@@ -1,10 +1,10 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.auto.value:auto-value-annotations:1.8.1
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:31.1-jre
@@ -16,7 +16,7 @@ javax.inject:javax.inject:1
 joda-time:joda-time:2.10.14
 junit:junit:4.13.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:3.21.4
+org.checkerframework:checker-qual:3.19.0
 org.hamcrest:hamcrest-core:1.3
 org.junit.jupiter:junit-jupiter-api:5.8.2
 org.junit.jupiter:junit-jupiter-engine:5.8.2

--- a/common/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/common/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -1,10 +1,10 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.auto.value:auto-value-annotations:1.8.1
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:31.1-jre
@@ -17,7 +17,7 @@ joda-time:joda-time:2.10.14
 junit:junit:4.13.2
 org.apiguardian:apiguardian-api:1.1.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:3.21.4
+org.checkerframework:checker-qual:3.19.0
 org.hamcrest:hamcrest-core:1.3
 org.junit.jupiter:junit-jupiter-api:5.8.2
 org.junit.jupiter:junit-jupiter-engine:5.8.2

--- a/common/gradle/dependency-locks/testRuntime.lockfile
+++ b/common/gradle/dependency-locks/testRuntime.lockfile
@@ -1,10 +1,10 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.auto.value:auto-value-annotations:1.8.1
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1
@@ -17,7 +17,7 @@ javax.inject:javax.inject:1
 joda-time:joda-time:2.10.14
 junit:junit:4.13.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:3.21.4
+org.checkerframework:checker-qual:3.19.0
 org.hamcrest:hamcrest-core:1.3
 org.junit.jupiter:junit-jupiter-api:5.8.2
 org.junit.jupiter:junit-jupiter-engine:5.8.2

--- a/common/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/common/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -1,10 +1,10 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.auto.value:auto-value-annotations:1.8.1
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1
@@ -17,7 +17,7 @@ javax.inject:javax.inject:1
 joda-time:joda-time:2.10.14
 junit:junit:4.13.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:3.21.4
+org.checkerframework:checker-qual:3.19.0
 org.hamcrest:hamcrest-core:1.3
 org.junit.jupiter:junit-jupiter-api:5.8.2
 org.junit.jupiter:junit-jupiter-engine:5.8.2

--- a/common/gradle/dependency-locks/testingCompile.lockfile
+++ b/common/gradle/dependency-locks/testingCompile.lockfile
@@ -1,10 +1,10 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.auto.value:auto-value-annotations:1.8.1
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:31.1-jre
@@ -16,6 +16,6 @@ javax.inject:javax.inject:1
 joda-time:joda-time:2.10.14
 junit:junit:4.13.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:3.21.4
+org.checkerframework:checker-qual:3.19.0
 org.hamcrest:hamcrest-core:1.3
 org.ow2.asm:asm:9.1

--- a/common/gradle/dependency-locks/testingCompileClasspath.lockfile
+++ b/common/gradle/dependency-locks/testingCompileClasspath.lockfile
@@ -1,10 +1,10 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.auto.value:auto-value-annotations:1.8.1
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:31.1-jre
@@ -16,6 +16,6 @@ javax.inject:javax.inject:1
 joda-time:joda-time:2.10.14
 junit:junit:4.13.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:3.21.4
+org.checkerframework:checker-qual:3.19.0
 org.hamcrest:hamcrest-core:1.3
 org.ow2.asm:asm:9.1

--- a/common/gradle/dependency-locks/testingRuntime.lockfile
+++ b/common/gradle/dependency-locks/testingRuntime.lockfile
@@ -1,10 +1,10 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.auto.value:auto-value-annotations:1.8.1
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1
@@ -17,6 +17,6 @@ javax.inject:javax.inject:1
 joda-time:joda-time:2.10.14
 junit:junit:4.13.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:3.21.4
+org.checkerframework:checker-qual:3.19.0
 org.hamcrest:hamcrest-core:1.3
 org.ow2.asm:asm:9.1

--- a/common/gradle/dependency-locks/testingRuntimeClasspath.lockfile
+++ b/common/gradle/dependency-locks/testingRuntimeClasspath.lockfile
@@ -1,10 +1,10 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.auto.value:auto-value-annotations:1.8.1
 com.google.code.findbugs:jsr305:3.0.2
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.11.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1
@@ -17,6 +17,6 @@ javax.inject:javax.inject:1
 joda-time:joda-time:2.10.14
 junit:junit:4.13.2
 org.checkerframework:checker-compat-qual:2.5.3
-org.checkerframework:checker-qual:3.21.4
+org.checkerframework:checker-qual:3.19.0
 org.hamcrest:hamcrest-core:1.3
 org.ow2.asm:asm:9.1

--- a/core/gradle/dependency-locks/compile.lockfile
+++ b/core/gradle/dependency-locks/compile.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -157,7 +157,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/core/gradle/dependency-locks/compileClasspath.lockfile
+++ b/core/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -156,7 +156,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/core/gradle/dependency-locks/default.lockfile
+++ b/core/gradle/dependency-locks/default.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/core/gradle/dependency-locks/deploy_jar.lockfile
+++ b/core/gradle/dependency-locks/deploy_jar.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/core/gradle/dependency-locks/nonprodCompile.lockfile
+++ b/core/gradle/dependency-locks/nonprodCompile.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -157,7 +157,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/core/gradle/dependency-locks/nonprodCompileClasspath.lockfile
+++ b/core/gradle/dependency-locks/nonprodCompileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -118,7 +118,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -156,7 +156,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/core/gradle/dependency-locks/nonprodRuntime.lockfile
+++ b/core/gradle/dependency-locks/nonprodRuntime.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -157,7 +157,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/core/gradle/dependency-locks/nonprodRuntimeClasspath.lockfile
+++ b/core/gradle/dependency-locks/nonprodRuntimeClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -157,7 +157,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/core/gradle/dependency-locks/runtime.lockfile
+++ b/core/gradle/dependency-locks/runtime.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -157,7 +157,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/core/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/core/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/core/gradle/dependency-locks/testCompile.lockfile
+++ b/core/gradle/dependency-locks/testCompile.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -121,7 +121,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -166,7 +166,7 @@ com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
 com.thoughtworks.qdox:qdox:1.12.1
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/core/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/core/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -165,7 +165,7 @@ com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
 com.thoughtworks.qdox:qdox:1.12.1
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/core/gradle/dependency-locks/testRuntime.lockfile
+++ b/core/gradle/dependency-locks/testRuntime.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -122,7 +122,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -167,7 +167,7 @@ com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
 com.thoughtworks.qdox:qdox:1.12.1
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/core/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/core/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -122,7 +122,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -167,7 +167,7 @@ com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
 com.thoughtworks.qdox:qdox:1.12.1
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -65,9 +65,11 @@ ext {
       'com.google.javascript:closure-compiler:v20210505',
       'com.google.closure-stylesheets:closure-stylesheets:1.5.0',
 
-      // Hibernate 6.0 has Java11-only dependencies
+      // Latest version of the following are Java11-only
       'org.hibernate:hibernate-core:[5.4.23.Final, 6.0)',
       'org.hibernate:hibernate-hikaricp:[5.4.23.Final, 6.0)',
+      'com.zaxxer:HikariCP:3.4.5',
+      'com.github.ben-manes.caffeine:caffeine:[2.9.3,3.0)',
 
       // Broken by asymmetric mirroring on Maven. Note that this should be
       // upgraded to org.ogce.xpp3
@@ -97,7 +99,6 @@ ext {
 
       // Dependencies with dynamic versions start from here.
       'args4j:args4j:[2.0.26,)',
-      'com.github.ben-manes.caffeine:caffeine:[2.9.3,)',
       'com.google.api:gax:[1.66.0,)',
       'com.google.api.grpc:proto-google-cloud-secretmanager-v1:[1.4.0,)',
       // The two below are needed only for Datastore bulk delete pipeline.
@@ -172,7 +173,6 @@ ext {
       'com.sun.activation:javax.activation:[1.2.0,)',
       'com.sun.xml.bind:jaxb-impl:[2.3.3,)',
       'com.sun.xml.bind:jaxb-osgi:[2.3.3,)',
-      'com.zaxxer:HikariCP:[3.4.5,)',
       'dnsjava:dnsjava:[3.3.1,)',
       'guru.nidi:graphviz-java-all-j2v8:[0.17.0,)',
       'io.github.classgraph:classgraph:[4.8.102,)',

--- a/docs/gradle/dependency-locks/compile.lockfile
+++ b/docs/gradle/dependency-locks/compile.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/docs/gradle/dependency-locks/compileClasspath.lockfile
+++ b/docs/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -118,7 +118,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -156,7 +156,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/docs/gradle/dependency-locks/default.lockfile
+++ b/docs/gradle/dependency-locks/default.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/docs/gradle/dependency-locks/deploy_jar.lockfile
+++ b/docs/gradle/dependency-locks/deploy_jar.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/docs/gradle/dependency-locks/runtime.lockfile
+++ b/docs/gradle/dependency-locks/runtime.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/docs/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/docs/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/docs/gradle/dependency-locks/testCompile.lockfile
+++ b/docs/gradle/dependency-locks/testCompile.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -160,7 +160,7 @@ com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
 com.thoughtworks.qdox:qdox:1.12.1
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/docs/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/docs/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -118,7 +118,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
 com.thoughtworks.qdox:qdox:1.12.1
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/docs/gradle/dependency-locks/testRuntime.lockfile
+++ b/docs/gradle/dependency-locks/testRuntime.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -160,7 +160,7 @@ com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
 com.thoughtworks.qdox:qdox:1.12.1
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/docs/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/docs/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -160,7 +160,7 @@ com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
 com.thoughtworks.qdox:qdox:1.12.1
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/networking/gradle/dependency-locks/compile.lockfile
+++ b/networking/gradle/dependency-locks/compile.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
@@ -22,7 +22,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:31.1-jre

--- a/networking/gradle/dependency-locks/compileClasspath.lockfile
+++ b/networking/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
 com.google.api.grpc:proto-google-cloud-tasks-v2beta2:0.91.11

--- a/networking/gradle/dependency-locks/default.lockfile
+++ b/networking/gradle/dependency-locks/default.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
@@ -22,7 +22,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/networking/gradle/dependency-locks/deploy_jar.lockfile
+++ b/networking/gradle/dependency-locks/deploy_jar.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
@@ -22,7 +22,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/networking/gradle/dependency-locks/runtime.lockfile
+++ b/networking/gradle/dependency-locks/runtime.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
@@ -22,7 +22,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/networking/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/networking/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11

--- a/networking/gradle/dependency-locks/testCompile.lockfile
+++ b/networking/gradle/dependency-locks/testCompile.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -26,7 +26,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:31.1-jre

--- a/networking/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/networking/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -25,7 +25,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:31.1-jre

--- a/networking/gradle/dependency-locks/testRuntime.lockfile
+++ b/networking/gradle/dependency-locks/testRuntime.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -26,7 +26,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/networking/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/networking/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -26,7 +26,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/prober/gradle/dependency-locks/compile.lockfile
+++ b/prober/gradle/dependency-locks/compile.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
@@ -22,7 +22,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/prober/gradle/dependency-locks/compileClasspath.lockfile
+++ b/prober/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
 com.google.api.grpc:proto-google-cloud-tasks-v2beta2:0.91.11

--- a/prober/gradle/dependency-locks/default.lockfile
+++ b/prober/gradle/dependency-locks/default.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
@@ -22,7 +22,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/prober/gradle/dependency-locks/deploy_jar.lockfile
+++ b/prober/gradle/dependency-locks/deploy_jar.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
@@ -22,7 +22,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/prober/gradle/dependency-locks/runtime.lockfile
+++ b/prober/gradle/dependency-locks/runtime.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
@@ -22,7 +22,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/prober/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/prober/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11

--- a/prober/gradle/dependency-locks/testCompile.lockfile
+++ b/prober/gradle/dependency-locks/testCompile.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -26,7 +26,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/prober/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/prober/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -25,7 +25,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/prober/gradle/dependency-locks/testRuntime.lockfile
+++ b/prober/gradle/dependency-locks/testRuntime.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -26,7 +26,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/prober/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/prober/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -26,7 +26,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/proxy/gradle/dependency-locks/compile.lockfile
+++ b/proxy/gradle/dependency-locks/compile.lockfile
@@ -4,7 +4,7 @@
 com.beust:jcommander:1.60
 com.fasterxml.jackson.core:jackson-core:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
@@ -32,7 +32,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/proxy/gradle/dependency-locks/compileClasspath.lockfile
+++ b/proxy/gradle/dependency-locks/compileClasspath.lockfile
@@ -4,7 +4,7 @@
 com.beust:jcommander:1.60
 com.fasterxml.jackson.core:jackson-core:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
 com.google.api.grpc:proto-google-cloud-tasks-v2beta2:0.91.11

--- a/proxy/gradle/dependency-locks/default.lockfile
+++ b/proxy/gradle/dependency-locks/default.lockfile
@@ -4,7 +4,7 @@
 com.beust:jcommander:1.60
 com.fasterxml.jackson.core:jackson-core:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
@@ -32,7 +32,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/proxy/gradle/dependency-locks/deploy_jar.lockfile
+++ b/proxy/gradle/dependency-locks/deploy_jar.lockfile
@@ -4,7 +4,7 @@
 com.beust:jcommander:1.60
 com.fasterxml.jackson.core:jackson-core:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
@@ -32,7 +32,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/proxy/gradle/dependency-locks/runtime.lockfile
+++ b/proxy/gradle/dependency-locks/runtime.lockfile
@@ -4,7 +4,7 @@
 com.beust:jcommander:1.60
 com.fasterxml.jackson.core:jackson-core:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
@@ -32,7 +32,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/proxy/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/proxy/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -4,7 +4,7 @@
 com.beust:jcommander:1.60
 com.fasterxml.jackson.core:jackson-core:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11

--- a/proxy/gradle/dependency-locks/testCompile.lockfile
+++ b/proxy/gradle/dependency-locks/testCompile.lockfile
@@ -5,7 +5,7 @@ com.beust:jcommander:1.60
 com.fasterxml.jackson.core:jackson-annotations:2.13.2
 com.fasterxml.jackson.core:jackson-core:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -36,7 +36,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/proxy/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/proxy/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -5,7 +5,7 @@ com.beust:jcommander:1.60
 com.fasterxml.jackson.core:jackson-annotations:2.13.2
 com.fasterxml.jackson.core:jackson-core:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -35,7 +35,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/proxy/gradle/dependency-locks/testRuntime.lockfile
+++ b/proxy/gradle/dependency-locks/testRuntime.lockfile
@@ -5,7 +5,7 @@ com.beust:jcommander:1.60
 com.fasterxml.jackson.core:jackson-annotations:2.13.2
 com.fasterxml.jackson.core:jackson-core:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -36,7 +36,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/proxy/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/proxy/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -5,7 +5,7 @@ com.beust:jcommander:1.60
 com.fasterxml.jackson.core:jackson-annotations:2.13.2
 com.fasterxml.jackson.core:jackson-core:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -36,7 +36,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/services/backend/gradle/dependency-locks/compile.lockfile
+++ b/services/backend/gradle/dependency-locks/compile.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/backend/gradle/dependency-locks/compileClasspath.lockfile
+++ b/services/backend/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -157,7 +157,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/backend/gradle/dependency-locks/default.lockfile
+++ b/services/backend/gradle/dependency-locks/default.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/backend/gradle/dependency-locks/runtime.lockfile
+++ b/services/backend/gradle/dependency-locks/runtime.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/backend/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/services/backend/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/backend/gradle/dependency-locks/testCompile.lockfile
+++ b/services/backend/gradle/dependency-locks/testCompile.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/backend/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/services/backend/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -157,7 +157,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/backend/gradle/dependency-locks/testRuntime.lockfile
+++ b/services/backend/gradle/dependency-locks/testRuntime.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/backend/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/services/backend/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/default/gradle/dependency-locks/compile.lockfile
+++ b/services/default/gradle/dependency-locks/compile.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/default/gradle/dependency-locks/compileClasspath.lockfile
+++ b/services/default/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -157,7 +157,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/default/gradle/dependency-locks/default.lockfile
+++ b/services/default/gradle/dependency-locks/default.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/default/gradle/dependency-locks/runtime.lockfile
+++ b/services/default/gradle/dependency-locks/runtime.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/default/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/services/default/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/default/gradle/dependency-locks/testCompile.lockfile
+++ b/services/default/gradle/dependency-locks/testCompile.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/default/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/services/default/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -157,7 +157,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/default/gradle/dependency-locks/testRuntime.lockfile
+++ b/services/default/gradle/dependency-locks/testRuntime.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/default/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/services/default/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/pubapi/gradle/dependency-locks/compile.lockfile
+++ b/services/pubapi/gradle/dependency-locks/compile.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/pubapi/gradle/dependency-locks/compileClasspath.lockfile
+++ b/services/pubapi/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -157,7 +157,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/pubapi/gradle/dependency-locks/default.lockfile
+++ b/services/pubapi/gradle/dependency-locks/default.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/pubapi/gradle/dependency-locks/runtime.lockfile
+++ b/services/pubapi/gradle/dependency-locks/runtime.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/pubapi/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/services/pubapi/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/pubapi/gradle/dependency-locks/testCompile.lockfile
+++ b/services/pubapi/gradle/dependency-locks/testCompile.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/pubapi/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/services/pubapi/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -157,7 +157,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/pubapi/gradle/dependency-locks/testRuntime.lockfile
+++ b/services/pubapi/gradle/dependency-locks/testRuntime.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/pubapi/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/services/pubapi/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/tools/gradle/dependency-locks/compile.lockfile
+++ b/services/tools/gradle/dependency-locks/compile.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/tools/gradle/dependency-locks/compileClasspath.lockfile
+++ b/services/tools/gradle/dependency-locks/compileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -157,7 +157,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/tools/gradle/dependency-locks/default.lockfile
+++ b/services/tools/gradle/dependency-locks/default.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/tools/gradle/dependency-locks/runtime.lockfile
+++ b/services/tools/gradle/dependency-locks/runtime.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/tools/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/services/tools/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/tools/gradle/dependency-locks/testCompile.lockfile
+++ b/services/tools/gradle/dependency-locks/testCompile.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/tools/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/services/tools/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -119,7 +119,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -157,7 +157,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/tools/gradle/dependency-locks/testRuntime.lockfile
+++ b/services/tools/gradle/dependency-locks/testRuntime.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/services/tools/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/services/tools/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -13,7 +13,7 @@ com.fasterxml.jackson.core:jackson-databind:2.13.2
 com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
 com.fasterxml.jackson:jackson-bom:2.13.2
 com.fasterxml:classmate:1.5.1
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -120,7 +120,7 @@ com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.common.html.types:types:1.0.6
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.escapevelocity:escapevelocity:0.9.1
 com.google.flatbuffers:flatbuffers-java:1.12.0
 com.google.flogger:flogger-system-backend:0.7.4
@@ -158,7 +158,7 @@ com.jcraft:jsch:0.1.55
 com.sun.istack:istack-commons-runtime:3.0.7
 com.sun.xml.fastinfoset:FastInfoset:1.2.15
 com.thoughtworks.paranamer:paranamer:2.7
-com.zaxxer:HikariCP:5.0.1
+com.zaxxer:HikariCP:3.4.5
 commons-codec:commons-codec:1.15
 commons-logging:commons-logging:1.2
 dnsjava:dnsjava:3.5.0

--- a/util/gradle/dependency-locks/compile.lockfile
+++ b/util/gradle/dependency-locks/compile.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
@@ -21,7 +21,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:31.1-jre

--- a/util/gradle/dependency-locks/compileClasspath.lockfile
+++ b/util/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
 com.google.api.grpc:proto-google-cloud-tasks-v2beta2:0.91.11

--- a/util/gradle/dependency-locks/default.lockfile
+++ b/util/gradle/dependency-locks/default.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
@@ -22,7 +22,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:31.1-jre

--- a/util/gradle/dependency-locks/deploy_jar.lockfile
+++ b/util/gradle/dependency-locks/deploy_jar.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
@@ -22,7 +22,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:31.1-jre

--- a/util/gradle/dependency-locks/runtime.lockfile
+++ b/util/gradle/dependency-locks/runtime.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11
@@ -22,7 +22,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava:31.1-jre

--- a/util/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/util/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.google.android:annotations:4.1.1.4
 com.google.api-client:google-api-client:1.34.0
 com.google.api.grpc:proto-google-cloud-tasks-v2:2.1.11

--- a/util/gradle/dependency-locks/testCompile.lockfile
+++ b/util/gradle/dependency-locks/testCompile.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -26,7 +26,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava-testlib:31.1-jre

--- a/util/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/util/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -25,7 +25,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1
 com.google.guava:guava-testlib:31.1-jre

--- a/util/gradle/dependency-locks/testRuntime.lockfile
+++ b/util/gradle/dependency-locks/testRuntime.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -27,7 +27,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1

--- a/util/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/util/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.fasterxml.jackson.core:jackson-annotations:2.10.3
-com.github.ben-manes.caffeine:caffeine:3.1.0
+com.github.ben-manes.caffeine:caffeine:2.9.3
 com.github.docker-java:docker-java-api:3.2.13
 com.github.docker-java:docker-java-transport-zerodep:3.2.13
 com.github.docker-java:docker-java-transport:3.2.13
@@ -27,7 +27,7 @@ com.google.cloud:google-cloud-tasks:2.1.11
 com.google.code.findbugs:jsr305:3.0.2
 com.google.code.gson:gson:2.9.0
 com.google.dagger:dagger:2.41
-com.google.errorprone:error_prone_annotations:2.13.1
+com.google.errorprone:error_prone_annotations:2.13.0
 com.google.flogger:flogger-system-backend:0.7.4
 com.google.flogger:flogger:0.7.4
 com.google.guava:failureaccess:1.0.1


### PR DESCRIPTION
Downgrade two dependencies whose latest versions no longer support
java8.

A follow up PR will add java8 compatibility to presubmit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1617)
<!-- Reviewable:end -->
