### PR TITLE
Allow UserAuthInfo to contain either old GAE Users or new console Users

### DIFF
--- a/core/src/main/java/google/registry/rdap/RdapModule.java
+++ b/core/src/main/java/google/registry/rdap/RdapModule.java
@@ -108,7 +108,7 @@ public final class RdapModule {
     if (userAuthInfo.isUserAdmin()) {
       return RdapAuthorization.ADMINISTRATOR_AUTHORIZATION;
     }
-    ImmutableSet<String> clientIds = registrarAccessor.getAllClientIdWithRoles().keySet();
+    ImmutableSet<String> clientIds = registrarAccessor.getAllRegistrarIdsWithRoles().keySet();
     if (clientIds.isEmpty()) {
       logger.atWarning().log("Couldn't find registrar for User %s.", authResult.userIdForLogging());
       return RdapAuthorization.PUBLIC_AUTHORIZATION;

--- a/core/src/main/java/google/registry/request/auth/AuthResult.java
+++ b/core/src/main/java/google/registry/request/auth/AuthResult.java
@@ -42,7 +42,7 @@ public abstract class AuthResult {
             userAuthInfo ->
                 String.format(
                     "%s %s",
-                    userAuthInfo.isUserAdmin() ? "admin" : "user", userAuthInfo.user().getEmail()))
+                    userAuthInfo.isUserAdmin() ? "admin" : "user", userAuthInfo.getEmailAddress()))
         .orElse("<logged-out user>");
   }
 

--- a/core/src/main/java/google/registry/ui/server/registrar/ConsoleUiAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/ConsoleUiAction.java
@@ -109,13 +109,13 @@ public final class ConsoleUiAction extends HtmlAction {
               .render());
       return;
     }
-    ImmutableSetMultimap<String, Role> roleMap = registrarAccessor.getAllClientIdWithRoles();
+    ImmutableSetMultimap<String, Role> roleMap = registrarAccessor.getAllRegistrarIdsWithRoles();
     soyMapData.put("allClientIds", roleMap.keySet());
     soyMapData.put("environment", RegistryEnvironment.get().toString());
     // We set the initial value to the value that will show if guessClientId throws.
     String clientId = "<null>";
     try {
-      clientId = paramClientId.orElse(registrarAccessor.guessClientId());
+      clientId = paramClientId.orElse(registrarAccessor.guessRegistrarId());
       soyMapData.put("clientId", clientId);
       soyMapData.put("isOwner", roleMap.containsEntry(clientId, OWNER));
       soyMapData.put("isAdmin", roleMap.containsEntry(clientId, ADMIN));

--- a/core/src/main/java/google/registry/ui/server/registrar/HtmlAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/HtmlAction.java
@@ -18,7 +18,6 @@ import static com.google.common.net.HttpHeaders.LOCATION;
 import static com.google.common.net.HttpHeaders.X_FRAME_OPTIONS;
 import static javax.servlet.http.HttpServletResponse.SC_MOVED_TEMPORARILY;
 
-import com.google.appengine.api.users.User;
 import com.google.appengine.api.users.UserService;
 import com.google.common.flogger.FluentLogger;
 import com.google.common.net.MediaType;
@@ -27,6 +26,7 @@ import google.registry.request.Action;
 import google.registry.request.RequestMethod;
 import google.registry.request.Response;
 import google.registry.request.auth.AuthResult;
+import google.registry.request.auth.UserAuthInfo;
 import google.registry.security.XsrfTokenManager;
 import java.util.HashMap;
 import java.util.Map;
@@ -86,16 +86,15 @@ public abstract class HtmlAction implements Runnable {
     }
     response.setContentType(MediaType.HTML_UTF_8);
 
-    User user = authResult.userAuthInfo().get().user();
-
+    UserAuthInfo authInfo = authResult.userAuthInfo().get();
     // Using HashMap to allow null values
     HashMap<String, Object> data = new HashMap<>();
     data.put("logoFilename", logoFilename);
     data.put("productName", productName);
-    data.put("username", user.getNickname());
+    data.put("username", authInfo.getUsername());
     data.put("logoutUrl", userService.createLogoutURL(getPath()));
     data.put("analyticsConfig", analyticsConfig);
-    data.put("xsrfToken", xsrfTokenManager.generateToken(user.getEmail()));
+    data.put("xsrfToken", xsrfTokenManager.generateToken(authInfo.getEmailAddress()));
 
     logger.atInfo().log(
         "User %s is accessing %s with method %s.",

--- a/core/src/test/java/google/registry/request/RequestHandlerTest.java
+++ b/core/src/test/java/google/registry/request/RequestHandlerTest.java
@@ -474,7 +474,7 @@ public final class RequestHandlerTest {
     assertThat(providedAuthResult).isNotNull();
     assertThat(providedAuthResult.authLevel()).isEqualTo(AuthLevel.USER);
     assertThat(providedAuthResult.userAuthInfo()).isPresent();
-    assertThat(providedAuthResult.userAuthInfo().get().user()).isEqualTo(testUser);
+    assertThat(providedAuthResult.userAuthInfo().get().appEngineUser()).hasValue(testUser);
     assertThat(providedAuthResult.userAuthInfo().get().oauthTokenInfo()).isEmpty();
     assertMetric("/auth/adminUser", GET, AuthLevel.USER, true);
   }

--- a/core/src/test/java/google/registry/request/auth/RequestAuthenticatorTest.java
+++ b/core/src/test/java/google/registry/request/auth/RequestAuthenticatorTest.java
@@ -209,7 +209,7 @@ class RequestAuthenticatorTest {
     assertThat(authResult).isPresent();
     assertThat(authResult.get().authLevel()).isEqualTo(AuthLevel.USER);
     assertThat(authResult.get().userAuthInfo()).isPresent();
-    assertThat(authResult.get().userAuthInfo().get().user()).isEqualTo(testUser);
+    assertThat(authResult.get().userAuthInfo().get().appEngineUser()).hasValue(testUser);
     assertThat(authResult.get().userAuthInfo().get().isUserAdmin()).isFalse();
     assertThat(authResult.get().userAuthInfo().get().oauthTokenInfo()).isEmpty();
   }
@@ -224,7 +224,7 @@ class RequestAuthenticatorTest {
     assertThat(authResult).isPresent();
     assertThat(authResult.get().authLevel()).isEqualTo(AuthLevel.USER);
     assertThat(authResult.get().userAuthInfo()).isPresent();
-    assertThat(authResult.get().userAuthInfo().get().user()).isEqualTo(testUser);
+    assertThat(authResult.get().userAuthInfo().get().appEngineUser()).hasValue(testUser);
     assertThat(authResult.get().userAuthInfo().get().oauthTokenInfo()).isEmpty();
   }
 
@@ -264,7 +264,7 @@ class RequestAuthenticatorTest {
     assertThat(authResult).isPresent();
     assertThat(authResult.get().authLevel()).isEqualTo(AuthLevel.USER);
     assertThat(authResult.get().userAuthInfo()).isPresent();
-    assertThat(authResult.get().userAuthInfo().get().user()).isEqualTo(testUser);
+    assertThat(authResult.get().userAuthInfo().get().appEngineUser()).hasValue(testUser);
     assertThat(authResult.get().userAuthInfo().get().isUserAdmin()).isTrue();
     assertThat(authResult.get().userAuthInfo().get().oauthTokenInfo()).isEmpty();
   }
@@ -280,7 +280,7 @@ class RequestAuthenticatorTest {
     assertThat(authResult).isPresent();
     assertThat(authResult.get().authLevel()).isEqualTo(AuthLevel.USER);
     assertThat(authResult.get().userAuthInfo()).isPresent();
-    assertThat(authResult.get().userAuthInfo().get().user()).isEqualTo(testUser);
+    assertThat(authResult.get().userAuthInfo().get().appEngineUser()).hasValue(testUser);
     assertThat(authResult.get().userAuthInfo().get().isUserAdmin()).isFalse();
     assertThat(authResult.get().userAuthInfo().get().oauthTokenInfo()).isPresent();
     assertThat(authResult.get().userAuthInfo().get().oauthTokenInfo().get().authorizedScopes())
@@ -303,7 +303,7 @@ class RequestAuthenticatorTest {
     assertThat(authResult).isPresent();
     assertThat(authResult.get().authLevel()).isEqualTo(AuthLevel.USER);
     assertThat(authResult.get().userAuthInfo()).isPresent();
-    assertThat(authResult.get().userAuthInfo().get().user()).isEqualTo(testUser);
+    assertThat(authResult.get().userAuthInfo().get().appEngineUser()).hasValue(testUser);
     assertThat(authResult.get().userAuthInfo().get().isUserAdmin()).isTrue();
     assertThat(authResult.get().userAuthInfo().get().oauthTokenInfo()).isPresent();
     assertThat(authResult.get().userAuthInfo().get().oauthTokenInfo().get().authorizedScopes())
@@ -372,7 +372,7 @@ class RequestAuthenticatorTest {
     assertThat(authResult).isPresent();
     assertThat(authResult.get().authLevel()).isEqualTo(AuthLevel.USER);
     assertThat(authResult.get().userAuthInfo()).isPresent();
-    assertThat(authResult.get().userAuthInfo().get().user()).isEqualTo(testUser);
+    assertThat(authResult.get().userAuthInfo().get().appEngineUser()).hasValue(testUser);
     assertThat(authResult.get().userAuthInfo().get().isUserAdmin()).isFalse();
     assertThat(authResult.get().userAuthInfo().get().oauthTokenInfo()).isPresent();
     assertThat(authResult.get().userAuthInfo().get().oauthTokenInfo().get().authorizedScopes())


### PR DESCRIPTION
This means that LegacyAuthenticationMechanism or a to-be-created
OAuth2AuthenticationMechanism) can return a UserAuthInfo object that
contains either the GAE User or the console User as appropriate. The
goal is that the non-auth flows shouldn't have to know about which user
type it is. Note: the registry lock flow (for now) needs to know about
the separate types of auth because it is a separate level of auth from
the standard AuthenticatedRegistrarAccessor.

The AuthenticatedRegistrarAccessor code is a bit odd because the new
role system doesn't quite fit neatly into the old registrar ->
OWNER,ADMIN system but this is a fine approximation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1744)
<!-- Reviewable:end -->
