### PR TITLE
Remove the beam parameter in RDE staging action

### DIFF
--- a/core/src/main/java/google/registry/rde/RdeModule.java
+++ b/core/src/main/java/google/registry/rde/RdeModule.java
@@ -42,7 +42,6 @@ public abstract class RdeModule {
   public static final String PARAM_WATERMARK = "watermark";
   public static final String PARAM_WATERMARKS = "watermarks";
   public static final String PARAM_MANUAL = "manual";
-  public static final String PARAM_BEAM = "beam";
   public static final String PARAM_DIRECTORY = "directory";
   public static final String PARAM_MODE = "mode";
   public static final String PARAM_REVISION = "revision";
@@ -68,12 +67,6 @@ public abstract class RdeModule {
   @Parameter(PARAM_MANUAL)
   static boolean provideManual(HttpServletRequest req) {
     return extractBooleanParameter(req, PARAM_MANUAL);
-  }
-
-  @Provides
-  @Parameter(PARAM_BEAM)
-  static boolean provideBeam(HttpServletRequest req) {
-    return extractBooleanParameter(req, PARAM_BEAM);
   }
 
   @Provides

--- a/core/src/main/java/google/registry/tools/GenerateEscrowDepositCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateEscrowDepositCommand.java
@@ -15,7 +15,6 @@
 package google.registry.tools;
 
 import static google.registry.model.tld.Registries.assertTldsExist;
-import static google.registry.rde.RdeModule.PARAM_BEAM;
 import static google.registry.rde.RdeModule.PARAM_DIRECTORY;
 import static google.registry.rde.RdeModule.PARAM_LENIENT;
 import static google.registry.rde.RdeModule.PARAM_MANUAL;
@@ -72,13 +71,6 @@ final class GenerateEscrowDepositCommand implements CommandWithRemoteApi {
   private boolean lenient = false;
 
   @Parameter(
-      names = {"-b", "--beam"},
-      description =
-          "Whether to explicitly launch the beam pipeline instead of letting the action decide"
-              + " which one to run.")
-  private boolean beam = false;
-
-  @Parameter(
       names = {"-r", "--revision"},
       description = "Revision number. Use >0 for resends.")
   private Integer revision;
@@ -119,7 +111,6 @@ final class GenerateEscrowDepositCommand implements CommandWithRemoteApi {
             .put(PARAM_MODE, mode.toString())
             .put(PARAM_DIRECTORY, outdir)
             .put(PARAM_LENIENT, Boolean.toString(lenient))
-            .put(PARAM_BEAM, Boolean.toString(beam))
             .put(PARAM_TLDS, tlds.stream().collect(Collectors.joining(",")))
             .put(
                 PARAM_WATERMARKS,

--- a/core/src/test/java/google/registry/tools/GenerateEscrowDepositCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateEscrowDepositCommandTest.java
@@ -202,29 +202,6 @@ public class GenerateEscrowDepositCommandTest
   }
 
   @Test
-  void testCommand_successWithBeam() throws Exception {
-    runCommand(
-        "--tld=tld",
-        "--watermark=2017-01-01T00:00:00Z",
-        "--mode=thin",
-        "--beam",
-        "-r 42",
-        "-o test");
-
-    cloudTasksHelper.assertTasksEnqueued(
-        "rde-report",
-        new TaskMatcher()
-            .url("/_dr/task/rdeStaging")
-            .param("mode", "THIN")
-            .param("beam", "true")
-            .param("watermarks", "2017-01-01T00:00:00.000Z")
-            .param("tlds", "tld")
-            .param("directory", "test")
-            .param("manual", "true")
-            .param("revision", "42"));
-  }
-
-  @Test
   void testCommand_successWithDefaultValidationMode() throws Exception {
     runCommand("--tld=tld", "--watermark=2017-01-01T00:00:00Z", "--mode=thin", "-r 42", "-o test");
 
@@ -250,7 +227,6 @@ public class GenerateEscrowDepositCommandTest
         new TaskMatcher()
             .url("/_dr/task/rdeStaging")
             .param("lenient", "false")
-            .param("beam", "false")
             .param("mode", "THIN")
             .param("watermarks", "2017-01-01T00:00:00.000Z")
             .param("tlds", "tld")
@@ -268,7 +244,6 @@ public class GenerateEscrowDepositCommandTest
             .url("/_dr/task/rdeStaging")
             .param("mode", "FULL")
             .param("lenient", "false")
-            .param("beam", "false")
             .param("watermarks", "2017-01-01T00:00:00.000Z")
             .param("tlds", "tld")
             .param("directory", "test")
@@ -291,7 +266,6 @@ public class GenerateEscrowDepositCommandTest
             .url("/_dr/task/rdeStaging")
             .param("mode", "THIN")
             .param("lenient", "false")
-            .param("beam", "false")
             .param("watermarks", "2017-01-01T00:00:00.000Z,2017-01-02T00:00:00.000Z")
             .param("tlds", "tld,anothertld")
             .param("directory", "test")


### PR DESCRIPTION
The parameter was used to force a RDE beam run, which is no longer
necessary, now that the mapreduce pipeline is deleted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1684)
<!-- Reviewable:end -->
