### PR TITLE
Optimize RDAP entity event query

### DIFF
--- a/core/src/main/java/google/registry/model/reporting/HistoryEntryDao.java
+++ b/core/src/main/java/google/registry/model/reporting/HistoryEntryDao.java
@@ -211,7 +211,7 @@ public class HistoryEntryDao {
         jpaTm().criteriaQuery(criteriaQuery).getResultList());
   }
 
-  private static Class<? extends HistoryEntry> getHistoryClassFromParent(
+  public static Class<? extends HistoryEntry> getHistoryClassFromParent(
       Class<? extends EppResource> parent) {
     if (!RESOURCE_TYPES_TO_HISTORY_TYPES.containsKey(parent)) {
       throw new IllegalArgumentException(
@@ -220,7 +220,7 @@ public class HistoryEntryDao {
     return RESOURCE_TYPES_TO_HISTORY_TYPES.get(parent);
   }
 
-  private static String getRepoIdFieldNameFromHistoryClass(
+  public static String getRepoIdFieldNameFromHistoryClass(
       Class<? extends HistoryEntry> historyClass) {
     if (!REPO_ID_FIELD_NAMES.containsKey(historyClass)) {
       throw new IllegalArgumentException(

--- a/core/src/test/java/google/registry/rdap/RdapJsonFormatterTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapJsonFormatterTest.java
@@ -15,6 +15,7 @@
 package google.registry.rdap;
 
 import static com.google.common.truth.Truth.assertThat;
+import static google.registry.rdap.RdapDataStructures.EventAction.TRANSFER;
 import static google.registry.rdap.RdapTestHelper.assertThat;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
@@ -28,7 +29,9 @@ import static google.registry.testing.TestDataHelper.loadFile;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import google.registry.model.contact.ContactResource;
@@ -51,6 +54,7 @@ import google.registry.testing.DualDatabaseTest;
 import google.registry.testing.FakeClock;
 import google.registry.testing.InjectExtension;
 import google.registry.testing.TestOfyAndSql;
+import google.registry.testing.TestSqlOnly;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -480,6 +484,17 @@ class RdapJsonFormatterTest {
   void testDomain_summary() {
     assertThat(rdapJsonFormatter.createRdapDomain(domainBaseFull, OutputDataType.SUMMARY).toJson())
         .isEqualTo(loadJson("rdapjson_domain_summary.json"));
+  }
+
+  @TestSqlOnly
+  void testGetLastHistoryEntryByType() {
+    // Expected data are from "rdapjson_domain_summary.json"
+    assertThat(
+            Maps.transformValues(
+                rdapJsonFormatter.getLastHistoryEntryByType(domainBaseFull),
+                HistoryEntry::getModificationTime))
+        .containsExactlyEntriesIn(
+            ImmutableMap.of(TRANSFER, DateTime.parse("1999-12-01T00:00:00.000Z")));
   }
 
   @TestOfyAndSql


### PR DESCRIPTION
For each EPP entity, directly load the latest HistoryEntry per event type
instead of loading all events through the HistoryEntryDao.

Although most entities have a small number of history entries, there are
a few entities with many entries, enough to cause OutOfMemory error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1635)
<!-- Reviewable:end -->
