### PR TITLE
Use new renew cost calculation in handleFeeRequest()

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -680,7 +680,19 @@ public class DomainFlowUtils {
         break;
       case RENEW:
         builder.setAvailIfSupported(true);
-        fees = pricingLogic.getRenewPrice(registry, domainNameString, now, years, null).getFees();
+        if (domain.isPresent()) {
+          fees =
+              pricingLogic
+                  .getRenewPrice(
+                      registry,
+                      domainNameString,
+                      now,
+                      years,
+                      tm().transact(() -> tm().loadByKey(domain.get().getAutorenewBillingEvent())))
+                  .getFees();
+        } else {
+          fees = pricingLogic.getRenewPrice(registry, domainNameString, now, years, null).getFees();
+        }
         break;
       case RESTORE:
         // The minimum allowable period per the EPP spec is 1, so, strangely, 1 year still has to be

--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -633,7 +633,8 @@ public class DomainFlowUtils {
       DateTime currentDate,
       DomainPricingLogic pricingLogic,
       Optional<AllocationToken> allocationToken,
-      boolean isAvailable)
+      boolean isAvailable,
+      @Nullable Recurring recurringBillingEvent)
       throws EppException {
     DateTime now = currentDate;
     // Use the custom effective date specified in the fee check request, if there is one.
@@ -680,19 +681,10 @@ public class DomainFlowUtils {
         break;
       case RENEW:
         builder.setAvailIfSupported(true);
-        if (domain.isPresent()) {
-          fees =
-              pricingLogic
-                  .getRenewPrice(
-                      registry,
-                      domainNameString,
-                      now,
-                      years,
-                      tm().transact(() -> tm().loadByKey(domain.get().getAutorenewBillingEvent())))
-                  .getFees();
-        } else {
-          fees = pricingLogic.getRenewPrice(registry, domainNameString, now, years, null).getFees();
-        }
+        fees =
+            pricingLogic
+                .getRenewPrice(registry, domainNameString, now, years, recurringBillingEvent)
+                .getFees();
         break;
       case RESTORE:
         // The minimum allowable period per the EPP spec is 1, so, strangely, 1 year still has to be

--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -682,9 +682,7 @@ public class DomainFlowUtils {
       case RENEW:
         builder.setAvailIfSupported(true);
         fees =
-            pricingLogic
-                .getRenewPrice(registry, domainNameString, now, years, recurringBillingEvent)
-                .getFees();
+            pricingLogic.getRenewPrice(registry, domainNameString, now, years, recurringBillingEvent).getFees();
         break;
       case RESTORE:
         // The minimum allowable period per the EPP spec is 1, so, strangely, 1 year still has to be

--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -682,7 +682,9 @@ public class DomainFlowUtils {
       case RENEW:
         builder.setAvailIfSupported(true);
         fees =
-            pricingLogic.getRenewPrice(registry, domainNameString, now, years, recurringBillingEvent).getFees();
+            pricingLogic
+                .getRenewPrice(registry, domainNameString, now, years, recurringBillingEvent)
+                .getFees();
         break;
       case RESTORE:
         // The minimum allowable period per the EPP spec is 1, so, strangely, 1 year still has to be

--- a/core/src/main/java/google/registry/flows/domain/DomainInfoFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainInfoFlow.java
@@ -169,7 +169,8 @@ public final class DomainInfoFlow implements Flow {
           now,
           pricingLogic,
           Optional.empty(),
-          false);
+          false,
+          tm().transact(() -> tm().loadByKey(domain.getAutorenewBillingEvent())));
       extensions.add(builder.build());
     }
     return extensions.build();

--- a/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
@@ -21,6 +21,7 @@ import static google.registry.model.tld.Registry.TldState.PREDELEGATION;
 import static google.registry.model.tld.Registry.TldState.START_DATE_SUNRISE;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.createTlds;
+import static google.registry.testing.DatabaseHelper.loadByEntity;
 import static google.registry.testing.DatabaseHelper.loadRegistrar;
 import static google.registry.testing.DatabaseHelper.newDomainBase;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
@@ -29,6 +30,7 @@ import static google.registry.testing.DatabaseHelper.persistPremiumList;
 import static google.registry.testing.DatabaseHelper.persistReservedList;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
+import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.joda.money.CurrencyUnit.JPY;
 import static org.joda.money.CurrencyUnit.USD;
@@ -66,7 +68,11 @@ import google.registry.flows.domain.DomainFlowUtils.TrailingDashException;
 import google.registry.flows.domain.DomainFlowUtils.TransfersAreAlwaysForOneYearException;
 import google.registry.flows.domain.DomainFlowUtils.UnknownFeeCommandException;
 import google.registry.flows.exceptions.TooManyResourceChecksException;
+import google.registry.model.billing.BillingEvent;
+import google.registry.model.billing.BillingEvent.Flag;
+import google.registry.model.billing.BillingEvent.Reason;
 import google.registry.model.domain.DomainBase;
+import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.token.AllocationToken;
 import google.registry.model.domain.token.AllocationToken.TokenStatus;
 import google.registry.model.eppcommon.StatusValue;
@@ -117,6 +123,31 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
         "premiumcollision,NAME_COLLISION",
         "reserved,FULLY_BLOCKED",
         "specificuse,RESERVED_FOR_SPECIFIC_USE");
+  }
+
+  private void setUpBillingEventForExistingDomain(DomainBase domain) {
+    DomainBase existingDomain = loadByEntity(domain);
+    DomainHistory historyEntry =
+        persistResource(
+            new DomainHistory.Builder()
+                .setDomain(domain)
+                .setType(HistoryEntry.Type.DOMAIN_CREATE)
+                .setModificationTime(domain.getCreationTime())
+                .setRegistrarId(domain.getCreationRegistrarId())
+                .build());
+    BillingEvent.Recurring renewEvent =
+        persistResource(
+            new BillingEvent.Recurring.Builder()
+                .setReason(Reason.RENEW)
+                .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
+                .setTargetId(domain.getDomainName())
+                .setRegistrarId("TheRegistrar")
+                .setEventTime(domain.getCreationTime())
+                .setRecurrenceEndTime(END_OF_TIME)
+                .setParent(historyEntry)
+                .build());
+    persistResource(
+        existingDomain.asBuilder().setAutorenewBillingEvent(renewEvent.createVKey()).build());
   }
 
   @BeforeEach
@@ -836,9 +867,17 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
   @TestOfyAndSql
   void testFeeExtension_premium_eap_v06_withRenewalOnRestore() throws Exception {
     createTld("example");
+    DomainBase domainBase = persistActiveDomain("rich.example");
+    setUpBillingEventForExistingDomain(domainBase);
     setEppInput("domain_check_fee_premium_v06.xml");
     clock.setTo(DateTime.parse("2010-01-01T10:00:00Z"));
-    persistPendingDeleteDomain("rich.example");
+    persistResource(
+        loadByEntity(domainBase)
+            .asBuilder()
+            .setDeletionTime(clock.nowUtc().plusDays(25))
+            .setRegistrationExpirationTime(clock.nowUtc().minusDays(1))
+            .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
+            .build());
     persistResource(
         Registry.get("example")
             .asBuilder()
@@ -850,7 +889,6 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
                     .put(clock.nowUtc().plusDays(2), Money.of(USD, 0))
                     .build())
             .build());
-
     runFlowAssertResponse(loadFile("domain_check_fee_premium_eap_response_v06_with_renewal.xml"));
   }
 
@@ -909,7 +947,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
   void testFeeExtension_premiumLabels_v12_withRenewalOnRestore() throws Exception {
     createTld("example");
     setEppInput("domain_check_fee_premium_v12.xml");
-    persistPendingDeleteDomain("rich.example");
+    setUpBillingEventForExistingDomain(persistPendingDeleteDomain("rich.example"));
     runFlowAssertResponse(loadFile("domain_check_fee_premium_response_v12_with_renewal.xml"));
   }
 
@@ -949,7 +987,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setPremiumList(persistPremiumList("tld", USD, "premiumcollision,USD 70"))
             .build());
     // The domain needs to exist in order for it to be loaded to check for restore fee.
-    persistActiveDomain("allowedinsunrise.tld");
+    setUpBillingEventForExistingDomain(persistActiveDomain("allowedinsunrise.tld"));
     setEppInput("domain_check_fee_reserved_dupes_v06.xml");
     runFlowAssertResponse(loadFile("domain_check_fee_reserved_response_dupes_v06.xml"));
   }
@@ -1041,8 +1079,8 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setPremiumList(persistPremiumList("tld", USD, "premiumcollision,USD 70"))
             .build());
     // The domain needs to exist in order for it to be loaded to check for restore fee.
-    persistActiveDomain("allowedinsunrise.tld");
     setEppInput("domain_check_fee_reserved_dupes_v12.xml");
+    setUpBillingEventForExistingDomain(persistActiveDomain("allowedinsunrise.tld"));
     runFlowAssertResponse(loadFile("domain_check_fee_reserved_dupes_response_v12.xml"));
   }
 
@@ -1069,10 +1107,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setReservedLists(createReservedList())
             .setPremiumList(persistPremiumList("tld", USD, "premiumcollision,USD 70"))
             .build());
-    persistPendingDeleteDomain("reserved.tld");
-    persistPendingDeleteDomain("allowedinsunrise.tld");
-    persistPendingDeleteDomain("collision.tld");
-    persistPendingDeleteDomain("premiumcollision.tld");
+    setUpBillingEventForExistingDomain(persistPendingDeleteDomain("reserved.tld"));
+    setUpBillingEventForExistingDomain(persistPendingDeleteDomain("allowedinsunrise.tld"));
+    setUpBillingEventForExistingDomain(persistPendingDeleteDomain("collision.tld"));
+    setUpBillingEventForExistingDomain(persistPendingDeleteDomain("premiumcollision.tld"));
     setEppInput("domain_check_fee_reserved_v06.xml");
     runFlowAssertResponse(
         loadFile("domain_check_fee_reserved_sunrise_response_v06_with_renewals.xml"));
@@ -1382,8 +1420,8 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
     assertTldsFieldLogged("com", "net", "org");
   }
 
-  private void persistPendingDeleteDomain(String domainName) {
-    persistResource(
+  private DomainBase persistPendingDeleteDomain(String domainName) {
+    return persistResource(
         newDomainBase(domainName)
             .asBuilder()
             .setDeletionTime(clock.nowUtc().plusDays(25))

--- a/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
@@ -16,6 +16,7 @@ package google.registry.flows.domain;
 
 import static com.google.common.io.BaseEncoding.base16;
 import static com.google.common.truth.Truth.assertThat;
+import static google.registry.model.billing.BillingEvent.RenewalPriceBehavior.DEFAULT;
 import static google.registry.model.tld.Registry.TldState.QUIET_PERIOD;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.assertNoBillingEvents;
@@ -49,6 +50,7 @@ import google.registry.flows.domain.DomainFlowUtils.TransfersAreAlwaysForOneYear
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Flag;
 import google.registry.model.billing.BillingEvent.Reason;
+import google.registry.model.billing.BillingEvent.Recurring;
 import google.registry.model.contact.ContactAuthInfo;
 import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.DesignatedContact;
@@ -205,6 +207,35 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
   private void doSuccessfulTestNoNameservers(String expectedXmlFilename) throws Exception {
     persistTestEntities(true);
     doSuccessfulTest(expectedXmlFilename, true);
+  }
+
+  /** sets up a sample recurring billing event as part of the domain creation process. */
+  private void setUpBillingEventForExistingDomain() {
+    DomainHistory historyEntry =
+        persistResource(
+            new DomainHistory.Builder()
+                .setRegistrarId(domain.getCreationRegistrarId())
+                .setType(HistoryEntry.Type.DOMAIN_CREATE)
+                .setModificationTime(domain.getCreationTime())
+                .setDomain(domain)
+                .build());
+    Recurring recurring =
+        persistResource(
+            new BillingEvent.Recurring.Builder()
+                .setParent(historyEntry)
+                .setRegistrarId(domain.getCreationRegistrarId())
+                .setEventTime(domain.getCreationTime())
+                .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
+                .setId(2L)
+                .setReason(Reason.RENEW)
+                .setRenewalPriceBehavior(DEFAULT)
+                .setRenewalPrice(null)
+                .setRecurrenceEndTime(END_OF_TIME)
+                .setTargetId(domain.getDomainName())
+                .build());
+    domain =
+        persistResource(
+            domain.asBuilder().setAutorenewBillingEvent(recurring.createVKey()).build());
   }
 
   @TestOfyAndSql
@@ -717,6 +748,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
             "COMMAND", "renew",
             "PERIOD", "2"));
     persistTestEntities(false);
+    setUpBillingEventForExistingDomain();
     doSuccessfulTest(
         "domain_info_fee_response.xml",
         false,
@@ -724,7 +756,8 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
             "COMMAND", "renew",
             "DESCRIPTION", "renew",
             "PERIOD", "2",
-            "FEE", "22.00"));
+            "FEE", "22.00"),
+        true);
   }
 
   /** Test transfer command. */
@@ -823,10 +856,12 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
             "COMMAND", "renew",
             "PERIOD", "1"));
     persistTestEntities("rich.example", false);
+    setUpBillingEventForExistingDomain();
     doSuccessfulTest(
         "domain_info_fee_premium_response.xml",
         false,
-        ImmutableMap.of("COMMAND", "renew", "DESCRIPTION", "renew"));
+        ImmutableMap.of("COMMAND", "renew", "DESCRIPTION", "renew"),
+        true);
   }
 
   /** Test transfer command on a premium label. */

--- a/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
@@ -916,9 +916,6 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
             SUBSTITUTION_BASE, "NAME", "example.tld", "COMMAND", "renew", "PERIOD", "1"));
     persistTestEntities("example.tld", false);
     setUpBillingEventForExistingDomain(SPECIFIED, Money.of(USD, 3));
-    System.out.println(
-        tm().transact(() -> tm().loadByKey(domain.getAutorenewBillingEvent()))
-            .getRenewalPriceBehavior());
     doSuccessfulTest(
         "domain_info_fee_response.xml",
         false,
@@ -940,9 +937,6 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
             SUBSTITUTION_BASE, "NAME", "example.tld", "COMMAND", "renew", "PERIOD", "3"));
     persistTestEntities("example.tld", false);
     setUpBillingEventForExistingDomain(NONPREMIUM, null);
-    System.out.println(
-        tm().transact(() -> tm().loadByKey(domain.getAutorenewBillingEvent()))
-            .getRenewalPriceBehavior());
     doSuccessfulTest(
         "domain_info_fee_response.xml",
         false,
@@ -964,9 +958,6 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
             SUBSTITUTION_BASE, "NAME", "example.tld", "COMMAND", "renew", "PERIOD", "3"));
     persistTestEntities("example.tld", false);
     setUpBillingEventForExistingDomain(SPECIFIED, Money.of(USD, 3));
-    System.out.println(
-        tm().transact(() -> tm().loadByKey(domain.getAutorenewBillingEvent()))
-            .getRenewalPriceBehavior());
     doSuccessfulTest(
         "domain_info_fee_response.xml",
         false,
@@ -983,9 +974,6 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, DomainBase
             SUBSTITUTION_BASE, "NAME", "example.tld", "COMMAND", "renew", "PERIOD", "1"));
     persistTestEntities("example.tld", false);
     setUpBillingEventForExistingDomain(SPECIFIED, Money.of(USD, 3));
-    System.out.println(
-        tm().transact(() -> tm().loadByKey(domain.getAutorenewBillingEvent()))
-            .getRenewalPriceBehavior());
     doSuccessfulTest(
         "domain_info_fee_response.xml",
         false,

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_fee_premium_eap_response_v06_with_renewal.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_fee_premium_eap_response_v06_with_renewal.xml
@@ -6,8 +6,7 @@
     <resData>
       <domain:chkData>
         <domain:cd>
-          <domain:name avail="false">rich.example</domain:name>
-          <domain:reason>In use</domain:reason>
+          <domain:name avail="true">rich.example</domain:name>
         </domain:cd>
       </domain:chkData>
     </resData>
@@ -19,7 +18,7 @@
           <fee:command>create</fee:command>
           <fee:period unit="y">1</fee:period>
           <fee:fee description="create">100.00</fee:fee>
-          <fee:fee description="Early Access Period, fee expires: 2010-01-02T10:00:00.001Z">100.00</fee:fee>
+          <fee:fee description="Early Access Period, fee expires: 2010-01-02T10:00:00.000Z">100.00</fee:fee>
           <fee:class>premium</fee:class>
         </fee:cd>
         <fee:cd>
@@ -43,9 +42,7 @@
           <fee:currency>USD</fee:currency>
           <fee:command>restore</fee:command>
           <fee:period unit="y">1</fee:period>
-          <fee:fee description="renew">100.00</fee:fee>
           <fee:fee description="restore">17.00</fee:fee>
-          <fee:class>premium</fee:class>
         </fee:cd>
       </fee:chkData>
     </extension>

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_fee_premium_eap_response_v06_with_renewal.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_fee_premium_eap_response_v06_with_renewal.xml
@@ -1,10 +1,10 @@
-<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+<epp xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xmlns:contact="urn:ietf:params:xml:ns:contact-1.0" xmlns:fee="urn:ietf:params:xml:ns:fee-0.6" xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0" xmlns:fee11="urn:ietf:params:xml:ns:fee-0.11" xmlns:fee12="urn:ietf:params:xml:ns:fee-0.12" xmlns:launch="urn:ietf:params:xml:ns:launch-1.0" xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1" xmlns:host="urn:ietf:params:xml:ns:host-1.0">
   <response>
     <result code="1000">
       <msg>Command completed successfully</msg>
     </result>
     <resData>
-      <domain:chkData xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+      <domain:chkData>
         <domain:cd>
           <domain:name avail="false">rich.example</domain:name>
           <domain:reason>In use</domain:reason>
@@ -12,18 +12,17 @@
       </domain:chkData>
     </resData>
     <extension>
-      <fee:chkData xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
-        <fee:cd xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
+      <fee:chkData>
+        <fee:cd>
           <fee:name>rich.example</fee:name>
           <fee:currency>USD</fee:currency>
           <fee:command>create</fee:command>
           <fee:period unit="y">1</fee:period>
           <fee:fee description="create">100.00</fee:fee>
-          <fee:fee description="Early Access Period, fee expires: 2010-01-02T10:00:00.002Z">100.00
-          </fee:fee>
+          <fee:fee description="Early Access Period, fee expires: 2010-01-02T10:00:00.001Z">100.00</fee:fee>
           <fee:class>premium</fee:class>
         </fee:cd>
-        <fee:cd xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
+        <fee:cd>
           <fee:name>rich.example</fee:name>
           <fee:currency>USD</fee:currency>
           <fee:command>renew</fee:command>
@@ -31,7 +30,7 @@
           <fee:fee description="renew">100.00</fee:fee>
           <fee:class>premium</fee:class>
         </fee:cd>
-        <fee:cd xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
+        <fee:cd>
           <fee:name>rich.example</fee:name>
           <fee:currency>USD</fee:currency>
           <fee:command>transfer</fee:command>
@@ -39,7 +38,7 @@
           <fee:fee description="renew">100.00</fee:fee>
           <fee:class>premium</fee:class>
         </fee:cd>
-        <fee:cd xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
+        <fee:cd>
           <fee:name>rich.example</fee:name>
           <fee:currency>USD</fee:currency>
           <fee:command>restore</fee:command>


### PR DESCRIPTION
The purpose of this PR is to change the renewal cost calculation in `handleFeeRequest()` in `DomainFlowUtil` and fix existing test cases in check and info flow test after adding the new renew price calculation to `DomainFlowUtil`. 

- Missing billing events in existing test cases of `DomainInfoFlowTest.Java`:  two of the existing test cases for renewal have `eventBillingAndHistory` in `doSuccessTest()` as false (which is the default setting). However, if the domain is persisted, corresponding billing event should be there as well. I added a helper method that creates sample `DomainHistory` and `Recurring`  for an existing domain and the changes were made in those two test cases. 

- Missing billing events in existing test cases of `DomainCheckFlowTest.Java`: similar to the issue in `DomainInfoFlowTest` where `DomainHistory` and `Recurring` billing event objects are missing. A helper method was added that could be used to persist billing event for an existing domain. Because of this change, one of the test cases failed because of mismatching xml response file. The content remains the same except the tags are now added in the first `<epp>` tag.  See the diff in `...s/google/registry/flows/domain/domain_check_fee_premium_eap_response_v06_with_renewal.xml`. This file currently has only been used once in all the test cases. 
Moreover, the tags include v11 and v12 and the expiration date ends with .001 second instead of .002.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1637)
<!-- Reviewable:end -->
