### PR TITLE
Add registry email to bcc for outgoing DNS failure emails

### DIFF
--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -1320,8 +1320,14 @@ public final class RegistryConfig {
 
     @Provides
     @Config("registrySupportEmail")
-    public static String provideRegistrySupportEmail(RegistryConfigSettings config) {
-      return config.dnsUpdate.registrySupportEmail;
+    public static InternetAddress provideRegistrySupportEmail(RegistryConfigSettings config) {
+      return parseEmailAddress(config.dnsUpdate.registrySupportEmail);
+    }
+
+    @Provides
+    @Config("registryCcEmail")
+    public static InternetAddress provideRegistryCcEmail(RegistryConfigSettings config) {
+      return parseEmailAddress(config.dnsUpdate.registryCcEmail);
     }
 
     @Provides

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -254,5 +254,6 @@ public class RegistryConfigSettings {
     public String dnsUpdateFailEmailBodyText;
     public String dnsUpdateFailRegistryName;
     public String registrySupportEmail;
+    public String registryCcEmail;
   }
 }

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -481,6 +481,7 @@ contactHistory:
 dnsUpdate:
   dnsUpdateFailRegistryName: Example name
   registrySupportEmail: email@example.com
+  registryCcEmail: email@example.com
   # Email subject text template to notify partners after repeatedly failing DNS update
   dnsUpdateFailEmailSubjectText: "[ACTION REQUIRED]: Incomplete DNS Update"
   # Email body text template for failing DNS update that accepts 5 parameters:


### PR DESCRIPTION
This adds registry support email to bcc for when DNS failure occurs and we send DNS failure emails. This should help us to track how many and what kind of emails are getting sent by us and make sure partners don't get flooded with emails.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1755)
<!-- Reviewable:end -->
