### PR TITLE
Add a registration_behavior column to AllocationToken

### DIFF
--- a/core/src/main/java/google/registry/tools/GenerateAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateAllocationTokensCommand.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Streams;
 import com.google.common.io.Files;
 import google.registry.model.billing.BillingEvent.RenewalPriceBehavior;
 import google.registry.model.domain.token.AllocationToken;
+import google.registry.model.domain.token.AllocationToken.RegistrationBehavior;
 import google.registry.model.domain.token.AllocationToken.TokenStatus;
 import google.registry.model.domain.token.AllocationToken.TokenType;
 import google.registry.persistence.VKey;
@@ -153,6 +154,14 @@ class GenerateAllocationTokensCommand implements CommandWithRemoteApi {
   private RenewalPriceBehavior renewalPriceBehavior = DEFAULT;
 
   @Parameter(
+      names = {"--registration_behavior"},
+      description =
+          "Any special registration behavior, including DEFAULT (no special behavior),"
+              + " BYPASS_TLD_STATE (allow registrations during e.g. QUIET_PERIOD), and"
+              + " ANCHOR_TENANT (used for anchor tenant registrations")
+  private RegistrationBehavior registrationBehavior = RegistrationBehavior.DEFAULT;
+
+  @Parameter(
       names = {"--dry_run"},
       description = "Do not actually persist the tokens; defaults to false")
   boolean dryRun;
@@ -196,6 +205,7 @@ class GenerateAllocationTokensCommand implements CommandWithRemoteApi {
                         new AllocationToken.Builder()
                             .setToken(t)
                             .setRenewalPriceBehavior(renewalPriceBehavior)
+                            .setRegistrationBehavior(registrationBehavior)
                             .setTokenType(tokenType == null ? SINGLE_USE : tokenType)
                             .setAllowedRegistrarIds(
                                 ImmutableSet.copyOf(nullToEmpty(allowedClientIds)))

--- a/core/src/main/java/google/registry/tools/UpdateAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdateAllocationTokensCommand.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import google.registry.model.billing.BillingEvent.RenewalPriceBehavior;
 import google.registry.model.domain.token.AllocationToken;
+import google.registry.model.domain.token.AllocationToken.RegistrationBehavior;
 import google.registry.model.domain.token.AllocationToken.TokenStatus;
 import google.registry.tools.params.TransitionListParameter.TokenStatusTransitions;
 import java.util.List;
@@ -100,6 +101,15 @@ final class UpdateAllocationTokensCommand extends UpdateOrDeleteAllocationTokens
   @Nullable
   private RenewalPriceBehavior renewalPriceBehavior;
 
+  @Parameter(
+      names = {"--registration_behavior"},
+      description =
+          "Any special registration behavior, including DEFAULT (no special behavior),"
+              + " BYPASS_TLD_STATE (allow registrations during e.g. QUIET_PERIOD), and"
+              + " ANCHOR_TENANT (used for anchor tenant registrations")
+  @Nullable
+  private RegistrationBehavior registrationBehavior;
+
   private static final int BATCH_SIZE = 20;
   private static final Joiner JOINER = Joiner.on(", ");
 
@@ -156,8 +166,8 @@ final class UpdateAllocationTokensCommand extends UpdateOrDeleteAllocationTokens
     Optional.ofNullable(discountPremiums).ifPresent(builder::setDiscountPremiums);
     Optional.ofNullable(discountYears).ifPresent(builder::setDiscountYears);
     Optional.ofNullable(tokenStatusTransitions).ifPresent(builder::setTokenStatusTransitions);
-    Optional.ofNullable(renewalPriceBehavior)
-        .ifPresent(behavior -> builder.setRenewalPriceBehavior(renewalPriceBehavior));
+    Optional.ofNullable(renewalPriceBehavior).ifPresent(builder::setRenewalPriceBehavior);
+    Optional.ofNullable(registrationBehavior).ifPresent(builder::setRegistrationBehavior);
     return builder.build();
   }
 

--- a/core/src/test/java/google/registry/tools/GenerateAllocationTokensCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateAllocationTokensCommandTest.java
@@ -14,6 +14,7 @@
 
 package google.registry.tools;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.billing.BillingEvent.RenewalPriceBehavior.NONPREMIUM;
 import static google.registry.model.billing.BillingEvent.RenewalPriceBehavior.SPECIFIED;
@@ -258,6 +259,64 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
         .isEqualTo(
             "Invalid value for --renewal_price_behavior parameter. Allowed values:[DEFAULT,"
                 + " NONPREMIUM, SPECIFIED]");
+  }
+
+  @Test
+  void testSuccess_defaultRegistrationBehavior() throws Exception {
+    runCommand("--tokens", "foobar,blah");
+    assertThat(
+            loadAllOf(AllocationToken.class).stream()
+                .map(AllocationToken::getRegistrationBehavior)
+                .collect(toImmutableList()))
+        .containsExactly(
+            AllocationToken.RegistrationBehavior.DEFAULT,
+            AllocationToken.RegistrationBehavior.DEFAULT);
+  }
+
+  @Test
+  void testSuccess_defaultRegistrationBehavior_specified() throws Exception {
+    runCommand("--tokens", "foobar,blah", "--registration_behavior", "DEFAULT");
+    assertThat(
+            loadAllOf(AllocationToken.class).stream()
+                .map(AllocationToken::getRegistrationBehavior)
+                .collect(toImmutableList()))
+        .containsExactly(
+            AllocationToken.RegistrationBehavior.DEFAULT,
+            AllocationToken.RegistrationBehavior.DEFAULT);
+  }
+
+  @Test
+  void testSuccess_specifiedRegistrationBehavior() throws Exception {
+    runCommand("--tokens", "foobar,blah", "--registration_behavior", "BYPASS_TLD_STATE");
+    assertThat(
+            loadAllOf(AllocationToken.class).stream()
+                .map(AllocationToken::getRegistrationBehavior)
+                .collect(toImmutableList()))
+        .containsExactly(
+            AllocationToken.RegistrationBehavior.BYPASS_TLD_STATE,
+            AllocationToken.RegistrationBehavior.BYPASS_TLD_STATE);
+  }
+
+  @Test
+  void testFailure_invalidRegistrationBehaviors() throws Exception {
+    assertThat(
+            assertThrows(
+                ParameterException.class,
+                () -> runCommand("--tokens", "foobar", "--registration_behavior")))
+        .hasMessageThat()
+        .contains("Expected a value after parameter --registration_behavior");
+    assertThat(
+            assertThrows(
+                ParameterException.class,
+                () -> runCommand("--tokens", "foobar", "--registration_behavior", "bad")))
+        .hasMessageThat()
+        .contains("Invalid value for --registration_behavior");
+    assertThat(
+            assertThrows(
+                ParameterException.class,
+                () -> runCommand("--tokens", "foobar", "--registration_behavior", "")))
+        .hasMessageThat()
+        .contains("Invalid value for --registration_behavior");
   }
 
   @Test

--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -338,12 +338,18 @@ class google.registry.model.domain.token.AllocationToken {
   google.registry.model.UpdateAutoTimestamp updateTimestamp;
   google.registry.model.billing.BillingEvent$RenewalPriceBehavior renewalPriceBehavior;
   google.registry.model.common.TimedTransitionProperty<google.registry.model.domain.token.AllocationToken$TokenStatus> tokenStatusTransitions;
+  google.registry.model.domain.token.AllocationToken$RegistrationBehavior registrationBehavior;
   google.registry.model.domain.token.AllocationToken$TokenType tokenType;
   google.registry.persistence.DomainHistoryVKey redemptionHistoryEntry;
   int discountYears;
   java.lang.String domainName;
   java.util.Set<java.lang.String> allowedClientIds;
   java.util.Set<java.lang.String> allowedTlds;
+}
+enum google.registry.model.domain.token.AllocationToken$RegistrationBehavior {
+  ANCHOR_TENANT;
+  BYPASS_TLD_STATE;
+  DEFAULT;
 }
 enum google.registry.model.domain.token.AllocationToken$TokenStatus {
   CANCELLED;

--- a/db/src/main/resources/sql/er_diagram/brief_er_diagram.html
+++ b/db/src/main/resources/sql/er_diagram/brief_er_diagram.html
@@ -261,7 +261,7 @@ td.section {
     </tr>
     <tr>
      <td class="property_name">generated on</td>
-     <td class="property_value">2022-07-15 16:41:11.765867</td>
+     <td class="property_value">2022-07-15 18:56:30.776055</td>
     </tr>
     <tr>
      <td class="property_name">last flyway file</td>
@@ -284,7 +284,7 @@ td.section {
      generated on
     </text>
     <text text-anchor="start" x="4055.5" y="-10.8" font-family="Helvetica,sans-Serif" font-size="14.00">
-     2022-07-15 16:41:11.765867
+     2022-07-15 18:56:30.776055
     </text>
     <polygon fill="none" stroke="#888888" points="3968,-4 3968,-44 4233,-44 4233,-4 3968,-4" /> <!-- allocationtoken_a08ccbef -->
     <g id="node1" class="node">

--- a/db/src/main/resources/sql/er_diagram/full_er_diagram.html
+++ b/db/src/main/resources/sql/er_diagram/full_er_diagram.html
@@ -261,7 +261,7 @@ td.section {
     </tr>
     <tr>
      <td class="property_name">generated on</td>
-     <td class="property_value">2022-07-15 16:41:09.696997</td>
+     <td class="property_value">2022-07-15 18:56:28.677292</td>
     </tr>
     <tr>
      <td class="property_name">last flyway file</td>
@@ -284,7 +284,7 @@ td.section {
      generated on
     </text>
     <text text-anchor="start" x="4755.52" y="-10.8" font-family="Helvetica,sans-Serif" font-size="14.00">
-     2022-07-15 16:41:09.696997
+     2022-07-15 18:56:28.677292
     </text>
     <polygon fill="none" stroke="#888888" points="4668.02,-4 4668.02,-44 4933.02,-44 4933.02,-4 4668.02,-4" /> <!-- allocationtoken_a08ccbef -->
     <g id="node1" class="node">

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -24,6 +24,7 @@
         domain_name text,
         redemption_domain_history_id int8,
         redemption_domain_repo_id text,
+        registration_behavior text not null,
         renewal_price_behavior text not null,
         token_status_transitions hstore,
         token_type text,


### PR DESCRIPTION
This is, as of now, unused but we can use it for b/237683906 and
b/237800445 in the future to allow for special behavior dictated by
allocation tokens rather than having to reserve specific domains.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1695)
<!-- Reviewable:end -->
