### PR TITLE
Remove TM references from GaeUserIdConverter

### DIFF
--- a/core/src/main/java/google/registry/model/ofy/Ofy.java
+++ b/core/src/main/java/google/registry/model/ofy/Ofy.java
@@ -242,7 +242,7 @@ public class Ofy {
   }
 
   /** Pause the current transaction (if any) and complete this one before returning to it. */
-  <R> R transactNew(Supplier<R> work) {
+  public <R> R transactNew(Supplier<R> work) {
     // Wrap the Work in a CommitLoggedWork so that we can give transactions a frozen view of time
     // and maintain commit logs for them.
     return transactCommitLoggedWork(new CommitLoggedWork<>(work, getClock()));

--- a/core/src/test/java/google/registry/model/common/GaeUserIdConverterTest.java
+++ b/core/src/test/java/google/registry/model/common/GaeUserIdConverterTest.java
@@ -15,8 +15,7 @@
 package google.registry.model.common;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.ofyTm;
-import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.model.ofy.ObjectifyService.auditedOfy;
 
 import google.registry.testing.AppEngineExtension;
 import org.junit.jupiter.api.AfterEach;
@@ -32,7 +31,7 @@ public class GaeUserIdConverterTest {
 
   @AfterEach
   void verifyNoLingeringEntities() {
-    assertThat(ofyTm().loadAllOf(GaeUserIdConverter.class)).hasSize(0);
+    assertThat(auditedOfy().load().type(GaeUserIdConverter.class).count()).isEqualTo(0);
   }
 
   @Test
@@ -43,9 +42,12 @@ public class GaeUserIdConverterTest {
 
   @Test
   void testSuccess_inTransaction() {
-    tm().transactNew(
-            () ->
-                assertThat(GaeUserIdConverter.convertEmailAddressToGaeUserId("example@example.com"))
-                    .matches("[0-9]+"));
+    auditedOfy()
+        .transactNew(
+            () -> {
+              assertThat(GaeUserIdConverter.convertEmailAddressToGaeUserId("example@example.com"))
+                  .matches("[0-9]+");
+              return null;
+            });
   }
 }


### PR DESCRIPTION
This is the only user of the ofy code that will stick around at least
until we move to the new registrar console. By removing references to
the transaction manager, we will be able to delete all the tm code
without interfering with this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1666)
<!-- Reviewable:end -->
