### PR TITLE
Use getRenewPrice() in DomainPricingLogic for restore flow 

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -696,7 +696,10 @@ public class DomainFlowUtils {
         // restore because they can't be restored in the first place.
         boolean isExpired =
             domain.isPresent() && domain.get().getRegistrationExpirationTime().isBefore(now);
-        fees = pricingLogic.getRestorePrice(registry, domainNameString, now, isExpired).getFees();
+        fees =
+            pricingLogic
+                .getRestorePrice(registry, domainNameString, now, isExpired, null)
+                .getFees();
         break;
       case TRANSFER:
         if (years != 1) {

--- a/core/src/main/java/google/registry/flows/domain/DomainPricingLogic.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainPricingLogic.java
@@ -171,18 +171,25 @@ public final class DomainPricingLogic {
 
   /** Returns a new restore price for the pricer. */
   FeesAndCredits getRestorePrice(
-      Registry registry, String domainName, DateTime dateTime, boolean isExpired)
+      Registry registry,
+      String domainName,
+      DateTime dateTime,
+      boolean isExpired,
+      @Nullable Recurring recurringBillingEvent)
       throws EppException {
-    DomainPrices domainPrices = getPricesForDomainName(domainName, dateTime);
     FeesAndCredits.Builder feesAndCredits =
         new FeesAndCredits.Builder()
             .setCurrency(registry.getCurrency())
             .addFeeOrCredit(
                 Fee.create(registry.getStandardRestoreCost().getAmount(), FeeType.RESTORE, false));
     if (isExpired) {
+      FeesAndCredits renewPrice =
+          getRenewPrice(registry, domainName, dateTime, 1, recurringBillingEvent);
       feesAndCredits.addFeeOrCredit(
           Fee.create(
-              domainPrices.getRenewCost().getAmount(), FeeType.RENEW, domainPrices.isPremium()));
+              renewPrice.getRenewCost().getAmount(),
+              FeeType.RENEW,
+              renewPrice.hasAnyPremiumFees()));
     }
     return customLogic.customizeRestorePrice(
         RestorePriceParameters.newBuilder()

--- a/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
@@ -144,7 +144,7 @@ public final class DomainRestoreRequestFlow implements TransactionalFlow {
     boolean isExpired = existingDomain.getRegistrationExpirationTime().isBefore(now);
     FeesAndCredits feesAndCredits =
         pricingLogic.getRestorePrice(
-            Registry.get(existingDomain.getTld()), targetId, now, isExpired);
+            Registry.get(existingDomain.getTld()), targetId, now, isExpired, null);
     Optional<FeeUpdateCommandExtension> feeUpdate =
         eppInput.getSingleExtension(FeeUpdateCommandExtension.class);
     verifyRestoreAllowed(command, existingDomain, feeUpdate, feesAndCredits, now);


### PR DESCRIPTION
The new implementation of `getRenewPrice()` should be used in `getRestorePrice()` in `DomainPricingLogic` in order to support the anchor tenants and internal registrations. Therefore, an additional parameter `recurringBillingEvent` was added as `@nullable` for clients with existing billing events (mainly for anchor tenants and internal registrations). 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1655)
<!-- Reviewable:end -->
