### PR TITLE
Remove Ofy support from Cursor

### DIFF
--- a/core/src/main/java/google/registry/beam/rde/RdeIO.java
+++ b/core/src/main/java/google/registry/beam/rde/RdeIO.java
@@ -279,7 +279,7 @@ public class RdeIO {
                     transactIfJpaTm(
                         () ->
                             tm().loadByKeyIfPresent(
-                                    Cursor.createVKey(key.cursor(), registry.getTldStr())));
+                                    Cursor.createScopedVKey(key.cursor(), registry)));
                 DateTime position = getCursorTimeOrStartOfTime(cursor);
                 checkState(key.interval() != null, "Interval must be present");
                 DateTime newPosition = key.watermark().plus(key.interval());
@@ -292,7 +292,7 @@ public class RdeIO {
                     "Partial ordering of RDE deposits broken: %s %s",
                     position,
                     key);
-                tm().put(Cursor.create(key.cursor(), newPosition, registry));
+                tm().put(Cursor.createScoped(key.cursor(), newPosition, registry));
                 logger.atInfo().log(
                     "Rolled forward %s on %s cursor to %s.", key.cursor(), key.tld(), newPosition);
                 RdeRevision.saveRevision(key.tld(), key.watermark(), key.mode(), input.getValue());

--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -27,7 +27,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ascii;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
-import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
@@ -42,7 +41,9 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.inject.Named;
@@ -1266,7 +1267,7 @@ public final class RegistryConfig {
                       e.getKey().equals("START_OF_TIME")
                           ? START_OF_TIME
                           : DateTime.parse(e.getKey()),
-                  e -> e.getValue()));
+                  Entry::getValue));
     }
 
     @Provides

--- a/core/src/main/java/google/registry/model/EntityClasses.java
+++ b/core/src/main/java/google/registry/model/EntityClasses.java
@@ -17,7 +17,6 @@ package google.registry.model;
 import com.google.common.collect.ImmutableSet;
 import google.registry.model.annotations.DeleteAfterMigration;
 import google.registry.model.billing.BillingEvent;
-import google.registry.model.common.Cursor;
 import google.registry.model.common.EntityGroupRoot;
 import google.registry.model.common.GaeUserIdConverter;
 import google.registry.model.contact.ContactHistory;
@@ -54,7 +53,6 @@ public final class EntityClasses {
           BillingEvent.Recurring.class,
           ContactHistory.class,
           ContactResource.class,
-          Cursor.class,
           DomainBase.class,
           DomainHistory.class,
           EntityGroupRoot.class,

--- a/core/src/main/java/google/registry/model/EppResource.java
+++ b/core/src/main/java/google/registry/model/EppResource.java
@@ -57,6 +57,8 @@ import org.joda.time.DateTime;
 @Access(AccessType.FIELD) // otherwise it'll use the default if the repoId (property)
 public abstract class EppResource extends BackupGroupRoot implements Buildable {
 
+  private static final long serialVersionUID = -252782773382339534L;
+
   /**
    * Unique identifier in the registry for this resource.
    *
@@ -102,13 +104,13 @@ public abstract class EppResource extends BackupGroupRoot implements Buildable {
    * The time when this resource was created.
    *
    * <p>Map the method to XML, not the field, because if we map the field (with an adaptor class) it
-   * will never be omitted from the xml even if the timestamp inside creationTime is null and we
+   * will never be omitted from the xml even if the timestamp inside creationTime is null, and we
    * return null from the adaptor (instead it gets written as an empty tag).
    *
    * <p>This can be null in the case of pre-Registry-3.0-migration history objects with null
    * resource fields.
    */
-  @AttributeOverrides({@AttributeOverride(name = "creationTime", column = @Column())})
+  @AttributeOverrides(@AttributeOverride(name = "creationTime", column = @Column))
   @Index
   CreateAutoTimestamp creationTime = CreateAutoTimestamp.create(null);
 
@@ -199,6 +201,7 @@ public abstract class EppResource extends BackupGroupRoot implements Buildable {
   public abstract String getForeignKey();
 
   /** Create the VKey for the specified EPP resource. */
+  @Override
   public abstract VKey<? extends EppResource> createVKey();
 
   /** Override of {@link Buildable#asBuilder} so that the extra methods are visible. */

--- a/core/src/main/java/google/registry/model/contact/ContactHistory.java
+++ b/core/src/main/java/google/registry/model/contact/ContactHistory.java
@@ -101,6 +101,7 @@ public class ContactHistory extends HistoryEntry implements UnsafeSerializable {
 
   /** Creates a {@link VKey} instance for this entity. */
   @SuppressWarnings("unchecked")
+  @Override
   public VKey<ContactHistory> createVKey() {
     return (VKey<ContactHistory>) createVKey(Key.create(this));
   }

--- a/core/src/main/java/google/registry/model/domain/DomainHistory.java
+++ b/core/src/main/java/google/registry/model/domain/DomainHistory.java
@@ -252,6 +252,7 @@ public class DomainHistory extends HistoryEntry {
 
   /** Creates a {@link VKey} instance for this entity. */
   @SuppressWarnings("unchecked")
+  @Override
   public VKey<DomainHistory> createVKey() {
     return (VKey<DomainHistory>) createVKey(Key.create(this));
   }

--- a/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
+++ b/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
@@ -248,6 +248,7 @@ public class AllocationToken extends BackupGroupRoot implements Buildable {
     return renewalPriceBehavior;
   }
 
+  @Override
   public VKey<AllocationToken> createVKey() {
     return VKey.create(AllocationToken.class, getToken(), Key.create(this));
   }

--- a/core/src/main/java/google/registry/model/host/HostHistory.java
+++ b/core/src/main/java/google/registry/model/host/HostHistory.java
@@ -102,6 +102,7 @@ public class HostHistory extends HistoryEntry implements UnsafeSerializable {
 
   /** Creates a {@link VKey} instance for this entity. */
   @SuppressWarnings("unchecked")
+  @Override
   public VKey<HostHistory> createVKey() {
     return (VKey<HostHistory>) createVKey(Key.create(this));
   }

--- a/core/src/main/java/google/registry/model/registrar/Registrar.java
+++ b/core/src/main/java/google/registry/model/registrar/Registrar.java
@@ -730,6 +730,7 @@ public class Registrar extends ImmutableObject
   }
 
   /** Creates a {@link VKey} for this instance. */
+  @Override
   public VKey<Registrar> createVKey() {
     return createVKey(Key.create(this));
   }

--- a/core/src/main/java/google/registry/model/registrar/RegistrarPoc.java
+++ b/core/src/main/java/google/registry/model/registrar/RegistrarPoc.java
@@ -317,6 +317,7 @@ public class RegistrarPoc extends ImmutableObject implements Jsonifiable, Unsafe
         .build();
   }
 
+  @Override
   public VKey<RegistrarPoc> createVKey() {
     return VKey.createSql(RegistrarPoc.class, new RegistrarPocId(emailAddress, registrarId));
   }

--- a/core/src/main/java/google/registry/persistence/EppHistoryVKey.java
+++ b/core/src/main/java/google/registry/persistence/EppHistoryVKey.java
@@ -96,6 +96,7 @@ public abstract class EppHistoryVKey<K, E extends EppResource> extends Immutable
   }
 
   /** Creates a {@link VKey} from this instance. */
+  @Override
   public VKey<K> createVKey() {
     Class<K> vKeyType = new TypeInstantiator<K>(getClass()) {}.getExactType();
     return VKey.create(vKeyType, createSqlKey(), createOfyKey());

--- a/core/src/main/java/google/registry/rde/EscrowTaskRunner.java
+++ b/core/src/main/java/google/registry/rde/EscrowTaskRunner.java
@@ -92,9 +92,7 @@ class EscrowTaskRunner {
           DateTime startOfToday = clock.nowUtc().withTimeAtStartOfDay();
           DateTime nextRequiredRun =
               transactIfJpaTm(
-                      () ->
-                          tm().loadByKeyIfPresent(
-                                  Cursor.createVKey(cursorType, registry.getTldStr())))
+                      () -> tm().loadByKeyIfPresent(Cursor.createScopedVKey(cursorType, registry)))
                   .map(Cursor::getCursorTime)
                   .orElse(startOfToday);
           if (nextRequiredRun.isAfter(startOfToday)) {
@@ -104,7 +102,7 @@ class EscrowTaskRunner {
           task.runWithLock(nextRequiredRun);
           DateTime nextRun = nextRequiredRun.plus(interval);
           logger.atInfo().log("Rolling cursor forward to %s.", nextRun);
-          tm().transact(() -> tm().put(Cursor.create(cursorType, nextRun, registry)));
+          tm().transact(() -> tm().put(Cursor.createScoped(cursorType, nextRun, registry)));
           return null;
         };
     String lockName = String.format("EscrowTaskRunner %s", task.getClass().getSimpleName());

--- a/core/src/main/java/google/registry/rde/PendingDepositChecker.java
+++ b/core/src/main/java/google/registry/rde/PendingDepositChecker.java
@@ -92,7 +92,7 @@ public final class PendingDepositChecker {
       // Avoid creating a transaction unless absolutely necessary.
       Optional<Cursor> maybeCursor =
           transactIfJpaTm(
-              () -> tm().loadByKeyIfPresent(Cursor.createVKey(cursorType, registry.getTldStr())));
+              () -> tm().loadByKeyIfPresent(Cursor.createScopedVKey(cursorType, registry)));
       DateTime cursorValue = maybeCursor.map(Cursor::getCursorTime).orElse(startingPoint);
       if (isBeforeOrAt(cursorValue, now)) {
         DateTime watermark =
@@ -112,11 +112,11 @@ public final class PendingDepositChecker {
     return tm().transact(
             () -> {
               Optional<Cursor> maybeCursor =
-                  tm().loadByKeyIfPresent(Cursor.createVKey(cursorType, registry.getTldStr()));
+                  tm().loadByKeyIfPresent(Cursor.createScopedVKey(cursorType, registry));
               if (maybeCursor.isPresent()) {
                 return maybeCursor.get().getCursorTime();
               }
-              tm().put(Cursor.create(cursorType, initialValue, registry));
+              tm().put(Cursor.createScoped(cursorType, initialValue, registry));
               return initialValue;
             });
   }

--- a/core/src/main/java/google/registry/reporting/icann/IcannReportingUploadAction.java
+++ b/core/src/main/java/google/registry/reporting/icann/IcannReportingUploadAction.java
@@ -166,7 +166,7 @@ public final class IcannReportingUploadAction implements Runnable {
     // Set cursor to first day of next month if the upload succeeded
     if (success) {
       Cursor newCursor =
-          Cursor.create(
+          Cursor.createScoped(
               cursorType,
               cursorTime.withTimeAtStartOfDay().withDayOfMonth(1).plusMonths(1),
               Registry.get(tldStr));
@@ -227,7 +227,7 @@ public final class IcannReportingUploadAction implements Runnable {
 
   private ImmutableMap<VKey<? extends Cursor>, Registry> loadKeyMap(
       ImmutableSet<Registry> registries, CursorType type) {
-    return Maps.uniqueIndex(registries, r -> Cursor.createVKey(type, r.getTldStr()));
+    return Maps.uniqueIndex(registries, r -> Cursor.createScopedVKey(type, r));
   }
 
   /**
@@ -247,7 +247,7 @@ public final class IcannReportingUploadAction implements Runnable {
           Cursor cursor =
               cursorMap.getOrDefault(
                   key,
-                  Cursor.create(
+                  Cursor.createScoped(
                       type,
                       clock.nowUtc().withDayOfMonth(1).withTimeAtStartOfDay().plusMonths(1),
                       registry));

--- a/core/src/main/java/google/registry/tools/ListCursorsCommand.java
+++ b/core/src/main/java/google/registry/tools/ListCursorsCommand.java
@@ -57,7 +57,7 @@ final class ListCursorsCommand implements CommandWithRemoteApi {
             .map(Registry::get)
             .filter(r -> r.getTldType() == filterTldType)
             .filter(r -> !filterEscrowEnabled || r.getEscrowEnabled())
-            .collect(toImmutableMap(r -> r, r -> Cursor.createVKey(cursorType, r.getTldStr())));
+            .collect(toImmutableMap(r -> r, r -> Cursor.createScopedVKey(cursorType, r)));
     ImmutableMap<VKey<? extends Cursor>, Cursor> cursors =
         transactIfJpaTm(() -> tm().loadByKeysIfPresent(registries.values()));
     if (!registries.isEmpty()) {

--- a/core/src/main/java/google/registry/tools/UpdateCursorsCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdateCursorsCommand.java
@@ -54,7 +54,7 @@ final class UpdateCursorsCommand extends ConfirmingCommand implements CommandWit
     } else {
       for (String tld : tlds) {
         Registry registry = Registry.get(tld);
-        result.add(Cursor.create(cursorType, newTimestamp, registry));
+        result.add(Cursor.createScoped(cursorType, newTimestamp, registry));
       }
     }
     cursorsToUpdate = result.build();

--- a/core/src/nonprod/java/google/registry/tools/GenerateSqlSchemaCommand.java
+++ b/core/src/nonprod/java/google/registry/tools/GenerateSqlSchemaCommand.java
@@ -30,9 +30,9 @@ import org.testcontainers.containers.PostgreSQLContainer;
 /**
  * Generates a schema for JPA annotated classes using Hibernate.
  *
- * <p>Note that this isn't complete yet, as all of the persistent classes have not yet been
- * converted. After converting a class, a call to "addAnnotatedClass()" for the new class must be
- * added to the code below.
+ * <p>Note that this isn't complete yet, as all the persistent classes have not yet been converted.
+ * After converting a class, a call to "addAnnotatedClass()" for the new class must be added to the
+ * code below.
  */
 @Parameters(separators = " =", commandDescription = "Generate PostgreSQL schema.")
 public class GenerateSqlSchemaCommand implements Command {
@@ -49,7 +49,7 @@ public class GenerateSqlSchemaCommand implements Command {
   @VisibleForTesting
   public static final int POSTGRESQL_PORT = 5432;
 
-  private PostgreSQLContainer postgresContainer = null;
+  private PostgreSQLContainer<?> postgresContainer = null;
 
   @Parameter(
       names = {"-o", "--out_file"},
@@ -85,12 +85,12 @@ public class GenerateSqlSchemaCommand implements Command {
 
       // Start the container and store the address information.
       postgresContainer =
-          new PostgreSQLContainer(NomulusPostgreSql.getDockerTag())
+          new PostgreSQLContainer<>(NomulusPostgreSql.getDockerTag())
               .withDatabaseName(DB_NAME)
               .withUsername(DB_USERNAME)
               .withPassword(DB_PASSWORD);
       postgresContainer.start();
-      databaseHost = postgresContainer.getContainerIpAddress();
+      databaseHost = postgresContainer.getHost();
       databasePort = postgresContainer.getMappedPort(POSTGRESQL_PORT);
     } else if (databaseHost == null) {
       System.err.println(

--- a/core/src/nonprod/java/google/registry/tools/PostgresqlCommand.java
+++ b/core/src/nonprod/java/google/registry/tools/PostgresqlCommand.java
@@ -34,7 +34,7 @@ public abstract class PostgresqlCommand implements Command {
 
   @VisibleForTesting public static final int POSTGRESQL_PORT = 5432;
 
-  protected PostgreSQLContainer postgresContainer = null;
+  protected PostgreSQLContainer<?> postgresContainer = null;
 
   @Parameter(
       names = {"-s", "--start_postgresql"},
@@ -68,7 +68,7 @@ public abstract class PostgresqlCommand implements Command {
 
       // Start the container and store the address information.
       postgresContainer =
-          new PostgreSQLContainer(NomulusPostgreSql.getDockerTag())
+          new PostgreSQLContainer<>(NomulusPostgreSql.getDockerTag())
               .withDatabaseName(DB_NAME)
               .withUsername(DB_USERNAME)
               .withPassword(DB_PASSWORD);
@@ -79,7 +79,7 @@ public abstract class PostgresqlCommand implements Command {
         return false;
       }
       postgresContainer.start();
-      databaseHost = postgresContainer.getContainerIpAddress();
+      databaseHost = postgresContainer.getHost();
       databasePort = postgresContainer.getMappedPort(POSTGRESQL_PORT);
     } else if (databaseHost == null) {
       System.err.println(

--- a/core/src/test/java/google/registry/beam/rde/RdePipelineTest.java
+++ b/core/src/test/java/google/registry/beam/rde/RdePipelineTest.java
@@ -257,8 +257,8 @@ public class RdePipelineTest {
 
     tm().transact(
             () -> {
-              tm().put(Cursor.create(CursorType.BRDA, now, Registry.get("soy")));
-              tm().put(Cursor.create(RDE_STAGING, now, Registry.get("soy")));
+              tm().put(Cursor.createScoped(CursorType.BRDA, now, Registry.get("soy")));
+              tm().put(Cursor.createScoped(RDE_STAGING, now, Registry.get("soy")));
               RdeRevision.saveRevision("soy", now, THIN, 0);
               RdeRevision.saveRevision("soy", now, FULL, 0);
             });
@@ -567,7 +567,9 @@ public class RdePipelineTest {
   }
 
   private static DateTime loadCursorTime(CursorType type) {
-    return tm().transact(() -> tm().loadByKey(Cursor.createVKey(type, "soy")).getCursorTime());
+    return tm().transact(
+            () ->
+                tm().loadByKey(Cursor.createScopedVKey(type, Registry.get("soy"))).getCursorTime());
   }
 
   private static Function<DepositFragment, String> getXmlElement(String pattern) {

--- a/core/src/test/java/google/registry/model/common/ClassPathManagerTest.java
+++ b/core/src/test/java/google/registry/model/common/ClassPathManagerTest.java
@@ -61,7 +61,6 @@ public class ClassPathManagerTest {
     assertThat(ClassPathManager.getClass("Modification")).isEqualTo(Modification.class);
     assertThat(ClassPathManager.getClass("AllocationToken")).isEqualTo(AllocationToken.class);
     assertThat(ClassPathManager.getClass("OneTime")).isEqualTo(OneTime.class);
-    assertThat(ClassPathManager.getClass("Cursor")).isEqualTo(Cursor.class);
     assertThat(ClassPathManager.getClass("RdeRevision")).isEqualTo(RdeRevision.class);
     assertThat(ClassPathManager.getClass("HostResource")).isEqualTo(HostResource.class);
     assertThat(ClassPathManager.getClass("Recurring")).isEqualTo(Recurring.class);
@@ -120,7 +119,6 @@ public class ClassPathManagerTest {
     assertThat(ClassPathManager.getClassName(Modification.class)).isEqualTo("Modification");
     assertThat(ClassPathManager.getClassName(AllocationToken.class)).isEqualTo("AllocationToken");
     assertThat(ClassPathManager.getClassName(OneTime.class)).isEqualTo("OneTime");
-    assertThat(ClassPathManager.getClassName(Cursor.class)).isEqualTo("Cursor");
     assertThat(ClassPathManager.getClassName(RdeRevision.class)).isEqualTo("RdeRevision");
     assertThat(ClassPathManager.getClassName(HostResource.class)).isEqualTo("HostResource");
     assertThat(ClassPathManager.getClassName(Recurring.class)).isEqualTo("Recurring");

--- a/core/src/test/java/google/registry/persistence/BillingVKeyTest.java
+++ b/core/src/test/java/google/registry/persistence/BillingVKeyTest.java
@@ -106,6 +106,7 @@ class BillingVKeyTest {
       return billingRecurrenceVKey.createVKey();
     }
 
+    @Override
     public VKey<BillingVKeyTestEntity> createVKey() {
       return VKey.createSql(BillingVKeyTestEntity.class, id);
     }

--- a/core/src/test/java/google/registry/persistence/DomainHistoryVKeyTest.java
+++ b/core/src/test/java/google/registry/persistence/DomainHistoryVKeyTest.java
@@ -96,6 +96,7 @@ class DomainHistoryVKeyTest {
       this.domainHistoryVKey = domainHistoryVKey;
     }
 
+    @Override
     public VKey<TestEntity> createVKey() {
       return VKey.createSql(TestEntity.class, id);
     }

--- a/core/src/test/java/google/registry/rde/BrdaCopyActionTest.java
+++ b/core/src/test/java/google/registry/rde/BrdaCopyActionTest.java
@@ -125,13 +125,13 @@ public class BrdaCopyActionTest {
             () -> {
               RdeRevision.saveRevision("lol", DateTime.parse("2010-10-17TZ"), RdeMode.THIN, 0);
             });
-    persistResource(Cursor.create(BRDA, action.watermark.plusDays(1), Registry.get("lol")));
+    persistResource(Cursor.createScoped(BRDA, action.watermark.plusDays(1), Registry.get("lol")));
   }
 
   @ParameterizedTest
   @ValueSource(strings = {"", "job-name/"})
   void testRun_stagingNotFinished_throws204(String prefix) throws Exception {
-    persistResource(Cursor.create(BRDA, action.watermark, Registry.get("lol")));
+    persistResource(Cursor.createScoped(BRDA, action.watermark, Registry.get("lol")));
     NoContentException thrown = assertThrows(NoContentException.class, () -> runAction(prefix));
     assertThat(thrown)
         .hasMessageThat()

--- a/core/src/test/java/google/registry/rde/EscrowTaskRunnerTest.java
+++ b/core/src/test/java/google/registry/rde/EscrowTaskRunnerTest.java
@@ -77,12 +77,12 @@ public class EscrowTaskRunnerTest {
   void testRun_cursorIsToday_advancesCursorToTomorrow() throws Exception {
     clock.setTo(DateTime.parse("2006-06-06T00:30:00Z"));
     persistResource(
-        Cursor.create(CursorType.RDE_STAGING, DateTime.parse("2006-06-06TZ"), registry));
+        Cursor.createScoped(CursorType.RDE_STAGING, DateTime.parse("2006-06-06TZ"), registry));
     runner.lockRunAndRollForward(
         task, registry, standardSeconds(30), CursorType.RDE_STAGING, standardDays(1));
     verify(task).runWithLock(DateTime.parse("2006-06-06TZ"));
     tm().clearSessionCache();
-    Cursor cursor = loadByKey(Cursor.createVKey(CursorType.RDE_STAGING, registry.getTldStr()));
+    Cursor cursor = loadByKey(Cursor.createScopedVKey(CursorType.RDE_STAGING, registry));
     assertThat(cursor.getCursorTime()).isEqualTo(DateTime.parse("2006-06-07TZ"));
   }
 
@@ -92,7 +92,7 @@ public class EscrowTaskRunnerTest {
     runner.lockRunAndRollForward(
         task, registry, standardSeconds(30), CursorType.RDE_STAGING, standardDays(1));
     verify(task).runWithLock(DateTime.parse("2006-06-06TZ"));
-    Cursor cursor = loadByKey(Cursor.createVKey(CursorType.RDE_STAGING, "lol"));
+    Cursor cursor = loadByKey(Cursor.createScopedVKey(CursorType.RDE_STAGING, registry));
     assertThat(cursor.getCursorTime()).isEqualTo(DateTime.parse("2006-06-07TZ"));
   }
 
@@ -100,7 +100,7 @@ public class EscrowTaskRunnerTest {
   void testRun_cursorInTheFuture_doesNothing() {
     clock.setTo(DateTime.parse("2006-06-06T00:30:00Z"));
     persistResource(
-        Cursor.create(CursorType.RDE_STAGING, DateTime.parse("2006-06-07TZ"), registry));
+        Cursor.createScoped(CursorType.RDE_STAGING, DateTime.parse("2006-06-07TZ"), registry));
     NoContentException thrown =
         assertThrows(
             NoContentException.class,
@@ -115,7 +115,7 @@ public class EscrowTaskRunnerTest {
     String lockName = "EscrowTaskRunner " + task.getClass().getSimpleName();
     clock.setTo(DateTime.parse("2006-06-06T00:30:00Z"));
     persistResource(
-        Cursor.create(CursorType.RDE_STAGING, DateTime.parse("2006-06-06TZ"), registry));
+        Cursor.createScoped(CursorType.RDE_STAGING, DateTime.parse("2006-06-06TZ"), registry));
     runner.lockHandler = new FakeLockHandler(false);
     ServiceUnavailableException thrown =
         assertThrows(

--- a/core/src/test/java/google/registry/rde/PendingDepositCheckerTest.java
+++ b/core/src/test/java/google/registry/rde/PendingDepositCheckerTest.java
@@ -101,10 +101,9 @@ public class PendingDepositCheckerTest {
     createTldWithEscrowEnabled("lol");
     clock.advanceOneMilli();
     Registry registry = Registry.get("lol");
-    Truth8.assertThat(loadByKeyIfPresent(Cursor.createVKey(RDE_STAGING, registry.getTldStr())))
-        .isEmpty();
+    Truth8.assertThat(loadByKeyIfPresent(Cursor.createScopedVKey(RDE_STAGING, registry))).isEmpty();
     checker.getTldsAndWatermarksPendingDepositForRdeAndBrda();
-    assertThat(loadByKey(Cursor.createVKey(RDE_STAGING, registry.getTldStr())).getCursorTime())
+    assertThat(loadByKey(Cursor.createScopedVKey(RDE_STAGING, registry)).getCursorTime())
         .isEqualTo(DateTime.parse("2000-01-01TZ"));
   }
 
@@ -117,7 +116,7 @@ public class PendingDepositCheckerTest {
     setCursor(Registry.get("lol"), RDE_STAGING, yesterday);
     clock.advanceOneMilli();
     checker.getTldsAndWatermarksPendingDepositForRdeAndBrda();
-    Cursor cursor = loadByKey(Cursor.createVKey(RDE_STAGING, "lol"));
+    Cursor cursor = loadByKey(Cursor.createScopedVKey(RDE_STAGING, Registry.get("lol")));
     assertThat(cursor.getCursorTime()).isEqualTo(yesterday);
   }
 
@@ -129,9 +128,9 @@ public class PendingDepositCheckerTest {
     clock.advanceOneMilli();
     setCursor(registry, RDE_STAGING, DateTime.parse("2000-01-02TZ")); // assume rde is already done
     clock.advanceOneMilli();
-    Truth8.assertThat(loadByKeyIfPresent(Cursor.createVKey(BRDA, registry.getTldStr()))).isEmpty();
+    Truth8.assertThat(loadByKeyIfPresent(Cursor.createScopedVKey(BRDA, registry))).isEmpty();
     assertThat(checker.getTldsAndWatermarksPendingDepositForRdeAndBrda()).isEmpty();
-    Truth8.assertThat(loadByKeyIfPresent(Cursor.createVKey(BRDA, registry.getTldStr()))).isEmpty();
+    Truth8.assertThat(loadByKeyIfPresent(Cursor.createScopedVKey(BRDA, registry))).isEmpty();
   }
 
   @TestOfyAndSql
@@ -171,7 +170,7 @@ public class PendingDepositCheckerTest {
 
   private static void setCursor(
       final Registry registry, final CursorType cursorType, final DateTime value) {
-    tm().transact(() -> tm().put(Cursor.create(cursorType, value, registry)));
+    tm().transact(() -> tm().put(Cursor.createScoped(cursorType, value, registry)));
   }
 
   private static void createTldWithEscrowEnabled(final String tld) {

--- a/core/src/test/java/google/registry/rde/RdeStagingActionTest.java
+++ b/core/src/test/java/google/registry/rde/RdeStagingActionTest.java
@@ -43,7 +43,7 @@ import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-/** Unit tests for {@link RdeStagingAction} in Cloud SQL. */
+/** Unit tests for {@link RdeStagingAction}. */
 @DualDatabaseTest
 public class RdeStagingActionTest extends BeamActionTestBase {
 

--- a/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
+++ b/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
@@ -267,7 +267,7 @@ public class RdeUploadActionTest {
     URI uploadUrl = URI.create(String.format("sftp://user:password@localhost:%d/", port));
     DateTime stagingCursor = DateTime.parse("2010-10-18TZ");
     DateTime uploadCursor = DateTime.parse("2010-10-17TZ");
-    persistResource(Cursor.create(RDE_STAGING, stagingCursor, Registry.get("tld")));
+    persistResource(Cursor.createScoped(RDE_STAGING, stagingCursor, Registry.get("tld")));
     RdeUploadAction action = createAction(uploadUrl);
     action.lazyJsch = Lazies.of(createThrowingJSchSpy(action.lazyJsch.get(), 2));
     action.runWithLock(uploadCursor);
@@ -286,7 +286,7 @@ public class RdeUploadActionTest {
     URI uploadUrl = URI.create(String.format("sftp://user:password@localhost:%d/", port));
     DateTime stagingCursor = DateTime.parse("2010-10-18TZ");
     DateTime uploadCursor = DateTime.parse("2010-10-17TZ");
-    persistResource(Cursor.create(RDE_STAGING, stagingCursor, Registry.get("tld")));
+    persistResource(Cursor.createScoped(RDE_STAGING, stagingCursor, Registry.get("tld")));
     RdeUploadAction action = createAction(uploadUrl);
     action.lazyJsch = Lazies.of(createThrowingJSchSpy(action.lazyJsch.get(), 3));
     RuntimeException thrown =
@@ -300,7 +300,7 @@ public class RdeUploadActionTest {
     URI uploadUrl = URI.create(String.format("sftp://user:password@localhost:%d/", port));
     DateTime stagingCursor = DateTime.parse("2010-10-18TZ");
     DateTime uploadCursor = DateTime.parse("2010-10-17TZ");
-    persistResource(Cursor.create(RDE_STAGING, stagingCursor, Registry.get("tld")));
+    persistResource(Cursor.createScoped(RDE_STAGING, stagingCursor, Registry.get("tld")));
     gcsUtils.delete(GHOSTRYDE_FILE_WITH_PREFIX);
     gcsUtils.delete(LENGTH_FILE_WITH_PREFIX);
     gcsUtils.delete(REPORT_FILE_WITH_PREFIX);
@@ -320,7 +320,7 @@ public class RdeUploadActionTest {
     URI uploadUrl = URI.create(String.format("sftp://user:password@localhost:%d/", port));
     DateTime stagingCursor = DateTime.parse("2010-10-18TZ");
     DateTime uploadCursor = DateTime.parse("2010-10-17TZ");
-    persistResource(Cursor.create(RDE_STAGING, stagingCursor, Registry.get("tld")));
+    persistResource(Cursor.createScoped(RDE_STAGING, stagingCursor, Registry.get("tld")));
     gcsUtils.delete(GHOSTRYDE_FILE_WITH_PREFIX);
     gcsUtils.delete(LENGTH_FILE_WITH_PREFIX);
     gcsUtils.delete(REPORT_FILE_WITH_PREFIX);
@@ -345,7 +345,7 @@ public class RdeUploadActionTest {
     URI uploadUrl = URI.create(String.format("sftp://user:password@localhost:%d/", port));
     DateTime stagingCursor = DateTime.parse("2010-10-18TZ");
     DateTime uploadCursor = DateTime.parse("2010-10-17TZ");
-    persistResource(Cursor.create(RDE_STAGING, stagingCursor, Registry.get("tld")));
+    persistResource(Cursor.createScoped(RDE_STAGING, stagingCursor, Registry.get("tld")));
     RdeUploadAction action = createAction(uploadUrl);
     action.prefix = Optional.of(JOB_PREFIX + "-job-name/");
     gcsUtils.delete(GHOSTRYDE_FILE);
@@ -374,7 +374,7 @@ public class RdeUploadActionTest {
     URI uploadUrl = URI.create(String.format("sftp://user:password@localhost:%d/", port));
     DateTime stagingCursor = DateTime.parse("2010-10-18TZ");
     DateTime uploadCursor = DateTime.parse("2010-10-17TZ");
-    persistResource(Cursor.create(RDE_STAGING, stagingCursor, Registry.get("tld")));
+    persistResource(Cursor.createScoped(RDE_STAGING, stagingCursor, Registry.get("tld")));
     RdeUploadAction action = createAction(uploadUrl);
     gcsUtils.delete(GHOSTRYDE_FILE);
     gcsUtils.delete(LENGTH_FILE);
@@ -415,7 +415,7 @@ public class RdeUploadActionTest {
     URI uploadUrl = URI.create(String.format("sftp://user:password@localhost:%d/", port));
     DateTime stagingCursor = DateTime.parse("2010-10-18TZ");
     DateTime uploadCursor = DateTime.parse("2010-10-17TZ");
-    persistSimpleResource(Cursor.create(RDE_STAGING, stagingCursor, Registry.get("tld")));
+    persistSimpleResource(Cursor.createScoped(RDE_STAGING, stagingCursor, Registry.get("tld")));
     BlobId ghostrydeR1FileWithPrefix =
         BlobId.of("bucket", JOB_PREFIX + "-job-name/tld_2010-10-17_full_S1_R1.xml.ghostryde");
     BlobId lengthR1FileWithPrefix =
@@ -446,7 +446,7 @@ public class RdeUploadActionTest {
     URI uploadUrl = URI.create(String.format("sftp://user:password@localhost:%d/", port));
     DateTime stagingCursor = DateTime.parse("2010-10-18TZ");
     DateTime uploadCursor = DateTime.parse("2010-10-17TZ");
-    persistResource(Cursor.create(RDE_STAGING, stagingCursor, Registry.get("tld")));
+    persistResource(Cursor.createScoped(RDE_STAGING, stagingCursor, Registry.get("tld")));
     createAction(uploadUrl).runWithLock(uploadCursor);
     // Only verify signature for SFTP versions, since we check elsewhere that the GCS files are
     // identical to the ones sent over SFTP.
@@ -484,7 +484,7 @@ public class RdeUploadActionTest {
     URI url = URI.create("sftp://user:password@localhost:32323/");
     DateTime stagingCursor = DateTime.parse("2010-10-17TZ");
     DateTime uploadCursor = DateTime.parse("2010-10-17TZ");
-    persistResource(Cursor.create(RDE_STAGING, stagingCursor, Registry.get("tld")));
+    persistResource(Cursor.createScoped(RDE_STAGING, stagingCursor, Registry.get("tld")));
     NoContentException thrown =
         assertThrows(NoContentException.class, () -> createAction(url).runWithLock(uploadCursor));
     assertThat(thrown)
@@ -501,8 +501,8 @@ public class RdeUploadActionTest {
     DateTime stagingCursor = DateTime.parse("2010-10-18TZ");
     DateTime uploadCursor = DateTime.parse("2010-10-17TZ");
     DateTime sftpCursor = uploadCursor.minusMinutes(97); // Within the 2 hour cooldown period.
-    persistResource(Cursor.create(RDE_STAGING, stagingCursor, Registry.get("tld")));
-    persistResource(Cursor.create(RDE_UPLOAD_SFTP, sftpCursor, Registry.get("tld")));
+    persistResource(Cursor.createScoped(RDE_STAGING, stagingCursor, Registry.get("tld")));
+    persistResource(Cursor.createScoped(RDE_UPLOAD_SFTP, sftpCursor, Registry.get("tld")));
     NoContentException thrown =
         assertThrows(NoContentException.class, () -> action.runWithLock(uploadCursor));
     assertThat(thrown)

--- a/core/src/test/java/google/registry/reporting/icann/IcannReportingUploadActionTest.java
+++ b/core/src/test/java/google/registry/reporting/icann/IcannReportingUploadActionTest.java
@@ -105,16 +105,16 @@ class IcannReportingUploadActionTest {
     when(mockReporter.send(PAYLOAD_SUCCESS, "foo-activity-200606.csv")).thenReturn(true);
     clock.setTo(DateTime.parse("2006-07-05T00:30:00Z"));
     persistResource(
-        Cursor.create(
+        Cursor.createScoped(
             CursorType.ICANN_UPLOAD_ACTIVITY, DateTime.parse("2006-07-01TZ"), Registry.get("tld")));
     persistResource(
-        Cursor.create(
+        Cursor.createScoped(
             CursorType.ICANN_UPLOAD_TX, DateTime.parse("2006-07-01TZ"), Registry.get("tld")));
     persistResource(
-        Cursor.create(
+        Cursor.createScoped(
             CursorType.ICANN_UPLOAD_ACTIVITY, DateTime.parse("2006-07-01TZ"), Registry.get("foo")));
     persistResource(
-        Cursor.create(
+        Cursor.createScoped(
             CursorType.ICANN_UPLOAD_TX, DateTime.parse("2006-07-01TZ"), Registry.get("foo")));
     loggerToIntercept.addHandler(logHandler);
   }
@@ -146,10 +146,10 @@ class IcannReportingUploadActionTest {
   void testSuccess_january() throws Exception {
     clock.setTo(DateTime.parse("2006-01-22T00:30:00Z"));
     persistResource(
-        Cursor.create(
+        Cursor.createScoped(
             CursorType.ICANN_UPLOAD_ACTIVITY, DateTime.parse("2006-01-01TZ"), Registry.get("tld")));
     persistResource(
-        Cursor.create(
+        Cursor.createScoped(
             CursorType.ICANN_UPLOAD_TX, DateTime.parse("2006-01-01TZ"), Registry.get("tld")));
     gcsUtils.createFromBytes(
         BlobId.of("basin/icann/monthly/2005-12", "tld-transactions-200512.csv"), PAYLOAD_SUCCESS);
@@ -183,7 +183,8 @@ class IcannReportingUploadActionTest {
     IcannReportingUploadAction action = createAction();
     action.run();
     tm().clearSessionCache();
-    Cursor cursor = loadByKey(Cursor.createVKey(CursorType.ICANN_UPLOAD_ACTIVITY, "tld"));
+    Cursor cursor =
+        loadByKey(Cursor.createScopedVKey(CursorType.ICANN_UPLOAD_ACTIVITY, Registry.get("tld")));
     assertThat(cursor.getCursorTime()).isEqualTo(DateTime.parse("2006-08-01TZ"));
   }
 
@@ -241,7 +242,8 @@ class IcannReportingUploadActionTest {
     runTest_nonRetryableException(
         new IOException("Your IP address 25.147.130.158 is not allowed to connect"));
     tm().clearSessionCache();
-    Cursor cursor = loadByKey(Cursor.createVKey(CursorType.ICANN_UPLOAD_ACTIVITY, "tld"));
+    Cursor cursor =
+        loadByKey(Cursor.createScopedVKey(CursorType.ICANN_UPLOAD_ACTIVITY, Registry.get("tld")));
     assertThat(cursor.getCursorTime()).isEqualTo(DateTime.parse("2006-07-01TZ"));
   }
 
@@ -251,7 +253,8 @@ class IcannReportingUploadActionTest {
     IcannReportingUploadAction action = createAction();
     action.run();
     tm().clearSessionCache();
-    Cursor cursor = loadByKey(Cursor.createVKey(CursorType.ICANN_UPLOAD_ACTIVITY, "foo"));
+    Cursor cursor =
+        loadByKey(Cursor.createScopedVKey(CursorType.ICANN_UPLOAD_ACTIVITY, Registry.get("foo")));
     assertThat(cursor.getCursorTime()).isEqualTo(DateTime.parse("2006-07-01TZ"));
     verifyNoMoreInteractions(mockReporter);
   }
@@ -286,7 +289,7 @@ class IcannReportingUploadActionTest {
   void testFail_fileNotFound() throws Exception {
     clock.setTo(DateTime.parse("2006-01-22T00:30:00Z"));
     persistResource(
-        Cursor.create(
+        Cursor.createScoped(
             CursorType.ICANN_UPLOAD_ACTIVITY, DateTime.parse("2006-01-01TZ"), Registry.get("tld")));
     IcannReportingUploadAction action = createAction();
     action.run();
@@ -302,7 +305,7 @@ class IcannReportingUploadActionTest {
   @TestOfyAndSql
   void testWarning_fileNotStagedYet() throws Exception {
     persistResource(
-        Cursor.create(
+        Cursor.createScoped(
             CursorType.ICANN_UPLOAD_ACTIVITY, DateTime.parse("2006-08-01TZ"), Registry.get("foo")));
     clock.setTo(DateTime.parse("2006-08-01T00:30:00Z"));
     IcannReportingUploadAction action = createAction();
@@ -352,9 +355,10 @@ class IcannReportingUploadActionTest {
                 new InternetAddress("sender@example.com")));
 
     Cursor newActivityCursor =
-        loadByKey(Cursor.createVKey(CursorType.ICANN_UPLOAD_ACTIVITY, "new"));
+        loadByKey(Cursor.createScopedVKey(CursorType.ICANN_UPLOAD_ACTIVITY, Registry.get("new")));
     assertThat(newActivityCursor.getCursorTime()).isEqualTo(DateTime.parse("2006-08-01TZ"));
-    Cursor newTransactionCursor = loadByKey(Cursor.createVKey(CursorType.ICANN_UPLOAD_TX, "new"));
+    Cursor newTransactionCursor =
+        loadByKey(Cursor.createScopedVKey(CursorType.ICANN_UPLOAD_TX, Registry.get("new")));
     assertThat(newTransactionCursor.getCursorTime()).isEqualTo(DateTime.parse("2006-08-01TZ"));
   }
 }

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -388,12 +388,12 @@ public class DatabaseHelper {
   }
 
   /** Creates and persists a tld. */
-  public static void createTld(String tld) {
-    createTld(tld, GENERAL_AVAILABILITY);
+  public static Registry createTld(String tld) {
+    return createTld(tld, GENERAL_AVAILABILITY);
   }
 
-  public static void createTld(String tld, String roidSuffix) {
-    createTld(tld, roidSuffix, ImmutableSortedMap.of(START_OF_TIME, GENERAL_AVAILABILITY));
+  public static Registry createTld(String tld, String roidSuffix) {
+    return createTld(tld, roidSuffix, ImmutableSortedMap.of(START_OF_TIME, GENERAL_AVAILABILITY));
   }
 
   /** Creates and persists the given TLDs. */
@@ -403,23 +403,25 @@ public class DatabaseHelper {
     }
   }
 
-  public static void createTld(String tld, TldState tldState) {
-    createTld(tld, ImmutableSortedMap.of(START_OF_TIME, tldState));
+  public static Registry createTld(String tld, TldState tldState) {
+    return createTld(tld, ImmutableSortedMap.of(START_OF_TIME, tldState));
   }
 
-  public static void createTld(String tld, ImmutableSortedMap<DateTime, TldState> tldStates) {
+  public static Registry createTld(String tld, ImmutableSortedMap<DateTime, TldState> tldStates) {
     // Coerce the TLD string into a valid ROID suffix.
     String roidSuffix =
         Ascii.toUpperCase(tld.replaceFirst(ACE_PREFIX_REGEX, "").replace('.', '_'))
             .replace('-', '_');
-    createTld(tld, roidSuffix.length() > 8 ? roidSuffix.substring(0, 8) : roidSuffix, tldStates);
+    return createTld(
+        tld, roidSuffix.length() > 8 ? roidSuffix.substring(0, 8) : roidSuffix, tldStates);
   }
 
-  public static void createTld(
+  public static Registry createTld(
       String tld, String roidSuffix, ImmutableSortedMap<DateTime, TldState> tldStates) {
-    persistResource(newRegistry(tld, roidSuffix, tldStates));
+    Registry registry = persistResource(newRegistry(tld, roidSuffix, tldStates));
     allowRegistrarAccess("TheRegistrar", tld);
     allowRegistrarAccess("NewRegistrar", tld);
+    return registry;
   }
 
   public static void deleteTld(String tld) {

--- a/core/src/test/java/google/registry/testing/DatastoreEntityExtension.java
+++ b/core/src/test/java/google/registry/testing/DatastoreEntityExtension.java
@@ -15,6 +15,7 @@
 package google.registry.testing;
 
 import google.registry.model.AppEngineEnvironment;
+import google.registry.model.annotations.DeleteAfterMigration;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -37,6 +38,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  *
  * @see AppEngineEnvironment
  */
+@DeleteAfterMigration
 public class DatastoreEntityExtension implements BeforeEachCallback, AfterEachCallback {
 
   private final AppEngineEnvironment environment;

--- a/core/src/test/java/google/registry/tools/ListCursorsCommandTest.java
+++ b/core/src/test/java/google/registry/tools/ListCursorsCommandTest.java
@@ -59,7 +59,7 @@ public class ListCursorsCommandTest extends CommandTestCase<ListCursorsCommand> 
   void testListCursors_twoTldsOneAbsent_printsAbsentAndTimestampSorted() throws Exception {
     createTlds("foo", "bar");
     persistResource(
-        Cursor.create(CursorType.BRDA, DateTime.parse("1984-12-18TZ"), Registry.get("bar")));
+        Cursor.createScoped(CursorType.BRDA, DateTime.parse("1984-12-18TZ"), Registry.get("bar")));
     runCommand("--type=BRDA");
     assertThat(getStdoutAsLines())
         .containsExactly(

--- a/core/src/test/java/google/registry/tools/UpdateCursorsCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateCursorsCommandTest.java
@@ -40,13 +40,12 @@ class UpdateCursorsCommandTest extends CommandTestCase<UpdateCursorsCommand> {
 
   @BeforeEach
   void beforeEach() {
-    createTld("foo");
-    registry = Registry.get("foo");
+    registry = createTld("foo");
   }
 
   void doUpdateTest() throws Exception {
     runCommandForced("--type=brda", "--timestamp=1984-12-18T00:00:00Z", "foo");
-    assertThat(loadByKey(Cursor.createVKey(CursorType.BRDA, "foo")).getCursorTime())
+    assertThat(loadByKey(Cursor.createScopedVKey(CursorType.BRDA, registry)).getCursorTime())
         .isEqualTo(DateTime.parse("1984-12-18TZ"));
     String changes = command.prompt();
     assertThat(changes)
@@ -66,14 +65,13 @@ class UpdateCursorsCommandTest extends CommandTestCase<UpdateCursorsCommand> {
 
   @TestOfyAndSql
   void testSuccess_oldValueisEmpty() throws Exception {
-    assertThat(loadByKeyIfPresent(Cursor.createVKey(CursorType.BRDA, registry.getTldStr())))
-        .isEmpty();
+    assertThat(loadByKeyIfPresent(Cursor.createScopedVKey(CursorType.BRDA, registry))).isEmpty();
     doUpdateTest();
   }
 
   @TestOfyAndSql
   void testSuccess_hasOldValue() throws Exception {
-    persistResource(Cursor.create(CursorType.BRDA, DateTime.parse("1950-12-18TZ"), registry));
+    persistResource(Cursor.createScoped(CursorType.BRDA, DateTime.parse("1950-12-18TZ"), registry));
     doUpdateTest();
   }
 
@@ -92,14 +90,15 @@ class UpdateCursorsCommandTest extends CommandTestCase<UpdateCursorsCommand> {
 
   @TestOfyAndSql
   void testSuccess_multipleTlds_hasOldValue() throws Exception {
-    createTld("bar");
+    Registry barRegistry = createTld("bar");
     Registry registry2 = Registry.get("bar");
-    persistResource(Cursor.create(CursorType.BRDA, DateTime.parse("1950-12-18TZ"), registry));
-    persistResource(Cursor.create(CursorType.BRDA, DateTime.parse("1950-12-18TZ"), registry2));
+    persistResource(Cursor.createScoped(CursorType.BRDA, DateTime.parse("1950-12-18TZ"), registry));
+    persistResource(
+        Cursor.createScoped(CursorType.BRDA, DateTime.parse("1950-12-18TZ"), registry2));
     runCommandForced("--type=brda", "--timestamp=1984-12-18T00:00:00Z", "foo", "bar");
-    assertThat(loadByKey(Cursor.createVKey(CursorType.BRDA, "foo")).getCursorTime())
+    assertThat(loadByKey(Cursor.createScopedVKey(CursorType.BRDA, registry)).getCursorTime())
         .isEqualTo(DateTime.parse("1984-12-18TZ"));
-    assertThat(loadByKey(Cursor.createVKey(CursorType.BRDA, "bar")).getCursorTime())
+    assertThat(loadByKey(Cursor.createScopedVKey(CursorType.BRDA, barRegistry)).getCursorTime())
         .isEqualTo(DateTime.parse("1984-12-18TZ"));
     String changes = command.prompt();
     assertThat(changes)
@@ -110,13 +109,13 @@ class UpdateCursorsCommandTest extends CommandTestCase<UpdateCursorsCommand> {
 
   @TestOfyAndSql
   void testSuccess_multipleTlds_oldValueisEmpty() throws Exception {
-    createTld("bar");
-    assertThat(loadByKeyIfPresent(Cursor.createVKey(CursorType.BRDA, "foo"))).isEmpty();
-    assertThat(loadByKeyIfPresent(Cursor.createVKey(CursorType.BRDA, "bar"))).isEmpty();
+    Registry barRegistry = createTld("bar");
+    assertThat(loadByKeyIfPresent(Cursor.createScopedVKey(CursorType.BRDA, registry))).isEmpty();
+    assertThat(loadByKeyIfPresent(Cursor.createScopedVKey(CursorType.BRDA, barRegistry))).isEmpty();
     runCommandForced("--type=brda", "--timestamp=1984-12-18T00:00:00Z", "foo", "bar");
-    assertThat(loadByKey(Cursor.createVKey(CursorType.BRDA, "foo")).getCursorTime())
+    assertThat(loadByKey(Cursor.createScopedVKey(CursorType.BRDA, registry)).getCursorTime())
         .isEqualTo(DateTime.parse("1984-12-18TZ"));
-    assertThat(loadByKey(Cursor.createVKey(CursorType.BRDA, "bar")).getCursorTime())
+    assertThat(loadByKey(Cursor.createScopedVKey(CursorType.BRDA, barRegistry)).getCursorTime())
         .isEqualTo(DateTime.parse("1984-12-18TZ"));
     String changes = command.prompt();
     assertThat(changes)

--- a/core/src/test/resources/google/registry/export/backup_kinds.txt
+++ b/core/src/test/resources/google/registry/export/backup_kinds.txt
@@ -1,7 +1,6 @@
 AllocationToken
 Cancellation
 ContactResource
-Cursor
 DomainBase
 EntityGroupRoot
 EppResourceIndex

--- a/core/src/test/resources/google/registry/export/crosstld_kinds.txt
+++ b/core/src/test/resources/google/registry/export/crosstld_kinds.txt
@@ -1,4 +1,3 @@
-Cursor
 Registrar
 Registry
 ServerSecret

--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -79,12 +79,6 @@ enum google.registry.model.billing.BillingEvent$RenewalPriceBehavior {
   NONPREMIUM;
   SPECIFIED;
 }
-class google.registry.model.common.Cursor {
-  @Id java.lang.String id;
-  @Parent com.googlecode.objectify.Key<google.registry.model.common.EntityGroupRoot> parent;
-  google.registry.model.UpdateAutoTimestamp lastUpdateTime;
-  org.joda.time.DateTime cursorTime;
-}
 class google.registry.model.common.EntityGroupRoot {
   @Id java.lang.String id;
   google.registry.model.UpdateAutoTimestamp updateTimestamp;


### PR DESCRIPTION
Cursor was originally envisioned to support arbitary ImmutableObject
scopes. However, in practice only the Registry scope is used. The SQL
representation of Cursor assumes that and the schema uses a composite ID
with a string column for the primary key of the scope object. Without a
schema migration to persist the VKey of the scope, we cannot support any
ImmutableObject other than those with a primitive string primary key.

Given the complexity involved and the limited use case, the scope is now
explictly limited to Registry only.

Also removed mapreduces that depends on Ofy keys of Cursors, and made
some code quality improvement based on IntelliJ suggestions on modified
files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1672)
<!-- Reviewable:end -->
