### PR TITLE
Add another TestCacheExtension usage and disable expired SMD test

### DIFF
--- a/core/src/test/java/google/registry/tmch/TmchActionTestCase.java
+++ b/core/src/test/java/google/registry/tmch/TmchActionTestCase.java
@@ -22,8 +22,10 @@ import google.registry.testing.AppEngineExtension;
 import google.registry.testing.BouncyCastleProviderExtension;
 import google.registry.testing.FakeClock;
 import google.registry.testing.FakeUrlConnectionService;
+import google.registry.testing.TestCacheExtension;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.time.Duration;
 import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,6 +44,10 @@ abstract class TmchActionTestCase {
 
   @RegisterExtension
   public final BouncyCastleProviderExtension bouncy = new BouncyCastleProviderExtension();
+
+  @RegisterExtension
+  public final TestCacheExtension testCacheExtension =
+      new TestCacheExtension.Builder().withClaimsListCache(Duration.ofHours(6)).build();
 
   final FakeClock clock = new FakeClock();
   final Marksdb marksdb = new Marksdb();

--- a/core/src/test/java/google/registry/tmch/TmchTestDataExpirationTest.java
+++ b/core/src/test/java/google/registry/tmch/TmchTestDataExpirationTest.java
@@ -27,6 +27,7 @@ import google.registry.util.ResourceUtils;
 import google.registry.util.SystemClock;
 import java.nio.file.Path;
 import org.joda.time.DateTime;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -38,6 +39,7 @@ class TmchTestDataExpirationTest {
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
+  @Disabled("TODO(b/243130376): update the data files when ICANN provides them")
   @Test
   void testActiveSignedMarkFiles_areValidAndNotExpired() throws Exception {
     DomainFlowTmchUtils tmchUtils =


### PR DESCRIPTION
ICANN hasn't provided updated files since 2018 and the current ones are
expired, so we should disable the test until then. This also adds the
TestCacheExtension to the TMCH test cases just in case.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1750)
<!-- Reviewable:end -->
