### PR TITLE
Use getRenewPrice() in DomainPricingLogic in transfer flow

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -703,7 +703,7 @@ public class DomainFlowUtils {
           throw new TransfersAreAlwaysForOneYearException();
         }
         builder.setAvailIfSupported(true);
-        fees = pricingLogic.getTransferPrice(registry, domainNameString, now).getFees();
+        fees = pricingLogic.getTransferPrice(registry, domainNameString, now, null).getFees();
         break;
       case UPDATE:
         builder.setAvailIfSupported(true);

--- a/core/src/main/java/google/registry/flows/domain/DomainPricingLogic.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainPricingLogic.java
@@ -194,9 +194,14 @@ public final class DomainPricingLogic {
   }
 
   /** Returns a new transfer price for the pricer. */
-  FeesAndCredits getTransferPrice(Registry registry, String domainName, DateTime dateTime)
+  FeesAndCredits getTransferPrice(
+      Registry registry,
+      String domainName,
+      DateTime dateTime,
+      @Nullable Recurring recurringBillingEvent)
       throws EppException {
-    DomainPrices domainPrices = getPricesForDomainName(domainName, dateTime);
+    FeesAndCredits renewPrice =
+        getRenewPrice(registry, domainName, dateTime, 1, recurringBillingEvent);
     return customLogic.customizeTransferPrice(
         TransferPriceParameters.newBuilder()
             .setFeesAndCredits(
@@ -204,9 +209,9 @@ public final class DomainPricingLogic {
                     .setCurrency(registry.getCurrency())
                     .addFeeOrCredit(
                         Fee.create(
-                            domainPrices.getRenewCost().getAmount(),
+                            renewPrice.getRenewCost().getAmount(),
                             FeeType.RENEW,
-                            domainPrices.isPremium()))
+                            renewPrice.hasAnyPremiumFees()))
                     .build())
             .setRegistry(registry)
             .setDomainName(InternetDomainName.from(domainName))

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
@@ -172,7 +172,7 @@ public final class DomainTransferRequestFlow implements TransactionalFlow {
     Optional<FeesAndCredits> feesAndCredits =
         (period.getValue() == 0)
             ? Optional.empty()
-            : Optional.of(pricingLogic.getTransferPrice(registry, targetId, now));
+            : Optional.of(pricingLogic.getTransferPrice(registry, targetId, now, null));
     if (feesAndCredits.isPresent()) {
       validateFeeChallenge(targetId, now, feeTransfer, feesAndCredits.get());
     }

--- a/core/src/test/java/google/registry/flows/domain/DomainPricingLogicTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainPricingLogicTest.java
@@ -402,4 +402,128 @@ public class DomainPricingLogicTest {
                     registry, "standard.example", clock.nowUtc(), -1, null));
     assertThat(thrown).hasMessageThat().isEqualTo("Number of years must be positive");
   }
+
+  @TestOfyAndSql
+  void testGetDomainTransferPrice_standardDomain_default_noBilling_defaultRenewalPrice()
+      throws EppException {
+    assertThat(
+            domainPricingLogic.getTransferPrice(registry, "standard.example", clock.nowUtc(), null))
+        .isEqualTo(
+            new FeesAndCredits.Builder()
+                .setCurrency(USD)
+                .addFeeOrCredit(Fee.create(Money.of(USD, 10).getAmount(), RENEW, false))
+                .build());
+  }
+
+  @TestOfyAndSql
+  void testGetDomainTransferPrice_premiumDomain_default_noBilling_premiumRenewalPrice()
+      throws EppException {
+    assertThat(
+            domainPricingLogic.getTransferPrice(registry, "premium.example", clock.nowUtc(), null))
+        .isEqualTo(
+            new FeesAndCredits.Builder()
+                .setCurrency(USD)
+                .addFeeOrCredit(Fee.create(Money.of(USD, 100).getAmount(), RENEW, true))
+                .build());
+  }
+
+  @TestOfyAndSql
+  void testGetDomainTransferPrice_standardDomain_default_defaultRenewalPrice() throws EppException {
+    assertThat(
+            domainPricingLogic.getTransferPrice(
+                registry,
+                "standard.example",
+                clock.nowUtc(),
+                persistDomainAndSetRecurringBillingEvent(
+                    "standard.example", DEFAULT, Optional.empty())))
+        .isEqualTo(
+            new FeesAndCredits.Builder()
+                .setCurrency(USD)
+                .addFeeOrCredit(Fee.create(Money.of(USD, 10).getAmount(), RENEW, false))
+                .build());
+  }
+
+  @TestOfyAndSql
+  void testGetDomainTransferPrice_premiumDomain_default_premiumRenewalPrice() throws EppException {
+    assertThat(
+            domainPricingLogic.getTransferPrice(
+                registry,
+                "premium.example",
+                clock.nowUtc(),
+                persistDomainAndSetRecurringBillingEvent(
+                    "premium.example", DEFAULT, Optional.empty())))
+        .isEqualTo(
+            new FeesAndCredits.Builder()
+                .setCurrency(USD)
+                .addFeeOrCredit(Fee.create(Money.of(USD, 100).getAmount(), RENEW, true))
+                .build());
+  }
+
+  @TestOfyAndSql
+  void testGetDomainTransferPrice_standardDomain_nonPremium_nonPremiumRenewalPrice()
+      throws EppException {
+    assertThat(
+            domainPricingLogic.getTransferPrice(
+                registry,
+                "standard.example",
+                clock.nowUtc(),
+                persistDomainAndSetRecurringBillingEvent(
+                    "standard.example", NONPREMIUM, Optional.empty())))
+        .isEqualTo(
+            new FeesAndCredits.Builder()
+                .setCurrency(USD)
+                .addFeeOrCredit(Fee.create(Money.of(USD, 10).getAmount(), RENEW, false))
+                .build());
+  }
+
+  @TestOfyAndSql
+  void testGetDomainTransferPrice_premiumDomain_nonPremium_nonPremiumRenewalPrice()
+      throws EppException {
+    assertThat(
+            domainPricingLogic.getTransferPrice(
+                registry,
+                "premium.example",
+                clock.nowUtc(),
+                persistDomainAndSetRecurringBillingEvent(
+                    "premium.example", NONPREMIUM, Optional.empty())))
+        .isEqualTo(
+            new FeesAndCredits.Builder()
+                .setCurrency(USD)
+                .addFeeOrCredit(Fee.create(Money.of(USD, 10).getAmount(), RENEW, false))
+                .build());
+  }
+
+  @TestOfyAndSql
+  void testGetDomainTransferPrice_standardDomain_specified_specifiedRenewalPrice()
+      throws EppException {
+    assertThat(
+            domainPricingLogic.getTransferPrice(
+                registry,
+                "standard.example",
+                clock.nowUtc(),
+                persistDomainAndSetRecurringBillingEvent(
+                    "standard.example", SPECIFIED, Optional.of(Money.of(USD, 1.23)))))
+        .isEqualTo(
+            new FeesAndCredits.Builder()
+                .setCurrency(USD)
+                .addFeeOrCredit(Fee.create(Money.of(USD, 1.23).getAmount(), RENEW, false))
+                .build());
+  }
+
+  @TestOfyAndSql
+  void testGetDomainTransferPrice_premiumDomain_specified_specifiedRenewalPrice()
+      throws EppException {
+    assertThat(
+            domainPricingLogic.getTransferPrice(
+                registry,
+                "premium.example",
+                clock.nowUtc(),
+                persistDomainAndSetRecurringBillingEvent(
+                    "premium.example", SPECIFIED, Optional.of(Money.of(USD, 1.23)))))
+        .isEqualTo(
+            new FeesAndCredits.Builder()
+                .setCurrency(USD)
+                .addFeeOrCredit(Fee.create(Money.of(USD, 1.23).getAmount(), RENEW, false))
+                .build());
+  }
 }


### PR DESCRIPTION
The new implementation of getRenewPrice() should be used in getTransferPrice() in DomainPricingLogic in order to support the anchor tenants and internal registrations. Therefore, an additional parameter recurringBillingEvent was added as @nullable for clients with existing billing events (mainly for anchor tenants and internal registrations).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1656)
<!-- Reviewable:end -->
