### PR TITLE
Fix EPP update NS delete bug

### DIFF
--- a/core/src/main/java/google/registry/persistence/VKey.java
+++ b/core/src/main/java/google/registry/persistence/VKey.java
@@ -53,8 +53,7 @@ public class VKey<T> extends ImmutableObject implements Serializable {
   Serializable sqlKey;
 
   // The objectify key for the referenced entity.
-  @Insignificant
-  Key<T> ofyKey;
+  @Insignificant Key<T> ofyKey;
 
   Class<? extends T> kind;
 

--- a/core/src/main/java/google/registry/persistence/VKey.java
+++ b/core/src/main/java/google/registry/persistence/VKey.java
@@ -53,6 +53,7 @@ public class VKey<T> extends ImmutableObject implements Serializable {
   Serializable sqlKey;
 
   // The objectify key for the referenced entity.
+  @Insignificant
   Key<T> ofyKey;
 
   Class<? extends T> kind;


### PR DESCRIPTION
When removing nameservers during an EPP update, we use the
Sets.difference(), which depends on the equals() method of the set
elements (VKey<HoseResource>), to compute the resulting NS set. The
equality check for a VKey checks for equality of all of its significant fields.

We are seeing strange issues where the removal of NS appeared to
have succeeded, but did not actually happen, because the equality check failed
for two VKey<HostResource> objects with identical SQL key, causing the VKeys to
not be removed by the Set.difference() method when they should have been.

The most likely cause is that the Ofy key field in VKey is no longer up-to-date,
now that we stopped replaying to datastore, and are actively tearing down
Ofy-related pieces.

While I did not check how the ofy keys were different between the VKeys loaded
from as part of the  domain (the existing NSes) and the VKeys loaded directly
from host resource, as specified in the EPP update command (the NSes to delete);
I did verify that by designating the field as @Insignificant, which causes it
to be ignored when checking for equality, the issue disappeared when repeatedly
adding and removing nameservers. Previously I was able to reproduce the issue
by adding/removing nameservers within a few iterations.

Also removed the logging that was put in place to help debug the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1665)
<!-- Reviewable:end -->
