### PR TITLE
Remove bracket in Cloud Build script

### DIFF
--- a/release/cloudbuild-schema-verify.yaml
+++ b/release/cloudbuild-schema-verify.yaml
@@ -23,7 +23,9 @@
 # variable references must avoid the ${var} format. Valid formats include
 # $var or ${"${var}"}. This file use the former. Since _ENV is expanded in the
 # copies sent to Spinnaker, we preserve the brackets around them for safe
-# pattern matching during release.
+# pattern matching during release. If the invalid ${var} format is used, the
+# Spinnaker error message will have the following:
+# 'Invalid JSON payload received. Unknown name \"expressionEvaluationSummary\"'
 # See https://github.com/spinnaker/spinnaker/issues/3028 for more information.
 steps:
 # Download and decrypt the nomulus tool credential, which has the privilege to


### PR DESCRIPTION
Due to spinnaker restriction: it cannot handle variable references where the var name has brackets around it.

This is documented inline in this doc, but we forgot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1658)
<!-- Reviewable:end -->
