### PR TITLE
Add batching to ExpandRecurringBillingEventsAction

### DIFF
--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -1351,6 +1351,12 @@ public final class RegistryConfig {
     public static int provideWipeOutQueryBatchSize(RegistryConfigSettings config) {
       return config.contactHistory.wipeOutQueryBatchSize;
     }
+
+    @Provides
+    @Config("jdbcBatchSize")
+    public static int provideHibernateJdbcBatchSize(RegistryConfigSettings config) {
+      return config.hibernate.jdbcBatchSize;
+    }
   }
 
   /** Returns the App Engine project ID, which is based off the environment name. */
@@ -1555,7 +1561,7 @@ public final class RegistryConfig {
    * https://docs.jboss.org/hibernate/orm/5.6/userguide/html_single/Hibernate_User_Guide.html,
    * recommend between 10 and 50.
    */
-  public static String getHibernateJdbcBatchSize() {
+  public static int getHibernateJdbcBatchSize() {
     return CONFIG_SETTINGS.get().hibernate.jdbcBatchSize;
   }
 

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -120,7 +120,7 @@ public class RegistryConfigSettings {
     public String hikariMinimumIdle;
     public String hikariMaximumPoolSize;
     public String hikariIdleTimeout;
-    public String jdbcBatchSize;
+    public int jdbcBatchSize;
     public String jdbcFetchSize;
   }
 

--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -107,7 +107,7 @@ public abstract class PersistenceModule {
     properties.put(HIKARI_MAXIMUM_POOL_SIZE, getHibernateHikariMaximumPoolSize());
     properties.put(HIKARI_IDLE_TIMEOUT, getHibernateHikariIdleTimeout());
     properties.put(Environment.DIALECT, NomulusPostgreSQLDialect.class.getName());
-    properties.put(JDBC_BATCH_SIZE, getHibernateJdbcBatchSize());
+    properties.put(JDBC_BATCH_SIZE, Integer.toString(getHibernateJdbcBatchSize()));
     properties.put(JDBC_FETCH_SIZE, getHibernateJdbcFetchSize());
     return properties.build();
   }


### PR DESCRIPTION
It's OOMing on trying to load every single BillingRecurrence that needs to be
expanded simultaneously (which is to be expected). So this processes them in
transactional batches of 50.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1636)
<!-- Reviewable:end -->
