### PR TITLE
Fix license-checking on GWT 2.10.0, which is Apache 2.0

### DIFF
--- a/config/dependency-license/allowed_licenses.json
+++ b/config/dependency-license/allowed_licenses.json
@@ -268,6 +268,12 @@
       "moduleName": "org.tukaani:xz"
     },
     {
+      // "Apache License, Version 2.0".
+      "moduleLicense": null,
+      "moduleVersion": "2.10.0",
+      "moduleName": "com.google.gwt:gwt-user"
+    },
+    {
       // "Apache License, Version 2.0". The plugin is able to parse up to
       // 2.11.3 correctly but then something changed with 2.12.* and it no
       // longer parses correctly, even though it's still Apache 2.0.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1685)
<!-- Reviewable:end -->
