### PR TITLE
Migrate ReadDnsQueueAction to use CloudTasksUtils

### DIFF
--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -34,7 +34,6 @@ import com.google.common.collect.ImmutableSortedMap;
 import dagger.Module;
 import dagger.Provides;
 import google.registry.persistence.transaction.JpaTransactionManager;
-import google.registry.util.TaskQueueUtils;
 import google.registry.util.YamlUtils;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -952,7 +951,7 @@ public final class RegistryConfig {
      * <p>Note that this uses {@code @Named} instead of {@code @Config} so that it can be used from
      * the low-level util package, which cannot have a dependency on the config package.
      *
-     * @see TaskQueueUtils
+     * @see google.registry.util.CloudTasksUtils
      */
     @Provides
     @Named("transientFailureRetries")

--- a/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
@@ -100,7 +100,6 @@ import org.joda.time.DateTime;
  * superuser. As such, adding or removing these statuses incurs a billing event. There will be only
  * one charge per update, even if several such statuses are updated at once.
  *
- * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
  * @error {@link google.registry.flows.EppException.UnimplementedExtensionException}
  * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.AddRemoveSameValueException}

--- a/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
@@ -48,7 +48,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Ordering;
 import com.google.common.collect.Sets;
-import com.google.common.flogger.FluentLogger;
 import com.google.common.net.InternetDomainName;
 import google.registry.dns.DnsQueue;
 import google.registry.flows.EppException;
@@ -101,6 +100,7 @@ import org.joda.time.DateTime;
  * superuser. As such, adding or removing these statuses incurs a billing event. There will be only
  * one charge per update, even if several such statuses are updated at once.
  *
+ * @error {@link google.registry.flows.EppException.ReadOnlyModeEppException}
  * @error {@link google.registry.flows.EppException.UnimplementedExtensionException}
  * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  * @error {@link google.registry.flows.ResourceFlowUtils.AddRemoveSameValueException}
@@ -145,8 +145,6 @@ public final class DomainUpdateFlow implements TransactionalFlow {
    */
   private static final ImmutableSet<StatusValue> UPDATE_DISALLOWED_STATUSES =
       ImmutableSet.of(StatusValue.PENDING_DELETE, StatusValue.SERVER_UPDATE_PROHIBITED);
-
-  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   @Inject ResourceCommand resourceCommand;
   @Inject ExtensionManager extensionManager;

--- a/core/src/test/java/google/registry/dns/DnsInjectionTest.java
+++ b/core/src/test/java/google/registry/dns/DnsInjectionTest.java
@@ -28,6 +28,7 @@ import google.registry.model.ofy.Ofy;
 import google.registry.request.HttpException.NotFoundException;
 import google.registry.request.RequestModule;
 import google.registry.testing.AppEngineExtension;
+import google.registry.testing.CloudTasksHelper.CloudTasksHelperModule;
 import google.registry.testing.FakeClock;
 import google.registry.testing.InjectExtension;
 import java.io.PrintWriter;
@@ -59,9 +60,11 @@ public final class DnsInjectionTest {
   void beforeEach() throws Exception {
     inject.setStaticField(Ofy.class, "clock", clock);
     when(rsp.getWriter()).thenReturn(new PrintWriter(httpOutput));
-    component = DaggerDnsTestComponent.builder()
-        .requestModule(new RequestModule(req, rsp))
-        .build();
+    component =
+        DaggerDnsTestComponent.builder()
+            .requestModule(new RequestModule(req, rsp))
+            .cloudTasksHelperModule(new CloudTasksHelperModule(clock))
+            .build();
     dnsQueue = component.dnsQueue();
     createTld("lol");
   }

--- a/core/src/test/java/google/registry/dns/DnsTestComponent.java
+++ b/core/src/test/java/google/registry/dns/DnsTestComponent.java
@@ -15,6 +15,8 @@
 package google.registry.dns;
 
 import dagger.Component;
+import google.registry.config.CloudTasksUtilsModule;
+import google.registry.config.CredentialModule;
 import google.registry.config.RegistryConfig.ConfigModule;
 import google.registry.cron.CronModule;
 import google.registry.dns.writer.VoidDnsWriterModule;
@@ -25,7 +27,9 @@ import javax.inject.Singleton;
 @Singleton
 @Component(
     modules = {
+      CloudTasksUtilsModule.class,
       ConfigModule.class,
+      CredentialModule.class,
       CronModule.class,
       DnsModule.class,
       RequestModule.class,

--- a/core/src/test/java/google/registry/dns/DnsTestComponent.java
+++ b/core/src/test/java/google/registry/dns/DnsTestComponent.java
@@ -15,21 +15,19 @@
 package google.registry.dns;
 
 import dagger.Component;
-import google.registry.config.CloudTasksUtilsModule;
-import google.registry.config.CredentialModule;
 import google.registry.config.RegistryConfig.ConfigModule;
 import google.registry.cron.CronModule;
 import google.registry.dns.writer.VoidDnsWriterModule;
 import google.registry.request.RequestModule;
+import google.registry.testing.CloudTasksHelper.CloudTasksHelperModule;
 import google.registry.util.UtilsModule;
 import javax.inject.Singleton;
 
 @Singleton
 @Component(
     modules = {
-      CloudTasksUtilsModule.class,
+      CloudTasksHelperModule.class,
       ConfigModule.class,
-      CredentialModule.class,
       CronModule.class,
       DnsModule.class,
       RequestModule.class,

--- a/core/src/test/java/google/registry/persistence/VKeyTest.java
+++ b/core/src/test/java/google/registry/persistence/VKeyTest.java
@@ -13,17 +13,12 @@
 // limitations under the License.
 package google.registry.persistence;
 
-import static com.google.appengine.api.taskqueue.QueueFactory.getQueue;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static google.registry.testing.DatabaseHelper.newDomainBase;
 import static google.registry.testing.DatabaseHelper.persistActiveContact;
-import static google.registry.testing.TaskQueueHelper.assertTasksEnqueued;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.google.appengine.api.taskqueue.TaskOptions;
-import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableMap;
 import com.googlecode.objectify.Key;
 import com.googlecode.objectify.annotation.Entity;
 import google.registry.model.billing.BillingEvent.OneTime;
@@ -32,10 +27,7 @@ import google.registry.model.domain.DomainBase;
 import google.registry.model.host.HostResource;
 import google.registry.model.registrar.RegistrarContact;
 import google.registry.testing.AppEngineExtension;
-import google.registry.testing.TaskQueueHelper.TaskMatcher;
 import google.registry.testing.TestObject;
-import google.registry.util.Retrier;
-import google.registry.util.TaskQueueUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -48,19 +40,7 @@ class VKeyTest {
       AppEngineExtension.builder()
           .withDatastoreAndCloudSql()
           .withOfyTestEntities(TestObject.class)
-          .withTaskQueue(
-              Joiner.on('\n')
-                  .join(
-                      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
-                      "<queue-entries>",
-                      "  <queue>",
-                      "    <name>test-queue-for-vkey</name>",
-                      "    <rate>1/s</rate>",
-                      "  </queue>",
-                      "</queue-entries>"))
           .build();
-
-  private final TaskQueueUtils taskQueueUtils = new TaskQueueUtils(new Retrier(null, 1));
 
   @BeforeAll
   static void beforeAll() {
@@ -345,97 +325,6 @@ class VKeyTest {
   void testStringifyThenCreate_symmetricVKey_success() {
     VKey<TestObject> vkey = TestObject.create("foo").key();
     assertThat(VKey.create(vkey.stringify())).isEqualTo(vkey);
-  }
-
-  /**
-   * Verifies a complete key can go into task queue and comes out unscathed.
-   *
-   * <p>TaskOption objects are being used here instead of Task objects, despite that we are in the
-   * process of migrating to using Cloud Tasks API, the stringify() and create() were written with
-   * the intention to handle all types of vkeys, inlcuding ofy only vkeys. The purpose of the
-   * following test cases is to make sure we don't deploy the system with parameters that don't work
-   * in the current implementation. Once migration is done, the following test cases with TaskOption
-   * or TaskHandle will go away.
-   */
-  @Test
-  void testStringifyThenCreate_ofyOnlyVKeyIntaskQueue_success() throws Exception {
-    VKey<TestObject> vkey =
-        VKey.createOfy(TestObject.class, Key.create(TestObject.class, "tmpKey"));
-
-    String vkeyStringFromQueue =
-        ImmutableMap.copyOf(
-                taskQueueUtils
-                    .enqueue(
-                        getQueue("test-queue-for-vkey"),
-                        TaskOptions.Builder.withUrl("/the/path").param("vkey", vkey.stringify()))
-                    .extractParams())
-            .get("vkey");
-
-    assertTasksEnqueued(
-        "test-queue-for-vkey", new TaskMatcher().url("/the/path").param("vkey", vkey.stringify()));
-    assertThat(vkeyStringFromQueue).isEqualTo(vkey.stringify());
-    assertThat(VKey.create(vkeyStringFromQueue)).isEqualTo(vkey);
-  }
-
-  @Test
-  void testStringifyThenCreate_sqlOnlyVKeyIntaskQueue_success() throws Exception {
-    VKey<TestObject> vkey = VKey.createSql(TestObject.class, "sqlKey");
-
-    String vkeyStringFromQueue =
-        ImmutableMap.copyOf(
-                taskQueueUtils
-                    .enqueue(
-                        getQueue("test-queue-for-vkey"),
-                        TaskOptions.Builder.withUrl("/the/path").param("vkey", vkey.stringify()))
-                    .extractParams())
-            .get("vkey");
-
-    assertTasksEnqueued(
-        "test-queue-for-vkey", new TaskMatcher().url("/the/path").param("vkey", vkey.stringify()));
-    assertThat(vkeyStringFromQueue).isEqualTo(vkey.stringify());
-    assertThat(VKey.create(vkeyStringFromQueue)).isEqualTo(vkey);
-  }
-
-  @Test
-  void testStringifyThenCreate_generalVKeyIntaskQueue_success() throws Exception {
-    VKey<TestObject> vkey =
-        VKey.create(TestObject.class, "12345", Key.create(TestObject.class, "12345"));
-
-    String vkeyStringFromQueue =
-        ImmutableMap.copyOf(
-                taskQueueUtils
-                    .enqueue(
-                        getQueue("test-queue-for-vkey"),
-                        TaskOptions.Builder.withUrl("/the/path").param("vkey", vkey.stringify()))
-                    .extractParams())
-            .get("vkey");
-
-    assertTasksEnqueued(
-        "test-queue-for-vkey", new TaskMatcher().url("/the/path").param("vkey", vkey.stringify()));
-    assertThat(vkeyStringFromQueue).isEqualTo(vkey.stringify());
-    assertThat(VKey.create(vkeyStringFromQueue)).isEqualTo(vkey);
-  }
-
-  @Test
-  void testStringifyThenCreate_vkeyFromWebsafeStringIntaskQueue_success() throws Exception {
-    VKey<DomainBase> vkey =
-        VKey.fromWebsafeKey(
-            Key.create(newDomainBase("example.com", "ROID-1", persistActiveContact("contact-1")))
-                .getString());
-
-    String vkeyStringFromQueue =
-        ImmutableMap.copyOf(
-                taskQueueUtils
-                    .enqueue(
-                        getQueue("test-queue-for-vkey"),
-                        TaskOptions.Builder.withUrl("/the/path").param("vkey", vkey.stringify()))
-                    .extractParams())
-            .get("vkey");
-
-    assertTasksEnqueued(
-        "test-queue-for-vkey", new TaskMatcher().url("/the/path").param("vkey", vkey.stringify()));
-    assertThat(vkeyStringFromQueue).isEqualTo(vkey.stringify());
-    assertThat(VKey.create(vkeyStringFromQueue)).isEqualTo(vkey);
   }
 
   @Test

--- a/core/src/test/java/google/registry/testing/CloudTasksHelper.java
+++ b/core/src/test/java/google/registry/testing/CloudTasksHelper.java
@@ -41,6 +41,8 @@ import com.google.common.net.MediaType;
 import com.google.common.truth.Truth8;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
+import dagger.Module;
+import dagger.Provides;
 import google.registry.model.ImmutableObject;
 import google.registry.util.CloudTasksUtils;
 import google.registry.util.Retrier;
@@ -61,6 +63,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
+import javax.inject.Singleton;
 import org.joda.time.DateTime;
 
 /**
@@ -178,6 +181,28 @@ public class CloudTasksHelper implements Serializable {
                     .collect(joining("\n")))
             .fail();
       }
+    }
+  }
+
+  @Module
+  public static class CloudTasksHelperModule {
+
+    private final FakeClock clock;
+
+    public CloudTasksHelperModule(FakeClock clock) {
+      this.clock = clock;
+    }
+
+    @Singleton
+    @Provides
+    CloudTasksUtils provideCloudTasksUtils(CloudTasksHelper cloudTasksHelper) {
+      return cloudTasksHelper.getTestCloudTasksUtils();
+    }
+
+    @Singleton
+    @Provides
+    CloudTasksHelper provideCloudTasksHelper() {
+      return new CloudTasksHelper(clock);
     }
   }
 

--- a/util/src/main/java/google/registry/util/TaskQueueUtils.java
+++ b/util/src/main/java/google/registry/util/TaskQueueUtils.java
@@ -26,7 +26,13 @@ import java.io.Serializable;
 import java.util.List;
 import javax.inject.Inject;
 
-/** Utilities for dealing with App Engine task queues. */
+/**
+ * Utilities for dealing with App Engine task queues.
+ *
+ * <p>Use {@link CloudTasksUtils} to interact with push queues (Cloud Task queues). Pull queues will
+ * be implemented separately in SQL and you can continue using this class for that for now.
+ */
+@Deprecated
 public class TaskQueueUtils implements Serializable {
 
   private static final long serialVersionUID = 7893211200220508362L;


### PR DESCRIPTION
Also marked TaskQueueUtils as deprecated and fixed a few linter errors.

The Task Queue related tests in VKeyTest are also removed, because with CloudTasksHelper the tasks are not sent to a locally simulated Cloud Task environment like the local Task Queue set up by AppEngineExtension. Therefore there's no point in verifying that the parameters of enqueued tasks are not meddled by service, which is mocked entirely by ourselves.

Note that DNS pull queue still requires the use of the GAE Task Queue API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1669)
<!-- Reviewable:end -->
