### PR TITLE
Only use GPG2 in tests

### DIFF
--- a/core/src/test/java/google/registry/rde/BrdaCopyActionTest.java
+++ b/core/src/test/java/google/registry/rde/BrdaCopyActionTest.java
@@ -20,6 +20,7 @@ import static google.registry.model.common.Cursor.CursorType.BRDA;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
+import static google.registry.testing.GpgSystemCommandExtension.GPG_BINARY;
 import static google.registry.testing.SystemInfo.hasCommand;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -152,14 +153,14 @@ public class BrdaCopyActionTest {
   @ParameterizedTest
   @ValueSource(strings = {"", "job-name/"})
   void testRun_rydeFormat(String prefix) throws Exception {
-    assumeTrue(hasCommand("gpg --version"));
+    assumeTrue(hasCommand(GPG_BINARY + " --version"));
     runAction(prefix);
 
     File rydeTmp = new File(gpg.getCwd(), "ryde");
     Files.write(gcsUtils.readBytesFrom(RYDE_FILE), rydeTmp);
     Process pid =
         gpg.exec(
-            "gpg",
+            GPG_BINARY,
             "--list-packets",
             "--ignore-mdc-error",
             "--keyid-format",
@@ -200,7 +201,7 @@ public class BrdaCopyActionTest {
   @ParameterizedTest
   @ValueSource(strings = {"", "job-name/"})
   void testRun_rydeSignature(String prefix) throws Exception {
-    assumeTrue(hasCommand("gpg --version"));
+    assumeTrue(hasCommand(GPG_BINARY + " --version"));
     runAction(prefix);
 
     File rydeTmp = new File(gpg.getCwd(), "ryde");
@@ -208,7 +209,7 @@ public class BrdaCopyActionTest {
     Files.write(gcsUtils.readBytesFrom(RYDE_FILE), rydeTmp);
     Files.write(gcsUtils.readBytesFrom(SIG_FILE), sigTmp);
 
-    Process pid = gpg.exec("gpg", "--verify", sigTmp.toString(), rydeTmp.toString());
+    Process pid = gpg.exec(GPG_BINARY, "--verify", sigTmp.toString(), rydeTmp.toString());
     String stderr = slurp(pid.getErrorStream());
     assertWithMessage(stderr).that(pid.waitFor()).isEqualTo(0);
     assertThat(stderr).contains("Good signature");

--- a/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
+++ b/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
@@ -24,6 +24,7 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DatabaseHelper.persistSimpleResource;
+import static google.registry.testing.GpgSystemCommandExtension.GPG_BINARY;
 import static google.registry.testing.SystemInfo.hasCommand;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.joda.time.Duration.standardDays;
@@ -440,7 +441,7 @@ public class RdeUploadActionTest {
 
   @TestOfyAndSql
   void testRunWithLock_producesValidSignature() throws Exception {
-    assumeTrue(hasCommand("gpg --version"));
+    assumeTrue(hasCommand(GPG_BINARY + " --version"));
     int port = sftpd.serve("user", "password", folder);
     URI uploadUrl = URI.create(String.format("sftp://user:password@localhost:%d/", port));
     DateTime stagingCursor = DateTime.parse("2010-10-18TZ");
@@ -451,7 +452,7 @@ public class RdeUploadActionTest {
     // identical to the ones sent over SFTP.
     Process pid =
         gpg.exec(
-            "gpg",
+            GPG_BINARY,
             "--verify",
             new File(folder, "tld_2010-10-17_full_S1_R0.sig").toString(),
             new File(folder, "tld_2010-10-17_full_S1_R0.ryde").toString());

--- a/core/src/test/java/google/registry/testing/GpgSystemCommandExtension.java
+++ b/core/src/test/java/google/registry/testing/GpgSystemCommandExtension.java
@@ -47,6 +47,7 @@ public final class GpgSystemCommandExtension implements BeforeEachCallback, Afte
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
   private static final File DEV_NULL = new File("/dev/null");
   private static final String TEMP_FILE_PREFIX = "gpgtest";
+  public static final String GPG_BINARY = "gpg2";
 
   private File cwd = DEV_NULL;
   private File conf = DEV_NULL;
@@ -105,7 +106,7 @@ public final class GpgSystemCommandExtension implements BeforeEachCallback, Afte
           "PATH=" + System.getenv("PATH"), "GNUPGHOME=" + conf.getAbsolutePath(),
         };
 
-    Process pid = exec("gpg", "--import");
+    Process pid = exec(GPG_BINARY, "--import");
     publicKeyring.copyTo(pid.getOutputStream());
     pid.getOutputStream().close();
     int returnValue = pid.waitFor();
@@ -114,7 +115,7 @@ public final class GpgSystemCommandExtension implements BeforeEachCallback, Afte
         .that(returnValue)
         .isEqualTo(0);
 
-    pid = exec("gpg", "--allow-secret-key-import", "--import");
+    pid = exec(GPG_BINARY, "--allow-secret-key-import", "--import");
     privateKeyring.copyTo(pid.getOutputStream());
     pid.getOutputStream().close();
     returnValue = pid.waitFor();

--- a/release/builder/build.sh
+++ b/release/builder/build.sh
@@ -19,6 +19,8 @@ apt-get install locales -y
 locale-gen en_US.UTF-8
 apt-get install apt-utils gnupg -y
 apt-get upgrade -y
+# Install GPG2 (in case it was not included)
+apt-get install gnupg2 -y
 # Install Java
 apt-get install openjdk-11-jdk-headless -y
 # Install Python


### PR DESCRIPTION
GPG1 is deprecated and stuck in v1.4 from 2018. GPG2 is recommended. We
only use the GPG binary in tests and when the host system has both
versions it causes problems because we hardcode the GPG import command
in GpgSystemCommandExension to use the binary named "gpg", which could
be linked to either GPG1 or GPG2, causing the other test to fail when
the version of GPG that runs in tests is incompatible with the version of GPG
that imports the keys.

With this PR we only support GPG2 from now on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1676)
<!-- Reviewable:end -->
