### PR TITLE
Added info on problematic `max-instances` param

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,6 +52,13 @@ you will need to make any modifications beyond simple changes to
 likely you'll need to add cronjobs, URL paths, Datastore indexes, and task
 queues, and thus edit those associated XML files.
 
+The existing codebase is configured for running a full-scale registry with
+multiple TLDs.  In order to deploy to App Engine, you will either need to
+[increase your
+quota](https://cloud.google.com/compute/quotas#requesting_additional_quota) to
+allow for at least 100 running instances or reduce `max-instances` in the
+backend `appengine-web.xml` files to 25 or less.
+
 ## Global configuration
 
 Global configuration is managed through YAML files that are built with and


### PR DESCRIPTION
We have backend max-instances set to 100, which apparently exceeds the default
quota for GAE.  Add info on updating the quota or changing this parameter to
the configuration doc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1639)
<!-- Reviewable:end -->
