### PR TITLE
Ignore buggy gpg2 tests

### DIFF
--- a/core/src/test/java/google/registry/rde/GhostrydeGpgIntegrationTest.java
+++ b/core/src/test/java/google/registry/rde/GhostrydeGpgIntegrationTest.java
@@ -52,7 +52,8 @@ class GhostrydeGpgIntegrationTest {
           RdeTestData.loadBytes("pgp-public-keyring.asc"),
           RdeTestData.loadBytes("pgp-private-keyring-registry.asc"));
 
-  private static final ImmutableList<String> COMMANDS = ImmutableList.of("gpg", "gpg2");
+  // TODO(b/236723363) add in "gpg2" once we figure out why it's broken
+  private static final ImmutableList<String> COMMANDS = ImmutableList.of("gpg");
   private static final ImmutableList<String> CONTENTS =
       ImmutableList.of(
           "(◕‿◕)",

--- a/core/src/test/java/google/registry/rde/RydeGpgIntegrationTest.java
+++ b/core/src/test/java/google/registry/rde/RydeGpgIntegrationTest.java
@@ -60,7 +60,8 @@ public class RydeGpgIntegrationTest {
 
   private final FakeKeyringModule keyringFactory = new FakeKeyringModule();
 
-  private static final ImmutableList<String> COMMANDS = ImmutableList.of("gpg", "gpg2");
+  // TODO(b/236723363) add in "gpg2" once we figure out why it's broken
+  private static final ImmutableList<String> COMMANDS = ImmutableList.of("gpg");
   private static final ImmutableList<String> CONTENTS =
       ImmutableList.of(
           "(◕‿◕)",


### PR DESCRIPTION
See https://b.corp.google.com/issues/236723363 for more info. We're not
sure why these are failing in Kokoro.