### PR TITLE
Create a registry lock permission and corresponding account manager role

### DIFF
--- a/core/src/main/java/google/registry/model/console/ConsolePermission.java
+++ b/core/src/main/java/google/registry/model/console/ConsolePermission.java
@@ -63,5 +63,7 @@ public enum ConsolePermission {
   /** View announcements in the UI. */
   VIEW_ANNOUNCEMENTS,
   /** Viewing a record of actions performed in the UI for a particular registrar. */
-  VIEW_ACTIVITY_LOG
+  VIEW_ACTIVITY_LOG,
+  /** View and perform registry locks. */
+  REGISTRY_LOCK
 }

--- a/core/src/main/java/google/registry/model/console/ConsoleRoleDefinitions.java
+++ b/core/src/main/java/google/registry/model/console/ConsoleRoleDefinitions.java
@@ -44,7 +44,8 @@ public class ConsoleRoleDefinitions {
           ConsolePermission.VIEW_OPERATIONAL_DATA,
           ConsolePermission.SEND_ANNOUNCEMENTS,
           ConsolePermission.VIEW_ANNOUNCEMENTS,
-          ConsolePermission.VIEW_ACTIVITY_LOG);
+          ConsolePermission.VIEW_ACTIVITY_LOG,
+          ConsolePermission.REGISTRY_LOCK);
 
   /** Permissions for a registry support lead. */
   static final ImmutableSet<ConsolePermission> SUPPORT_LEAD_PERMISSIONS =
@@ -76,10 +77,17 @@ public class ConsoleRoleDefinitions {
           ConsolePermission.VIEW_OPERATIONAL_DATA,
           ConsolePermission.VIEW_ANNOUNCEMENTS);
 
+  /** Permissions for a registrar partner account manager that can perform registry locks. */
+  static final ImmutableSet<ConsolePermission> ACCOUNT_MANAGER_WITH_REGISTRY_LOCK_PERMISSIONS =
+      new ImmutableSet.Builder<ConsolePermission>()
+          .addAll(ACCOUNT_MANAGER_PERMISSIONS)
+          .add(ConsolePermission.REGISTRY_LOCK)
+          .build();
+
   /** Permissions for the tech contact of a registrar. */
   static final ImmutableSet<ConsolePermission> TECH_CONTACT_PERMISSIONS =
       new ImmutableSet.Builder<ConsolePermission>()
-          .addAll(ACCOUNT_MANAGER_PERMISSIONS)
+          .addAll(ACCOUNT_MANAGER_WITH_REGISTRY_LOCK_PERMISSIONS)
           .add(
               ConsolePermission.MANAGE_ACCREDITATION,
               ConsolePermission.CONFIGURE_EPP_CONNECTION,

--- a/core/src/main/java/google/registry/model/console/RegistrarRole.java
+++ b/core/src/main/java/google/registry/model/console/RegistrarRole.java
@@ -15,6 +15,7 @@
 package google.registry.model.console;
 
 import static google.registry.model.console.ConsoleRoleDefinitions.ACCOUNT_MANAGER_PERMISSIONS;
+import static google.registry.model.console.ConsoleRoleDefinitions.ACCOUNT_MANAGER_WITH_REGISTRY_LOCK_PERMISSIONS;
 import static google.registry.model.console.ConsoleRoleDefinitions.PRIMARY_CONTACT_PERMISSIONS;
 import static google.registry.model.console.ConsoleRoleDefinitions.TECH_CONTACT_PERMISSIONS;
 
@@ -25,6 +26,8 @@ public enum RegistrarRole {
 
   /** The user is a standard account manager at a registrar. */
   ACCOUNT_MANAGER(ACCOUNT_MANAGER_PERMISSIONS),
+  /** The user is an account manager that can perform registry locks. */
+  ACCOUNT_MANAGER_WITH_REGISTRY_LOCK(ACCOUNT_MANAGER_WITH_REGISTRY_LOCK_PERMISSIONS),
   /** The user is a technical contact of a registrar. */
   TECH_CONTACT(TECH_CONTACT_PERMISSIONS),
   /** The user is the primary contact at a registrar. */

--- a/core/src/test/java/google/registry/model/console/ConsoleRoleDefinitionsTest.java
+++ b/core/src/test/java/google/registry/model/console/ConsoleRoleDefinitionsTest.java
@@ -49,21 +49,30 @@ public class ConsoleRoleDefinitionsTest {
     // Note: we can't use Truth's IterableSubject to check all the subset/superset restrictions
     // because it is generic to iterables and doesn't know about sets.
     assertThat(
-            ConsoleRoleDefinitions.SUPPORT_LEAD_PERMISSIONS.containsAll(
-                ConsoleRoleDefinitions.SUPPORT_AGENT_PERMISSIONS))
+            ConsoleRoleDefinitions.ACCOUNT_MANAGER_WITH_REGISTRY_LOCK_PERMISSIONS.containsAll(
+                ConsoleRoleDefinitions.ACCOUNT_MANAGER_PERMISSIONS))
         .isTrue();
     assertThat(
-            ConsoleRoleDefinitions.SUPPORT_AGENT_PERMISSIONS.containsAll(
-                ConsoleRoleDefinitions.SUPPORT_LEAD_PERMISSIONS))
+            ConsoleRoleDefinitions.ACCOUNT_MANAGER_PERMISSIONS.containsAll(
+                ConsoleRoleDefinitions.ACCOUNT_MANAGER_WITH_REGISTRY_LOCK_PERMISSIONS))
         .isFalse();
 
     assertThat(
-            ConsoleRoleDefinitions.SUPPORT_LEAD_PERMISSIONS.containsAll(
-                ConsoleRoleDefinitions.SUPPORT_AGENT_PERMISSIONS))
+            ConsoleRoleDefinitions.TECH_CONTACT_PERMISSIONS.containsAll(
+                ConsoleRoleDefinitions.ACCOUNT_MANAGER_WITH_REGISTRY_LOCK_PERMISSIONS))
         .isTrue();
     assertThat(
-            ConsoleRoleDefinitions.SUPPORT_AGENT_PERMISSIONS.containsAll(
-                ConsoleRoleDefinitions.SUPPORT_LEAD_PERMISSIONS))
+            ConsoleRoleDefinitions.ACCOUNT_MANAGER_WITH_REGISTRY_LOCK_PERMISSIONS.containsAll(
+                ConsoleRoleDefinitions.TECH_CONTACT_PERMISSIONS))
+        .isFalse();
+
+    assertThat(
+            ConsoleRoleDefinitions.PRIMARY_CONTACT_PERMISSIONS.containsAll(
+                ConsoleRoleDefinitions.TECH_CONTACT_PERMISSIONS))
+        .isTrue();
+    assertThat(
+            ConsoleRoleDefinitions.TECH_CONTACT_PERMISSIONS.containsAll(
+                ConsoleRoleDefinitions.PRIMARY_CONTACT_PERMISSIONS))
         .isFalse();
   }
 }

--- a/core/src/test/java/google/registry/model/console/UserTest.java
+++ b/core/src/test/java/google/registry/model/console/UserTest.java
@@ -58,4 +58,33 @@ public class UserTest {
     builder.setUserRoles(new UserRoles.Builder().build());
     builder.build();
   }
+
+  @Test
+  void testRegistryLockPassword() {
+    assertThat(
+            assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                    new User.Builder()
+                        .setUserRoles(new UserRoles.Builder().build())
+                        .setRegistryLockPassword("foobar")))
+        .hasMessageThat()
+        .isEqualTo("User has no registry lock permission");
+
+    User user =
+        new User.Builder()
+            .setGaiaId("gaiaId")
+            .setEmailAddress("email@email.com")
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.FTE).build())
+            .build();
+    assertThat(user.hasRegistryLockPassword()).isFalse();
+
+    user = user.asBuilder().setRegistryLockPassword("foobar").build();
+    assertThat(user.hasRegistryLockPassword()).isTrue();
+    assertThat(user.verifyRegistryLockPassword("foobar")).isTrue();
+
+    user = user.asBuilder().removeRegistryLockPassword().build();
+    assertThat(user.hasRegistryLockPassword()).isFalse();
+    assertThat(user.verifyRegistryLockPassword("foobar")).isFalse();
+  }
 }


### PR DESCRIPTION
This allows us to distinguish between standard account managers and
users that might have the registry lock permission. This will make the
registry lock password-setting flow easier (user can reset their
password iff they have the REGISTRY_LOCK permission, instead of having a
separate boolean) and allows us to easily determine whether or not a
user should have access to registry lock views in the UI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1740)
<!-- Reviewable:end -->
