### PR TITLE
Reduce the number of manually scaled instances for default/pubapi

### DIFF
--- a/core/src/main/java/google/registry/env/production/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/default/WEB-INF/appengine-web.xml
@@ -7,7 +7,7 @@
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <manual-scaling>
-    <instances>15</instances>
+    <instances>12</instances>
   </manual-scaling>
 
   <system-properties>

--- a/core/src/main/java/google/registry/env/production/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/pubapi/WEB-INF/appengine-web.xml
@@ -7,7 +7,7 @@
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <manual-scaling>
-    <instances>20</instances>
+    <instances>12</instances>
   </manual-scaling>
 
   <system-properties>

--- a/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/appengine-web.xml
@@ -7,7 +7,7 @@
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <manual-scaling>
-    <instances>10</instances>
+    <instances>6</instances>
   </manual-scaling>
 
   <system-properties>


### PR DESCRIPTION
This is in the spirit of "not always running significantly over-provisioned",
which helps to save costs and also expose potential scaling issues when they are
still small rather than all at once when they're a big problem.

This can always be reverted if necessary, and can be instantaneously adjusted by
running the `nomulus set_num_instances` command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1620)
<!-- Reviewable:end -->
