### PR TITLE
Remove billing identifier

### DIFF
--- a/core/src/main/java/google/registry/export/sheet/SyncRegistrarsSheet.java
+++ b/core/src/main/java/google/registry/export/sheet/SyncRegistrarsSheet.java
@@ -120,7 +120,6 @@ class SyncRegistrarsSheet {
                   builder.put("registrarName", convert(registrar.getRegistrarName()));
                   builder.put("state", convert(registrar.getState()));
                   builder.put("ianaIdentifier", convert(registrar.getIanaIdentifier()));
-                  builder.put("billingIdentifier", convert(registrar.getBillingIdentifier()));
                   builder.put("billingAccountMap", convert(registrar.getBillingAccountMap()));
                   builder.put("primaryContacts", convertContacts(contacts, byType(ADMIN)));
                   builder.put("techContacts", convertContacts(contacts, byType(TECH)));

--- a/core/src/main/java/google/registry/model/registrar/Registrar.java
+++ b/core/src/main/java/google/registry/model/registrar/Registrar.java
@@ -387,9 +387,6 @@ public class Registrar extends ImmutableObject
    */
   @Index @Nullable Long ianaIdentifier;
 
-  /** Identifier of registrar used in external billing system (e.g. Oracle). */
-  @Nullable Long billingIdentifier;
-
   /** Purchase Order number used for invoices in external billing system, if applicable. */
   @Nullable String poNumber;
 
@@ -494,11 +491,6 @@ public class Registrar extends ImmutableObject
   @Nullable
   public Long getIanaIdentifier() {
     return ianaIdentifier;
-  }
-
-  @Nullable
-  public Long getBillingIdentifier() {
-    return billingIdentifier;
   }
 
   public Optional<String> getPoNumber() {
@@ -688,7 +680,6 @@ public class Registrar extends ImmutableObject
     return new JsonMapBuilder()
         .put("clientIdentifier", clientIdentifier)
         .put("ianaIdentifier", ianaIdentifier)
-        .put("billingIdentifier", billingIdentifier)
         .putString("creationTime", creationTime.getTimestamp())
         .putString("lastUpdateTime", lastUpdateTime.getTimestamp())
         .putString("lastCertificateUpdateTime", lastCertificateUpdateTime)
@@ -782,14 +773,6 @@ public class Registrar extends ImmutableObject
       checkArgument(
           ianaIdentifier == null || ianaIdentifier > 0, "IANA ID must be a positive number");
       getInstance().ianaIdentifier = ianaIdentifier;
-      return this;
-    }
-
-    public Builder setBillingIdentifier(@Nullable Long billingIdentifier) {
-      checkArgument(
-          billingIdentifier == null || billingIdentifier > 0,
-          "Billing ID must be a positive number");
-      getInstance().billingIdentifier = billingIdentifier;
       return this;
     }
 

--- a/core/src/main/java/google/registry/tools/CreateOrUpdateRegistrarCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdateRegistrarCommand.java
@@ -152,14 +152,6 @@ abstract class CreateOrUpdateRegistrarCommand extends MutatingCommand {
 
   @Nullable
   @Parameter(
-      names = "--billing_id",
-      description = "Registrar Billing ID (i.e. Oracle #)",
-      converter = OptionalLongParameter.class,
-      validateWith = OptionalLongParameter.class)
-  private Optional<Long> billingId;
-
-  @Nullable
-  @Parameter(
       names = "--po_number",
       description = "Purchase Order number used for billing invoices",
       converter = OptionalStringParameter.class,
@@ -361,9 +353,6 @@ abstract class CreateOrUpdateRegistrarCommand extends MutatingCommand {
       }
       if (ianaId != null) {
         builder.setIanaIdentifier(ianaId.orElse(null));
-      }
-      if (billingId != null) {
-        builder.setBillingIdentifier(billingId.orElse(null));
       }
       Optional.ofNullable(poNumber).ifPresent(builder::setPoNumber);
       if (billingAccountMap != null) {

--- a/core/src/test/java/google/registry/model/registrar/RegistrarTest.java
+++ b/core/src/test/java/google/registry/model/registrar/RegistrarTest.java
@@ -121,7 +121,6 @@ class RegistrarTest extends EntityTestCase {
                 .setIcannReferralEmail("foo@example.com")
                 .setDriveFolderId("drive folder id")
                 .setIanaIdentifier(8L)
-                .setBillingIdentifier(5325L)
                 .setBillingAccountMap(
                     ImmutableMap.of(CurrencyUnit.USD, "abc123", CurrencyUnit.JPY, "789xyz"))
                 .setPhonePasscode("01234")
@@ -266,7 +265,6 @@ class RegistrarTest extends EntityTestCase {
         .asBuilder()
         .setType(Type.TEST)
         .setIanaIdentifier(null)
-        .setBillingIdentifier(null)
         .build();
   }
 

--- a/core/src/test/java/google/registry/tools/CreateRegistrarCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateRegistrarCommandTest.java
@@ -552,7 +552,6 @@ class CreateRegistrarCommandTest extends CommandTestCase<CreateRegistrarCommand>
         "--password=some_password",
         "--registrar_type=REAL",
         "--iana_id=8",
-        "--billing_id=12345",
         "--passcode=01234",
         "--icann_referral_email=foo@bar.test",
         "--street=\"123 Fake St\"",
@@ -564,7 +563,6 @@ class CreateRegistrarCommandTest extends CommandTestCase<CreateRegistrarCommand>
 
     Optional<Registrar> registrar = Registrar.loadByRegistrarId("clientz");
     assertThat(registrar).isPresent();
-    assertThat(registrar.get().getBillingIdentifier()).isEqualTo(12345);
   }
 
   @TestOfyAndSql
@@ -805,7 +803,6 @@ class CreateRegistrarCommandTest extends CommandTestCase<CreateRegistrarCommand>
         "--registrar_type=TEST",
         "--icann_referral_email=foo@bar.test",
         "--iana_id=null",
-        "--billing_id=null",
         "--phone=null",
         "--fax=null",
         "--url=null",
@@ -821,7 +818,6 @@ class CreateRegistrarCommandTest extends CommandTestCase<CreateRegistrarCommand>
     assertThat(registrarOptional).isPresent();
     Registrar registrar = registrarOptional.get();
     assertThat(registrar.getIanaIdentifier()).isNull();
-    assertThat(registrar.getBillingIdentifier()).isNull();
     assertThat(registrar.getPhoneNumber()).isNull();
     assertThat(registrar.getFaxNumber()).isNull();
     assertThat(registrar.getUrl()).isNull();
@@ -835,7 +831,6 @@ class CreateRegistrarCommandTest extends CommandTestCase<CreateRegistrarCommand>
         "--password=some_password",
         "--registrar_type=TEST",
         "--iana_id=",
-        "--billing_id=",
         "--phone=",
         "--fax=",
         "--url=",
@@ -852,7 +847,6 @@ class CreateRegistrarCommandTest extends CommandTestCase<CreateRegistrarCommand>
     assertThat(registrarOptional).isPresent();
     Registrar registrar = registrarOptional.get();
     assertThat(registrar.getIanaIdentifier()).isNull();
-    assertThat(registrar.getBillingIdentifier()).isNull();
     assertThat(registrar.getPhoneNumber()).isNull();
     assertThat(registrar.getFaxNumber()).isNull();
     assertThat(registrar.getUrl()).isNull();

--- a/core/src/test/java/google/registry/tools/MutatingCommandTest.java
+++ b/core/src/test/java/google/registry/tools/MutatingCommandTest.java
@@ -58,7 +58,6 @@ public class MutatingCommandTest {
   void beforeEach() {
     registrar1 = persistNewRegistrar("Registrar1", "Registrar1", Registrar.Type.REAL, 1L);
     registrar2 = persistNewRegistrar("Registrar2", "Registrar2", Registrar.Type.REAL, 2L);
-    newRegistrar1 = registrar1.asBuilder().setBillingIdentifier(42L).build();
     newRegistrar2 = registrar2.asBuilder().setBlockPremiumNames(true).build();
 
     createTld("tld");
@@ -100,9 +99,6 @@ public class MutatingCommandTest {
             + "\n"
             + "Update HostResource@3-ROID\n"
             + "currentSponsorClientId: TheRegistrar -> Registrar2\n"
-            + "\n"
-            + "Update Registrar@Registrar1\n"
-            + "billingIdentifier: null -> 42\n"
             + "\n"
             + "Update Registrar@Registrar2\n"
             + "blockPremiumNames: false -> true\n");

--- a/core/src/test/java/google/registry/tools/UpdateRegistrarCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateRegistrarCommandTest.java
@@ -348,13 +348,6 @@ class UpdateRegistrarCommandTest extends CommandTestCase<UpdateRegistrarCommand>
   }
 
   @Test
-  void testSuccess_billingId() throws Exception {
-    assertThat(loadRegistrar("NewRegistrar").getBillingIdentifier()).isNull();
-    runCommand("--billing_id=12345", "--force", "NewRegistrar");
-    assertThat(loadRegistrar("NewRegistrar").getBillingIdentifier()).isEqualTo(12345);
-  }
-
-  @Test
   void testSuccess_poNumber() throws Exception {
     assertThat(loadRegistrar("NewRegistrar").getPoNumber()).isEmpty();
     runCommand("--po_number=52345", "--force", "NewRegistrar");
@@ -495,7 +488,7 @@ class UpdateRegistrarCommandTest extends CommandTestCase<UpdateRegistrarCommand>
             .setContactsRequireSyncing(true)
             .build());
     // Make some unrelated change where we don't specify the flags for the booleans.
-    runCommandForced("--billing_id=12345", "NewRegistrar");
+    runCommandForced("--zip=10011", "NewRegistrar");
     // Make sure that the boolean fields didn't get reset back to false.
     Registrar reloadedRegistrar = loadRegistrar("NewRegistrar");
     assertThat(reloadedRegistrar.getBlockPremiumNames()).isTrue();
@@ -520,7 +513,6 @@ class UpdateRegistrarCommandTest extends CommandTestCase<UpdateRegistrarCommand>
                 .asBuilder()
                 .setType(Type.PDT) // for non-null IANA ID
                 .setIanaIdentifier(9995L)
-                .setBillingIdentifier(1L)
                 .setPhoneNumber("+1.2125555555")
                 .setFaxNumber("+1.2125555556")
                 .setUrl("http://www.example.tld")
@@ -528,7 +520,6 @@ class UpdateRegistrarCommandTest extends CommandTestCase<UpdateRegistrarCommand>
                 .build());
 
     assertThat(registrar.getIanaIdentifier()).isNotNull();
-    assertThat(registrar.getBillingIdentifier()).isNotNull();
     assertThat(registrar.getPhoneNumber()).isNotNull();
     assertThat(registrar.getFaxNumber()).isNotNull();
     assertThat(registrar.getUrl()).isNotNull();
@@ -537,7 +528,6 @@ class UpdateRegistrarCommandTest extends CommandTestCase<UpdateRegistrarCommand>
     runCommand(
         "--registrar_type=TEST", // necessary for null IANA ID
         "--iana_id=null",
-        "--billing_id=null",
         "--phone=null",
         "--fax=null",
         "--url=null",
@@ -547,7 +537,6 @@ class UpdateRegistrarCommandTest extends CommandTestCase<UpdateRegistrarCommand>
 
     registrar = loadRegistrar("NewRegistrar");
     assertThat(registrar.getIanaIdentifier()).isNull();
-    assertThat(registrar.getBillingIdentifier()).isNull();
     assertThat(registrar.getPhoneNumber()).isNull();
     assertThat(registrar.getFaxNumber()).isNull();
     assertThat(registrar.getUrl()).isNull();
@@ -563,7 +552,6 @@ class UpdateRegistrarCommandTest extends CommandTestCase<UpdateRegistrarCommand>
                 .asBuilder()
                 .setType(Type.PDT) // for non-null IANA ID
                 .setIanaIdentifier(9995L)
-                .setBillingIdentifier(1L)
                 .setPhoneNumber("+1.2125555555")
                 .setFaxNumber("+1.2125555556")
                 .setUrl("http://www.example.tld")
@@ -571,7 +559,6 @@ class UpdateRegistrarCommandTest extends CommandTestCase<UpdateRegistrarCommand>
                 .build());
 
     assertThat(registrar.getIanaIdentifier()).isNotNull();
-    assertThat(registrar.getBillingIdentifier()).isNotNull();
     assertThat(registrar.getPhoneNumber()).isNotNull();
     assertThat(registrar.getFaxNumber()).isNotNull();
     assertThat(registrar.getUrl()).isNotNull();
@@ -580,7 +567,6 @@ class UpdateRegistrarCommandTest extends CommandTestCase<UpdateRegistrarCommand>
     runCommand(
         "--registrar_type=TEST", // necessary for null IANA ID
         "--iana_id=",
-        "--billing_id=",
         "--phone=",
         "--fax=",
         "--url=",
@@ -590,7 +576,6 @@ class UpdateRegistrarCommandTest extends CommandTestCase<UpdateRegistrarCommand>
 
     registrar = loadRegistrar("NewRegistrar");
     assertThat(registrar.getIanaIdentifier()).isNull();
-    assertThat(registrar.getBillingIdentifier()).isNull();
     assertThat(registrar.getPhoneNumber()).isNull();
     assertThat(registrar.getFaxNumber()).isNull();
     assertThat(registrar.getUrl()).isNull();
@@ -652,20 +637,6 @@ class UpdateRegistrarCommandTest extends CommandTestCase<UpdateRegistrarCommand>
   void testFailure_nonIntegerIanaId() {
     assertThrows(
         ParameterException.class, () -> runCommand("--iana_id=ABC123", "--force", "NewRegistrar"));
-  }
-
-  @Test
-  void testFailure_negativeBillingId() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> runCommand("--billing_id=-1", "--force", "NewRegistrar"));
-  }
-
-  @Test
-  void testFailure_nonIntegerBillingId() {
-    assertThrows(
-        ParameterException.class,
-        () -> runCommand("--billing_id=ABC123", "--force", "NewRegistrar"));
   }
 
   @Test

--- a/db/src/main/resources/sql/flyway.txt
+++ b/db/src/main/resources/sql/flyway.txt
@@ -114,3 +114,4 @@ V113__add_host_missing_indexes.sql
 V114__add_allocation_token_indexes.sql
 V115__add_renewal_columns_to_billing_recurrence.sql
 V116__add_renewal_column_to_allocation_token.sql
+V117__drop_billing_identifier_column_in_registrar.sql

--- a/db/src/main/resources/sql/flyway/V117__drop_billing_identifier_column_in_registrar.sql
+++ b/db/src/main/resources/sql/flyway/V117__drop_billing_identifier_column_in_registrar.sql
@@ -1,0 +1,15 @@
+-- Copyright 2022 The Nomulus Authors. All Rights Reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+alter table "Registrar" drop column billing_identifier;


### PR DESCRIPTION
This id was used pre-billing3. There is no reason to keep it, which only
adds confusion.
