### PR TITLE
Make Caffeine cache loading work in non-GAE thread

### DIFF
--- a/core/src/main/java/google/registry/model/AppEngineEnvironment.java
+++ b/core/src/main/java/google/registry/model/AppEngineEnvironment.java
@@ -116,4 +116,9 @@ public class AppEngineEnvironment {
               }
             });
   }
+
+  /** Returns true if the current thread is in an App Engine Environment.*/
+  public static boolean isInAppEngineEnvironment() {
+    return ApiProxy.getCurrentEnvironment() != null;
+  }
 }

--- a/core/src/main/java/google/registry/model/tld/Registry.java
+++ b/core/src/main/java/google/registry/model/tld/Registry.java
@@ -48,6 +48,7 @@ import com.googlecode.objectify.annotation.Id;
 import com.googlecode.objectify.annotation.Mapify;
 import com.googlecode.objectify.annotation.OnSave;
 import com.googlecode.objectify.annotation.Parent;
+import google.registry.model.AppEngineEnvironment;
 import google.registry.model.Buildable;
 import google.registry.model.CacheUtils;
 import google.registry.model.CreateAutoTimestamp;
@@ -119,6 +120,8 @@ public class Registry extends ImmutableObject
 
   /** The suffix that identifies roids as belonging to this specific tld, e.g. -HOW for .how. */
   String roidSuffix;
+
+  private static final AppEngineEnvironment environment = new AppEngineEnvironment();
 
   /** Default values for all the relevant TLD parameters. */
   public static final TldState DEFAULT_TLD_STATE = TldState.PREDELEGATION;
@@ -288,7 +291,15 @@ public class Registry extends ImmutableObject
               });
 
   public static VKey<Registry> createVKey(String tld) {
-    return VKey.create(Registry.class, tld, Key.create(getCrossTldKey(), Registry.class, tld));
+    VKey<Registry> vkey;
+    if (environment.isInAppEngineEnvironment()) {
+      environment.setEnvironmentForCurrentThread();
+    }
+    vkey = VKey.create(Registry.class, tld, Key.create(getCrossTldKey(), Registry.class, tld));
+    if (environment.isInAppEngineEnvironment()) {
+      environment.unsetEnvironmentForCurrentThread();
+    }
+    return vkey;
   }
 
   public static VKey<Registry> createVKey(Key<Registry> key) {


### PR DESCRIPTION
Caffeine cache loading happens asynchronously in a different thread than
the main app engine thread. When a VKey is created in that thread, it
tries to ascertain that the current thread is an GAE thread and fails.

Of all CacheLoader::load implementations, only the one in Registry
creates a VKey, so we wrap the call to VKey.create() in a method that
sets and unsets the thread local field used to indicate whether the
current thread is an GAE thread.
