### PR TITLE
Tell IANA not to encode the RDAP base URL response

### DIFF
--- a/core/src/main/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsAction.java
+++ b/core/src/main/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsAction.java
@@ -99,6 +99,8 @@ public final class UpdateRegistrarRdapBaseUrlsAction implements Runnable {
     CSVParser csv;
     try {
       HttpRequest request = httpTransport.createRequestFactory().buildGetRequest(RDAP_IDS_URL);
+      // AppEngine might insert accept-encodings for us if we use the default gzip, so remove it
+      request.getHeaders().setAcceptEncoding(null);
       HttpResponse response = request.execute();
       String csvString = new String(ByteStreams.toByteArray(response.getContent()), UTF_8);
       csv =

--- a/core/src/test/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsActionTest.java
+++ b/core/src/test/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsActionTest.java
@@ -98,6 +98,7 @@ public final class UpdateRegistrarRdapBaseUrlsActionTest {
   private void assertCorrectRequestSent() {
     assertThat(httpTransport.getRequestSent().getUrl())
         .isEqualTo("https://www.iana.org/assignments/registrar-ids/registrar-ids-1.csv");
+    assertThat(httpTransport.getRequestSent().getHeaders().get("accept-encoding")).isNull();
   }
 
   private static void persistRegistrar(


### PR DESCRIPTION
tested on alpha (which I should have done before), our request header tells IANA to gzip the data but they're using Brotli instead. Instead of trying to worry about decoding whatever they happen to send, just don't encode it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1705)
<!-- Reviewable:end -->
