### PR TITLE
Cleanup gpg-agent instances and home directories

### DIFF
--- a/core/src/test/java/google/registry/testing/GpgSystemCommandExtension.java
+++ b/core/src/test/java/google/registry/testing/GpgSystemCommandExtension.java
@@ -122,9 +122,25 @@ public final class GpgSystemCommandExtension implements BeforeEachCallback, Afte
         .isEqualTo(0);
   }
 
+  static void deleteTree(File dir) {
+    for (File file : dir.listFiles()) {
+      if (file.isDirectory()) {
+        deleteTree(file);
+      } else {
+        file.delete();
+      }
+    }
+    dir.delete();
+  }
+
   @Override
-  public void afterEach(ExtensionContext context) {
-    // TODO(weiminyu): we should delete the cwd tree.
+  public void afterEach(ExtensionContext context) throws IOException {
+    // Kill the gpg-agent.
+    exec("gpgconf", "--homedir", conf.getPath(), "--kill", "gpg-agent");
+
+    // Clean up the temporary directory.
+    deleteTree(cwd);
+
     cwd = DEV_NULL;
     conf = DEV_NULL;
   }


### PR DESCRIPTION
The GpgSystemCommandException leaks home directories, but more importantly it
leaks gpg-agent instances.  This can cause problems with inotify limits, since
the agent seems to make use of inotify.  Do a proper cleanup in afterEach().