### PR TITLE
Fix GAE build under Gradle 7

### DIFF
--- a/appengine_war.gradle
+++ b/appengine_war.gradle
@@ -26,6 +26,7 @@ project.convention.plugins['war'].webAppDirName =
 apply plugin: 'com.google.cloud.tools.appengine'
 
 def coreResourcesDir = "${rootDir}/core/build/resources/main"
+def coreLibsDir = "${rootDir}/core/build/libs"
 
 // Get the web.xml file for the service.
 war {
@@ -37,6 +38,10 @@ war {
 war {
     from("${coreResourcesDir}/google/registry/ui/html") {
         include "*.html"
+    }
+    from("${coreLibsDir}") {
+        include "core.jar"
+        into("WEB-INF/lib")
     }
 }
 
@@ -98,6 +103,7 @@ rootProject.deploy.dependsOn appengineDeployAll
 rootProject.stage.dependsOn appengineStage
 tasks['war'].dependsOn ':core:compileProdJS'
 tasks['war'].dependsOn ':core:processResources'
+tasks['war'].dependsOn ':core:jar'
 
 // Impose verification for all of the deployment tasks.  We haven't found a
 // better way to do this other than to apply to each of them independently.


### PR DESCRIPTION
For some reason after the upgrade to Gradle, the core.jar file is no
longer included in the generated WAR, even though the deploy_jar
configuration is specified as a dependency.

I could not figure out a way to tweak the configuration dependency to
have core.jar pulled into the .war, so I decided to just explicitly pick
it from its known location.


TESTED=deployed to alpha and verified that the instances can start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1730)
<!-- Reviewable:end -->
