### PR TITLE
Add existing renewal behaviors to restore flow

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
@@ -163,11 +163,14 @@ public final class DomainRestoreRequestFlow implements TransactionalFlow {
     // Always bill for the restore itself.
     entitiesToSave.add(
         createRestoreBillingEvent(domainHistoryKey, feesAndCredits.getRestoreCost(), now));
-
+    BillingEvent.Recurring existingBillingEvent =
+        tm().loadByKey(existingDomain.getAutorenewBillingEvent());
     BillingEvent.Recurring autorenewEvent =
         newAutorenewBillingEvent(existingDomain)
             .setEventTime(newExpirationTime)
             .setRecurrenceEndTime(END_OF_TIME)
+            .setRenewalPriceBehavior(existingBillingEvent.getRenewalPriceBehavior())
+            .setRenewalPrice(existingBillingEvent.getRenewalPrice().orElse(null))
             .setParent(domainHistoryKey)
             .build();
     PollMessage.Autorenew autorenewPollMessage =


### PR DESCRIPTION
The purpose of PR is to add existing renewal behavior to the recurring billing event when a domain is being restored. The renewal behavior should remain the same since the domain is not deleted yet.

The helper method `persistPendingDeleteDomain()` was used to set up domain before running the restore flow. However, the set up was incomplete because there's no billing event when a domain was created. Therefore, a billing event was added in the method and the set up is the same as the set up from `DomainDeleteFlow`. 

In order to use the same `clock.nowUTC()` as the deletion time in the entire test case, a new parameter `deletionTime` is now added to the helper method, which is used to set up the pending delete billing event and assertion on billing events at the end of test case. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1649)
<!-- Reviewable:end -->
