### PR TITLE
Add caches to ClaimsListDao and ClaimsList

### DIFF
--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -1427,6 +1427,11 @@ public final class RegistryConfig {
     return CONFIG_SETTINGS.get().caching.eppResourceMaxCachedEntries;
   }
 
+  /** Returns the amount of time that a particular claims list should be cached. */
+  public static java.time.Duration getClaimsListCacheDuration() {
+    return java.time.Duration.ofSeconds(CONFIG_SETTINGS.get().caching.claimsListCachingSeconds);
+  }
+
   /** Returns the email address that outgoing emails from the app are sent from. */
   public static InternetAddress getGSuiteOutgoingEmailAddress() {
     return parseEmailAddress(CONFIG_SETTINGS.get().gSuite.outgoingEmailAddress);

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -155,6 +155,7 @@ public class RegistryConfigSettings {
     public boolean eppResourceCachingEnabled;
     public int eppResourceCachingSeconds;
     public int eppResourceMaxCachedEntries;
+    public int claimsListCachingSeconds;
   }
 
   /** Configuration for ICANN monthly reporting. */

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -294,6 +294,10 @@ caching:
   # have to be very large to achieve the vast majority of possible gains.
   eppResourceMaxCachedEntries: 500
 
+  # Length of time that a claims list will be cached after retrieval. A fairly
+  # long duration is acceptable because claims lists don't change frequently.
+  claimsListCachingSeconds: 21600 # six hours
+
 oAuth:
   # OAuth scopes to detect on access tokens. Superset of requiredOauthScopes.
   availableOauthScopes:

--- a/core/src/main/java/google/registry/model/tld/label/PremiumListDao.java
+++ b/core/src/main/java/google/registry/model/tld/label/PremiumListDao.java
@@ -73,7 +73,7 @@ public class PremiumListDao {
   }
 
   /**
-   * In-memory price cache for for a given premium list revision and domain label.
+   * In-memory price cache for a given premium list revision and domain label.
    *
    * <p>Note that premium list revision ids are globally unique, so this cache is specific to a
    * given premium list. Premium list entries might not be present, as indicated by the Optional

--- a/core/src/main/java/google/registry/model/tld/label/ReservedList.java
+++ b/core/src/main/java/google/registry/model/tld/label/ReservedList.java
@@ -90,12 +90,13 @@ public final class ReservedList
    *
    * <p>We need to persist the list entries, but only on the initial insert (not on update) since
    * the entries themselves never get changed, so we only annotate it with {@link PostPersist}, not
-   * {@link PostUpdate}.
+   * PostUpdate.
    */
   @PostPersist
   void postPersist() {
     if (reservedListMap != null) {
-      reservedListMap.values().stream()
+      reservedListMap
+          .values()
           .forEach(
               entry -> {
                 // We can safely change the revision id since it's "Insignificant".

--- a/core/src/main/java/google/registry/tools/GetClaimsListCommand.java
+++ b/core/src/main/java/google/registry/tools/GetClaimsListCommand.java
@@ -30,8 +30,8 @@ import java.nio.file.Paths;
 /**
  * A command to download the current claims list.
  *
- * <p>This is not the original file we fetched from TMCH. It is just a representation of what we
- * are currently storing in Datastore.
+ * <p>This is not the original file we fetched from TMCH. It is just a representation of what we are
+ * currently storing in SQL.
  */
 @Parameters(separators = " =", commandDescription = "Download the current claims list")
 final class GetClaimsListCommand implements CommandWithRemoteApi {

--- a/core/src/test/java/google/registry/flows/domain/DomainClaimsCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainClaimsCheckFlowTest.java
@@ -41,12 +41,19 @@ import google.registry.flows.exceptions.TooManyResourceChecksException;
 import google.registry.model.domain.Domain;
 import google.registry.model.tld.Registry;
 import google.registry.model.tld.Registry.TldState;
+import google.registry.testing.TestCacheExtension;
+import java.time.Duration;
 import org.joda.money.Money;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link DomainClaimsCheckFlow}. */
 public class DomainClaimsCheckFlowTest extends ResourceFlowTestCase<DomainClaimsCheckFlow, Domain> {
+
+  @RegisterExtension
+  public final TestCacheExtension testCacheExtension =
+      new TestCacheExtension.Builder().withClaimsListCache(Duration.ofHours(6)).build();
 
   DomainClaimsCheckFlowTest() {
     setEppInput("domain_check_claims.xml");

--- a/core/src/test/java/google/registry/testing/TestCacheExtension.java
+++ b/core/src/test/java/google/registry/testing/TestCacheExtension.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import google.registry.model.EppResource;
 import google.registry.model.index.ForeignKeyIndex;
 import google.registry.model.tld.label.PremiumListDao;
+import google.registry.model.tmch.ClaimsListDao;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
@@ -72,6 +73,12 @@ public class TestCacheExtension implements BeforeEachCallback, AfterEachCallback
       cacheHandlerMap.put(
           "PremiumListSqlDao.premiumListCache",
           new TestCacheHandler(PremiumListDao::setPremiumListCacheForTest, expiry));
+      return this;
+    }
+
+    public Builder withClaimsListCache(Duration expiry) {
+      cacheHandlerMap.put(
+          "ClaimsListDao.CACHE", new TestCacheHandler(ClaimsListDao::setCacheForTest, expiry));
       return this;
     }
 

--- a/core/src/test/java/google/registry/tools/EppLifecycleToolsTest.java
+++ b/core/src/test/java/google/registry/tools/EppLifecycleToolsTest.java
@@ -29,7 +29,9 @@ import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.reporting.HistoryEntry.Type;
 import google.registry.testing.AppEngineExtension;
+import google.registry.testing.TestCacheExtension;
 import google.registry.util.Clock;
+import java.time.Duration;
 import java.util.List;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
@@ -43,6 +45,10 @@ class EppLifecycleToolsTest extends EppTestCase {
   @RegisterExtension
   final AppEngineExtension appEngine =
       AppEngineExtension.builder().withClock(clock).withCloudSql().withTaskQueue().build();
+
+  @RegisterExtension
+  public final TestCacheExtension testCacheExtension =
+      new TestCacheExtension.Builder().withClaimsListCache(Duration.ofHours(6)).build();
 
   @BeforeEach
   void beforeEach() {


### PR DESCRIPTION
We cache the ClaimsList Java object for six hours (we don't expect it to
change frequently, and the cron job to update it only runs every twelve
hours). Subsequent calls to ClaimsListDao::get will return the cached
value.

Within the ClaimsList Java object itself, we cache any labels that we
have retrieved. While we already have a form of a cache here in the
"labelsToKeys" map, that only handles situations where we've loaded the
entire map from the database. We want to have a non-guaranteed cache in
order to make repeated calls to getClaimKey fast.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1731)
<!-- Reviewable:end -->
