### PR TITLE
Disable Ofy tests.

### DIFF
--- a/core/src/test/java/google/registry/testing/DualDatabaseTestInvocationContextProvider.java
+++ b/core/src/test/java/google/registry/testing/DualDatabaseTestInvocationContextProvider.java
@@ -1,3 +1,4 @@
+
 // Copyright 2020 The Nomulus Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,15 +65,13 @@ class DualDatabaseTestInvocationContextProvider implements TestTemplateInvocatio
   @Override
   public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
       ExtensionContext context) {
-    TestTemplateInvocationContext ofyContext =
-        createInvocationContext(context.getDisplayName() + " with Datastore", DatabaseType.OFY);
     TestTemplateInvocationContext sqlContext =
         createInvocationContext(context.getDisplayName() + " with PostgreSQL", DatabaseType.JPA);
     Method testMethod = context.getTestMethod().orElseThrow(IllegalStateException::new);
     if (testMethod.isAnnotationPresent(TestOfyAndSql.class)) {
-      return Stream.of(ofyContext, sqlContext);
+      return Stream.of(sqlContext);
     } else if (testMethod.isAnnotationPresent(TestOfyOnly.class)) {
-      return Stream.of(ofyContext);
+      throw new RuntimeException("Ofy-only test invoked.");
     } else if (testMethod.isAnnotationPresent(TestSqlOnly.class)) {
       return Stream.of(sqlContext);
     } else {

--- a/core/src/test/java/google/registry/testing/DualDatabaseTestInvocationContextProviderTest.java
+++ b/core/src/test/java/google/registry/testing/DualDatabaseTestInvocationContextProviderTest.java
@@ -73,10 +73,10 @@ public class DualDatabaseTestInvocationContextProviderTest {
 
   @AfterAll
   static void assertEachTransactionManagerIsUsed() {
-    assertThat(testBothDbsOfyCounter).isEqualTo(1);
+    assertThat(testBothDbsOfyCounter).isEqualTo(0);
     assertThat(testBothDbsSqlCounter).isEqualTo(1);
 
-    assertThat(testOfyOnlyOfyCounter).isEqualTo(1);
+    assertThat(testOfyOnlyOfyCounter).isEqualTo(0);
     assertThat(testOfyOnlySqlCounter).isEqualTo(0);
 
     assertThat(testSqlOnlyOfyCounter).isEqualTo(0);

--- a/core/src/test/java/google/registry/testing/TestOfyOnly.java
+++ b/core/src/test/java/google/registry/testing/TestOfyOnly.java
@@ -19,10 +19,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-import org.junit.jupiter.api.TestTemplate;
 
 /** Annotation to indicate a test method will be executed only with Datastore. */
 @Target({METHOD})
 @Retention(RUNTIME)
-@TestTemplate
 public @interface TestOfyOnly {}


### PR DESCRIPTION
This change just turns off the Ofy tests at the root, by removing processing
for dual tests and disassociating the TestOfyOnly annotation from test
annotations.

This is far less comprehensive than #1631, but it's probably worth entering as
a stopgap solution just because it should speed up our test runs and unblock a
lot of other cleanup work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1644)
<!-- Reviewable:end -->
