### PR TITLE
Slightly improve performance of ExpandRecurringBillingEventsAction

### DIFF
--- a/core/src/test/java/google/registry/flows/domain/DomainPricingLogicTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainPricingLogicTest.java
@@ -117,7 +117,7 @@ public class DomainPricingLogicTest {
             new BillingEvent.Recurring.Builder()
                 .setParent(historyEntry)
                 .setRegistrarId(domain.getCreationRegistrarId())
-                .setEventTime((DateTime.parse("1999-01-05T00:00:00Z")))
+                .setEventTime(DateTime.parse("1999-01-05T00:00:00Z"))
                 .setFlags(ImmutableSet.of(AUTO_RENEW))
                 .setId(2L)
                 .setReason(Reason.RENEW)


### PR DESCRIPTION
We don't need to log every single no-op batch of 50 Recurrences that are
processed (considering we have 1.5M total in our system), and we also don't need
to process Recurrences that already ended prior to the Cursor time (this gets us
down to 420k from 1.5M).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1642)
<!-- Reviewable:end -->
