### PR TITLE
Allow usage of allocation tokens in nomulus create_domain

### DIFF
--- a/core/src/main/java/google/registry/tools/CreateDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateDomainCommand.java
@@ -46,6 +46,11 @@ final class CreateDomainCommand extends CreateOrUpdateDomainCommand
       description = "Force the creation of premium domains.")
   private boolean forcePremiums;
 
+  @Parameter(
+      names = "--allocation_token",
+      description = "Allocation token to use when creating the domain(s)")
+  private String allocationToken;
+
   @Inject
   @Named("base64StringGenerator")
   StringGenerator passwordGenerator;
@@ -92,7 +97,8 @@ final class CreateDomainCommand extends CreateOrUpdateDomainCommand
               "currency", currency,
               "price", cost,
               "dsRecords", DsRecord.convertToSoy(dsRecords),
-              "reason", reason);
+              "reason", reason,
+              "allocationToken", allocationToken);
       if (requestedByRegistrar != null) {
         soyMapData.put("requestedByRegistrar", requestedByRegistrar.toString());
       }

--- a/core/src/main/resources/google/registry/tools/soy/DomainCreate.soy
+++ b/core/src/main/resources/google/registry/tools/soy/DomainCreate.soy
@@ -29,6 +29,7 @@
   {@param dsRecords: list<[keyTag:int, alg:int, digestType:int, digest:string]>}
   {@param? reason: string}
   {@param? requestedByRegistrar: string}
+  {@param? allocationToken: string}
 
   <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
   <epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
@@ -56,7 +57,7 @@
           </domain:authInfo>
         </domain:create>
       </create>
-      {if length($dsRecords) > 0 or $price != null or $reason or $requestedByRegistrar}
+      {if length($dsRecords) > 0 or $price != null or $reason or $requestedByRegistrar or $allocationToken}
         <extension>
           {if $price != null}
             <fee:create xmlns:fee="urn:ietf:params:xml:ns:fee-0.12">
@@ -85,6 +86,13 @@
               <metadata:requestedByRegistrar>{$requestedByRegistrar}</metadata:requestedByRegistrar>
             {/if}
             </metadata:metadata>
+          {/if}
+          {if $allocationToken}
+            <allocationToken:allocationToken
+                xmlns:allocationToken=
+                    "urn:ietf:params:xml:ns:allocationToken-1.0">
+              {$allocationToken}
+            </allocationToken:allocationToken>
           {/if}
         </extension>
       {/if}

--- a/core/src/test/java/google/registry/tools/CreateDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateDomainCommandTest.java
@@ -180,6 +180,19 @@ class CreateDomainCommandTest extends EppToolCommandTestCase<CreateDomainCommand
   }
 
   @Test
+  void testSuccess_allocationToken() throws Exception {
+    createTld("tld");
+    runCommandForced(
+        "--client=NewRegistrar",
+        "--registrant=crr-admin",
+        "--admins=crr-admin",
+        "--techs=crr-tech",
+        "--allocation_token=abc123",
+        "example.tld");
+    eppVerifier.verifySent("domain_create_token.xml");
+  }
+
+  @Test
   void testFailure_duplicateDomains() {
     IllegalArgumentException thrown =
         assertThrows(

--- a/core/src/test/resources/google/registry/tools/server/domain_create_token.xml
+++ b/core/src/test/resources/google/registry/tools/server/domain_create_token.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <command>
+    <create>
+      <domain:create
+          xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>example.tld</domain:name>
+        <domain:period unit="y">1</domain:period>
+        <domain:registrant>crr-admin</domain:registrant>
+        <domain:contact type="admin">crr-admin</domain:contact>
+        <domain:contact type="tech">crr-tech</domain:contact>
+        <domain:authInfo>
+          <domain:pw>abcdefghijklmnop</domain:pw>
+        </domain:authInfo>
+      </domain:create>
+    </create>
+    <extension>
+      <allocationToken:allocationToken
+          xmlns:allocationToken=
+              "urn:ietf:params:xml:ns:allocationToken-1.0">
+        abc123
+      </allocationToken:allocationToken>
+    </extension>
+    <clTRID>RegistryTool</clTRID>
+  </command>
+</epp>


### PR DESCRIPTION
Useful when doing internal registrations like get.boo

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1756)
<!-- Reviewable:end -->
