### PR TITLE
Disable all tests that uses Ofy

### DIFF
--- a/core/src/test/java/google/registry/model/ofy/DatastoreTransactionManagerTest.java
+++ b/core/src/test/java/google/registry/model/ofy/DatastoreTransactionManagerTest.java
@@ -29,11 +29,13 @@ import google.registry.model.annotations.InCrossTld;
 import google.registry.model.common.EntityGroupRoot;
 import google.registry.testing.AppEngineExtension;
 import google.registry.testing.TmOverrideExtension;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link DatastoreTransactionManager}. */
+@Disabled
 public class DatastoreTransactionManagerTest {
 
   @RegisterExtension

--- a/core/src/test/java/google/registry/model/ofy/OfyTest.java
+++ b/core/src/test/java/google/registry/model/ofy/OfyTest.java
@@ -55,11 +55,13 @@ import java.util.ConcurrentModificationException;
 import java.util.function.Supplier;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Tests for our wrapper around Objectify. */
+@Disabled
 public class OfyTest {
 
   private final FakeClock fakeClock = new FakeClock(DateTime.parse("2000-01-01TZ"));


### PR DESCRIPTION
These tests use Ofy exclusively and should not run anymore, as any class
they test also use Ofy and should be deleted.

More importantly, running tests in Ofy mode makes it hard to remove Ofy
from entities, especially Registrar and RegistrarContact, as some of
them are created as canned data when tests are initiated, and the
creation would fail if they are not registered as Ofy entities.

It is therefore a prerequisite to disable these tests before we can
remove Ofy from those entities. We could have deleted them, but I think
that should be done when the corresponding classes tested by them are
deleted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1679)
<!-- Reviewable:end -->
