### PR TITLE
Reset the claims list cache in any test that saves to it

### DIFF
--- a/core/src/test/java/google/registry/tools/GetClaimsListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetClaimsListCommandTest.java
@@ -22,13 +22,19 @@ import static org.joda.time.DateTimeZone.UTC;
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.tmch.ClaimsList;
 import google.registry.model.tmch.ClaimsListDao;
+import google.registry.testing.TestCacheExtension;
 import java.io.File;
 import java.nio.file.Files;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link GetClaimsListCommand}. */
 class GetClaimsListCommandTest extends CommandTestCase<GetClaimsListCommand> {
+
+  @RegisterExtension
+  public final TestCacheExtension testCacheExtension =
+      new TestCacheExtension.Builder().withClaimsListCache(java.time.Duration.ofHours(6)).build();
 
   @Test
   void testSuccess_getWorks() throws Exception {

--- a/core/src/test/java/google/registry/tools/UploadClaimsListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UploadClaimsListCommandTest.java
@@ -20,12 +20,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.model.tmch.ClaimsList;
 import google.registry.model.tmch.ClaimsListDao;
+import google.registry.testing.TestCacheExtension;
 import java.io.FileNotFoundException;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 /** Unit tests for {@link UploadClaimsListCommand}. */
 class UploadClaimsListCommandTest extends CommandTestCase<UploadClaimsListCommand> {
+
+  @RegisterExtension
+  public final TestCacheExtension testCacheExtension =
+      new TestCacheExtension.Builder().withClaimsListCache(java.time.Duration.ofHours(6)).build();
 
   @Test
   void testSuccess() throws Exception {


### PR DESCRIPTION
Unfortunately we're getting some flakes caused by the cache sticking around in tests after it shouldn't. This covers the rest of the cases where any test calls ClaimsListDao.save to reset the cache after the test finishes. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1754)
<!-- Reviewable:end -->
