### PR TITLE
Don't include deleted domains in the ICANN reporting total_domains field

### DIFF
--- a/core/src/main/java/google/registry/reporting/icann/sql/cloud_sql_total_domains.sql
+++ b/core/src/main/java/google/registry/reporting/icann/sql/cloud_sql_total_domains.sql
@@ -36,7 +36,7 @@ JOIN
     tld,
     current_sponsor_registrar_id,
     domain_name
-  FROM "Domain" AS d;''')
+  FROM "Domain" AS d WHERE d.deletion_time > now();''')
 ON
   current_sponsor_registrar_id = registrar_id
 GROUP BY tld, registrar_name

--- a/core/src/test/java/google/registry/reporting/icann/TransactionsReportingQueryBuilderTest.java
+++ b/core/src/test/java/google/registry/reporting/icann/TransactionsReportingQueryBuilderTest.java
@@ -62,7 +62,6 @@ class TransactionsReportingQueryBuilderTest {
 
     TransactionsReportingQueryBuilder queryBuilder =
         createQueryBuilder("cloud_sql_icann_reporting");
-    ;
     ImmutableMap<String, String> actualQueries = queryBuilder.getViewQueryMap(yearMonth);
     for (String queryName : expectedQueryNames) {
       String actualTableName = String.format("%s_201709", queryName);

--- a/core/src/test/resources/google/registry/reporting/icann/total_domains_test_cloud_sql.sql
+++ b/core/src/test/resources/google/registry/reporting/icann/total_domains_test_cloud_sql.sql
@@ -36,7 +36,7 @@ JOIN
     tld,
     current_sponsor_registrar_id,
     domain_name
-  FROM "Domain" AS d;''')
+  FROM "Domain" AS d WHERE d.deletion_time > now();''')
 ON
   current_sponsor_registrar_id = registrar_id
 GROUP BY tld, registrar_name


### PR DESCRIPTION
This shouldn't matter for billing or anything like that because the
actual actions performed that month are still correct, but before this
PR we're including all domains ever created in the total_domains number,
including deleted domains

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1713)
<!-- Reviewable:end -->
