### PR TITLE
Fix some small transactional issues in SQL mode

### DIFF
--- a/core/src/main/java/google/registry/tools/UniformRapidSuspensionCommand.java
+++ b/core/src/main/java/google/registry/tools/UniformRapidSuspensionCommand.java
@@ -204,7 +204,8 @@ final class UniformRapidSuspensionCommand extends MutatingEppToolCommand {
 
   private ImmutableSortedSet<String> getExistingNameservers(DomainBase domain) {
     ImmutableSortedSet.Builder<String> nameservers = ImmutableSortedSet.naturalOrder();
-    for (HostResource host : tm().loadByKeys(domain.getNameservers()).values()) {
+    for (HostResource host :
+        tm().transact(() -> tm().loadByKeys(domain.getNameservers()).values())) {
       nameservers.add(host.getForeignKey());
     }
     return nameservers.build();

--- a/core/src/test/java/google/registry/tools/GetAllocationTokenCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetAllocationTokenCommandTest.java
@@ -29,13 +29,15 @@ import com.googlecode.objectify.Key;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.domain.token.AllocationToken;
 import google.registry.model.reporting.HistoryEntry;
+import google.registry.testing.DualDatabaseTest;
+import google.registry.testing.TestSqlOnly;
 import org.joda.time.DateTime;
-import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link GetAllocationTokenCommand}. */
+@DualDatabaseTest
 class GetAllocationTokenCommandTest extends CommandTestCase<GetAllocationTokenCommand> {
 
-  @Test
+  @TestSqlOnly
   void testSuccess_oneToken() throws Exception {
     createTlds("bar");
     AllocationToken token =
@@ -49,7 +51,7 @@ class GetAllocationTokenCommandTest extends CommandTestCase<GetAllocationTokenCo
     assertInStdout(token.toString(), "Token foo was not redeemed.");
   }
 
-  @Test
+  @TestSqlOnly
   void testSuccess_multipleTokens() throws Exception {
     createTlds("baz");
     ImmutableList<AllocationToken> tokens =
@@ -73,7 +75,7 @@ class GetAllocationTokenCommandTest extends CommandTestCase<GetAllocationTokenCo
         "Token fii was not redeemed.");
   }
 
-  @Test
+  @TestSqlOnly
   void testSuccess_redeemedToken() throws Exception {
     createTld("tld");
     DomainBase domain =
@@ -93,7 +95,7 @@ class GetAllocationTokenCommandTest extends CommandTestCase<GetAllocationTokenCo
         "Token foo was redeemed to create domain fqqdn.tld at 2016-04-07T22:19:17.044Z.");
   }
 
-  @Test
+  @TestSqlOnly
   void testSuccess_oneTokenDoesNotExist() throws Exception {
     createTlds("bar");
     AllocationToken token =
@@ -108,7 +110,7 @@ class GetAllocationTokenCommandTest extends CommandTestCase<GetAllocationTokenCo
         token.toString(), "Token foo was not redeemed.", "ERROR: Token bar does not exist.");
   }
 
-  @Test
+  @TestSqlOnly
   void testFailure_noAllocationTokensSpecified() {
     assertThrows(ParameterException.class, this::runCommand);
   }


### PR DESCRIPTION
These weren't caught until I switched the default database type in tests
to be SQL (separate PR). Fortunately these don't seem to be catastrophic

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1662)
<!-- Reviewable:end -->
