### PR TITLE
Temporarily disable Caffeine refreshAfterWrite()

### DIFF
--- a/core/src/main/java/google/registry/model/CacheUtils.java
+++ b/core/src/main/java/google/registry/model/CacheUtils.java
@@ -62,15 +62,6 @@ public class CacheUtils {
    * cost of the load will never be incurred during the read.
    */
   public static Caffeine<Object, Object> newCacheBuilder(Duration expireAfterWrite) {
-    Duration refreshAfterWrite = expireAfterWrite.dividedBy(2);
-    Caffeine<Object, Object> caffeine = Caffeine.newBuilder().expireAfterWrite(expireAfterWrite);
-    // In tests, the cache duration is usually set to 0, which means the cache load synchronously
-    // blocks every time it is called anyway because of the expireAfterWrite() above. Thus, setting
-    // the refreshAfterWrite won't do anything, plus it's not legal to call it with a zero value
-    // anyway (Caffeine allows expireAfterWrite to be zero but not refreshAfterWrite).
-    if (!refreshAfterWrite.isZero()) {
-      caffeine = caffeine.refreshAfterWrite(refreshAfterWrite);
-    }
-    return caffeine;
+    return Caffeine.newBuilder().expireAfterWrite(expireAfterWrite);
   }
 }


### PR DESCRIPTION
We will re-enable this by reverting this commit in the near future (a few weeks
from now), but for the present, we need to disable the async refresh behavior on
the cache because unmanaged threading does not play along well with App Engine,
resulting in Objectify errors when it can't get the GAE environment during Ofy
Key construction as part of making the VKeys for the entities being
cached. Right now this code is sadly just throwing lots of warnings into the
logs without actually successfully refreshing anything.

As soon as we are no longer using Objectify this will no longer be an issue, and
we can revert this commit and then go back to refreshing asynchronously in
background.