### PR TITLE
Deal with some getOfyKey() references

### DIFF
--- a/core/src/main/java/google/registry/flows/ResourceFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/ResourceFlowUtils.java
@@ -169,7 +169,7 @@ public final class ResourceFlowUtils {
     // The roid should match one of the contacts.
     Optional<VKey<ContactResource>> foundContact =
         domain.getReferencedContacts().stream()
-            .filter(key -> key.getOfyKey().getName().equals(authRepoId))
+            .filter(key -> key.getSqlKey().equals(authRepoId))
             .findFirst();
     if (!foundContact.isPresent()) {
       throw new BadAuthInfoForResourceException();

--- a/core/src/main/java/google/registry/model/transfer/DomainTransferData.java
+++ b/core/src/main/java/google/registry/model/transfer/DomainTransferData.java
@@ -122,16 +122,6 @@ public class DomainTransferData extends TransferData<DomainTransferData.Builder>
     return super.copyConstantFieldsToBuilder().setTransferPeriod(this.transferPeriod);
   }
 
-  /**
-   * Fix the VKey "kind" for the PollMessage keys.
-   *
-   * <p>For use by DomainBase/DomainHistory OnLoad methods ONLY.
-   */
-  public void convertVKeys() {
-    serverApproveAutorenewPollMessage =
-        PollMessage.Autorenew.convertVKey(serverApproveAutorenewPollMessage);
-  }
-
   public Period getTransferPeriod() {
     return transferPeriod;
   }


### PR DESCRIPTION
Now that ofy keys aren't necessarily being restored, it seemed prudent to
audit existing uses to verify that we aren't relying on any keys that may now
be null.

This fixes one case that appeared to be potentially problematic (in
ResourceFlowUtils), removes a few methods that call getOfyKey() but are no
longer used, and adds comments to one use of the key that appears to be safe
after visual inspection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1696)
<!-- Reviewable:end -->
