### PR TITLE
Rename ContactResource -> Contact

### DIFF
--- a/core/src/main/java/google/registry/batch/DeleteLoadTestDataAction.java
+++ b/core/src/main/java/google/registry/batch/DeleteLoadTestDataAction.java
@@ -29,7 +29,7 @@ import google.registry.config.RegistryEnvironment;
 import google.registry.flows.poll.PollFlowUtils;
 import google.registry.model.EppResource;
 import google.registry.model.EppResourceUtils;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.host.Host;
 import google.registry.model.poll.PollMessage;
@@ -43,8 +43,8 @@ import google.registry.util.Clock;
 import javax.inject.Inject;
 
 /**
- * Hard deletes load-test ContactResources, Hosts, their subordinate history entries, and the
- * associated ForeignKey and EppResourceIndex entities.
+ * Hard deletes load-test Contacts, Hosts, their subordinate history entries, and the associated
+ * ForeignKey and EppResourceIndex entities.
  *
  * <p>This only deletes contacts and hosts, NOT domains. To delete domains, use {@link
  * DeleteProberDataAction} and pass it the TLD(s) that the load test domains were created on. Note
@@ -92,7 +92,7 @@ public class DeleteLoadTestDataAction implements Runnable {
     tm().transact(
             () -> {
               LOAD_TEST_REGISTRARS.forEach(this::deletePollMessages);
-              tm().loadAllOfStream(ContactResource.class).forEach(this::deleteContact);
+              tm().loadAllOfStream(Contact.class).forEach(this::deleteContact);
               tm().loadAllOfStream(Host.class).forEach(this::deleteHost);
             });
   }
@@ -108,7 +108,7 @@ public class DeleteLoadTestDataAction implements Runnable {
     }
   }
 
-  private void deleteContact(ContactResource contact) {
+  private void deleteContact(Contact contact) {
     if (!LOAD_TEST_REGISTRARS.contains(contact.getPersistedCurrentSponsorRegistrarId())) {
       return;
     }

--- a/core/src/main/java/google/registry/beam/common/JpaDemoPipeline.java
+++ b/core/src/main/java/google/registry/beam/common/JpaDemoPipeline.java
@@ -17,7 +17,7 @@ package google.registry.beam.common;
 import static com.google.common.base.Verify.verify;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.persistence.transaction.CriteriaQueryBuilder;
 import google.registry.persistence.transaction.JpaTransactionManager;
 import java.io.Serializable;
@@ -46,8 +46,7 @@ public class JpaDemoPipeline implements Serializable {
         .apply(
             "Read contacts",
             RegistryJpaIO.read(
-                () -> CriteriaQueryBuilder.create(ContactResource.class).build(),
-                ContactResource::getRepoId))
+                () -> CriteriaQueryBuilder.create(Contact.class).build(), Contact::getRepoId))
         .apply(
             "Count Contacts",
             ParDo.of(

--- a/core/src/main/java/google/registry/beam/resave/ResaveAllEppResourcesPipeline.java
+++ b/core/src/main/java/google/registry/beam/resave/ResaveAllEppResourcesPipeline.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableSet;
 import google.registry.beam.common.RegistryJpaIO;
 import google.registry.beam.common.RegistryJpaIO.Read;
 import google.registry.model.EppResource;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.host.Host;
@@ -53,7 +53,7 @@ import org.joda.time.DateTime;
 public class ResaveAllEppResourcesPipeline implements Serializable {
 
   private static final ImmutableSet<Class<? extends EppResource>> EPP_RESOURCE_CLASSES =
-      ImmutableSet.of(ContactResource.class, Domain.class, Host.class);
+      ImmutableSet.of(Contact.class, Domain.class, Host.class);
 
   /**
    * There exist three possible situations where we know we'll want to project domains to the
@@ -99,13 +99,13 @@ public class ResaveAllEppResourcesPipeline implements Serializable {
 
   /** Projects to the current time and saves any contacts with expired transfers. */
   private void fastResaveContacts(Pipeline pipeline) {
-    Read<ContactResource, ContactResource> read =
+    Read<Contact, Contact> read =
         RegistryJpaIO.read(
             "FROM Contact WHERE transferData.transferStatus = 'PENDING' AND"
                 + " transferData.pendingTransferExpirationTime < current_timestamp()",
-            ContactResource.class,
+            Contact.class,
             c -> c);
-    projectAndResaveResources(pipeline, ContactResource.class, read);
+    projectAndResaveResources(pipeline, Contact.class, read);
   }
 
   /**

--- a/core/src/main/java/google/registry/env/common/default/WEB-INF/datastore-indexes.xml
+++ b/core/src/main/java/google/registry/env/common/default/WEB-INF/datastore-indexes.xml
@@ -1,6 +1,6 @@
 <datastore-indexes autoGenerate="false">
   <!-- For finding contact resources by registrar. -->
-  <datastore-index kind="ContactResource" ancestor="false" source="manual">
+  <datastore-index kind="Contact" ancestor="false" source="manual">
     <property name="currentSponsorClientId" direction="asc"/>
     <property name="deletionTime" direction="asc"/>
     <property name="searchName" direction="asc"/>
@@ -91,7 +91,7 @@
     <property name="deletionTime" direction="asc"/>
     <property name="fullyQualifiedHostName" direction="asc"/>
   </datastore-index>
-  <datastore-index kind="ContactResource" ancestor="false" source="manual">
+  <datastore-index kind="Contact" ancestor="false" source="manual">
     <property name="deletionTime" direction="asc"/>
     <property name="searchName" direction="asc"/>
   </datastore-index>

--- a/core/src/main/java/google/registry/flows/ResourceFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/ResourceFlowUtils.java
@@ -38,7 +38,7 @@ import google.registry.flows.exceptions.TooManyResourceChecksException;
 import google.registry.model.EppResource;
 import google.registry.model.EppResource.ForeignKeyedEppResource;
 import google.registry.model.EppResource.ResourceWithTransferData;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.domain.Period;
@@ -139,7 +139,7 @@ public final class ResourceFlowUtils {
   }
 
   /** Check that the given AuthInfo is either missing or else is valid for the given resource. */
-  public static void verifyOptionalAuthInfo(Optional<AuthInfo> authInfo, ContactResource contact)
+  public static void verifyOptionalAuthInfo(Optional<AuthInfo> authInfo, Contact contact)
       throws EppException {
     if (authInfo.isPresent()) {
       verifyAuthInfo(authInfo.get(), contact);
@@ -167,7 +167,7 @@ public final class ResourceFlowUtils {
       return;
     }
     // The roid should match one of the contacts.
-    Optional<VKey<ContactResource>> foundContact =
+    Optional<VKey<Contact>> foundContact =
         domain.getReferencedContacts().stream()
             .filter(key -> key.getSqlKey().equals(authRepoId))
             .findFirst();
@@ -179,8 +179,7 @@ public final class ResourceFlowUtils {
   }
 
   /** Check that the given {@link AuthInfo} is valid for the given contact. */
-  public static void verifyAuthInfo(AuthInfo authInfo, ContactResource contact)
-      throws EppException {
+  public static void verifyAuthInfo(AuthInfo authInfo, Contact contact) throws EppException {
     String authRepoId = authInfo.getPw().getRepoId();
     String authPassword = authInfo.getPw().getValue();
     String contactPassword = contact.getAuthInfo().getPw().getValue();

--- a/core/src/main/java/google/registry/flows/contact/ContactCheckFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactCheckFlow.java
@@ -26,8 +26,8 @@ import google.registry.flows.ExtensionManager;
 import google.registry.flows.Flow;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.annotations.ReportingSpec;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactCommand.Check;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.eppinput.ResourceCommand;
 import google.registry.model.eppoutput.CheckData.ContactCheck;
 import google.registry.model.eppoutput.CheckData.ContactCheckData;
@@ -62,7 +62,7 @@ public final class ContactCheckFlow implements Flow {
     ImmutableList<String> targetIds = ((Check) resourceCommand).getTargetIds();
     verifyTargetIdCount(targetIds, maxChecks);
     ImmutableSet<String> existingIds =
-        checkResourcesExist(ContactResource.class, targetIds, clock.nowUtc());
+        checkResourcesExist(Contact.class, targetIds, clock.nowUtc());
     ImmutableList.Builder<ContactCheck> checks = new ImmutableList.Builder<>();
     for (String id : targetIds) {
       boolean unused = !existingIds.contains(id);

--- a/core/src/main/java/google/registry/flows/contact/ContactCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactCreateFlow.java
@@ -33,9 +33,9 @@ import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.exceptions.ResourceAlreadyExistsForThisClientException;
 import google.registry.flows.exceptions.ResourceCreateContentionException;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactCommand.Create;
 import google.registry.model.contact.ContactHistory;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.metadata.MetadataExtension;
 import google.registry.model.eppinput.ResourceCommand;
 import google.registry.model.eppoutput.CreateData.ContactCreateData;
@@ -75,9 +75,9 @@ public final class ContactCreateFlow implements TransactionalFlow {
     extensionManager.validate();
     Create command = (Create) resourceCommand;
     DateTime now = tm().getTransactionTime();
-    verifyResourceDoesNotExist(ContactResource.class, targetId, now, registrarId);
-    ContactResource newContact =
-        new ContactResource.Builder()
+    verifyResourceDoesNotExist(Contact.class, targetId, now, registrarId);
+    Contact newContact =
+        new Contact.Builder()
             .setContactId(targetId)
             .setAuthInfo(command.getAuthInfo())
             .setCreationRegistrarId(registrarId)

--- a/core/src/main/java/google/registry/flows/contact/ContactDeleteFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactDeleteFlow.java
@@ -35,8 +35,8 @@ import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
 import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactHistory;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.metadata.MetadataExtension;
 import google.registry.model.eppcommon.AuthInfo;
 import google.registry.model.eppcommon.StatusValue;
@@ -91,15 +91,15 @@ public final class ContactDeleteFlow implements TransactionalFlow {
     validateRegistrarIsLoggedIn(registrarId);
     extensionManager.validate();
     DateTime now = tm().getTransactionTime();
-    checkLinkedDomains(targetId, now, ContactResource.class);
-    ContactResource existingContact = loadAndVerifyExistence(ContactResource.class, targetId, now);
+    checkLinkedDomains(targetId, now, Contact.class);
+    Contact existingContact = loadAndVerifyExistence(Contact.class, targetId, now);
     verifyNoDisallowedStatuses(existingContact, DISALLOWED_STATUSES);
     verifyOptionalAuthInfo(authInfo, existingContact);
     if (!isSuperuser) {
       verifyResourceOwnership(registrarId, existingContact);
     }
     // Handle pending transfers on contact deletion.
-    ContactResource newContact =
+    Contact newContact =
         existingContact.getStatusValues().contains(StatusValue.PENDING_TRANSFER)
             ? denyPendingTransfer(existingContact, SERVER_CANCELLED, now, registrarId)
             : existingContact;

--- a/core/src/main/java/google/registry/flows/contact/ContactFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactFlowUtils.java
@@ -24,10 +24,10 @@ import com.googlecode.objectify.Key;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ParameterValuePolicyErrorException;
 import google.registry.flows.EppException.ParameterValueSyntaxErrorException;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactAddress;
 import google.registry.model.contact.ContactHistory;
 import google.registry.model.contact.ContactHistory.ContactHistoryId;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.contact.PostalInfo;
 import google.registry.model.poll.PendingActionNotificationResponse.ContactPendingActionNotificationResponse;
 import google.registry.model.poll.PollMessage;
@@ -61,7 +61,7 @@ public class ContactFlowUtils {
   }
 
   /** Check contact's state against server policy. */
-  static void validateContactAgainstPolicy(ContactResource contact) throws EppException {
+  static void validateContactAgainstPolicy(Contact contact) throws EppException {
     if (contact.getDisclose() != null && !contact.getDisclose().getFlag()) {
       throw new DeclineContactDisclosureFieldDisallowedPolicyException();
     }

--- a/core/src/main/java/google/registry/flows/contact/ContactInfoFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactInfoFlow.java
@@ -27,8 +27,8 @@ import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
 import google.registry.flows.annotations.ReportingSpec;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactInfoData;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.eppcommon.AuthInfo;
 import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.eppoutput.EppResponse;
@@ -69,7 +69,7 @@ public final class ContactInfoFlow implements Flow {
     DateTime now = clock.nowUtc();
     validateRegistrarIsLoggedIn(registrarId);
     extensionManager.validate(); // There are no legal extensions for this flow.
-    ContactResource contact = loadAndVerifyExistence(ContactResource.class, targetId, now);
+    Contact contact = loadAndVerifyExistence(Contact.class, targetId, now);
     if (!isSuperuser) {
       verifyResourceOwnership(registrarId, contact);
     }

--- a/core/src/main/java/google/registry/flows/contact/ContactTransferApproveFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactTransferApproveFlow.java
@@ -33,8 +33,8 @@ import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.TargetId;
 import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactHistory;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.metadata.MetadataExtension;
 import google.registry.model.eppcommon.AuthInfo;
 import google.registry.model.eppinput.ResourceCommand;
@@ -74,7 +74,7 @@ public final class ContactTransferApproveFlow implements TransactionalFlow {
 
   /**
    * The logic in this flow, which handles client approvals, very closely parallels the logic in
-   * {@link ContactResource#cloneProjectedAtTime} which handles implicit server approvals.
+   * {@link Contact#cloneProjectedAtTime} which handles implicit server approvals.
    */
   @Override
   public EppResponse run() throws EppException {
@@ -82,11 +82,11 @@ public final class ContactTransferApproveFlow implements TransactionalFlow {
     validateRegistrarIsLoggedIn(registrarId);
     extensionManager.validate();
     DateTime now = tm().getTransactionTime();
-    ContactResource existingContact = loadAndVerifyExistence(ContactResource.class, targetId, now);
+    Contact existingContact = loadAndVerifyExistence(Contact.class, targetId, now);
     verifyOptionalAuthInfo(authInfo, existingContact);
     verifyHasPendingTransfer(existingContact);
     verifyResourceOwnership(registrarId, existingContact);
-    ContactResource newContact =
+    Contact newContact =
         approvePendingTransfer(existingContact, TransferStatus.CLIENT_APPROVED, now);
     ContactHistory contactHistory =
         historyBuilder.setType(CONTACT_TRANSFER_APPROVE).setContact(newContact).build();

--- a/core/src/main/java/google/registry/flows/contact/ContactTransferCancelFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactTransferCancelFlow.java
@@ -33,8 +33,8 @@ import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.TargetId;
 import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactHistory;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.metadata.MetadataExtension;
 import google.registry.model.eppcommon.AuthInfo;
 import google.registry.model.eppinput.ResourceCommand;
@@ -78,11 +78,11 @@ public final class ContactTransferCancelFlow implements TransactionalFlow {
     validateRegistrarIsLoggedIn(registrarId);
     extensionManager.validate();
     DateTime now = tm().getTransactionTime();
-    ContactResource existingContact = loadAndVerifyExistence(ContactResource.class, targetId, now);
+    Contact existingContact = loadAndVerifyExistence(Contact.class, targetId, now);
     verifyOptionalAuthInfo(authInfo, existingContact);
     verifyHasPendingTransfer(existingContact);
     verifyTransferInitiator(registrarId, existingContact);
-    ContactResource newContact =
+    Contact newContact =
         denyPendingTransfer(existingContact, TransferStatus.CLIENT_CANCELLED, now, registrarId);
     ContactHistory contactHistory =
         historyBuilder.setType(CONTACT_TRANSFER_CANCEL).setContact(newContact).build();

--- a/core/src/main/java/google/registry/flows/contact/ContactTransferQueryFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactTransferQueryFlow.java
@@ -27,7 +27,7 @@ import google.registry.flows.FlowModule.TargetId;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.exceptions.NoTransferHistoryToQueryException;
 import google.registry.flows.exceptions.NotAuthorizedToViewTransferException;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.eppcommon.AuthInfo;
 import google.registry.model.eppoutput.EppResponse;
 import google.registry.model.reporting.IcannReportingTypes.ActivityReportField;
@@ -66,8 +66,7 @@ public final class ContactTransferQueryFlow implements Flow {
   public EppResponse run() throws EppException {
     validateRegistrarIsLoggedIn(registrarId);
     extensionManager.validate(); // There are no legal extensions for this flow.
-    ContactResource contact =
-        loadAndVerifyExistence(ContactResource.class, targetId, clock.nowUtc());
+    Contact contact = loadAndVerifyExistence(Contact.class, targetId, clock.nowUtc());
     verifyOptionalAuthInfo(authInfo, contact);
     // Most of the fields on the transfer response are required, so there's no way to return valid
     // XML if the object has never been transferred (and hence the fields aren't populated).

--- a/core/src/main/java/google/registry/flows/contact/ContactTransferRejectFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactTransferRejectFlow.java
@@ -33,8 +33,8 @@ import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.TargetId;
 import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactHistory;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.metadata.MetadataExtension;
 import google.registry.model.eppcommon.AuthInfo;
 import google.registry.model.eppoutput.EppResponse;
@@ -76,11 +76,11 @@ public final class ContactTransferRejectFlow implements TransactionalFlow {
     validateRegistrarIsLoggedIn(registrarId);
     extensionManager.validate();
     DateTime now = tm().getTransactionTime();
-    ContactResource existingContact = loadAndVerifyExistence(ContactResource.class, targetId, now);
+    Contact existingContact = loadAndVerifyExistence(Contact.class, targetId, now);
     verifyOptionalAuthInfo(authInfo, existingContact);
     verifyHasPendingTransfer(existingContact);
     verifyResourceOwnership(registrarId, existingContact);
-    ContactResource newContact =
+    Contact newContact =
         denyPendingTransfer(existingContact, TransferStatus.CLIENT_REJECTED, now, registrarId);
     ContactHistory contactHistory =
         historyBuilder.setType(CONTACT_TRANSFER_REJECT).setContact(newContact).build();

--- a/core/src/main/java/google/registry/flows/contact/ContactTransferRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactTransferRequestFlow.java
@@ -38,8 +38,8 @@ import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.exceptions.AlreadyPendingTransferException;
 import google.registry.flows.exceptions.ObjectAlreadySponsoredException;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactHistory;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.metadata.MetadataExtension;
 import google.registry.model.eppcommon.AuthInfo;
 import google.registry.model.eppcommon.StatusValue;
@@ -96,7 +96,7 @@ public final class ContactTransferRequestFlow implements TransactionalFlow {
     validateRegistrarIsLoggedIn(gainingClientId);
     extensionManager.validate();
     DateTime now = tm().getTransactionTime();
-    ContactResource existingContact = loadAndVerifyExistence(ContactResource.class, targetId, now);
+    Contact existingContact = loadAndVerifyExistence(Contact.class, targetId, now);
     verifyAuthInfoPresentForResourceTransfer(authInfo);
     verifyAuthInfo(authInfo.get(), existingContact);
     // Verify that the resource does not already have a pending transfer.
@@ -146,10 +146,12 @@ public final class ContactTransferRequestFlow implements TransactionalFlow {
             .asBuilder()
             .setEventTime(now) // Unlike the serverApprove messages, this applies immediately.
             .build();
-    ContactResource newContact = existingContact.asBuilder()
-        .setTransferData(pendingTransferData)
-        .addStatusValue(StatusValue.PENDING_TRANSFER)
-        .build();
+    Contact newContact =
+        existingContact
+            .asBuilder()
+            .setTransferData(pendingTransferData)
+            .addStatusValue(StatusValue.PENDING_TRANSFER)
+            .build();
     tm().update(newContact);
     tm().insertAll(
             ImmutableSet.of(

--- a/core/src/main/java/google/registry/flows/contact/ContactUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactUpdateFlow.java
@@ -36,10 +36,10 @@ import google.registry.flows.FlowModule.TargetId;
 import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.exceptions.ResourceHasClientUpdateProhibitedException;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactCommand.Update;
 import google.registry.model.contact.ContactCommand.Update.Change;
 import google.registry.model.contact.ContactHistory;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.contact.PostalInfo;
 import google.registry.model.domain.metadata.MetadataExtension;
 import google.registry.model.eppcommon.AuthInfo;
@@ -94,7 +94,7 @@ public final class ContactUpdateFlow implements TransactionalFlow {
     extensionManager.validate();
     Update command = (Update) resourceCommand;
     DateTime now = tm().getTransactionTime();
-    ContactResource existingContact = loadAndVerifyExistence(ContactResource.class, targetId, now);
+    Contact existingContact = loadAndVerifyExistence(Contact.class, targetId, now);
     verifyOptionalAuthInfo(authInfo, existingContact);
     ImmutableSet<StatusValue> statusToRemove = command.getInnerRemove().getStatusValues();
     ImmutableSet<StatusValue> statusesToAdd = command.getInnerAdd().getStatusValues();
@@ -104,7 +104,7 @@ public final class ContactUpdateFlow implements TransactionalFlow {
     }
     verifyNoDisallowedStatuses(existingContact, DISALLOWED_STATUSES);
     checkSameValuesNotAddedAndRemoved(statusesToAdd, statusToRemove);
-    ContactResource.Builder builder = existingContact.asBuilder();
+    Contact.Builder builder = existingContact.asBuilder();
     Change change = command.getInnerChange();
     // The spec requires the following behaviors:
     //   * If you update part of a postal info, the fields that you didn't update are unchanged.
@@ -126,7 +126,7 @@ public final class ContactUpdateFlow implements TransactionalFlow {
         builder.setInternationalizedPostalInfo(null);
       }
     }
-    ContactResource newContact =
+    Contact newContact =
         builder
             .setLastEppUpdateTime(now)
             .setLastEppUpdateRegistrarId(registrarId)

--- a/core/src/main/java/google/registry/model/EntityClasses.java
+++ b/core/src/main/java/google/registry/model/EntityClasses.java
@@ -18,8 +18,8 @@ import com.google.common.collect.ImmutableSet;
 import google.registry.model.annotations.DeleteAfterMigration;
 import google.registry.model.common.EntityGroupRoot;
 import google.registry.model.common.GaeUserIdConverter;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactHistory;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.token.AllocationToken;
@@ -42,8 +42,8 @@ public final class EntityClasses {
   public static final ImmutableSet<Class<? extends ImmutableObject>> ALL_CLASSES =
       ImmutableSet.of(
           AllocationToken.class,
+          Contact.class,
           ContactHistory.class,
-          ContactResource.class,
           Domain.class,
           DomainHistory.class,
           EntityGroupRoot.class,

--- a/core/src/main/java/google/registry/model/EppResourceUtils.java
+++ b/core/src/main/java/google/registry/model/EppResourceUtils.java
@@ -32,7 +32,7 @@ import google.registry.config.RegistryConfig;
 import google.registry.model.EppResource.BuilderWithTransferData;
 import google.registry.model.EppResource.ForeignKeyedEppResource;
 import google.registry.model.EppResource.ResourceWithTransferData;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.host.Host;
@@ -345,10 +345,10 @@ public final class EppResourceUtils {
   public static ImmutableSet<VKey<Domain>> getLinkedDomainKeys(
       VKey<? extends EppResource> key, DateTime now, @Nullable Integer limit) {
     checkArgument(
-        key.getKind().equals(ContactResource.class) || key.getKind().equals(Host.class),
-        "key must be either VKey<ContactResource> or VKey<Host>, but it is %s",
+        key.getKind().equals(Contact.class) || key.getKind().equals(Host.class),
+        "key must be either VKey<Contact> or VKey<Host>, but it is %s",
         key);
-    boolean isContactKey = key.getKind().equals(ContactResource.class);
+    boolean isContactKey = key.getKind().equals(Contact.class);
     if (tm().isOfy()) {
       com.googlecode.objectify.cmd.Query<Domain> query =
           auditedOfy()

--- a/core/src/main/java/google/registry/model/ResourceTransferUtils.java
+++ b/core/src/main/java/google/registry/model/ResourceTransferUtils.java
@@ -25,7 +25,7 @@ import com.google.common.collect.Sets;
 import google.registry.model.EppResource.BuilderWithTransferData;
 import google.registry.model.EppResource.ForeignKeyedEppResource;
 import google.registry.model.EppResource.ResourceWithTransferData;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.eppcommon.Trid;
@@ -60,7 +60,7 @@ public final class ResourceTransferUtils {
       EppResource eppResource, TransferData transferData) {
     assertIsContactOrDomain(eppResource);
     TransferResponse.Builder<? extends TransferResponse, ?> builder;
-    if (eppResource instanceof ContactResource) {
+    if (eppResource instanceof Contact) {
       builder = new ContactTransferResponse.Builder().setContactId(eppResource.getForeignKey());
     } else {
       DomainTransferData domainTransferData = (DomainTransferData) transferData;
@@ -93,7 +93,7 @@ public final class ResourceTransferUtils {
       boolean actionResult,
       DateTime processedDate) {
     assertIsContactOrDomain(eppResource);
-    return eppResource instanceof ContactResource
+    return eppResource instanceof Contact
         ? ContactPendingActionNotificationResponse.create(
             eppResource.getForeignKey(), actionResult, transferRequestTrid, processedDate)
         : DomainPendingActionNotificationResponse.create(
@@ -101,7 +101,7 @@ public final class ResourceTransferUtils {
   }
 
   private static void assertIsContactOrDomain(EppResource eppResource) {
-    checkState(eppResource instanceof ContactResource || eppResource instanceof Domain);
+    checkState(eppResource instanceof Contact || eppResource instanceof Domain);
   }
 
   /** Update the relevant {@link ForeignKeyIndex} to cache the new deletion time. */

--- a/core/src/main/java/google/registry/model/contact/Contact.java
+++ b/core/src/main/java/google/registry/model/contact/Contact.java
@@ -15,7 +15,6 @@
 package google.registry.model.contact;
 
 import com.googlecode.objectify.Key;
-import com.googlecode.objectify.annotation.Entity;
 import google.registry.model.EppResource.ForeignKeyedEppResource;
 import google.registry.model.annotations.ExternalMessagingName;
 import google.registry.model.annotations.ReportedOn;
@@ -23,6 +22,10 @@ import google.registry.persistence.VKey;
 import google.registry.persistence.WithStringVKey;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
 import org.joda.time.DateTime;
 
 /**
@@ -32,35 +35,35 @@ import org.joda.time.DateTime;
  */
 @ReportedOn
 @Entity
-@javax.persistence.Entity(name = "Contact")
-@javax.persistence.Table(
+@com.googlecode.objectify.annotation.Entity
+@Table(
     name = "Contact",
     indexes = {
-      @javax.persistence.Index(columnList = "creationTime"),
-      @javax.persistence.Index(columnList = "currentSponsorRegistrarId"),
-      @javax.persistence.Index(columnList = "deletionTime"),
-      @javax.persistence.Index(columnList = "contactId"),
-      @javax.persistence.Index(columnList = "searchName")
+      @Index(columnList = "creationTime"),
+      @Index(columnList = "currentSponsorRegistrarId"),
+      @Index(columnList = "deletionTime"),
+      @Index(columnList = "contactId"),
+      @Index(columnList = "searchName")
     })
 @ExternalMessagingName("contact")
 @WithStringVKey
 @Access(AccessType.FIELD)
-public class ContactResource extends ContactBase implements ForeignKeyedEppResource {
+public class Contact extends ContactBase implements ForeignKeyedEppResource {
 
   @Override
-  public VKey<ContactResource> createVKey() {
-    return VKey.create(ContactResource.class, getRepoId(), Key.create(this));
+  public VKey<Contact> createVKey() {
+    return VKey.create(Contact.class, getRepoId(), Key.create(this));
   }
 
   @Override
-  @javax.persistence.Id
+  @Id
   @Access(AccessType.PROPERTY)
   public String getRepoId() {
     return super.getRepoId();
   }
 
   @Override
-  public ContactResource cloneProjectedAtTime(DateTime now) {
+  public Contact cloneProjectedAtTime(DateTime now) {
     return ContactBase.cloneContactProjectedAtTime(this, now);
   }
 
@@ -69,12 +72,12 @@ public class ContactResource extends ContactBase implements ForeignKeyedEppResou
     return new Builder(clone(this));
   }
 
-  /** A builder for constructing {@link ContactResource}, since it is immutable. */
-  public static class Builder extends ContactBase.Builder<ContactResource, Builder> {
+  /** A builder for constructing {@link Contact}, since it is immutable. */
+  public static class Builder extends ContactBase.Builder<Contact, Builder> {
 
     public Builder() {}
 
-    private Builder(ContactResource instance) {
+    private Builder(Contact instance) {
       super(instance);
     }
 

--- a/core/src/main/java/google/registry/model/contact/ContactBase.java
+++ b/core/src/main/java/google/registry/model/contact/ContactBase.java
@@ -67,7 +67,7 @@ public class ContactBase extends EppResource implements ResourceWithTransferData
 
   /**
    * Localized postal info for the contact. All contained values must be representable in the 7-bit
-   * US-ASCII character set. Personal info; cleared by {@link ContactResource.Builder#wipeOut}.
+   * US-ASCII character set. Personal info; cleared by {@link Contact.Builder#wipeOut}.
    */
   @Ignore
   @Embedded
@@ -95,7 +95,7 @@ public class ContactBase extends EppResource implements ResourceWithTransferData
 
   /**
    * Internationalized postal info for the contact. Personal info; cleared by {@link
-   * ContactResource.Builder#wipeOut}.
+   * Contact.Builder#wipeOut}.
    */
   @Ignore
   @Embedded
@@ -124,11 +124,11 @@ public class ContactBase extends EppResource implements ResourceWithTransferData
   /**
    * Contact name used for name searches. This is set automatically to be the internationalized
    * postal name, or if null, the localized postal name, or if that is null as well, null. Personal
-   * info; cleared by {@link ContactResource.Builder#wipeOut}.
+   * info; cleared by {@link Contact.Builder#wipeOut}.
    */
   @Index String searchName;
 
-  /** Contact’s voice number. Personal info; cleared by {@link ContactResource.Builder#wipeOut}. */
+  /** Contact’s voice number. Personal info; cleared by {@link Contact.Builder#wipeOut}. */
   @IgnoreSave(IfNull.class)
   @Embedded
   @AttributeOverrides({
@@ -137,7 +137,7 @@ public class ContactBase extends EppResource implements ResourceWithTransferData
   })
   ContactPhoneNumber voice;
 
-  /** Contact’s fax number. Personal info; cleared by {@link ContactResource.Builder#wipeOut}. */
+  /** Contact’s fax number. Personal info; cleared by {@link Contact.Builder#wipeOut}. */
   @IgnoreSave(IfNull.class)
   @Embedded
   @AttributeOverrides({
@@ -146,7 +146,7 @@ public class ContactBase extends EppResource implements ResourceWithTransferData
   })
   ContactPhoneNumber fax;
 
-  /** Contact’s email address. Personal info; cleared by {@link ContactResource.Builder#wipeOut}. */
+  /** Contact’s email address. Personal info; cleared by {@link Contact.Builder#wipeOut}. */
   @IgnoreSave(IfNull.class)
   String email;
 
@@ -188,7 +188,7 @@ public class ContactBase extends EppResource implements ResourceWithTransferData
   public VKey<? extends ContactBase> createVKey() {
     throw new UnsupportedOperationException(
         "ContactBase is not an actual persisted entity you can create a key to;"
-            + " use ContactResource instead");
+            + " use Contact instead");
   }
 
   @OnLoad
@@ -292,7 +292,7 @@ public class ContactBase extends EppResource implements ResourceWithTransferData
     return new Builder<>(clone(this));
   }
 
-  /** A builder for constructing {@link ContactResource}, since it is immutable. */
+  /** A builder for constructing {@link Contact}, since it is immutable. */
   public static class Builder<T extends ContactBase, B extends Builder<T, B>>
       extends EppResource.Builder<T, B> implements BuilderWithTransferData<ContactTransferData, B> {
 

--- a/core/src/main/java/google/registry/model/contact/ContactCommand.java
+++ b/core/src/main/java/google/registry/model/contact/ContactCommand.java
@@ -34,13 +34,13 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-/** A collection of {@link ContactResource} commands. */
+/** A collection of {@link Contact} commands. */
 public class ContactCommand {
 
   /** The fields on "chgType" from <a href="http://tools.ietf.org/html/rfc5733">RFC5733</a>. */
   @XmlTransient
   public static class ContactCreateOrChange extends ImmutableObject
-      implements ResourceCreateOrChange<ContactResource.Builder> {
+      implements ResourceCreateOrChange<Contact.Builder> {
 
     /** Postal info for the contact. */
     List<PostalInfo> postalInfo;
@@ -111,13 +111,13 @@ public class ContactCommand {
   }
 
   /**
-   * A create command for a {@link ContactResource}, mapping "createType" from <a
+   * A create command for a {@link Contact}, mapping "createType" from <a
    * href="http://tools.ietf.org/html/rfc5733">RFC5733</a>}.
    */
   @XmlType(propOrder = {"contactId", "postalInfo", "voice", "fax", "email", "authInfo", "disclose"})
   @XmlRootElement
   public static class Create extends ContactCreateOrChange
-      implements SingleResourceCommand, ResourceCreateOrChange<ContactResource.Builder> {
+      implements SingleResourceCommand, ResourceCreateOrChange<Contact.Builder> {
     /**
      * Unique identifier for this contact.
      *
@@ -139,29 +139,29 @@ public class ContactCommand {
     }
   }
 
-  /** A delete command for a {@link ContactResource}. */
+  /** A delete command for a {@link Contact}. */
   @XmlRootElement
   public static class Delete extends AbstractSingleResourceCommand {}
 
-  /** An info request for a {@link ContactResource}. */
+  /** An info request for a {@link Contact}. */
   @XmlRootElement
   @XmlType(propOrder = {"targetId", "authInfo"})
   public static class Info extends AbstractContactAuthCommand {}
 
-  /** A check request for {@link ContactResource}. */
+  /** A check request for {@link Contact}. */
   @XmlRootElement
   public static class Check extends ResourceCheck {}
 
-  /** A transfer operation for a {@link ContactResource}. */
+  /** A transfer operation for a {@link Contact}. */
   @XmlRootElement
   @XmlType(propOrder = {"targetId", "authInfo"})
   public static class Transfer extends AbstractContactAuthCommand {}
 
-  /** An update to a {@link ContactResource}. */
+  /** An update to a {@link Contact}. */
   @XmlRootElement
   @XmlType(propOrder = {"targetId", "innerAdd", "innerRemove", "innerChange"})
   public static class Update
-      extends ResourceUpdate<Update.AddRemove, ContactResource.Builder, Update.Change> {
+      extends ResourceUpdate<Update.AddRemove, Contact.Builder, Update.Change> {
 
     @XmlElement(name = "chg")
     protected Change innerChange;

--- a/core/src/main/java/google/registry/model/contact/ContactHistory.java
+++ b/core/src/main/java/google/registry/model/contact/ContactHistory.java
@@ -58,7 +58,7 @@ import javax.persistence.PostLoad;
 @IdClass(ContactHistoryId.class)
 public class ContactHistory extends HistoryEntry implements UnsafeSerializable {
 
-  // Store ContactBase instead of ContactResource so we don't pick up its @Id
+  // Store ContactBase instead of Contact so we don't pick up its @Id
   // Nullable for the sake of pre-Registry-3.0 history objects
   @DoNotCompare @Nullable ContactBase contactBase;
 
@@ -73,7 +73,7 @@ public class ContactHistory extends HistoryEntry implements UnsafeSerializable {
   /** This method is private because it is only used by Hibernate. */
   @SuppressWarnings("unused")
   private void setContactRepoId(String contactRepoId) {
-    parent = Key.create(ContactResource.class, contactRepoId);
+    parent = Key.create(Contact.class, contactRepoId);
   }
 
   @Id
@@ -98,9 +98,9 @@ public class ContactHistory extends HistoryEntry implements UnsafeSerializable {
     return Optional.ofNullable(contactBase);
   }
 
-  /** The key to the {@link ContactResource} this is based off of. */
-  public VKey<ContactResource> getParentVKey() {
-    return VKey.create(ContactResource.class, getContactRepoId());
+  /** The key to the {@link Contact} this is based off of. */
+  public VKey<Contact> getParentVKey() {
+    return VKey.create(Contact.class, getContactRepoId());
   }
 
   /** Creates a {@link VKey} instance for this entity. */
@@ -112,8 +112,7 @@ public class ContactHistory extends HistoryEntry implements UnsafeSerializable {
 
   @Override
   public Optional<? extends EppResource> getResourceAtPointInTime() {
-    return getContactBase()
-        .map(contactBase -> new ContactResource.Builder().copyFrom(contactBase).build());
+    return getContactBase().map(contactBase -> new Contact.Builder().copyFrom(contactBase).build());
   }
 
   @PostLoad
@@ -210,7 +209,7 @@ public class ContactHistory extends HistoryEntry implements UnsafeSerializable {
     }
 
     public Builder setContactRepoId(String contactRepoId) {
-      getInstance().parent = Key.create(ContactResource.class, contactRepoId);
+      getInstance().parent = Key.create(Contact.class, contactRepoId);
       return this;
     }
 

--- a/core/src/main/java/google/registry/model/contact/ContactPhoneNumber.java
+++ b/core/src/main/java/google/registry/model/contact/ContactPhoneNumber.java
@@ -21,11 +21,11 @@ import javax.persistence.Embeddable;
 /**
  * EPP Contact Phone Number
  *
- * <p>This class is embedded inside a {@link ContactResource} hold the phone number of an EPP
- * contact. The fields are all defined in the parent class {@link PhoneNumber}, but the subclass is
- * still necessary to pick up the contact namespace.
+ * <p>This class is embedded inside a {@link Contact} hold the phone number of an EPP contact. The
+ * fields are all defined in the parent class {@link PhoneNumber}, but the subclass is still
+ * necessary to pick up the contact namespace.
  *
- * @see ContactResource
+ * @see Contact
  */
 @Embed
 @Embeddable

--- a/core/src/main/java/google/registry/model/domain/DesignatedContact.java
+++ b/core/src/main/java/google/registry/model/domain/DesignatedContact.java
@@ -22,7 +22,7 @@ import com.googlecode.objectify.annotation.Ignore;
 import com.googlecode.objectify.annotation.Index;
 import google.registry.model.ImmutableObject;
 import google.registry.model.UnsafeSerializable;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.persistence.VKey;
 import javax.persistence.Embeddable;
 import javax.xml.bind.annotation.XmlEnumValue;
@@ -64,7 +64,7 @@ public class DesignatedContact extends ImmutableObject implements UnsafeSerializ
     REGISTRANT
   }
 
-  public static DesignatedContact create(Type type, VKey<ContactResource> contact) {
+  public static DesignatedContact create(Type type, VKey<Contact> contact) {
     DesignatedContact instance = new DesignatedContact();
     instance.type = type;
     instance.contactVKey = checkArgumentNotNull(contact, "Must specify contact key");
@@ -74,14 +74,14 @@ public class DesignatedContact extends ImmutableObject implements UnsafeSerializ
 
   Type type;
 
-  @Index Key<ContactResource> contact;
-  @Ignore VKey<ContactResource> contactVKey;
+  @Index Key<Contact> contact;
+  @Ignore VKey<Contact> contactVKey;
 
   public Type getType() {
     return type;
   }
 
-  public VKey<ContactResource> getContactKey() {
+  public VKey<Contact> getContactKey() {
     return contactVKey;
   }
 

--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -52,7 +52,7 @@ import google.registry.model.EppResource;
 import google.registry.model.EppResource.ResourceWithTransferData;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.common.EntityGroupRoot;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.launch.LaunchNotice;
 import google.registry.model.domain.rgp.GracePeriodStatus;
 import google.registry.model.domain.secdns.DelegationSignerData;
@@ -132,11 +132,11 @@ public class DomainBase extends EppResource
   @EmptySetToNull @Index @Transient Set<VKey<Host>> nsHosts;
 
   /** Contacts. */
-  VKey<ContactResource> adminContact;
+  VKey<Contact> adminContact;
 
-  VKey<ContactResource> billingContact;
-  VKey<ContactResource> techContact;
-  VKey<ContactResource> registrantContact;
+  VKey<Contact> billingContact;
+  VKey<Contact> techContact;
+  VKey<Contact> registrantContact;
 
   /** Authorization info (aka transfer secret) of the domain. */
   @Embedded
@@ -602,19 +602,19 @@ public class DomainBase extends EppResource
   }
 
   /** A key to the registrant who registered this domain. */
-  public VKey<ContactResource> getRegistrant() {
+  public VKey<Contact> getRegistrant() {
     return registrantContact;
   }
 
-  public VKey<ContactResource> getAdminContact() {
+  public VKey<Contact> getAdminContact() {
     return adminContact;
   }
 
-  public VKey<ContactResource> getBillingContact() {
+  public VKey<Contact> getBillingContact() {
     return billingContact;
   }
 
-  public VKey<ContactResource> getTechContact() {
+  public VKey<Contact> getTechContact() {
     return techContact;
   }
 
@@ -628,7 +628,7 @@ public class DomainBase extends EppResource
   }
 
   /** Returns all referenced contacts from this domain. */
-  public ImmutableSet<VKey<ContactResource>> getReferencedContacts() {
+  public ImmutableSet<VKey<Contact>> getReferencedContacts() {
     return nullToEmptyImmutableCopy(getAllContacts(true)).stream()
         .map(DesignatedContact::getContactKey)
         .filter(Objects::nonNull)
@@ -771,7 +771,7 @@ public class DomainBase extends EppResource
       return thisCastToDerived();
     }
 
-    public B setRegistrant(VKey<ContactResource> registrant) {
+    public B setRegistrant(VKey<Contact> registrant) {
       // Set the registrant field specifically.
       getInstance().registrantContact = registrant;
       return thisCastToDerived();

--- a/core/src/main/java/google/registry/model/domain/DomainCommand.java
+++ b/core/src/main/java/google/registry/model/domain/DomainCommand.java
@@ -32,7 +32,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import google.registry.model.EppResource;
 import google.registry.model.ImmutableObject;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.eppinput.ResourceCommand.AbstractSingleResourceCommand;
 import google.registry.model.eppinput.ResourceCommand.ResourceCheck;
 import google.registry.model.eppinput.ResourceCommand.ResourceCreateOrChange;
@@ -80,7 +80,7 @@ public class DomainCommand {
     String registrantContactId;
 
     /** A resolved key to the registrant who registered this domain. */
-    @XmlTransient VKey<ContactResource> registrant;
+    @XmlTransient VKey<Contact> registrant;
 
     /** Authorization info (aka transfer secret) of the domain. */
     DomainAuthInfo authInfo;
@@ -90,7 +90,7 @@ public class DomainCommand {
     }
 
     @Nullable
-    public VKey<ContactResource> getRegistrant() {
+    public VKey<Contact> getRegistrant() {
       return registrant;
     }
 
@@ -391,7 +391,7 @@ public class DomainCommand {
                 ? null
                 : getOnlyElement(
                     loadByForeignKeysCached(
-                            ImmutableSet.of(clone.registrantContactId), ContactResource.class, now)
+                            ImmutableSet.of(clone.registrantContactId), Contact.class, now)
                         .values());
         return clone;
       }
@@ -431,8 +431,8 @@ public class DomainCommand {
     for (ForeignKeyedDesignatedContact contact : contacts) {
       foreignKeys.add(contact.contactId);
     }
-    ImmutableMap<String, VKey<ContactResource>> loadedContacts =
-        loadByForeignKeysCached(foreignKeys.build(), ContactResource.class, now);
+    ImmutableMap<String, VKey<Contact>> loadedContacts =
+        loadByForeignKeysCached(foreignKeys.build(), Contact.class, now);
     ImmutableSet.Builder<DesignatedContact> linkedContacts = new ImmutableSet.Builder<>();
     for (ForeignKeyedDesignatedContact contact : contacts) {
       linkedContacts.add(

--- a/core/src/main/java/google/registry/model/eppcommon/StatusValue.java
+++ b/core/src/main/java/google/registry/model/eppcommon/StatusValue.java
@@ -20,8 +20,8 @@ import static com.google.common.base.Strings.nullToEmpty;
 
 import com.google.common.collect.ImmutableSet;
 import google.registry.model.EppResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactBase;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.host.Host;
@@ -130,12 +130,12 @@ public enum StatusValue implements EppEnum {
   /** Enum to help clearly list which resource types a status value is allowed to be present on. */
   private enum AllowedOn {
     ALL(
+        Contact.class,
         ContactBase.class,
-        ContactResource.class,
-        DomainBase.class,
         Domain.class,
-        HostBase.class,
-        Host.class),
+        DomainBase.class,
+        Host.class,
+        HostBase.class),
     NONE,
     DOMAINS(DomainBase.class, Domain.class);
 

--- a/core/src/main/java/google/registry/model/index/ForeignKeyIndex.java
+++ b/core/src/main/java/google/registry/model/index/ForeignKeyIndex.java
@@ -47,7 +47,7 @@ import google.registry.model.CacheUtils.AppEngineEnvironmentCacheLoader;
 import google.registry.model.EppResource;
 import google.registry.model.annotations.DeleteAfterMigration;
 import google.registry.model.annotations.ReportedOn;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.host.Host;
 import google.registry.persistence.VKey;
@@ -70,10 +70,10 @@ import org.joda.time.DateTime;
 @DeleteAfterMigration
 public abstract class ForeignKeyIndex<E extends EppResource> extends BackupGroupRoot {
 
-  /** The {@link ForeignKeyIndex} type for {@link ContactResource} entities. */
+  /** The {@link ForeignKeyIndex} type for {@link Contact} entities. */
   @ReportedOn
   @Entity
-  public static class ForeignKeyContactIndex extends ForeignKeyIndex<ContactResource> {}
+  public static class ForeignKeyContactIndex extends ForeignKeyIndex<Contact> {}
 
   /** The {@link ForeignKeyIndex} type for {@link Domain} entities. */
   @ReportedOn
@@ -89,14 +89,14 @@ public abstract class ForeignKeyIndex<E extends EppResource> extends BackupGroup
           Class<? extends EppResource>, Class<? extends ForeignKeyIndex<?>>>
       RESOURCE_CLASS_TO_FKI_CLASS =
           ImmutableBiMap.of(
-              ContactResource.class, ForeignKeyContactIndex.class,
+              Contact.class, ForeignKeyContactIndex.class,
               Domain.class, ForeignKeyDomainIndex.class,
               Host.class, ForeignKeyHostIndex.class);
 
   private static final ImmutableMap<Class<? extends EppResource>, String>
       RESOURCE_CLASS_TO_FKI_PROPERTY =
           ImmutableMap.of(
-              ContactResource.class, "contactId",
+              Contact.class, "contactId",
               Domain.class, "fullyQualifiedDomainName",
               Host.class, "fullyQualifiedHostName");
 

--- a/core/src/main/java/google/registry/model/package-info.java
+++ b/core/src/main/java/google/registry/model/package-info.java
@@ -34,7 +34,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  *
  * <p>All first class entities are represented as a resource class - {@link
  * google.registry.model.domain.Domain}, {@link google.registry.model.host.Host}, {@link
- * google.registry.model.contact.ContactResource}, and {@link
+ * google.registry.model.contact.Contact}, and {@link
  * google.registry.model.registrar.Registrar}. Resource objects are written in a single shared
  * entity group per TLD. All commands that operate on those entities are grouped in a "Command"
  * class- {@link google.registry.model.domain.DomainCommand}, {@link

--- a/core/src/main/java/google/registry/model/poll/PollMessage.java
+++ b/core/src/main/java/google/registry/model/poll/PollMessage.java
@@ -26,9 +26,9 @@ import google.registry.model.ImmutableObject;
 import google.registry.model.UnsafeSerializable;
 import google.registry.model.annotations.ExternalMessagingName;
 import google.registry.model.annotations.OfyIdAllocation;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactHistory;
 import google.registry.model.contact.ContactHistory.ContactHistoryId;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.DomainHistory.DomainHistoryId;
@@ -95,7 +95,7 @@ public abstract class PollMessage extends ImmutableObject
   /** Indicates the type of entity the poll message is for. */
   public enum Type {
     DOMAIN(1L, Domain.class),
-    CONTACT(2L, ContactResource.class),
+    CONTACT(2L, Contact.class),
     HOST(3L, Host.class);
 
     private final long id;
@@ -179,7 +179,7 @@ public abstract class PollMessage extends ImmutableObject
   /**
    * Returns the contact repo id.
    *
-   * <p>This may only be used on a ContactResource poll event.
+   * <p>This may only be used on a {@link Contact} poll event.
    */
   public String getContactRepoId() {
     checkArgument(getType() == Type.CONTACT);

--- a/core/src/main/java/google/registry/model/reporting/HistoryEntry.java
+++ b/core/src/main/java/google/registry/model/reporting/HistoryEntry.java
@@ -34,10 +34,10 @@ import google.registry.model.EppResource;
 import google.registry.model.ImmutableObject;
 import google.registry.model.UnsafeSerializable;
 import google.registry.model.annotations.ReportedOn;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactBase;
 import google.registry.model.contact.ContactHistory;
 import google.registry.model.contact.ContactHistory.ContactHistoryId;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.domain.DomainHistory;
@@ -392,7 +392,7 @@ public class HistoryEntry extends ImmutableObject implements Buildable, UnsafeSe
     } else if (parentKind.equals(getKind(Host.class))) {
       resultEntity =
           new HostHistory.Builder().copyFrom(this).setHostRepoId(parent.getName()).build();
-    } else if (parentKind.equals(getKind(ContactResource.class))) {
+    } else if (parentKind.equals(getKind(Contact.class))) {
       resultEntity =
           new ContactHistory.Builder().copyFrom(this).setContactRepoId(parent.getName()).build();
     } else {
@@ -418,7 +418,7 @@ public class HistoryEntry extends ImmutableObject implements Buildable, UnsafeSe
           HostHistory.class,
           new HostHistoryId(repoId, id),
           Key.create(parent, HostHistory.class, id));
-    } else if (parentKind.equals(getKind(ContactResource.class))) {
+    } else if (parentKind.equals(getKind(Contact.class))) {
       return VKey.create(
           ContactHistory.class,
           new ContactHistoryId(repoId, id),

--- a/core/src/main/java/google/registry/model/reporting/HistoryEntryDao.java
+++ b/core/src/main/java/google/registry/model/reporting/HistoryEntryDao.java
@@ -25,8 +25,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
 import google.registry.model.EppResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactHistory;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.host.Host;
@@ -51,7 +51,7 @@ public class HistoryEntryDao {
   public static ImmutableMap<Class<? extends EppResource>, Class<? extends HistoryEntry>>
       RESOURCE_TYPES_TO_HISTORY_TYPES =
           ImmutableMap.of(
-              ContactResource.class,
+              Contact.class,
               ContactHistory.class,
               Domain.class,
               DomainHistory.class,

--- a/core/src/main/java/google/registry/model/translators/EppHistoryVKeyTranslatorFactory.java
+++ b/core/src/main/java/google/registry/model/translators/EppHistoryVKeyTranslatorFactory.java
@@ -40,7 +40,7 @@ public class EppHistoryVKeyTranslatorFactory
   // one dedicated VKey class, e.g. DomainHistoryVKey, for each such kind of entity, and we need
   // a way to map the raw Datastore key to its VKey class. So, we use the kind path as the key of
   // the map, and the kind path is created by concatenating all the kind strings in a raw Datastore
-  // key, e.g. the map key for ContactPollMessageVKey is "ContactResource/HistoryEntry/PollMessage".
+  // key, e.g. the map key for ContactPollMessageVKey is "Contact/HistoryEntry/PollMessage".
   @VisibleForTesting
   static final ImmutableMap<String, Class<? extends EppHistoryVKey>> kindPathToVKeyClass =
       ImmutableSet.of(DomainHistoryVKey.class).stream()

--- a/core/src/main/java/google/registry/rdap/RdapEntityAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapEntityAction.java
@@ -23,7 +23,7 @@ import static google.registry.request.Action.Method.HEAD;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Longs;
 import com.google.re2j.Pattern;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.registrar.Registrar;
 import google.registry.persistence.VKey;
 import google.registry.rdap.RdapJsonFormatter.OutputDataType;
@@ -69,14 +69,14 @@ public class RdapEntityAction extends RdapActionBase {
     // RDAP Technical Implementation Guide 2.3.1 - MUST support contact entity lookup using the
     // handle
     if (ROID_PATTERN.matcher(pathSearchString).matches()) {
-      VKey<ContactResource> contactVKey = VKey.create(ContactResource.class, pathSearchString);
-      Optional<ContactResource> contactResource =
+      VKey<Contact> contactVKey = VKey.create(Contact.class, pathSearchString);
+      Optional<Contact> contact =
           replicaJpaTm().transact(() -> replicaJpaTm().loadByKeyIfPresent(contactVKey));
       // As per Andy Newton on the regext mailing list, contacts by themselves have no role, since
       // they are global, and might have different roles for different domains.
-      if (contactResource.isPresent() && isAuthorized(contactResource.get())) {
+      if (contact.isPresent() && isAuthorized(contact.get())) {
         return rdapJsonFormatter.createRdapContactEntity(
-            contactResource.get(), ImmutableSet.of(), OutputDataType.FULL);
+            contact.get(), ImmutableSet.of(), OutputDataType.FULL);
       }
     }
 

--- a/core/src/main/java/google/registry/rde/ContactToXjcConverter.java
+++ b/core/src/main/java/google/registry/rde/ContactToXjcConverter.java
@@ -16,9 +16,9 @@ package google.registry.rde;
 
 import static google.registry.util.XmlEnumUtils.enumToXml;
 
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactAddress;
 import google.registry.model.contact.ContactPhoneNumber;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.contact.Disclose;
 import google.registry.model.contact.Disclose.PostalInfoChoice;
 import google.registry.model.contact.PostalInfo;
@@ -39,16 +39,16 @@ import google.registry.xjc.rdecontact.XjcRdeContactTransferDataType;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-/** Utility class that turns {@link ContactResource} as {@link XjcRdeContactElement}. */
-final class ContactResourceToXjcConverter {
+/** Utility class that turns {@link Contact} as {@link XjcRdeContactElement}. */
+final class ContactToXjcConverter {
 
-  /** Converts {@link ContactResource} to {@link XjcRdeContactElement}. */
-  static XjcRdeContactElement convert(ContactResource host) {
+  /** Converts {@link Contact} to {@link XjcRdeContactElement}. */
+  static XjcRdeContactElement convert(Contact host) {
     return new XjcRdeContactElement(convertContact(host));
   }
 
-  /** Converts {@link ContactResource} to {@link XjcRdeContact}. */
-  static XjcRdeContact convertContact(ContactResource model) {
+  /** Converts {@link Contact} to {@link XjcRdeContact}. */
+  static XjcRdeContact convertContact(Contact model) {
     XjcRdeContact bean = new XjcRdeContact();
     bean.setRoid(model.getRepoId());
     for (StatusValue status : model.getStatusValues()) {
@@ -188,5 +188,5 @@ final class ContactResourceToXjcConverter {
     return bean;
   }
 
-  private ContactResourceToXjcConverter() {}
+  private ContactToXjcConverter() {}
 }

--- a/core/src/main/java/google/registry/rde/DomainToXjcConverter.java
+++ b/core/src/main/java/google/registry/rde/DomainToXjcConverter.java
@@ -21,7 +21,7 @@ import com.google.common.base.Ascii;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.FluentLogger;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.DesignatedContact;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.rgp.GracePeriodStatus;
@@ -168,11 +168,11 @@ final class DomainToXjcConverter {
         // o  An OPTIONAL <registrant> element that contain the identifier for
         //    the human or organizational social information object associated
         //    as the holder of the domain name object.
-        VKey<ContactResource> registrant = model.getRegistrant();
+        VKey<Contact> registrant = model.getRegistrant();
         if (registrant == null) {
           logger.atWarning().log("Domain %s has no registrant contact.", domainName);
         } else {
-          ContactResource registrantContact = tm().transact(() -> tm().loadByKey(registrant));
+          Contact registrantContact = tm().transact(() -> tm().loadByKey(registrant));
           checkState(
               registrantContact != null,
               "Registrant contact %s on domain %s does not exist",
@@ -304,7 +304,7 @@ final class DomainToXjcConverter {
         "Contact key for type %s is null on domain %s",
         model.getType(),
         domainName);
-    ContactResource contact = tm().transact(() -> tm().loadByKey(model.getContactKey()));
+    Contact contact = tm().transact(() -> tm().loadByKey(model.getContactKey()));
     checkState(
         contact != null,
         "Contact %s on domain %s does not exist",

--- a/core/src/main/java/google/registry/rde/RdeFragmenter.java
+++ b/core/src/main/java/google/registry/rde/RdeFragmenter.java
@@ -20,7 +20,7 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.EppResource;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.host.Host;
 import google.registry.model.rde.RdeMode;
@@ -66,8 +66,8 @@ public class RdeFragmenter {
       result = Optional.of(marshaller.marshalDomain((Domain) resource, mode));
       cache.put(WatermarkModePair.create(watermark, mode), result);
       return result;
-    } else if (resource instanceof ContactResource) {
-      result = Optional.of(marshaller.marshalContact((ContactResource) resource));
+    } else if (resource instanceof Contact) {
+      result = Optional.of(marshaller.marshalContact((Contact) resource));
       cache.put(WatermarkModePair.create(watermark, RdeMode.FULL), result);
       cache.put(WatermarkModePair.create(watermark, RdeMode.THIN), result);
       return result;

--- a/core/src/main/java/google/registry/rde/RdeMarshaller.java
+++ b/core/src/main/java/google/registry/rde/RdeMarshaller.java
@@ -20,7 +20,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.flogger.FluentLogger;
 import com.googlecode.objectify.Key;
 import google.registry.model.ImmutableObject;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.host.Host;
 import google.registry.model.rde.RdeMode;
@@ -117,10 +117,10 @@ public final class RdeMarshaller implements Serializable {
     }
   }
 
-  /** Turns {@link ContactResource} object into an XML fragment. */
-  public DepositFragment marshalContact(ContactResource contact) {
-    return marshalResource(RdeResourceType.CONTACT, contact,
-        ContactResourceToXjcConverter.convert(contact));
+  /** Turns {@link Contact} object into an XML fragment. */
+  public DepositFragment marshalContact(Contact contact) {
+    return marshalResource(
+        RdeResourceType.CONTACT, contact, ContactToXjcConverter.convert(contact));
   }
 
   /** Turns {@link Domain} object into an XML fragment. */

--- a/core/src/main/java/google/registry/rde/RdeStagingAction.java
+++ b/core/src/main/java/google/registry/rde/RdeStagingAction.java
@@ -45,7 +45,7 @@ import google.registry.gcs.GcsUtils;
 import google.registry.keyring.api.KeyModule.Key;
 import google.registry.model.common.Cursor;
 import google.registry.model.common.Cursor.CursorType;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.host.Host;
 import google.registry.model.index.EppResourceIndex;
@@ -82,8 +82,8 @@ import org.joda.time.Duration;
  * type and loads the embedded resource from it, which is then projected to watermark time to
  * account for things like pending transfer.
  *
- * <p>Only {@link ContactResource}s and {@link Host}s that are referenced by an included {@link
- * Domain} will be included in the corresponding pending deposit.
+ * <p>Only {@link Contact}s and {@link Host}s that are referenced by an included {@link Domain} will
+ * be included in the corresponding pending deposit.
  *
  * <p>{@link Registrar} entities, both active and inactive, are included in all deposits. They are
  * not rewinded point-in-time.

--- a/core/src/main/java/google/registry/tools/CommandUtilities.java
+++ b/core/src/main/java/google/registry/tools/CommandUtilities.java
@@ -19,7 +19,7 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.base.Ascii;
 import com.google.common.base.Strings;
 import google.registry.model.EppResource;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.host.Host;
 import google.registry.model.index.ForeignKeyIndex;
@@ -31,7 +31,7 @@ class CommandUtilities {
 
   /** A useful parameter enum for commands that operate on {@link EppResource} objects. */
   public enum ResourceType {
-    CONTACT(ContactResource.class),
+    CONTACT(Contact.class),
     HOST(Host.class),
     DOMAIN(Domain.class);
 

--- a/core/src/main/java/google/registry/tools/GetContactCommand.java
+++ b/core/src/main/java/google/registry/tools/GetContactCommand.java
@@ -18,7 +18,7 @@ import static google.registry.model.EppResourceUtils.loadByForeignKey;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import java.util.List;
 
 /** Command to show one or more contacts. */
@@ -34,7 +34,7 @@ final class GetContactCommand extends GetEppResourceCommand {
   public void runAndPrint() {
     for (String contactId : mainParameters) {
       printResource(
-          "Contact", contactId, loadByForeignKey(ContactResource.class, contactId, readTimestamp));
+          "Contact", contactId, loadByForeignKey(Contact.class, contactId, readTimestamp));
     }
   }
 }

--- a/core/src/main/java/google/registry/tools/params/EppResourceTypeParameter.java
+++ b/core/src/main/java/google/registry/tools/params/EppResourceTypeParameter.java
@@ -15,13 +15,13 @@
 package google.registry.tools.params;
 
 import google.registry.model.EppResource;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.host.Host;
 
 /** Enum to make it easy for a command to accept a flag that specifies an EppResource subclass. */
 public enum EppResourceTypeParameter {
-  CONTACT(ContactResource.class),
+  CONTACT(Contact.class),
   DOMAIN(Domain.class),
   HOST(Host.class);
 

--- a/core/src/main/resources/META-INF/persistence.xml
+++ b/core/src/main/resources/META-INF/persistence.xml
@@ -45,7 +45,7 @@
     <class>google.registry.model.common.DatabaseMigrationStateSchedule</class>
     <class>google.registry.model.console.User</class>
     <class>google.registry.model.contact.ContactHistory</class>
-    <class>google.registry.model.contact.ContactResource</class>
+    <class>google.registry.model.contact.Contact</class>
     <class>google.registry.model.domain.Domain</class>
     <class>google.registry.model.domain.DomainHistory</class>
     <class>google.registry.model.domain.GracePeriod</class>
@@ -104,7 +104,7 @@
     <class>google.registry.model.billing.VKeyConverter_Cancellation</class>
     <class>google.registry.model.billing.VKeyConverter_OneTime</class>
     <class>google.registry.model.billing.VKeyConverter_Recurring</class>
-    <class>google.registry.model.contact.VKeyConverter_ContactResource</class>
+    <class>google.registry.model.contact.VKeyConverter_Contact</class>
     <class>google.registry.model.domain.VKeyConverter_Domain</class>
     <class>google.registry.model.domain.token.VKeyConverter_AllocationToken</class>
     <class>google.registry.model.host.VKeyConverter_Host</class>

--- a/core/src/test/java/google/registry/batch/AsyncTaskEnqueuerTest.java
+++ b/core/src/test/java/google/registry/batch/AsyncTaskEnqueuerTest.java
@@ -27,7 +27,7 @@ import static org.joda.time.Duration.standardSeconds;
 
 import com.google.cloud.tasks.v2.HttpMethod;
 import com.google.common.collect.ImmutableSortedSet;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.testing.AppEngineExtension;
 import google.registry.testing.CloudTasksHelper;
 import google.registry.testing.CloudTasksHelper.TaskMatcher;
@@ -80,7 +80,7 @@ public class AsyncTaskEnqueuerTest {
 
   @Test
   void test_enqueueAsyncResave_success() {
-    ContactResource contact = persistActiveContact("jd23456");
+    Contact contact = persistActiveContact("jd23456");
     asyncTaskEnqueuer.enqueueAsyncResave(
         contact.createVKey(), clock.nowUtc(), clock.nowUtc().plusDays(5));
     cloudTasksHelper.assertTasksEnqueued(
@@ -97,7 +97,7 @@ public class AsyncTaskEnqueuerTest {
 
   @Test
   void test_enqueueAsyncResave_multipleResaves() {
-    ContactResource contact = persistActiveContact("jd23456");
+    Contact contact = persistActiveContact("jd23456");
     DateTime now = clock.nowUtc();
     asyncTaskEnqueuer.enqueueAsyncResave(
         contact.createVKey(),
@@ -119,7 +119,7 @@ public class AsyncTaskEnqueuerTest {
   @MockitoSettings(strictness = Strictness.LENIENT)
   @Test
   void test_enqueueAsyncResave_ignoresTasksTooFarIntoFuture() {
-    ContactResource contact = persistActiveContact("jd23456");
+    Contact contact = persistActiveContact("jd23456");
     asyncTaskEnqueuer.enqueueAsyncResave(
         contact.createVKey(), clock.nowUtc(), clock.nowUtc().plusDays(31));
     cloudTasksHelper.assertNoTasksEnqueued(QUEUE_ASYNC_ACTIONS);

--- a/core/src/test/java/google/registry/batch/WipeOutContactHistoryPiiActionTest.java
+++ b/core/src/test/java/google/registry/batch/WipeOutContactHistoryPiiActionTest.java
@@ -23,12 +23,12 @@ import static org.apache.http.HttpStatus.SC_OK;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactAddress;
 import google.registry.model.contact.ContactAuthInfo;
 import google.registry.model.contact.ContactBase;
 import google.registry.model.contact.ContactHistory;
 import google.registry.model.contact.ContactPhoneNumber;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.contact.Disclose;
 import google.registry.model.contact.PostalInfo;
 import google.registry.model.eppcommon.AuthInfo.PasswordAuth;
@@ -48,8 +48,8 @@ class WipeOutContactHistoryPiiActionTest {
 
   private static final int TEST_BATCH_SIZE = 20;
   private static final int MIN_MONTHS_BEFORE_WIPE_OUT = 18;
-  private static final ContactResource defaultContactResource =
-      new ContactResource.Builder()
+  private static final Contact DEFAULT_CONTACT =
+      new Contact.Builder()
           .setContactId("sh8013")
           .setRepoId("2FF-ROID")
           .setStatusValues(ImmutableSet.of(StatusValue.CLIENT_DELETE_PROHIBITED))
@@ -117,8 +117,7 @@ class WipeOutContactHistoryPiiActionTest {
   @Test
   void getAllHistoryEntitiesOlderThan_returnsAllPersistedEntities() {
     ImmutableList<ContactHistory> expectedToBeWipedOut =
-        persistLotsOfContactHistoryEntities(
-            20, MIN_MONTHS_BEFORE_WIPE_OUT + 1, 0, defaultContactResource);
+        persistLotsOfContactHistoryEntities(20, MIN_MONTHS_BEFORE_WIPE_OUT + 1, 0, DEFAULT_CONTACT);
     jpaTm()
         .transact(
             () ->
@@ -131,12 +130,10 @@ class WipeOutContactHistoryPiiActionTest {
   @Test
   void getAllHistoryEntitiesOlderThan_returnsOnlyOldEnoughPersistedEntities() {
     ImmutableList<ContactHistory> expectedToBeWipedOut =
-        persistLotsOfContactHistoryEntities(
-            19, MIN_MONTHS_BEFORE_WIPE_OUT + 2, 0, defaultContactResource);
+        persistLotsOfContactHistoryEntities(19, MIN_MONTHS_BEFORE_WIPE_OUT + 2, 0, DEFAULT_CONTACT);
 
     // persisted entities that should not be part of the actual result
-    persistLotsOfContactHistoryEntities(
-        15, 17, MIN_MONTHS_BEFORE_WIPE_OUT - 1, defaultContactResource);
+    persistLotsOfContactHistoryEntities(15, 17, MIN_MONTHS_BEFORE_WIPE_OUT - 1, DEFAULT_CONTACT);
 
     jpaTm()
         .transact(
@@ -179,7 +176,7 @@ class WipeOutContactHistoryPiiActionTest {
   void run_withOneBatchOfEntities_success() {
     int numOfMonthsFromNow = MIN_MONTHS_BEFORE_WIPE_OUT + 2;
     ImmutableList<ContactHistory> expectedToBeWipedOut =
-        persistLotsOfContactHistoryEntities(20, numOfMonthsFromNow, 0, defaultContactResource);
+        persistLotsOfContactHistoryEntities(20, numOfMonthsFromNow, 0, DEFAULT_CONTACT);
 
     // The query should return a stream of all persisted entities.
     assertThat(
@@ -216,7 +213,7 @@ class WipeOutContactHistoryPiiActionTest {
   void run_withMultipleBatches_numOfEntitiesAsNonMultipleOfBatchSize_success() {
     int numOfMonthsFromNow = MIN_MONTHS_BEFORE_WIPE_OUT + 2;
     ImmutableList<ContactHistory> expectedToBeWipedOut =
-        persistLotsOfContactHistoryEntities(56, numOfMonthsFromNow, 0, defaultContactResource);
+        persistLotsOfContactHistoryEntities(56, numOfMonthsFromNow, 0, DEFAULT_CONTACT);
 
     // The query should return a subset of all persisted data.
     assertThat(
@@ -253,7 +250,7 @@ class WipeOutContactHistoryPiiActionTest {
     int numOfMonthsFromNow = MIN_MONTHS_BEFORE_WIPE_OUT + 2;
     ImmutableList<ContactHistory> expectedToBeWipedOut =
         persistLotsOfContactHistoryEntities(
-            TEST_BATCH_SIZE * 2, numOfMonthsFromNow, 0, defaultContactResource);
+            TEST_BATCH_SIZE * 2, numOfMonthsFromNow, 0, DEFAULT_CONTACT);
 
     // The query should return a subset of all persisted data.
     assertThat(
@@ -302,7 +299,7 @@ class WipeOutContactHistoryPiiActionTest {
   void wipeOutContactHistoryData_wipesOutMultipleEntities() {
     int numOfMonthsFromNow = MIN_MONTHS_BEFORE_WIPE_OUT + 3;
     ImmutableList<ContactHistory> expectedToBeWipedOut =
-        persistLotsOfContactHistoryEntities(20, numOfMonthsFromNow, 0, defaultContactResource);
+        persistLotsOfContactHistoryEntities(20, numOfMonthsFromNow, 0, DEFAULT_CONTACT);
 
     assertAllEntitiesContainPii(DatabaseHelper.loadByEntitiesIfPresent(expectedToBeWipedOut));
 
@@ -319,7 +316,7 @@ class WipeOutContactHistoryPiiActionTest {
 
   /** persists a number of ContactHistory entities for load and query testing. */
   ImmutableList<ContactHistory> persistLotsOfContactHistoryEntities(
-      int numOfEntities, int minusMonths, int minusDays, ContactResource contact) {
+      int numOfEntities, int minusMonths, int minusDays, Contact contact) {
     ImmutableList.Builder<ContactHistory> expectedEntitesBuilder = new ImmutableList.Builder<>();
     for (int i = 0; i < numOfEntities; i++) {
       expectedEntitesBuilder.add(

--- a/core/src/test/java/google/registry/beam/rde/RdePipelineTest.java
+++ b/core/src/test/java/google/registry/beam/rde/RdePipelineTest.java
@@ -53,9 +53,9 @@ import google.registry.gcs.GcsUtils;
 import google.registry.keyring.api.PgpHelper;
 import google.registry.model.common.Cursor;
 import google.registry.model.common.Cursor.CursorType;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactBase;
 import google.registry.model.contact.ContactHistory;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.DesignatedContact;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainBase;
@@ -265,9 +265,9 @@ public class RdePipelineTest {
 
     // This contact is never referenced.
     persistContactHistory(persistActiveContact("contactX"));
-    ContactResource contact1 = persistActiveContact("contact1234");
+    Contact contact1 = persistActiveContact("contact1234");
     persistContactHistory(contact1);
-    ContactResource contact2 = persistActiveContact("contact456");
+    Contact contact2 = persistActiveContact("contact456");
     persistContactHistory(contact2);
 
     // This host is never referenced.
@@ -302,7 +302,7 @@ public class RdePipelineTest {
     persistDomainHistory(deletedDomain.asBuilder().setDeletionTime(clock.nowUtc()).build());
     kittyDomain = kittyDomain.asBuilder().setDomainName("cat.fun").build();
     persistDomainHistory(kittyDomain);
-    ContactResource contact3 = persistActiveContact("contact789");
+    Contact contact3 = persistActiveContact("contact789");
     persistContactHistory(contact3);
     // This is a subordinate domain in TLD .cat, which is not included in any pending deposit. But
     // it should still be included as a subordinate host in the pendign deposit for .soy.
@@ -329,7 +329,7 @@ public class RdePipelineTest {
     // resulting deposit fragments.
     clock.advanceBy(Duration.standardDays(2));
     persistDomainHistory(kittyDomain.asBuilder().setDeletionTime(clock.nowUtc()).build());
-    ContactResource futureContact = persistActiveContact("future-contact");
+    Contact futureContact = persistActiveContact("future-contact");
     persistContactHistory(futureContact);
     Host futureHost = persistActiveHost("ns1.future.tld");
     persistHostHistory(futureHost);

--- a/core/src/test/java/google/registry/beam/resave/ResaveAllEppResourcesPipelineTest.java
+++ b/core/src/test/java/google/registry/beam/resave/ResaveAllEppResourcesPipelineTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.verify;
 
 import google.registry.beam.TestPipelineExtension;
 import google.registry.model.EppResource;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.GracePeriod;
 import google.registry.model.eppcommon.StatusValue;
@@ -81,7 +81,7 @@ public class ResaveAllEppResourcesPipelineTest {
 
   @Test
   void testPipeline_unchangedEntity() {
-    ContactResource contact = persistActiveContact("test123");
+    Contact contact = persistActiveContact("test123");
     DateTime creationTime = contact.getUpdateTimestamp().getTimestamp();
     fakeClock.advanceOneMilli();
     assertThat(loadByEntity(contact).getUpdateTimestamp().getTimestamp()).isEqualTo(creationTime);
@@ -92,7 +92,7 @@ public class ResaveAllEppResourcesPipelineTest {
 
   @Test
   void testPipeline_fulfilledContactTransfer() {
-    ContactResource contact = persistActiveContact("test123");
+    Contact contact = persistActiveContact("test123");
     DateTime now = fakeClock.nowUtc();
     contact = persistContactWithPendingTransfer(contact, now, now.plusDays(5), now);
     fakeClock.advanceBy(Duration.standardDays(10));
@@ -154,7 +154,7 @@ public class ResaveAllEppResourcesPipelineTest {
   @Test
   void testPipeline_fastOnlySavesChanged() {
     DateTime now = fakeClock.nowUtc();
-    ContactResource contact = persistActiveContact("jd1234");
+    Contact contact = persistActiveContact("jd1234");
     persistDomainWithDependentResources("renewed", "tld", contact, now, now, now.plusYears(1));
     persistActiveDomain("nonrenewed.tld", now, now.plusYears(20));
     // Spy the transaction manager so we can be sure we're only saving the renewed domain
@@ -171,7 +171,7 @@ public class ResaveAllEppResourcesPipelineTest {
   void testPipeline_notFastResavesAll() {
     options.setFast(false);
     DateTime now = fakeClock.nowUtc();
-    ContactResource contact = persistActiveContact("jd1234");
+    Contact contact = persistActiveContact("jd1234");
     Domain renewed =
         persistDomainWithDependentResources("renewed", "tld", contact, now, now, now.plusYears(1));
     Domain nonRenewed =

--- a/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
+++ b/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
@@ -37,7 +37,7 @@ import com.google.common.truth.Correspondence.BinaryPredicate;
 import google.registry.beam.TestPipelineExtension;
 import google.registry.beam.spec11.SafeBrowsingTransforms.EvaluateSafeBrowsingFn;
 import google.registry.beam.spec11.SafeBrowsingTransformsTest.HttpResponder;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainAuthInfo;
 import google.registry.model.eppcommon.AuthInfo.PasswordAuth;
@@ -258,9 +258,9 @@ class Spec11PipelineTest {
     createTld("bank");
     createTld("dev");
 
-    ContactResource contact1 = persistActiveContact(registrar1.getRegistrarId());
-    ContactResource contact2 = persistActiveContact(registrar2.getRegistrarId());
-    ContactResource contact3 = persistActiveContact(registrar3.getRegistrarId());
+    Contact contact1 = persistActiveContact(registrar1.getRegistrarId());
+    Contact contact2 = persistActiveContact(registrar2.getRegistrarId());
+    Contact contact3 = persistActiveContact(registrar3.getRegistrarId());
 
     persistResource(createDomain("111.com", "123456789-COM", registrar1, contact1));
     persistResource(createDomain("party-night.net", "2244AABBC-NET", registrar2, contact2));
@@ -297,7 +297,7 @@ class Spec11PipelineTest {
   }
 
   private Domain createDomain(
-      String domainName, String repoId, Registrar registrar, ContactResource contact) {
+      String domainName, String repoId, Registrar registrar, Contact contact) {
     return new Domain.Builder()
         .setDomainName(domainName)
         .setRepoId(repoId)

--- a/core/src/test/java/google/registry/flows/contact/ContactCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactCheckFlowTest.java
@@ -24,11 +24,11 @@ import google.registry.flows.EppException;
 import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceCheckFlowTestCase;
 import google.registry.flows.exceptions.TooManyResourceChecksException;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link ContactCheckFlow}. */
-class ContactCheckFlowTest extends ResourceCheckFlowTestCase<ContactCheckFlow, ContactResource> {
+class ContactCheckFlowTest extends ResourceCheckFlowTestCase<ContactCheckFlow, Contact> {
 
   ContactCheckFlowTest() {
     setEppInput("contact_check.xml");

--- a/core/src/test/java/google/registry/flows/contact/ContactCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactCreateFlowTest.java
@@ -15,9 +15,9 @@
 package google.registry.flows.contact;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.testing.ContactResourceSubject.assertAboutContacts;
+import static google.registry.testing.ContactSubject.assertAboutContacts;
 import static google.registry.testing.DatabaseHelper.assertNoBillingEvents;
-import static google.registry.testing.DatabaseHelper.newContactResource;
+import static google.registry.testing.DatabaseHelper.newContact;
 import static google.registry.testing.DatabaseHelper.persistActiveContact;
 import static google.registry.testing.DatabaseHelper.persistDeletedContact;
 import static google.registry.testing.DatabaseHelper.persistResource;
@@ -31,12 +31,12 @@ import google.registry.flows.contact.ContactFlowUtils.BadInternationalizedPostal
 import google.registry.flows.contact.ContactFlowUtils.DeclineContactDisclosureFieldDisallowedPolicyException;
 import google.registry.flows.exceptions.ResourceAlreadyExistsForThisClientException;
 import google.registry.flows.exceptions.ResourceCreateContentionException;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link ContactCreateFlow}. */
-class ContactCreateFlowTest extends ResourceFlowTestCase<ContactCreateFlow, ContactResource> {
+class ContactCreateFlowTest extends ResourceFlowTestCase<ContactCreateFlow, Contact> {
 
   ContactCreateFlowTest() {
     setEppInput("contact_create.xml");
@@ -47,7 +47,7 @@ class ContactCreateFlowTest extends ResourceFlowTestCase<ContactCreateFlow, Cont
     assertTransactionalFlow(true);
     runFlowAssertResponse(loadFile("contact_create_response.xml"));
     // Check that the contact was created and persisted with a history entry.
-    ContactResource contact = reloadResourceByForeignKey();
+    Contact contact = reloadResourceByForeignKey();
     assertAboutContacts().that(contact).hasOnlyOneHistoryEntryWhich().hasNoXml();
     assertNoBillingEvents();
     assertLastHistoryContainsResource(contact);
@@ -93,7 +93,7 @@ class ContactCreateFlowTest extends ResourceFlowTestCase<ContactCreateFlow, Cont
   void testFailure_resourceContention() throws Exception {
     String targetId = getUniqueIdFromCommand();
     persistResource(
-        newContactResource(targetId)
+        newContact(targetId)
             .asBuilder()
             .setPersistedCurrentSponsorRegistrarId("NewRegistrar")
             .build());

--- a/core/src/test/java/google/registry/flows/contact/ContactDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactDeleteFlowTest.java
@@ -17,11 +17,11 @@ package google.registry.flows.contact;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.batch.AsyncTaskEnqueuer.QUEUE_ASYNC_DELETE;
-import static google.registry.testing.ContactResourceSubject.assertAboutContacts;
+import static google.registry.testing.ContactSubject.assertAboutContacts;
 import static google.registry.testing.DatabaseHelper.assertNoBillingEvents;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.getPollMessages;
-import static google.registry.testing.DatabaseHelper.newContactResource;
+import static google.registry.testing.DatabaseHelper.newContact;
 import static google.registry.testing.DatabaseHelper.persistActiveContact;
 import static google.registry.testing.DatabaseHelper.persistContactWithPendingTransfer;
 import static google.registry.testing.DatabaseHelper.persistDeletedContact;
@@ -39,7 +39,7 @@ import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException;
 import google.registry.flows.exceptions.ResourceStatusProhibitsOperationException;
 import google.registry.flows.exceptions.ResourceToDeleteIsReferencedException;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.eppcommon.Trid;
 import google.registry.model.poll.PendingActionNotificationResponse;
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link ContactDeleteFlow}. */
-class ContactDeleteFlowTest extends ResourceFlowTestCase<ContactDeleteFlow, ContactResource> {
+class ContactDeleteFlowTest extends ResourceFlowTestCase<ContactDeleteFlow, Contact> {
 
   @BeforeEach
   void initFlowTest() {
@@ -99,7 +99,7 @@ class ContactDeleteFlowTest extends ResourceFlowTestCase<ContactDeleteFlow, Cont
     assertTransactionalFlow(true);
     runFlowAssertResponse(loadFile("contact_delete_response.xml"));
     assertSqlDeleteSuccess(Type.CONTACT_DELETE, Type.CONTACT_TRANSFER_REQUEST);
-    ContactResource softDeletedContact = reloadResourceByForeignKey(clock.nowUtc().minusMillis(1));
+    Contact softDeletedContact = reloadResourceByForeignKey(clock.nowUtc().minusMillis(1));
     assertThat(softDeletedContact.getTransferData())
         .isEqualTo(
             oldTransferData
@@ -175,7 +175,7 @@ class ContactDeleteFlowTest extends ResourceFlowTestCase<ContactDeleteFlow, Cont
   private void doFailingStatusTest(StatusValue statusValue, Class<? extends EppException> exception)
       throws Exception {
     persistResource(
-        newContactResource(getUniqueIdFromCommand())
+        newContact(getUniqueIdFromCommand())
             .asBuilder()
             .setStatusValues(ImmutableSet.of(statusValue))
             .build());

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferApproveFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferApproveFlowTest.java
@@ -16,7 +16,7 @@ package google.registry.flows.contact;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.testing.ContactResourceSubject.assertAboutContacts;
+import static google.registry.testing.ContactSubject.assertAboutContacts;
 import static google.registry.testing.DatabaseHelper.assertNoBillingEvents;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.getOnlyPollMessage;
@@ -31,8 +31,8 @@ import google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException;
 import google.registry.flows.exceptions.NotPendingTransferException;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactAuthInfo;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.eppcommon.AuthInfo.PasswordAuth;
 import google.registry.model.eppcommon.Trid;
 import google.registry.model.poll.PendingActionNotificationResponse;
@@ -46,7 +46,7 @@ import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link ContactTransferApproveFlow}. */
 class ContactTransferApproveFlowTest
-    extends ContactTransferFlowTestCase<ContactTransferApproveFlow, ContactResource> {
+    extends ContactTransferFlowTestCase<ContactTransferApproveFlow, Contact> {
 
   @BeforeEach
   void setUp() {

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferCancelFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferCancelFlowTest.java
@@ -16,7 +16,7 @@ package google.registry.flows.contact;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.testing.ContactResourceSubject.assertAboutContacts;
+import static google.registry.testing.ContactSubject.assertAboutContacts;
 import static google.registry.testing.DatabaseHelper.assertNoBillingEvents;
 import static google.registry.testing.DatabaseHelper.getOnlyPollMessage;
 import static google.registry.testing.DatabaseHelper.getPollMessages;
@@ -30,8 +30,8 @@ import google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.exceptions.NotPendingTransferException;
 import google.registry.flows.exceptions.NotTransferInitiatorException;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactAuthInfo;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.eppcommon.AuthInfo.PasswordAuth;
 import google.registry.model.poll.PollMessage;
 import google.registry.model.reporting.HistoryEntry;
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link ContactTransferCancelFlow}. */
 class ContactTransferCancelFlowTest
-    extends ContactTransferFlowTestCase<ContactTransferCancelFlow, ContactResource> {
+    extends ContactTransferFlowTestCase<ContactTransferCancelFlow, Contact> {
 
   @BeforeEach
   void setUp() {

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferFlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferFlowTestCase.java
@@ -15,14 +15,14 @@
 package google.registry.flows.contact;
 
 import static com.google.common.base.Preconditions.checkState;
-import static google.registry.testing.DatabaseHelper.newContactResource;
+import static google.registry.testing.DatabaseHelper.newContact;
 import static google.registry.testing.DatabaseHelper.persistContactWithPendingTransfer;
 import static google.registry.testing.DatabaseHelper.persistResource;
 
 import google.registry.flows.Flow;
 import google.registry.flows.ResourceFlowTestCase;
 import google.registry.model.EppResource;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.tld.Registry;
 import google.registry.model.transfer.TransferStatus;
 import google.registry.testing.AppEngineExtension;
@@ -47,7 +47,7 @@ abstract class ContactTransferFlowTestCase<F extends Flow, R extends EppResource
       TRANSFER_REQUEST_TIME.plus(Registry.DEFAULT_TRANSFER_GRACE_PERIOD);
   private static final Duration TIME_SINCE_REQUEST = Duration.standardDays(3);
 
-  protected ContactResource contact;
+  protected Contact contact;
 
   ContactTransferFlowTestCase() {
     checkState(!Registry.DEFAULT_TRANSFER_GRACE_PERIOD.isShorterThan(TIME_SINCE_REQUEST));
@@ -64,11 +64,12 @@ abstract class ContactTransferFlowTestCase<F extends Flow, R extends EppResource
 
   /** Adds a contact that has a pending transfer on it from TheRegistrar to NewRegistrar. */
   void setupContactWithPendingTransfer() {
-    contact = persistContactWithPendingTransfer(
-        newContactResource("sh8013"),
-        TRANSFER_REQUEST_TIME,
-        TRANSFER_EXPIRATION_TIME,
-        TRANSFER_REQUEST_TIME);
+    contact =
+        persistContactWithPendingTransfer(
+            newContact("sh8013"),
+            TRANSFER_REQUEST_TIME,
+            TRANSFER_EXPIRATION_TIME,
+            TRANSFER_REQUEST_TIME);
   }
 
   /** Changes the transfer status on the persisted contact. */

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferQueryFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferQueryFlowTest.java
@@ -15,7 +15,7 @@
 package google.registry.flows.contact;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.testing.ContactResourceSubject.assertAboutContacts;
+import static google.registry.testing.ContactSubject.assertAboutContacts;
 import static google.registry.testing.DatabaseHelper.assertNoBillingEvents;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
@@ -27,8 +27,8 @@ import google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.exceptions.NoTransferHistoryToQueryException;
 import google.registry.flows.exceptions.NotAuthorizedToViewTransferException;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactAuthInfo;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.eppcommon.AuthInfo.PasswordAuth;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.transfer.TransferStatus;
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link ContactTransferQueryFlow}. */
 class ContactTransferQueryFlowTest
-    extends ContactTransferFlowTestCase<ContactTransferQueryFlow, ContactResource> {
+    extends ContactTransferFlowTestCase<ContactTransferQueryFlow, Contact> {
 
   @BeforeEach
   void setUp() {

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferRejectFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferRejectFlowTest.java
@@ -16,7 +16,7 @@ package google.registry.flows.contact;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.testing.ContactResourceSubject.assertAboutContacts;
+import static google.registry.testing.ContactSubject.assertAboutContacts;
 import static google.registry.testing.DatabaseHelper.assertNoBillingEvents;
 import static google.registry.testing.DatabaseHelper.getOnlyPollMessage;
 import static google.registry.testing.DatabaseHelper.getPollMessages;
@@ -30,8 +30,8 @@ import google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException;
 import google.registry.flows.exceptions.NotPendingTransferException;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactAuthInfo;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.eppcommon.AuthInfo.PasswordAuth;
 import google.registry.model.eppcommon.Trid;
 import google.registry.model.poll.PendingActionNotificationResponse;
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link ContactTransferRejectFlow}. */
 class ContactTransferRejectFlowTest
-    extends ContactTransferFlowTestCase<ContactTransferRejectFlow, ContactResource> {
+    extends ContactTransferFlowTestCase<ContactTransferRejectFlow, Contact> {
 
   @BeforeEach
   void setUp() {

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferRequestFlowTest.java
@@ -20,7 +20,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.config.RegistryConfig.getContactAutomaticTransferLength;
-import static google.registry.testing.ContactResourceSubject.assertAboutContacts;
+import static google.registry.testing.ContactSubject.assertAboutContacts;
 import static google.registry.testing.DatabaseHelper.assertNoBillingEvents;
 import static google.registry.testing.DatabaseHelper.assertPollMessagesEqual;
 import static google.registry.testing.DatabaseHelper.deleteResource;
@@ -42,8 +42,8 @@ import google.registry.flows.exceptions.AlreadyPendingTransferException;
 import google.registry.flows.exceptions.MissingTransferRequestAuthInfoException;
 import google.registry.flows.exceptions.ObjectAlreadySponsoredException;
 import google.registry.flows.exceptions.ResourceStatusProhibitsOperationException;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactAuthInfo;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.eppcommon.AuthInfo.PasswordAuth;
 import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.eppcommon.Trid;
@@ -57,7 +57,7 @@ import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link ContactTransferRequestFlow}. */
 class ContactTransferRequestFlowTest
-    extends ContactTransferFlowTestCase<ContactTransferRequestFlow, ContactResource> {
+    extends ContactTransferFlowTestCase<ContactTransferRequestFlow, Contact> {
 
   ContactTransferRequestFlowTest() {
     // We need the transfer to happen at exactly this time in order for the response to match up.

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -43,7 +43,7 @@ import static google.registry.testing.DatabaseHelper.createTlds;
 import static google.registry.testing.DatabaseHelper.deleteTld;
 import static google.registry.testing.DatabaseHelper.getHistoryEntries;
 import static google.registry.testing.DatabaseHelper.loadRegistrar;
-import static google.registry.testing.DatabaseHelper.newContactResource;
+import static google.registry.testing.DatabaseHelper.newContact;
 import static google.registry.testing.DatabaseHelper.newHost;
 import static google.registry.testing.DatabaseHelper.persistActiveContact;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
@@ -1723,8 +1723,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistActiveHost("ns1.example.net");
     persistActiveHost("ns2.example.net");
     persistActiveContact("sh8013");
-    persistResource(
-        newContactResource("jd1234").asBuilder().addStatusValue(PENDING_DELETE).build());
+    persistResource(newContact("jd1234").asBuilder().addStatusValue(PENDING_DELETE).build());
     clock.advanceOneMilli();
     LinkedResourceInPendingDeleteProhibitsOperationException thrown =
         assertThrows(LinkedResourceInPendingDeleteProhibitsOperationException.class, this::runFlow);

--- a/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
@@ -80,7 +80,7 @@ import google.registry.flows.exceptions.ResourceStatusProhibitsOperationExceptio
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Flag;
 import google.registry.model.billing.BillingEvent.Reason;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.GracePeriod;
@@ -155,7 +155,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
 
   private void createReferencedEntities(DateTime expirationTime) throws Exception {
     // Persist a linked contact.
-    ContactResource contact = persistActiveContact("sh8013");
+    Contact contact = persistActiveContact("sh8013");
     domain =
         persistResource(
             DatabaseHelper.newDomain(getUniqueIdFromCommand())
@@ -742,9 +742,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         DatabaseHelper.newDomain("example1.tld")
             .asBuilder()
             .setRegistrant(
-                loadByForeignKey(ContactResource.class, "sh8013", clock.nowUtc())
-                    .get()
-                    .createVKey())
+                loadByForeignKey(Contact.class, "sh8013", clock.nowUtc()).get().createVKey())
             .setNameservers(ImmutableSet.of(host.createVKey()))
             .setDeletionTime(START_OF_TIME)
             .build());

--- a/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
@@ -52,8 +52,8 @@ import google.registry.model.billing.BillingEvent.Flag;
 import google.registry.model.billing.BillingEvent.Reason;
 import google.registry.model.billing.BillingEvent.Recurring;
 import google.registry.model.billing.BillingEvent.RenewalPriceBehavior;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactAuthInfo;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.DesignatedContact;
 import google.registry.model.domain.DesignatedContact.Type;
 import google.registry.model.domain.Domain;
@@ -94,8 +94,8 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
 
   private static final Pattern OK_PATTERN = Pattern.compile("\"ok\"");
 
-  private ContactResource registrant;
-  private ContactResource contact;
+  private Contact registrant;
+  private Contact contact;
   private Host host1;
   private Host host2;
   private Host host3;
@@ -661,7 +661,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
   @Test
   void testFailure_differentRegistrarUnrelatedContactAuthInfo() {
     persistTestEntities(false);
-    ContactResource unrelatedContact = persistActiveContact("foo1234");
+    Contact unrelatedContact = persistActiveContact("foo1234");
     sessionMetadata.setRegistrarId("ClientZ");
     setEppInput("domain_info_with_contact_auth.xml");
     // Replace the ROID in the xml file with the one for our unrelated contact.
@@ -673,7 +673,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
   @Test
   void testFailure_unrelatedContactAuthInfo() {
     persistTestEntities(false);
-    ContactResource unrelatedContact = persistActiveContact("foo1234");
+    Contact unrelatedContact = persistActiveContact("foo1234");
     setEppInput("domain_info_with_contact_auth.xml");
     // Replace the ROID in the xml file with the one for our unrelated contact.
     eppLoader.replaceAll("JD1234-REP", unrelatedContact.getRepoId());

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferFlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferFlowTestCase.java
@@ -35,7 +35,7 @@ import google.registry.model.EppResource;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Flag;
 import google.registry.model.billing.BillingEvent.Reason;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.eppcommon.StatusValue;
@@ -71,7 +71,7 @@ abstract class DomainTransferFlowTestCase<F extends Flow, R extends EppResource>
   static final DateTime EXTENDED_REGISTRATION_EXPIRATION_TIME =
       REGISTRATION_EXPIRATION_TIME.plusYears(EXTENDED_REGISTRATION_YEARS);
 
-  protected ContactResource contact;
+  protected Contact contact;
   protected Domain domain;
   Host subordinateHost;
   private DomainHistory historyEntryDomainCreate;

--- a/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
@@ -91,7 +91,7 @@ import google.registry.flows.exceptions.ResourceHasClientUpdateProhibitedExcepti
 import google.registry.flows.exceptions.ResourceStatusProhibitsOperationException;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Reason;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.DesignatedContact;
 import google.registry.model.domain.DesignatedContact.Type;
 import google.registry.model.domain.Domain;
@@ -127,9 +127,9 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
           "DIGEST_TYPE", "1",
           "DIGEST", "A94A8FE5CCB19BA61C4C0873D391E987982FBBD3");
 
-  private ContactResource sh8013Contact;
-  private ContactResource mak21Contact;
-  private ContactResource unusedContact;
+  private Contact sh8013Contact;
+  private Contact mak21Contact;
+  private Contact unusedContact;
 
   @BeforeEach
   void beforeEach() {
@@ -419,8 +419,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
   void testSuccess_registrantMovedToTechContact() throws Exception {
     setEppInput("domain_update_registrant_to_tech.xml");
     persistReferencedEntities();
-    ContactResource sh8013 =
-        loadByForeignKey(ContactResource.class, "sh8013", clock.nowUtc()).get();
+    Contact sh8013 = loadByForeignKey(Contact.class, "sh8013", clock.nowUtc()).get();
     persistResource(
         DatabaseHelper.newDomain(getUniqueIdFromCommand())
             .asBuilder()
@@ -434,9 +433,8 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
   void testSuccess_multipleReferencesToSameContactRemoved() throws Exception {
     setEppInput("domain_update_remove_multiple_contacts.xml");
     persistReferencedEntities();
-    ContactResource sh8013 =
-        loadByForeignKey(ContactResource.class, "sh8013", clock.nowUtc()).get();
-    VKey<ContactResource> sh8013Key = sh8013.createVKey();
+    Contact sh8013 = loadByForeignKey(Contact.class, "sh8013", clock.nowUtc()).get();
+    VKey<Contact> sh8013Key = sh8013.createVKey();
     persistResource(
         DatabaseHelper.newDomain(getUniqueIdFromCommand())
             .asBuilder()
@@ -1111,9 +1109,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .setContacts(
                 DesignatedContact.create(
                     Type.TECH,
-                    loadByForeignKey(ContactResource.class, "foo", clock.nowUtc())
-                        .get()
-                        .createVKey()))
+                    loadByForeignKey(Contact.class, "foo", clock.nowUtc()).get().createVKey()))
             .build());
     EppException thrown = assertThrows(DuplicateContactForRoleException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
@@ -1436,9 +1432,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .setContacts(
                 DesignatedContact.create(
                     Type.TECH,
-                    loadByForeignKey(ContactResource.class, "sh8013", clock.nowUtc())
-                        .get()
-                        .createVKey()))
+                    loadByForeignKey(Contact.class, "sh8013", clock.nowUtc()).get().createVKey()))
             .build());
     EppException thrown = assertThrows(AddRemoveSameValueException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
@@ -1484,7 +1478,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     persistActiveHost("ns2.example.foo");
     persistActiveContact("sh8013");
     persistResource(
-        loadByForeignKey(ContactResource.class, "mak21", clock.nowUtc())
+        loadByForeignKey(Contact.class, "mak21", clock.nowUtc())
             .get()
             .asBuilder()
             .addStatusValue(StatusValue.PENDING_DELETE)

--- a/core/src/test/java/google/registry/flows/poll/PollAckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/poll/PollAckFlowTest.java
@@ -28,7 +28,7 @@ import google.registry.flows.poll.PollAckFlow.InvalidMessageIdException;
 import google.registry.flows.poll.PollAckFlow.MessageDoesNotExistException;
 import google.registry.flows.poll.PollAckFlow.MissingMessageIdException;
 import google.registry.flows.poll.PollAckFlow.NotAuthorizedToAckMessageException;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.poll.PollMessage;
 import google.registry.testing.DatabaseHelper;
@@ -43,7 +43,7 @@ class PollAckFlowTest extends FlowTestCase<PollAckFlow> {
   private static final long MESSAGE_ID = 3;
 
   private Domain domain;
-  private ContactResource contact;
+  private Contact contact;
 
   @BeforeEach
   void setUp() {
@@ -116,7 +116,7 @@ class PollAckFlowTest extends FlowTestCase<PollAckFlow> {
   }
 
   @Test
-  void testSuccess_messageOnContactResource() throws Exception {
+  void testSuccess_messageOnContact() throws Exception {
     persistOneTimePollMessage(MESSAGE_ID);
     assertTransactionalFlow(true);
     runFlowAssertResponse(loadFile("poll_ack_response_empty.xml"));

--- a/core/src/test/java/google/registry/flows/poll/PollRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/poll/PollRequestFlowTest.java
@@ -27,8 +27,8 @@ import com.google.common.collect.ImmutableList;
 import google.registry.flows.EppException;
 import google.registry.flows.FlowTestCase;
 import google.registry.flows.poll.PollRequestFlow.UnexpectedMessageIdException;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactHistory;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.Domain;
 import google.registry.model.eppcommon.Trid;
 import google.registry.model.host.Host;
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Test;
 class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
 
   private Domain domain;
-  private ContactResource contact;
+  private Contact contact;
   private Host host;
 
   @BeforeEach

--- a/core/src/test/java/google/registry/model/EppResourceTest.java
+++ b/core/src/test/java/google/registry/model/EppResourceTest.java
@@ -22,7 +22,7 @@ import static google.registry.testing.DatabaseHelper.persistActiveHost;
 import static google.registry.testing.DatabaseHelper.persistResource;
 
 import com.google.common.collect.ImmutableList;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.host.Host;
 import google.registry.testing.TestCacheExtension;
 import java.time.Duration;
@@ -38,14 +38,14 @@ public class EppResourceTest extends EntityTestCase {
 
   @Test
   void test_loadCached_ignoresContactChange() {
-    ContactResource originalContact = persistActiveContact("contact123");
+    Contact originalContact = persistActiveContact("contact123");
     assertThat(EppResource.loadCached(ImmutableList.of(originalContact.createVKey())))
         .containsExactly(originalContact.createVKey(), originalContact);
-    ContactResource modifiedContact =
+    Contact modifiedContact =
         persistResource(originalContact.asBuilder().setEmailAddress("different@fake.lol").build());
     assertThat(EppResource.loadCached(ImmutableList.of(originalContact.createVKey())))
         .containsExactly(originalContact.createVKey(), originalContact);
-    assertThat(loadByForeignKey(ContactResource.class, "contact123", fakeClock.nowUtc()))
+    assertThat(loadByForeignKey(Contact.class, "contact123", fakeClock.nowUtc()))
         .hasValue(modifiedContact);
   }
 

--- a/core/src/test/java/google/registry/model/bulkquery/TestSetupHelper.java
+++ b/core/src/test/java/google/registry/model/bulkquery/TestSetupHelper.java
@@ -22,7 +22,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableSet;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.DesignatedContact;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainAuthInfo;
@@ -72,7 +72,7 @@ public final class TestSetupHelper {
 
   public Registry registry;
   public Registrar registrar;
-  public ContactResource contact;
+  public Contact contact;
   public Domain domain;
   public DomainHistory domainHistory;
   public Host host;
@@ -118,8 +118,8 @@ public final class TestSetupHelper {
     }
   }
 
-  static ContactResource createContact(String repoId, String registrarId) {
-    return new ContactResource.Builder()
+  static Contact createContact(String repoId, String registrarId) {
+    return new Contact.Builder()
         .setRepoId(repoId)
         .setCreationRegistrarId(registrarId)
         .setTransferData(new ContactTransferData.Builder().build())
@@ -127,7 +127,7 @@ public final class TestSetupHelper {
         .build();
   }
 
-  static Domain createSimpleDomain(ContactResource contact) {
+  static Domain createSimpleDomain(Contact contact) {
     return DatabaseHelper.newDomain(DOMAIN_NAME, DOMAIN_REPO_ID, contact)
         .asBuilder()
         .setCreationRegistrarId(REGISTRAR_ID)
@@ -135,7 +135,7 @@ public final class TestSetupHelper {
         .build();
   }
 
-  static Domain createFullDomain(ContactResource contact, Host host, FakeClock fakeClock) {
+  static Domain createFullDomain(Contact contact, Host host, FakeClock fakeClock) {
     return createSimpleDomain(contact)
         .asBuilder()
         .setDomainName(DOMAIN_NAME)

--- a/core/src/test/java/google/registry/model/common/ClassPathManagerTest.java
+++ b/core/src/test/java/google/registry/model/common/ClassPathManagerTest.java
@@ -17,7 +17,7 @@ package google.registry.model.common;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.token.AllocationToken;
@@ -54,7 +54,7 @@ public class ClassPathManagerTest {
     assertThat(ClassPathManager.getClass("RdeRevision")).isEqualTo(RdeRevision.class);
     assertThat(ClassPathManager.getClass("Host")).isEqualTo(Host.class);
     assertThat(ClassPathManager.getClass("Registrar")).isEqualTo(Registrar.class);
-    assertThat(ClassPathManager.getClass("ContactResource")).isEqualTo(ContactResource.class);
+    assertThat(ClassPathManager.getClass("Contact")).isEqualTo(Contact.class);
     assertThat(ClassPathManager.getClass("GaeUserIdConverter")).isEqualTo(GaeUserIdConverter.class);
     assertThat(ClassPathManager.getClass("EppResourceIndexBucket"))
         .isEqualTo(EppResourceIndexBucket.class);
@@ -106,7 +106,7 @@ public class ClassPathManagerTest {
     assertThat(ClassPathManager.getClassName(RdeRevision.class)).isEqualTo("RdeRevision");
     assertThat(ClassPathManager.getClassName(Host.class)).isEqualTo("Host");
     assertThat(ClassPathManager.getClassName(Registrar.class)).isEqualTo("Registrar");
-    assertThat(ClassPathManager.getClassName(ContactResource.class)).isEqualTo("ContactResource");
+    assertThat(ClassPathManager.getClassName(Contact.class)).isEqualTo("Contact");
     assertThat(ClassPathManager.getClassName(GaeUserIdConverter.class))
         .isEqualTo("GaeUserIdConverter");
     assertThat(ClassPathManager.getClassName(EppResourceIndexBucket.class))

--- a/core/src/test/java/google/registry/model/domain/DomainSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainSqlTest.java
@@ -39,7 +39,7 @@ import com.googlecode.objectify.Key;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Flag;
 import google.registry.model.billing.BillingEvent.Reason;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.DesignatedContact.Type;
 import google.registry.model.domain.launch.LaunchNotice;
 import google.registry.model.domain.rgp.GracePeriodStatus;
@@ -80,12 +80,12 @@ public class DomainSqlTest {
 
   private Domain domain;
   private DomainHistory historyEntry;
-  private VKey<ContactResource> contactKey;
-  private VKey<ContactResource> contact2Key;
+  private VKey<Contact> contactKey;
+  private VKey<Contact> contact2Key;
   private VKey<Host> host1VKey;
   private Host host;
-  private ContactResource contact;
-  private ContactResource contact2;
+  private Contact contact;
+  private Contact contact2;
   private ImmutableSet<GracePeriod> gracePeriods;
   private AllocationToken allocationToken;
 
@@ -94,8 +94,8 @@ public class DomainSqlTest {
     saveRegistrar("registrar1");
     saveRegistrar("registrar2");
     saveRegistrar("registrar3");
-    contactKey = createKey(ContactResource.class, "contact_id1");
-    contact2Key = createKey(ContactResource.class, "contact_id2");
+    contactKey = createKey(Contact.class, "contact_id1");
+    contact2Key = createKey(Contact.class, "contact_id2");
 
     host1VKey = createKey(Host.class, "host1");
 
@@ -406,8 +406,8 @@ public class DomainSqlTest {
         .isEqualExceptFields(domain, "updateTimestamp", "creationTime");
   }
 
-  static ContactResource makeContact(String repoId) {
-    return new ContactResource.Builder()
+  static Contact makeContact(String repoId) {
+    return new Contact.Builder()
         .setRepoId(repoId)
         .setCreationRegistrarId("registrar1")
         .setTransferData(new ContactTransferData.Builder().build())

--- a/core/src/test/java/google/registry/model/domain/DomainTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainTest.java
@@ -46,7 +46,7 @@ import google.registry.model.ImmutableObjectSubject;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Flag;
 import google.registry.model.billing.BillingEvent.Reason;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.DesignatedContact.Type;
 import google.registry.model.domain.launch.LaunchNotice;
 import google.registry.model.domain.rgp.GracePeriodStatus;
@@ -89,7 +89,7 @@ public class DomainTest {
   private VKey<BillingEvent.OneTime> oneTimeBillKey;
   private VKey<BillingEvent.Recurring> recurringBillKey;
   private DomainHistory domainHistory;
-  private VKey<ContactResource> contact1Key, contact2Key;
+  private VKey<Contact> contact1Key, contact2Key;
 
   @BeforeEach
   void setUp() {
@@ -938,8 +938,8 @@ public class DomainTest {
 
   @Test
   void testContactFields() {
-    VKey<ContactResource> contact3Key = persistActiveContact("contact_id3").createVKey();
-    VKey<ContactResource> contact4Key = persistActiveContact("contact_id4").createVKey();
+    VKey<Contact> contact3Key = persistActiveContact("contact_id3").createVKey();
+    VKey<Contact> contact4Key = persistActiveContact("contact_id4").createVKey();
 
     // Set all of the contacts.
     domain.setContactFields(

--- a/core/src/test/java/google/registry/model/eppinput/EppInputTest.java
+++ b/core/src/test/java/google/registry/model/eppinput/EppInputTest.java
@@ -20,7 +20,7 @@ import static google.registry.model.eppcommon.EppXmlTransformer.unmarshal;
 import static google.registry.testing.TestDataHelper.loadBytes;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import google.registry.model.contact.ContactResourceTest;
+import google.registry.model.contact.ContactTest;
 import google.registry.model.domain.DomainTest;
 import google.registry.model.eppinput.EppInput.InnerCommand;
 import google.registry.model.eppinput.EppInput.Login;
@@ -33,7 +33,7 @@ class EppInputTest {
   @Test
   void testUnmarshalling_contactInfo() throws Exception {
     EppInput input =
-        unmarshal(EppInput.class, loadBytes(ContactResourceTest.class, "contact_info.xml").read());
+        unmarshal(EppInput.class, loadBytes(ContactTest.class, "contact_info.xml").read());
     assertThat(input.getCommandWrapper().getClTrid()).hasValue("ABC-12345");
     assertThat(input.getCommandType()).isEqualTo("info");
     assertThat(input.getResourceType()).hasValue("contact");

--- a/core/src/test/java/google/registry/model/history/ContactHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/ContactHistoryTest.java
@@ -19,16 +19,16 @@ import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableO
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.loadByEntity;
-import static google.registry.testing.DatabaseHelper.newContactResourceWithRoid;
+import static google.registry.testing.DatabaseHelper.newContactWithRoid;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableList;
 import google.registry.model.EntityTestCase;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactAddress;
 import google.registry.model.contact.ContactBase;
 import google.registry.model.contact.ContactHistory;
 import google.registry.model.contact.ContactPhoneNumber;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.contact.PostalInfo;
 import google.registry.model.eppcommon.Trid;
 import google.registry.model.reporting.HistoryEntry;
@@ -44,9 +44,9 @@ public class ContactHistoryTest extends EntityTestCase {
 
   @Test
   void testPersistence() {
-    ContactResource contact = newContactResourceWithRoid("contactId", "contact1");
+    Contact contact = newContactWithRoid("contactId", "contact1");
     insertInDb(contact);
-    ContactResource contactFromDb = loadByEntity(contact);
+    Contact contactFromDb = loadByEntity(contact);
     ContactHistory contactHistory = createContactHistory(contactFromDb);
     insertInDb(contactHistory);
     jpaTm()
@@ -60,9 +60,9 @@ public class ContactHistoryTest extends EntityTestCase {
 
   @Test
   void testSerializable() {
-    ContactResource contact = newContactResourceWithRoid("contactId", "contact1");
+    Contact contact = newContactWithRoid("contactId", "contact1");
     insertInDb(contact);
-    ContactResource contactFromDb = loadByEntity(contact);
+    Contact contactFromDb = loadByEntity(contact);
     ContactHistory contactHistory = createContactHistory(contactFromDb);
     insertInDb(contactHistory);
     ContactHistory fromDatabase =
@@ -72,9 +72,9 @@ public class ContactHistoryTest extends EntityTestCase {
 
   @Test
   void testLegacyPersistence_nullContactBase() {
-    ContactResource contact = newContactResourceWithRoid("contactId", "contact1");
+    Contact contact = newContactWithRoid("contactId", "contact1");
     insertInDb(contact);
-    ContactResource contactFromDb = loadByEntity(contact);
+    Contact contactFromDb = loadByEntity(contact);
     ContactHistory contactHistory =
         createContactHistory(contactFromDb).asBuilder().setContact(null).build();
     insertInDb(contactHistory);
@@ -92,7 +92,7 @@ public class ContactHistoryTest extends EntityTestCase {
   void testWipeOutPii_assertsAllPiiFieldsAreNull() {
     ContactHistory originalEntity =
         createContactHistory(
-            new ContactResource.Builder()
+            new Contact.Builder()
                 .setRepoId("1-FOOBAR")
                 .setLocalizedPostalInfo(
                     new PostalInfo.Builder()

--- a/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
@@ -19,7 +19,7 @@ import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableO
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.insertInDb;
-import static google.registry.testing.DatabaseHelper.newContactResourceWithRoid;
+import static google.registry.testing.DatabaseHelper.newContactWithRoid;
 import static google.registry.testing.DatabaseHelper.newDomain;
 import static google.registry.testing.DatabaseHelper.newHostWithRoid;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
@@ -27,7 +27,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableSet;
 import google.registry.model.EntityTestCase;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainBase;
 import google.registry.model.domain.DomainHistory;
@@ -103,7 +103,7 @@ public class DomainHistoryTest extends EntityTestCase {
   static Domain createDomainWithContactsAndHosts() {
     createTld("tld");
     Host host = newHostWithRoid("ns1.example.com", "host1");
-    ContactResource contact = newContactResourceWithRoid("contactId", "contact1");
+    Contact contact = newContactWithRoid("contactId", "contact1");
 
     jpaTm()
         .transact(

--- a/core/src/test/java/google/registry/model/ofy/OfyFilterTest.java
+++ b/core/src/test/java/google/registry/model/ofy/OfyFilterTest.java
@@ -16,7 +16,7 @@ package google.registry.model.ofy;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ofy.ObjectifyService.initOfy;
-import static google.registry.testing.DatabaseHelper.newContactResource;
+import static google.registry.testing.DatabaseHelper.newContact;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
@@ -27,7 +27,7 @@ import com.googlecode.objectify.ObjectifyFilter;
 import com.googlecode.objectify.ObjectifyService;
 import com.googlecode.objectify.annotation.Entity;
 import com.googlecode.objectify.annotation.Id;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -81,7 +81,7 @@ class OfyFilterTest {
   @Test
   void testKeyCreateAfterFilter() {
     new OfyFilter().init(null);
-    ContactResource contact = newContactResource("contact1234");
+    Contact contact = newContact("contact1234");
     Key.create(contact);
   }
 

--- a/core/src/test/java/google/registry/model/ofy/OfyTest.java
+++ b/core/src/test/java/google/registry/model/ofy/OfyTest.java
@@ -22,7 +22,7 @@ import static google.registry.model.common.EntityGroupRoot.getCrossTldKey;
 import static google.registry.model.ofy.ObjectifyService.auditedOfy;
 import static google.registry.model.ofy.ObjectifyService.ofy;
 import static google.registry.model.ofy.Ofy.getBaseEntityClassFromEntityOrKey;
-import static google.registry.testing.DatabaseHelper.newContactResource;
+import static google.registry.testing.DatabaseHelper.newContact;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -39,8 +39,8 @@ import com.googlecode.objectify.annotation.OnLoad;
 import com.googlecode.objectify.annotation.OnSave;
 import com.googlecode.objectify.annotation.Parent;
 import google.registry.model.ImmutableObject;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactHistory;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.eppcommon.Trid;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.testing.AppEngineExtension;
@@ -74,7 +74,7 @@ public class OfyTest {
             .setRegistrarId("clientid")
             .setModificationTime(START_OF_TIME)
             .setType(HistoryEntry.Type.CONTACT_CREATE)
-            .setContact(newContactResource("parentContact"))
+            .setContact(newContact("parentContact"))
             .setTrid(Trid.create("client", "server"))
             .setXmlBytes("<xml></xml>".getBytes(UTF_8))
             .build();
@@ -294,10 +294,9 @@ public class OfyTest {
 
   @Test
   void test_getBaseEntityClassFromEntityOrKey_regularEntity() {
-    ContactResource contact = newContactResource("testcontact");
-    assertThat(getBaseEntityClassFromEntityOrKey(contact)).isEqualTo(ContactResource.class);
-    assertThat(getBaseEntityClassFromEntityOrKey(Key.create(contact)))
-        .isEqualTo(ContactResource.class);
+    Contact contact = newContact("testcontact");
+    assertThat(getBaseEntityClassFromEntityOrKey(contact)).isEqualTo(Contact.class);
+    assertThat(getBaseEntityClassFromEntityOrKey(Key.create(contact))).isEqualTo(Contact.class);
   }
 
   @Test

--- a/core/src/test/java/google/registry/model/poll/PollMessageTest.java
+++ b/core/src/test/java/google/registry/model/poll/PollMessageTest.java
@@ -25,7 +25,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableList;
 import google.registry.model.EntityTestCase;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.Period;
@@ -53,7 +53,7 @@ public class PollMessageTest extends EntityTestCase {
   @BeforeEach
   void setUp() {
     createTld("foobar");
-    ContactResource contact = persistActiveContact("contact1234");
+    Contact contact = persistActiveContact("contact1234");
     domain = persistResource(DatabaseHelper.newDomain("foo.foobar", contact));
     historyEntry =
         persistResource(

--- a/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchDaoTest.java
+++ b/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchDaoTest.java
@@ -24,7 +24,7 @@ import static google.registry.testing.DatabaseHelper.persistResource;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import google.registry.model.EntityTestCase;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.reporting.Spec11ThreatMatch.ThreatType;
 import google.registry.testing.DatabaseHelper;
@@ -46,7 +46,7 @@ class Spec11ThreatMatchDaoTest extends EntityTestCase {
   @BeforeEach
   void setUp() {
     createTlds("com", "org");
-    ContactResource contact = persistActiveContact("jd1234");
+    Contact contact = persistActiveContact("jd1234");
     todayComDomain = persistResource(DatabaseHelper.newDomain("today.com", contact));
     todayOrgDomain = persistResource(DatabaseHelper.newDomain("today.org", contact));
     yesterdayComDomain = persistResource(DatabaseHelper.newDomain("yesterday.com", contact));

--- a/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchTest.java
+++ b/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableSet;
 import google.registry.model.EntityTestCase;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.host.Host;
 import google.registry.model.transfer.ContactTransferData;
@@ -46,7 +46,7 @@ public final class Spec11ThreatMatchTest extends EntityTestCase {
   private Spec11ThreatMatch threat;
   private Domain domain;
   private Host host;
-  private ContactResource registrantContact;
+  private Contact registrantContact;
 
   Spec11ThreatMatchTest() {
     super(JpaEntityCoverageCheck.ENABLED);
@@ -55,8 +55,7 @@ public final class Spec11ThreatMatchTest extends EntityTestCase {
   @BeforeEach
   void setUp() {
     VKey<Host> hostVKey = VKey.createSql(Host.class, "host");
-    VKey<ContactResource> registrantContactVKey =
-        VKey.createSql(ContactResource.class, "contact_id");
+    VKey<Contact> registrantContactVKey = VKey.createSql(Contact.class, "contact_id");
     String domainRepoId = "4-TLD";
     createTld("tld");
 
@@ -75,7 +74,7 @@ public final class Spec11ThreatMatchTest extends EntityTestCase {
 
     // Create a contact for the purpose of testing a foreign key reference in the Domain table.
     registrantContact =
-        new ContactResource.Builder()
+        new Contact.Builder()
             .setRepoId("contact_id")
             .setCreationRegistrarId(REGISTRAR_ID)
             .setTransferData(new ContactTransferData.Builder().build())

--- a/core/src/test/java/google/registry/rdap/RdapDomainActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapDomainActionTest.java
@@ -19,16 +19,15 @@ import static google.registry.rdap.RdapTestHelper.assertThat;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DatabaseHelper.persistSimpleResources;
-import static google.registry.testing.FullFieldsTestEntityHelper.makeAndPersistContactResource;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeAndPersistHost;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeDomain;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeHistoryEntry;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrar;
-import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrarContacts;
+import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrarPocs;
 import static org.mockito.Mockito.verify;
 
 import com.google.gson.JsonObject;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.Period;
 import google.registry.model.host.Host;
@@ -40,6 +39,7 @@ import google.registry.rdap.RdapMetrics.SearchType;
 import google.registry.rdap.RdapMetrics.WildcardType;
 import google.registry.rdap.RdapSearchResults.IncompletenessWarningType;
 import google.registry.request.Action;
+import google.registry.testing.FullFieldsTestEntityHelper;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -63,28 +63,24 @@ class RdapDomainActionTest extends RdapActionBaseTestCase<RdapDomainAction> {
     createTld("lol");
     Registrar registrarLol = persistResource(makeRegistrar(
         "evilregistrar", "Yes Virginia <script>", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarContacts(registrarLol));
-    ContactResource registrantLol =
-        makeAndPersistContactResource(
+    persistSimpleResources(makeRegistrarPocs(registrarLol));
+    Contact registrantLol =
+        FullFieldsTestEntityHelper.makeAndPersistContact(
             "5372808-ERL",
             "Goblin Market",
             "lol@cat.lol",
             clock.nowUtc().minusYears(1),
             registrarLol);
-    ContactResource adminContactLol =
-        makeAndPersistContactResource(
+    Contact adminContactLol =
+        FullFieldsTestEntityHelper.makeAndPersistContact(
             "5372808-IRL",
             "Santa Claus",
             "BOFH@cat.lol",
             clock.nowUtc().minusYears(2),
             registrarLol);
-    ContactResource techContactLol =
-        makeAndPersistContactResource(
-            "5372808-TRL",
-            "The Raven",
-            "bog@cat.lol",
-            clock.nowUtc().minusYears(3),
-            registrarLol);
+    Contact techContactLol =
+        FullFieldsTestEntityHelper.makeAndPersistContact(
+            "5372808-TRL", "The Raven", "bog@cat.lol", clock.nowUtc().minusYears(3), registrarLol);
     Host host1 = makeAndPersistHost("ns1.cat.lol", "1.2.3.4", null, clock.nowUtc().minusYears(1));
     Host host2 =
         makeAndPersistHost(
@@ -111,19 +107,19 @@ class RdapDomainActionTest extends RdapActionBaseTestCase<RdapDomainAction> {
         persistResource(
             makeDomain(
                     "dodo.lol",
-                    makeAndPersistContactResource(
+                    FullFieldsTestEntityHelper.makeAndPersistContact(
                         "5372808-ERL",
                         "Goblin Market",
                         "lol@cat.lol",
                         clock.nowUtc().minusYears(1),
                         registrarLol),
-                    makeAndPersistContactResource(
+                    FullFieldsTestEntityHelper.makeAndPersistContact(
                         "5372808-IRL",
                         "Santa Claus",
                         "BOFH@cat.lol",
                         clock.nowUtc().minusYears(2),
                         registrarLol),
-                    makeAndPersistContactResource(
+                    FullFieldsTestEntityHelper.makeAndPersistContact(
                         "5372808-TRL",
                         "The Raven",
                         "bog@cat.lol",
@@ -141,28 +137,24 @@ class RdapDomainActionTest extends RdapActionBaseTestCase<RdapDomainAction> {
     createTld("xn--q9jyb4c");
     Registrar registrarIdn =
         persistResource(makeRegistrar("idnregistrar", "IDN Registrar", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarContacts(registrarIdn));
-    ContactResource registrantIdn =
-        makeAndPersistContactResource(
+    persistSimpleResources(makeRegistrarPocs(registrarIdn));
+    Contact registrantIdn =
+        FullFieldsTestEntityHelper.makeAndPersistContact(
             "5372808-ERL",
             "Goblin Market",
             "lol@cat.lol",
             clock.nowUtc().minusYears(1),
             registrarIdn);
-    ContactResource adminContactIdn =
-        makeAndPersistContactResource(
+    Contact adminContactIdn =
+        FullFieldsTestEntityHelper.makeAndPersistContact(
             "5372808-IRL",
             "Santa Claus",
             "BOFH@cat.lol",
             clock.nowUtc().minusYears(2),
             registrarIdn);
-    ContactResource techContactIdn =
-        makeAndPersistContactResource(
-            "5372808-TRL",
-            "The Raven",
-            "bog@cat.lol",
-            clock.nowUtc().minusYears(3),
-            registrarIdn);
+    Contact techContactIdn =
+        FullFieldsTestEntityHelper.makeAndPersistContact(
+            "5372808-TRL", "The Raven", "bog@cat.lol", clock.nowUtc().minusYears(3), registrarIdn);
     persistResource(
         makeDomain(
                 "cat.みんな",
@@ -181,28 +173,24 @@ class RdapDomainActionTest extends RdapActionBaseTestCase<RdapDomainAction> {
     createTld("1.tld");
     Registrar registrar1Tld = persistResource(
         makeRegistrar("1tldregistrar", "Multilevel Registrar", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarContacts(registrar1Tld));
-    ContactResource registrant1Tld =
-        makeAndPersistContactResource(
+    persistSimpleResources(makeRegistrarPocs(registrar1Tld));
+    Contact registrant1Tld =
+        FullFieldsTestEntityHelper.makeAndPersistContact(
             "5372808-ERL",
             "Goblin Market",
             "lol@cat.lol",
             clock.nowUtc().minusYears(1),
             registrar1Tld);
-    ContactResource adminContact1Tld =
-        makeAndPersistContactResource(
+    Contact adminContact1Tld =
+        FullFieldsTestEntityHelper.makeAndPersistContact(
             "5372808-IRL",
             "Santa Claus",
             "BOFH@cat.lol",
             clock.nowUtc().minusYears(2),
             registrar1Tld);
-    ContactResource techContact1Tld =
-        makeAndPersistContactResource(
-            "5372808-TRL",
-            "The Raven",
-            "bog@cat.lol",
-            clock.nowUtc().minusYears(3),
-            registrar1Tld);
+    Contact techContact1Tld =
+        FullFieldsTestEntityHelper.makeAndPersistContact(
+            "5372808-TRL", "The Raven", "bog@cat.lol", clock.nowUtc().minusYears(3), registrar1Tld);
     persistResource(
         makeDomain(
                 "cat.1.tld",

--- a/core/src/test/java/google/registry/rdap/RdapDomainSearchActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapDomainSearchActionTest.java
@@ -23,11 +23,10 @@ import static google.registry.testing.DatabaseHelper.persistDomainAsDeleted;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DatabaseHelper.persistResources;
 import static google.registry.testing.DatabaseHelper.persistSimpleResources;
-import static google.registry.testing.FullFieldsTestEntityHelper.makeAndPersistContactResource;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeDomain;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeHistoryEntry;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrar;
-import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrarContacts;
+import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrarPocs;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
@@ -36,7 +35,7 @@ import com.google.common.collect.Range;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.Period;
 import google.registry.model.host.Host;
@@ -70,9 +69,9 @@ class RdapDomainSearchActionTest extends RdapSearchActionTestCase<RdapDomainSear
   private Domain domainCatExample;
   private Domain domainIdn;
   private Domain domainMultipart;
-  private ContactResource contact1;
-  private ContactResource contact2;
-  private ContactResource contact3;
+  private Contact contact1;
+  private Contact contact2;
+  private Contact contact3;
   private Host hostNs1CatLol;
   private Host hostNs2CatLol;
   private HashMap<String, Host> hostNameToHostMap = new HashMap<>();
@@ -134,15 +133,15 @@ class RdapDomainSearchActionTest extends RdapSearchActionTestCase<RdapDomainSear
     registrar =
         persistResource(
             makeRegistrar("evilregistrar", "Yes Virginia <script>", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarContacts(registrar));
+    persistSimpleResources(makeRegistrarPocs(registrar));
     contact1 =
-        makeAndPersistContactResource(
+        FullFieldsTestEntityHelper.makeAndPersistContact(
             "5372808-ERL", "Goblin Market", "lol@cat.lol", clock.nowUtc().minusYears(1), registrar);
     contact2 =
-        makeAndPersistContactResource(
+        FullFieldsTestEntityHelper.makeAndPersistContact(
             "5372808-IRL", "Santa Claus", "BOFH@cat.lol", clock.nowUtc().minusYears(2), registrar);
     contact3 =
-        makeAndPersistContactResource(
+        FullFieldsTestEntityHelper.makeAndPersistContact(
             "5372808-TRL", "The Raven", "bog@cat.lol", clock.nowUtc().minusYears(3), registrar);
     hostNs1CatLol =
         addHostToMap(
@@ -176,19 +175,19 @@ class RdapDomainSearchActionTest extends RdapSearchActionTestCase<RdapDomainSear
         persistResource(
             makeDomain(
                     "cat2.lol",
-                    makeAndPersistContactResource(
+                    FullFieldsTestEntityHelper.makeAndPersistContact(
                         "6372808-ERL",
                         "Siegmund",
                         "siegmund@cat2.lol",
                         clock.nowUtc().minusYears(1),
                         registrar),
-                    makeAndPersistContactResource(
+                    FullFieldsTestEntityHelper.makeAndPersistContact(
                         "6372808-IRL",
                         "Sieglinde",
                         "sieglinde@cat2.lol",
                         clock.nowUtc().minusYears(2),
                         registrar),
-                    makeAndPersistContactResource(
+                    FullFieldsTestEntityHelper.makeAndPersistContact(
                         "6372808-TRL",
                         "Siegfried",
                         "siegfried@cat2.lol",
@@ -212,24 +211,24 @@ class RdapDomainSearchActionTest extends RdapSearchActionTestCase<RdapDomainSear
     registrar =
         persistResource(
             makeRegistrar("goodregistrar", "St. John Chrysostom", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarContacts(registrar));
+    persistSimpleResources(makeRegistrarPocs(registrar));
     domainCatExample =
         persistResource(
             makeDomain(
                     "cat.example",
-                    makeAndPersistContactResource(
+                    FullFieldsTestEntityHelper.makeAndPersistContact(
                         "7372808-ERL",
                         "Matthew",
                         "lol@cat.lol",
                         clock.nowUtc().minusYears(1),
                         registrar),
-                    makeAndPersistContactResource(
+                    FullFieldsTestEntityHelper.makeAndPersistContact(
                         "7372808-IRL",
                         "Mark",
                         "BOFH@cat.lol",
                         clock.nowUtc().minusYears(2),
                         registrar),
-                    makeAndPersistContactResource(
+                    FullFieldsTestEntityHelper.makeAndPersistContact(
                         "7372808-TRL",
                         "Luke",
                         "bog@cat.lol",
@@ -249,24 +248,24 @@ class RdapDomainSearchActionTest extends RdapSearchActionTestCase<RdapDomainSear
     // cat.みんな
     createTld("xn--q9jyb4c");
     registrar = persistResource(makeRegistrar("unicoderegistrar", "みんな", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarContacts(registrar));
+    persistSimpleResources(makeRegistrarPocs(registrar));
     domainIdn =
         persistResource(
             makeDomain(
                     "cat.みんな",
-                    makeAndPersistContactResource(
+                    FullFieldsTestEntityHelper.makeAndPersistContact(
                         "8372808-ERL",
                         "(◕‿◕)",
                         "lol@cat.みんな",
                         clock.nowUtc().minusYears(1),
                         registrar),
-                    makeAndPersistContactResource(
+                    FullFieldsTestEntityHelper.makeAndPersistContact(
                         "8372808-IRL",
                         "Santa Claus",
                         "BOFH@cat.みんな",
                         clock.nowUtc().minusYears(2),
                         registrar),
-                    makeAndPersistContactResource(
+                    FullFieldsTestEntityHelper.makeAndPersistContact(
                         "8372808-TRL",
                         "The Raven",
                         "bog@cat.みんな",
@@ -288,24 +287,24 @@ class RdapDomainSearchActionTest extends RdapSearchActionTestCase<RdapDomainSear
     // cat.1.test
     createTld("1.test");
     registrar = persistResource(makeRegistrar("multiregistrar", "1.test", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarContacts(registrar));
+    persistSimpleResources(makeRegistrarPocs(registrar));
     domainMultipart =
         persistResource(
             makeDomain(
                     "cat.1.test",
-                    makeAndPersistContactResource(
+                    FullFieldsTestEntityHelper.makeAndPersistContact(
                         "9372808-ERL",
                         "(◕‿◕)",
                         "lol@cat.みんな",
                         clock.nowUtc().minusYears(1),
                         registrar),
-                    makeAndPersistContactResource(
+                    FullFieldsTestEntityHelper.makeAndPersistContact(
                         "9372808-IRL",
                         "Santa Claus",
                         "BOFH@cat.みんな",
                         clock.nowUtc().minusYears(2),
                         registrar),
-                    makeAndPersistContactResource(
+                    FullFieldsTestEntityHelper.makeAndPersistContact(
                         "9372808-TRL",
                         "The Raven",
                         "bog@cat.みんな",

--- a/core/src/test/java/google/registry/rdap/RdapEntityActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapEntityActionTest.java
@@ -20,17 +20,16 @@ import static google.registry.rdap.RdapTestHelper.loadJsonFile;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DatabaseHelper.persistSimpleResources;
-import static google.registry.testing.FullFieldsTestEntityHelper.makeAndPersistContactResource;
-import static google.registry.testing.FullFieldsTestEntityHelper.makeAndPersistDeletedContactResource;
+import static google.registry.testing.FullFieldsTestEntityHelper.makeAndPersistDeletedContact;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeDomain;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeHost;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrar;
-import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrarContacts;
+import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrarPocs;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonObject;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.host.Host;
 import google.registry.model.registrar.Registrar;
 import google.registry.rdap.RdapMetrics.EndpointType;
@@ -38,6 +37,7 @@ import google.registry.rdap.RdapMetrics.SearchType;
 import google.registry.rdap.RdapMetrics.WildcardType;
 import google.registry.rdap.RdapSearchResults.IncompletenessWarningType;
 import google.registry.request.Action;
+import google.registry.testing.FullFieldsTestEntityHelper;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,11 +51,11 @@ class RdapEntityActionTest extends RdapActionBaseTestCase<RdapEntityAction> {
   }
 
   private Registrar registrarLol;
-  private ContactResource registrant;
-  private ContactResource adminContact;
-  private ContactResource techContact;
-  private ContactResource disconnectedContact;
-  private ContactResource deletedContact;
+  private Contact registrant;
+  private Contact adminContact;
+  private Contact techContact;
+  private Contact disconnectedContact;
+  private Contact deletedContact;
 
   @BeforeEach
   void beforeEach() {
@@ -63,28 +63,31 @@ class RdapEntityActionTest extends RdapActionBaseTestCase<RdapEntityAction> {
     createTld("lol");
     registrarLol = persistResource(makeRegistrar(
         "evilregistrar", "Yes Virginia <script>", Registrar.State.ACTIVE, 101L));
-    persistSimpleResources(makeRegistrarContacts(registrarLol));
-    registrant = makeAndPersistContactResource(
-        "8372808-REG",
-        "(◕‿◕)",
-        "lol@cat.みんな",
-        ImmutableList.of("1 Smiley Row", "Suite みんな"),
-        clock.nowUtc(),
-        registrarLol);
-    adminContact = makeAndPersistContactResource(
-        "8372808-ADM",
-        "(◕‿◕)",
-        "lol@cat.みんな",
-        ImmutableList.of("1 Smiley Row", "Suite みんな"),
-        clock.nowUtc(),
-        registrarLol);
-    techContact = makeAndPersistContactResource(
-        "8372808-TEC",
-        "(◕‿◕)",
-        "lol@cat.みんな",
-        ImmutableList.of("1 Smiley Row", "Suite みんな"),
-        clock.nowUtc(),
-        registrarLol);
+    persistSimpleResources(makeRegistrarPocs(registrarLol));
+    registrant =
+        FullFieldsTestEntityHelper.makeAndPersistContact(
+            "8372808-REG",
+            "(◕‿◕)",
+            "lol@cat.みんな",
+            ImmutableList.of("1 Smiley Row", "Suite みんな"),
+            clock.nowUtc(),
+            registrarLol);
+    adminContact =
+        FullFieldsTestEntityHelper.makeAndPersistContact(
+            "8372808-ADM",
+            "(◕‿◕)",
+            "lol@cat.みんな",
+            ImmutableList.of("1 Smiley Row", "Suite みんな"),
+            clock.nowUtc(),
+            registrarLol);
+    techContact =
+        FullFieldsTestEntityHelper.makeAndPersistContact(
+            "8372808-TEC",
+            "(◕‿◕)",
+            "lol@cat.みんな",
+            ImmutableList.of("1 Smiley Row", "Suite みんな"),
+            clock.nowUtc(),
+            registrarLol);
     Host host1 = persistResource(makeHost("ns1.cat.lol", "1.2.3.4"));
     Host host2 = persistResource(makeHost("ns2.cat.lol", "bad:f00d:cafe:0:0:0:15:beef"));
     persistResource(
@@ -93,19 +96,19 @@ class RdapEntityActionTest extends RdapActionBaseTestCase<RdapEntityAction> {
     createTld("xn--q9jyb4c");
     Registrar registrarIdn = persistResource(
         makeRegistrar("idnregistrar", "IDN Registrar", Registrar.State.ACTIVE, 102L));
-    persistSimpleResources(makeRegistrarContacts(registrarIdn));
+    persistSimpleResources(makeRegistrarPocs(registrarIdn));
     // 1.tld
     createTld("1.tld");
     Registrar registrar1tld = persistResource(
         makeRegistrar("1tldregistrar", "Multilevel Registrar", Registrar.State.ACTIVE, 103L));
-    persistSimpleResources(makeRegistrarContacts(registrar1tld));
+    persistSimpleResources(makeRegistrarPocs(registrar1tld));
     // deleted registrar
     Registrar registrarDeleted = persistResource(
         makeRegistrar("deletedregistrar", "Yes Virginia <script>", Registrar.State.PENDING, 104L));
-    persistSimpleResources(makeRegistrarContacts(registrarDeleted));
+    persistSimpleResources(makeRegistrarPocs(registrarDeleted));
     // other contacts
     disconnectedContact =
-        makeAndPersistContactResource(
+        FullFieldsTestEntityHelper.makeAndPersistContact(
             "8372808-DIS",
             "(◕‿◕)",
             "lol@cat.みんな",
@@ -113,7 +116,7 @@ class RdapEntityActionTest extends RdapActionBaseTestCase<RdapEntityAction> {
             clock.nowUtc(),
             registrarLol);
     deletedContact =
-        makeAndPersistDeletedContactResource(
+        makeAndPersistDeletedContact(
             "8372808-DEL",
             clock.nowUtc().minusYears(1),
             registrarLol,

--- a/core/src/test/java/google/registry/rdap/RdapEntitySearchActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapEntitySearchActionTest.java
@@ -23,12 +23,10 @@ import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DatabaseHelper.persistResources;
 import static google.registry.testing.DatabaseHelper.persistSimpleResources;
-import static google.registry.testing.FullFieldsTestEntityHelper.makeAndPersistContactResource;
-import static google.registry.testing.FullFieldsTestEntityHelper.makeAndPersistDeletedContactResource;
-import static google.registry.testing.FullFieldsTestEntityHelper.makeContactResource;
+import static google.registry.testing.FullFieldsTestEntityHelper.makeAndPersistDeletedContact;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeHistoryEntry;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrar;
-import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrarContacts;
+import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrarPocs;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
@@ -37,13 +35,14 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import google.registry.model.ImmutableObject;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.registrar.Registrar;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.rdap.RdapMetrics.EndpointType;
 import google.registry.rdap.RdapMetrics.SearchType;
 import google.registry.rdap.RdapSearchResults.IncompletenessWarningType;
 import google.registry.testing.FakeResponse;
+import google.registry.testing.FullFieldsTestEntityHelper;
 import java.net.URLDecoder;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -110,12 +109,12 @@ class RdapEntitySearchActionTest extends RdapSearchActionTestCase<RdapEntitySear
     registrarDeleted =
         persistResource(
             makeRegistrar("2-Registrar", "Yes Virginia <script>", Registrar.State.ACTIVE, 20L));
-    persistSimpleResources(makeRegistrarContacts(registrarDeleted));
+    persistSimpleResources(makeRegistrarPocs(registrarDeleted));
 
     // inactive
     registrarInactive =
         persistResource(makeRegistrar("2-RegistrarInact", "No Way", Registrar.State.PENDING, 21L));
-    persistSimpleResources(makeRegistrarContacts(registrarInactive));
+    persistSimpleResources(makeRegistrarPocs(registrarInactive));
 
     // test
     registrarTest =
@@ -125,9 +124,9 @@ class RdapEntitySearchActionTest extends RdapSearchActionTestCase<RdapEntitySear
                 .setType(Registrar.Type.TEST)
                 .setIanaIdentifier(null)
                 .build());
-    persistSimpleResources(makeRegistrarContacts(registrarTest));
+    persistSimpleResources(makeRegistrarPocs(registrarTest));
 
-    makeAndPersistContactResource(
+    FullFieldsTestEntityHelper.makeAndPersistContact(
         "blinky",
         "Blinky (赤ベイ)",
         "blinky@b.tld",
@@ -135,7 +134,7 @@ class RdapEntitySearchActionTest extends RdapSearchActionTestCase<RdapEntitySear
         clock.nowUtc(),
         registrarTest);
 
-    makeAndPersistContactResource(
+    FullFieldsTestEntityHelper.makeAndPersistContact(
         "blindly",
         "Blindly",
         "blindly@b.tld",
@@ -143,11 +142,8 @@ class RdapEntitySearchActionTest extends RdapSearchActionTestCase<RdapEntitySear
         clock.nowUtc(),
         registrarTest);
 
-    makeAndPersistDeletedContactResource(
-        "clyde",
-        clock.nowUtc().minusYears(1),
-        registrarDeleted,
-        clock.nowUtc().minusMonths(6));
+    makeAndPersistDeletedContact(
+        "clyde", clock.nowUtc().minusYears(1), registrarDeleted, clock.nowUtc().minusMonths(6));
 
     action.fnParam = Optional.empty();
     action.handleParam = Optional.empty();
@@ -200,8 +196,8 @@ class RdapEntitySearchActionTest extends RdapSearchActionTestCase<RdapEntitySear
     ImmutableList.Builder<ImmutableObject> resourcesBuilder = new ImmutableList.Builder<>();
     for (int i = 1; i <= numContacts; i++) {
       // Set the ROIDs to a known value for later use.
-      ContactResource contact =
-          makeContactResource(
+      Contact contact =
+          FullFieldsTestEntityHelper.makeContact(
                   String.format("contact%d", i),
                   String.format("Entity %d", i),
                   String.format("contact%d@gmail.com", i),
@@ -222,7 +218,7 @@ class RdapEntitySearchActionTest extends RdapSearchActionTestCase<RdapEntitySear
               Registrar.State.ACTIVE,
               300L + i);
       resourcesBuilder.add(registrar);
-      resourcesBuilder.addAll(makeRegistrarContacts(registrar));
+      resourcesBuilder.addAll(makeRegistrarPocs(registrar));
     }
     persistResources(resourcesBuilder.build());
   }

--- a/core/src/test/java/google/registry/rdap/RdapNameserverSearchActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapNameserverSearchActionTest.java
@@ -23,10 +23,9 @@ import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DatabaseHelper.persistResources;
 import static google.registry.testing.DatabaseHelper.persistSimpleResources;
-import static google.registry.testing.FullFieldsTestEntityHelper.makeContactResource;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeDomain;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrar;
-import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrarContacts;
+import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrarPocs;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
@@ -104,7 +103,7 @@ class RdapNameserverSearchActionTest extends RdapSearchActionTestCase<RdapNamese
     Registrar registrar =
         persistResource(
             makeRegistrar("evilregistrar", "Yes Virginia <script>", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarContacts(registrar));
+    persistSimpleResources(makeRegistrarPocs(registrar));
     hostNs1CatLol =
         FullFieldsTestEntityHelper.makeAndPersistHost(
             "ns1.cat.lol", "1.2.3.4", clock.nowUtc().minusYears(1));
@@ -119,14 +118,14 @@ class RdapNameserverSearchActionTest extends RdapSearchActionTestCase<RdapNamese
     // cat.みんな
     createTld("xn--q9jyb4c");
     registrar = persistResource(makeRegistrar("unicoderegistrar", "みんな", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarContacts(registrar));
+    persistSimpleResources(makeRegistrarPocs(registrar));
     FullFieldsTestEntityHelper.makeAndPersistHost(
         "ns1.cat.みんな", "1.2.3.5", clock.nowUtc().minusYears(1));
 
     // cat.1.test
     createTld("1.test");
     registrar = persistResource(makeRegistrar("multiregistrar", "1.test", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarContacts(registrar));
+    persistSimpleResources(makeRegistrarPocs(registrar));
     FullFieldsTestEntityHelper.makeAndPersistHost(
         "ns1.cat.1.test", "1.2.3.6", clock.nowUtc().minusYears(1));
 
@@ -136,13 +135,14 @@ class RdapNameserverSearchActionTest extends RdapSearchActionTestCase<RdapNamese
             makeDomain(
                     "cat.lol",
                     persistResource(
-                        makeContactResource(
+                        FullFieldsTestEntityHelper.makeContact(
                             "5372808-ERL", "Goblin Market", "lol@cat.lol", registrar)),
                     persistResource(
-                        makeContactResource(
+                        FullFieldsTestEntityHelper.makeContact(
                             "5372808-IRL", "Santa Claus", "BOFH@cat.lol", registrar)),
                     persistResource(
-                        makeContactResource("5372808-TRL", "The Raven", "bog@cat.lol", registrar)),
+                        FullFieldsTestEntityHelper.makeContact(
+                            "5372808-TRL", "The Raven", "bog@cat.lol", registrar)),
                     hostNs1CatLol,
                     hostNs2CatLol,
                     registrar)

--- a/core/src/test/java/google/registry/rde/ContactToXjcConverterTest.java
+++ b/core/src/test/java/google/registry/rde/ContactToXjcConverterTest.java
@@ -21,10 +21,10 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactAddress;
 import google.registry.model.contact.ContactAuthInfo;
 import google.registry.model.contact.ContactPhoneNumber;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.contact.Disclose;
 import google.registry.model.contact.PostalInfo;
 import google.registry.model.eppcommon.AuthInfo.PasswordAuth;
@@ -52,12 +52,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 /**
- * Unit tests for {@link ContactResourceToXjcConverter}.
+ * Unit tests for {@link ContactToXjcConverter}.
  *
- * <p>This tests the mapping between {@link ContactResource} and {@link XjcRdeContact} as well as
- * some exceptional conditions.
+ * <p>This tests the mapping between {@link Contact} and {@link XjcRdeContact} as well as some
+ * exceptional conditions.
  */
-public class ContactResourceToXjcConverterTest {
+public class ContactToXjcConverterTest {
 
   @RegisterExtension
   public final AppEngineExtension appEngine = AppEngineExtension.builder().withCloudSql().build();
@@ -69,8 +69,8 @@ public class ContactResourceToXjcConverterTest {
 
   @Test
   void testConvertContact() {
-    ContactResource contact = makeContactResource();
-    XjcRdeContact bean = ContactResourceToXjcConverter.convertContact(contact);
+    Contact contact = makeContact();
+    XjcRdeContact bean = ContactToXjcConverter.convertContact(contact);
 
     // o  A <id> element that contains the server-unique identifier of the
     //    contact object
@@ -230,38 +230,32 @@ public class ContactResourceToXjcConverterTest {
 
   @Test
   void testConvertContact_absentVoiceAndFaxNumbers() {
-    XjcRdeContact bean = ContactResourceToXjcConverter.convertContact(
-        makeContactResource().asBuilder()
-            .setVoiceNumber(null)
-            .setFaxNumber(null)
-            .build());
+    XjcRdeContact bean =
+        ContactToXjcConverter.convertContact(
+            makeContact().asBuilder().setVoiceNumber(null).setFaxNumber(null).build());
     assertThat(bean.getVoice()).isNull();
     assertThat(bean.getFax()).isNull();
   }
 
   @Test
   void testConvertContact_absentDisclose() {
-    XjcRdeContact bean = ContactResourceToXjcConverter.convertContact(
-        makeContactResource().asBuilder()
-            .setDisclose(null)
-            .build());
+    XjcRdeContact bean =
+        ContactToXjcConverter.convertContact(makeContact().asBuilder().setDisclose(null).build());
     assertThat(bean.getDisclose()).isNull();
   }
 
   @Test
   void testConvertContact_absentTransferData() {
-    XjcRdeContact bean = ContactResourceToXjcConverter.convertContact(
-        makeContactResource().asBuilder()
-            .setLastTransferTime(null)
-            .setTransferData(null)
-            .build());
+    XjcRdeContact bean =
+        ContactToXjcConverter.convertContact(
+            makeContact().asBuilder().setLastTransferTime(null).setTransferData(null).build());
     assertThat(bean.getTrDate()).isNull();
     assertThat(bean.getTrnData()).isNull();
   }
 
   @Test
   void testMarshal() throws Exception {
-    XjcRdeContact bean = ContactResourceToXjcConverter.convertContact(makeContactResource());
+    XjcRdeContact bean = ContactToXjcConverter.convertContact(makeContact());
     wrapDeposit(bean).marshal(new ByteArrayOutputStream(), UTF_8);
   }
 
@@ -282,8 +276,8 @@ public class ContactResourceToXjcConverterTest {
     return deposit;
   }
 
-  private static ContactResource makeContactResource() {
-    return new ContactResource.Builder()
+  private static Contact makeContact() {
+    return new Contact.Builder()
         .setContactId("love-id")
         .setRepoId("2-ROID")
         .setCreationRegistrarId("NewRegistrar")

--- a/core/src/test/java/google/registry/rde/DomainToXjcConverterTest.java
+++ b/core/src/test/java/google/registry/rde/DomainToXjcConverterTest.java
@@ -33,9 +33,9 @@ import com.google.common.net.InetAddresses;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Flag;
 import google.registry.model.billing.BillingEvent.Reason;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactAddress;
 import google.registry.model.contact.ContactPhoneNumber;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.contact.PostalInfo;
 import google.registry.model.domain.DesignatedContact;
 import google.registry.model.domain.Domain;
@@ -247,7 +247,7 @@ public class DomainToXjcConverterTest {
                 ImmutableSet.of(
                     DesignatedContact.create(
                         DesignatedContact.Type.ADMIN,
-                        makeContactResource(
+                        makeContact(
                                 clock,
                                 "10-Q9JYB4C",
                                 "5372808-IRL",
@@ -256,7 +256,7 @@ public class DomainToXjcConverterTest {
                             .createVKey()),
                     DesignatedContact.create(
                         DesignatedContact.Type.TECH,
-                        makeContactResource(
+                        makeContact(
                                 clock,
                                 "11-Q9JYB4C",
                                 "5372808-TRL",
@@ -279,7 +279,7 @@ public class DomainToXjcConverterTest {
                     makeHost(clock, "4-Q9JYB4C", "ns2.cat.みんな", "bad:f00d:cafe::15:beef")
                         .createVKey()))
             .setRegistrant(
-                makeContactResource(
+                makeContact(
                         clock, "12-Q9JYB4C", "5372808-ERL", "(◕‿◕) nevermore", "prophet@evil.みんな")
                     .createVKey())
             .setRegistrationExpirationTime(DateTime.parse("1930-01-01T00:00:00Z"))
@@ -379,11 +379,11 @@ public class DomainToXjcConverterTest {
     return persistResource(domain);
   }
 
-  private static ContactResource makeContactResource(
+  private static Contact makeContact(
       FakeClock clock, String repoId, String id, String name, String email) {
     clock.advanceOneMilli();
     return persistEppResource(
-        new ContactResource.Builder()
+        new Contact.Builder()
             .setContactId(id)
             .setEmailAddress(email)
             .setPersistedCurrentSponsorRegistrarId("TheRegistrar")

--- a/core/src/test/java/google/registry/rde/RdeFixtures.java
+++ b/core/src/test/java/google/registry/rde/RdeFixtures.java
@@ -28,9 +28,9 @@ import com.google.common.net.InetAddresses;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Flag;
 import google.registry.model.billing.BillingEvent.Reason;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactAddress;
 import google.registry.model.contact.ContactPhoneNumber;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.contact.PostalInfo;
 import google.registry.model.domain.DesignatedContact;
 import google.registry.model.domain.Domain;
@@ -62,7 +62,7 @@ final class RdeFixtures {
             .setDomainName("example." + tld)
             .setRepoId(generateNewDomainRoid(tld))
             .setRegistrant(
-                makeContactResource(clock, "5372808-ERL", "(◕‿◕) nevermore", "prophet@evil.みんな")
+                makeContact(clock, "5372808-ERL", "(◕‿◕) nevermore", "prophet@evil.みんな")
                     .createVKey())
             .build();
     DomainHistory historyEntry =
@@ -94,7 +94,7 @@ final class RdeFixtures {
                 ImmutableSet.of(
                     DesignatedContact.create(
                         DesignatedContact.Type.ADMIN,
-                        makeContactResource(
+                        makeContact(
                                 clock,
                                 "5372808-IRL",
                                 "be that word our sign in parting",
@@ -102,7 +102,7 @@ final class RdeFixtures {
                             .createVKey()),
                     DesignatedContact.create(
                         DesignatedContact.Type.TECH,
-                        makeContactResource(
+                        makeContact(
                                 clock,
                                 "5372808-TRL",
                                 "bird or fiend!? i shrieked upstarting",
@@ -220,11 +220,10 @@ final class RdeFixtures {
     return persistResource(domain);
   }
 
-  static ContactResource makeContactResource(
-      FakeClock clock, String id, String name, String email) {
+  static Contact makeContact(FakeClock clock, String id, String name, String email) {
     clock.advanceOneMilli();
     return persistResource(
-        new ContactResource.Builder()
+        new Contact.Builder()
             .setContactId(id)
             .setRepoId(generateNewContactHostRoid())
             .setEmailAddress(email)

--- a/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
+++ b/core/src/test/java/google/registry/schema/integration/SqlIntegrationTestSuite.java
@@ -19,7 +19,7 @@ import static com.google.common.truth.Truth.assert_;
 import google.registry.model.billing.BillingEventTest;
 import google.registry.model.common.CursorTest;
 import google.registry.model.console.UserTest;
-import google.registry.model.contact.ContactResourceTest;
+import google.registry.model.contact.ContactTest;
 import google.registry.model.domain.DomainSqlTest;
 import google.registry.model.domain.token.AllocationTokenTest;
 import google.registry.model.domain.token.PackagePromotionTest;
@@ -84,7 +84,7 @@ import org.junit.runner.RunWith;
   BillingEventTest.class,
   ClaimsListDaoTest.class,
   ContactHistoryTest.class,
-  ContactResourceTest.class,
+  ContactTest.class,
   CursorTest.class,
   DomainSqlTest.class,
   DomainHistoryTest.class,

--- a/core/src/test/java/google/registry/server/Fixture.java
+++ b/core/src/test/java/google/registry/server/Fixture.java
@@ -19,7 +19,7 @@ import static google.registry.model.domain.DesignatedContact.Type.BILLING;
 import static google.registry.model.domain.DesignatedContact.Type.TECH;
 import static google.registry.testing.DatabaseHelper.createTlds;
 import static google.registry.testing.DatabaseHelper.loadRegistrar;
-import static google.registry.testing.DatabaseHelper.newContactResource;
+import static google.registry.testing.DatabaseHelper.newContact;
 import static google.registry.testing.DatabaseHelper.persistActiveHost;
 import static google.registry.testing.DatabaseHelper.persistPremiumList;
 import static google.registry.testing.DatabaseHelper.persistResource;
@@ -28,8 +28,8 @@ import static org.joda.money.CurrencyUnit.USD;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import google.registry.model.OteStatsTestHelper;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactAddress;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.contact.PostalInfo;
 import google.registry.model.domain.DesignatedContact;
 import google.registry.testing.DatabaseHelper;
@@ -59,56 +59,69 @@ public enum Fixture {
         throw new RuntimeException(e);
       }
 
-      ContactResource google = persistResource(newContactResource("google")
-          .asBuilder()
-          .setLocalizedPostalInfo(new PostalInfo.Builder()
-              .setType(PostalInfo.Type.LOCALIZED)
-              .setName("Mr. Google")
-              .setOrg("Google Inc.")
-              .setAddress(new ContactAddress.Builder()
-                  .setStreet(ImmutableList.of("111 8th Ave", "4th Floor"))
-                  .setCity("New York")
-                  .setState("NY")
-                  .setZip("10011")
-                  .setCountryCode("US")
-                  .build())
-              .build())
-            .build());
+      Contact google =
+          persistResource(
+              newContact("google")
+                  .asBuilder()
+                  .setLocalizedPostalInfo(
+                      new PostalInfo.Builder()
+                          .setType(PostalInfo.Type.LOCALIZED)
+                          .setName("Mr. Google")
+                          .setOrg("Google Inc.")
+                          .setAddress(
+                              new ContactAddress.Builder()
+                                  .setStreet(ImmutableList.of("111 8th Ave", "4th Floor"))
+                                  .setCity("New York")
+                                  .setState("NY")
+                                  .setZip("10011")
+                                  .setCountryCode("US")
+                                  .build())
+                          .build())
+                  .build());
 
-      ContactResource justine = persistResource(newContactResource("justine")
-          .asBuilder()
-          .setLocalizedPostalInfo(new PostalInfo.Builder()
-              .setType(PostalInfo.Type.LOCALIZED)
-              .setName("Justine Bean")
-              .setOrg("(✿◕ ‿◕ )ノ Incorporated")
-              .setAddress(new ContactAddress.Builder()
-                  .setStreet(ImmutableList.of("123 Fake St."))
-                  .setCity("Stratford")
-                  .setState("CT")
-                  .setZip("06615")
-                  .setCountryCode("US")
-                  .build())
-              .build())
-            .build());
+      Contact justine =
+          persistResource(
+              newContact("justine")
+                  .asBuilder()
+                  .setLocalizedPostalInfo(
+                      new PostalInfo.Builder()
+                          .setType(PostalInfo.Type.LOCALIZED)
+                          .setName("Justine Bean")
+                          .setOrg("(✿◕ ‿◕ )ノ Incorporated")
+                          .setAddress(
+                              new ContactAddress.Builder()
+                                  .setStreet(ImmutableList.of("123 Fake St."))
+                                  .setCity("Stratford")
+                                  .setState("CT")
+                                  .setZip("06615")
+                                  .setCountryCode("US")
+                                  .build())
+                          .build())
+                  .build());
 
-      ContactResource robert = persistResource(newContactResource("robert")
-          .asBuilder()
-          .setLocalizedPostalInfo(new PostalInfo.Builder()
-              .setType(PostalInfo.Type.LOCALIZED)
-              .setName("Captain Robert")
-              .setOrg("Ancient World")
-              .setAddress(new ContactAddress.Builder()
-                  .setStreet(ImmutableList.of(
-                      "A skeleton crew is what came back",
-                      "And once in port he filled his sack",
-                      "With bribes and cash and fame and coin"))
-                  .setCity("Things to make a new crew join")
-                  .setState("NY")
-                  .setZip("10011")
-                  .setCountryCode("US")
-                  .build())
-              .build())
-            .build());
+      Contact robert =
+          persistResource(
+              newContact("robert")
+                  .asBuilder()
+                  .setLocalizedPostalInfo(
+                      new PostalInfo.Builder()
+                          .setType(PostalInfo.Type.LOCALIZED)
+                          .setName("Captain Robert")
+                          .setOrg("Ancient World")
+                          .setAddress(
+                              new ContactAddress.Builder()
+                                  .setStreet(
+                                      ImmutableList.of(
+                                          "A skeleton crew is what came back",
+                                          "And once in port he filled his sack",
+                                          "With bribes and cash and fame and coin"))
+                                  .setCity("Things to make a new crew join")
+                                  .setState("NY")
+                                  .setZip("10011")
+                                  .setCountryCode("US")
+                                  .build())
+                          .build())
+                  .build());
 
       persistResource(
           DatabaseHelper.newDomain("love.xn--q9jyb4c", justine)

--- a/core/src/test/java/google/registry/testing/AppEngineExtensionTest.java
+++ b/core/src/test/java/google/registry/testing/AppEngineExtensionTest.java
@@ -53,7 +53,7 @@ class AppEngineExtensionTest {
       Joiner.on('\n')
           .join(
               "<datastore-indexes autoGenerate=\"false\">",
-              "  <datastore-index kind=\"ContactResource\" ancestor=\"false\" source=\"manual\">",
+              "  <datastore-index kind=\"Contact\" ancestor=\"false\" source=\"manual\">",
               "    <property name=\"currentSponsorClientId\" direction=\"asc\"/>",
               "    <property name=\"deletionTime\" direction=\"asc\"/>",
               "    <property name=\"searchName\" direction=\"asc\"/>",
@@ -61,7 +61,7 @@ class AppEngineExtensionTest {
               "</datastore-indexes>");
 
   private static final String UNDECLARED_INDEX =
-      DECLARED_INDEX.replace("ContactResource", "NoSuchResource");
+      DECLARED_INDEX.replace("Contact", "NoSuchResource");
 
   /**
    * Sets up test AppEngine instance.

--- a/core/src/test/java/google/registry/testing/ContactSubject.java
+++ b/core/src/test/java/google/registry/testing/ContactSubject.java
@@ -20,124 +20,120 @@ import static com.google.common.truth.Truth.assertAbout;
 
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.SimpleSubjectBuilder;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.PostalInfo;
 import google.registry.model.eppcommon.AuthInfo;
 import google.registry.testing.TruthChainer.And;
 import org.joda.time.DateTime;
 
-/** Truth subject for asserting things about {@link ContactResource} instances. */
-public final class ContactResourceSubject
-    extends AbstractEppResourceSubject<ContactResource, ContactResourceSubject> {
+/** Truth subject for asserting things about {@link Contact} entities. */
+public final class ContactSubject extends AbstractEppResourceSubject<Contact, ContactSubject> {
 
-  private final ContactResource actual;
+  private final Contact actual;
 
-  public ContactResourceSubject(FailureMetadata failureMetadata, ContactResource subject) {
+  public ContactSubject(FailureMetadata failureMetadata, Contact subject) {
     super(failureMetadata, checkNotNull(subject));
     this.actual = subject;
   }
 
-  public And<ContactResourceSubject> hasLocalizedPostalInfo(PostalInfo postalInfo) {
+  public And<ContactSubject> hasLocalizedPostalInfo(PostalInfo postalInfo) {
     return hasValue(postalInfo, actual.getLocalizedPostalInfo(), "has localizedPostalInfo");
   }
 
-  public And<ContactResourceSubject> hasNullLocalizedPostalInfo() {
+  public And<ContactSubject> hasNullLocalizedPostalInfo() {
     if (actual.getLocalizedPostalInfo() != null) {
       failWithActual(simpleFact("expected to have null localized postal info"));
     }
     return andChainer();
   }
 
-  public And<ContactResourceSubject> hasNonNullLocalizedPostalInfo() {
+  public And<ContactSubject> hasNonNullLocalizedPostalInfo() {
     if (actual.getLocalizedPostalInfo() == null) {
       failWithActual(simpleFact("expected to have non-null localized postal info"));
     }
     return andChainer();
   }
 
-  public And<ContactResourceSubject> hasInternationalizedPostalInfo(
-      PostalInfo postalInfo) {
+  public And<ContactSubject> hasInternationalizedPostalInfo(PostalInfo postalInfo) {
     return hasValue(
         postalInfo, actual.getInternationalizedPostalInfo(), "has internationalizedPostalInfo");
   }
 
-  public And<ContactResourceSubject> hasNullInternationalizedPostalInfo() {
+  public And<ContactSubject> hasNullInternationalizedPostalInfo() {
     if (actual.getInternationalizedPostalInfo() != null) {
       failWithActual(simpleFact("expected to have null internationalized postal info"));
     }
     return andChainer();
   }
 
-
-  public And<ContactResourceSubject> hasNonNullInternationalizedPostalInfo() {
+  public And<ContactSubject> hasNonNullInternationalizedPostalInfo() {
     if (actual.getInternationalizedPostalInfo() == null) {
       failWithActual(simpleFact("expected to have non-null internationalized postal info"));
     }
     return andChainer();
   }
 
-  public And<ContactResourceSubject> hasNullEmailAddress() {
+  public And<ContactSubject> hasNullEmailAddress() {
     if (actual.getEmailAddress() != null) {
       failWithActual(simpleFact("expected to have null email address"));
     }
     return andChainer();
   }
 
-  public And<ContactResourceSubject> hasNonNullEmailAddress() {
+  public And<ContactSubject> hasNonNullEmailAddress() {
     if (actual.getEmailAddress() == null) {
       failWithActual(simpleFact("expected to have non-null email address"));
     }
     return andChainer();
   }
 
-  public And<ContactResourceSubject> hasNullVoiceNumber() {
+  public And<ContactSubject> hasNullVoiceNumber() {
     if (actual.getVoiceNumber() != null) {
       failWithActual(simpleFact("expected to have null voice number"));
     }
     return andChainer();
   }
 
-  public And<ContactResourceSubject> hasNonNullVoiceNumber() {
+  public And<ContactSubject> hasNonNullVoiceNumber() {
     if (actual.getVoiceNumber() == null) {
       failWithActual(simpleFact("expected to have non-null voice number"));
     }
     return andChainer();
   }
 
-  public And<ContactResourceSubject> hasNullFaxNumber() {
+  public And<ContactSubject> hasNullFaxNumber() {
     if (actual.getFaxNumber() != null) {
       failWithActual(simpleFact("expected to have null fax number"));
     }
     return andChainer();
   }
 
-  public And<ContactResourceSubject> hasNonNullFaxNumber() {
+  public And<ContactSubject> hasNonNullFaxNumber() {
     if (actual.getFaxNumber() == null) {
       failWithActual(simpleFact("expected to have non-null fax number"));
     }
     return andChainer();
   }
 
-  public And<ContactResourceSubject> hasAuthInfoPwd(String pw) {
+  public And<ContactSubject> hasAuthInfoPwd(String pw) {
     AuthInfo authInfo = actual.getAuthInfo();
     return hasValue(pw, authInfo == null ? null : authInfo.getPw().getValue(), "has auth info pw");
   }
 
-  public And<ContactResourceSubject> hasLastTransferTime(DateTime lastTransferTime) {
+  public And<ContactSubject> hasLastTransferTime(DateTime lastTransferTime) {
     return hasValue(lastTransferTime, actual.getLastTransferTime(), "has lastTransferTime");
   }
 
-  public And<ContactResourceSubject> hasLastTransferTimeNotEqualTo(DateTime lastTransferTime) {
+  public And<ContactSubject> hasLastTransferTimeNotEqualTo(DateTime lastTransferTime) {
     return doesNotHaveValue(lastTransferTime, actual.getLastTransferTime(), "lastTransferTime");
   }
 
-  public And<ContactResourceSubject> hasCurrentSponsorRegistrarId(String registrarId) {
+  public And<ContactSubject> hasCurrentSponsorRegistrarId(String registrarId) {
     return hasValue(
         registrarId, actual.getCurrentSponsorRegistrarId(), "has currentSponsorRegistrarId");
   }
 
-  public static SimpleSubjectBuilder<ContactResourceSubject, ContactResource>
-      assertAboutContacts() {
-    return assertAbout(ContactResourceSubject::new);
+  public static SimpleSubjectBuilder<ContactSubject, Contact> assertAboutContacts() {
+    return assertAbout(ContactSubject::new);
   }
 }

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -73,9 +73,9 @@ import google.registry.model.billing.BillingEvent.Recurring;
 import google.registry.model.billing.BillingEvent.RenewalPriceBehavior;
 import google.registry.model.common.DatabaseMigrationStateSchedule;
 import google.registry.model.common.DatabaseMigrationStateSchedule.MigrationState;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactAuthInfo;
 import google.registry.model.contact.ContactHistory;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.domain.DesignatedContact;
 import google.registry.model.domain.DesignatedContact.Type;
 import google.registry.model.domain.Domain;
@@ -173,7 +173,7 @@ public class DatabaseHelper {
     return newDomain(domainName, repoId, persistActiveContact("contact1234"));
   }
 
-  public static Domain newDomain(String domainName, ContactResource contact) {
+  public static Domain newDomain(String domainName, Contact contact) {
     return newDomain(domainName, generateNewDomainRoid(getTldFromDomainName(domainName)), contact);
   }
 
@@ -183,8 +183,8 @@ public class DatabaseHelper {
     return newDomain(domainName).asBuilder().setNameservers(hostKeys).build();
   }
 
-  public static Domain newDomain(String domainName, String repoId, ContactResource contact) {
-    VKey<ContactResource> contactKey = contact.createVKey();
+  public static Domain newDomain(String domainName, String repoId, Contact contact) {
+    VKey<Contact> contactKey = contact.createVKey();
     return new Domain.Builder()
         .setRepoId(repoId)
         .setDomainName(domainName)
@@ -202,15 +202,15 @@ public class DatabaseHelper {
   }
 
   /**
-   * Returns a newly created {@link ContactResource} for the given contactId (which is the foreign
-   * key) with an auto-generated repoId.
+   * Returns a newly created {@link Contact} for the given contactId (which is the foreign key) with
+   * an auto-generated repoId.
    */
-  public static ContactResource newContactResource(String contactId) {
-    return newContactResourceWithRoid(contactId, generateNewContactHostRoid());
+  public static Contact newContact(String contactId) {
+    return newContactWithRoid(contactId, generateNewContactHostRoid());
   }
 
-  public static ContactResource newContactResourceWithRoid(String contactId, String repoId) {
-    return new ContactResource.Builder()
+  public static Contact newContactWithRoid(String contactId, String repoId) {
+    return new Contact.Builder()
         .setRepoId(repoId)
         .setContactId(contactId)
         .setCreationRegistrarId("TheRegistrar")
@@ -259,14 +259,13 @@ public class DatabaseHelper {
         .build();
   }
 
-  public static ContactResource persistActiveContact(String contactId) {
-    return persistResource(newContactResource(contactId));
+  public static Contact persistActiveContact(String contactId) {
+    return persistResource(newContact(contactId));
   }
 
   /** Persists a contact resource with the given contact id deleted at the specified time. */
-  public static ContactResource persistDeletedContact(String contactId, DateTime deletionTime) {
-    return persistResource(
-        newContactResource(contactId).asBuilder().setDeletionTime(deletionTime).build());
+  public static Contact persistDeletedContact(String contactId, DateTime deletionTime) {
+    return persistResource(newContact(contactId).asBuilder().setDeletionTime(deletionTime).build());
   }
 
   public static Host persistActiveHost(String hostName) {
@@ -558,8 +557,8 @@ public class DatabaseHelper {
         .build();
   }
 
-  public static ContactResource persistContactWithPendingTransfer(
-      ContactResource contact, DateTime requestTime, DateTime expirationTime, DateTime now) {
+  public static Contact persistContactWithPendingTransfer(
+      Contact contact, DateTime requestTime, DateTime expirationTime, DateTime now) {
     HistoryEntry historyEntryContactTransfer =
         persistResource(
             new ContactHistory.Builder()
@@ -609,7 +608,7 @@ public class DatabaseHelper {
   public static Domain persistDomainWithDependentResources(
       String label,
       String tld,
-      ContactResource contact,
+      Contact contact,
       DateTime now,
       DateTime creationTime,
       DateTime expirationTime) {
@@ -1150,7 +1149,7 @@ public class DatabaseHelper {
   }
 
   private static HistoryEntry.Type getHistoryEntryType(EppResource resource) {
-    if (resource instanceof ContactResource) {
+    if (resource instanceof Contact) {
       return resource.getRepoId() != null
           ? HistoryEntry.Type.CONTACT_CREATE
           : HistoryEntry.Type.CONTACT_UPDATE;

--- a/core/src/test/java/google/registry/testing/FullFieldsTestEntityHelper.java
+++ b/core/src/test/java/google/registry/testing/FullFieldsTestEntityHelper.java
@@ -24,9 +24,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.InetAddresses;
 import google.registry.model.EppResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactAddress;
 import google.registry.model.contact.ContactPhoneNumber;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.contact.PostalInfo;
 import google.registry.model.domain.DesignatedContact;
 import google.registry.model.domain.Domain;
@@ -89,7 +89,7 @@ public final class FullFieldsTestEntityHelper {
         .build();
   }
 
-  public static ImmutableList<RegistrarPoc> makeRegistrarContacts(Registrar registrar) {
+  public static ImmutableList<RegistrarPoc> makeRegistrarPocs(Registrar registrar) {
     return ImmutableList.of(
         new RegistrarPoc.Builder()
             .setRegistrar(registrar)
@@ -178,28 +178,26 @@ public final class FullFieldsTestEntityHelper {
     return host;
   }
 
-  public static ContactResource makeContactResource(
-      String id, String name, @Nullable String email) {
-    return makeContactResource(
-        id, name, email, ImmutableList.of("123 Example Boulevard <script>"), null);
+  public static Contact makeContact(String id, String name, @Nullable String email) {
+    return makeContact(id, name, email, ImmutableList.of("123 Example Boulevard <script>"), null);
   }
 
-  public static ContactResource makeContactResource(
+  public static Contact makeContact(
       String id, String name, @Nullable String email, @Nullable Registrar registrar) {
-    return makeContactResource(
+    return makeContact(
         id, name, email, ImmutableList.of("123 Example Boulevard <script>"), registrar);
   }
 
-  public static ContactResource makeContactResource(
+  public static Contact makeContact(
       String id,
       String name,
       @Nullable String email,
       @Nullable List<String> street,
       @Nullable Registrar registrar) {
-    return makeContactResource(id, name, email, street, registrar, null);
+    return makeContact(id, name, email, street, registrar, null);
   }
 
-  public static ContactResource makeContactResource(
+  public static Contact makeContact(
       String id,
       String name,
       @Nullable String email,
@@ -219,8 +217,8 @@ public final class FullFieldsTestEntityHelper {
             .setCountryCode("US")
             .build());
     }
-    ContactResource.Builder builder =
-        new ContactResource.Builder()
+    Contact.Builder builder =
+        new Contact.Builder()
             .setContactId(id)
             .setRepoId(generateNewContactHostRoid())
             .setCreationTimeForTest(DateTime.parse("2000-10-08T00:45:00Z"))
@@ -239,14 +237,13 @@ public final class FullFieldsTestEntityHelper {
     return builder.build();
   }
 
-  public static ContactResource makeWipedOutContactResource(
-      String id,
-      @Nullable Registrar registrar,
-      @Nullable DateTime deletionTime) {
-    ContactResource.Builder builder = new ContactResource.Builder()
-        .setContactId(id)
-        .setRepoId(generateNewContactHostRoid())
-        .setCreationTimeForTest(DateTime.parse("2000-10-08T00:45:00Z"));
+  public static Contact makeWipedOutContact(
+      String id, @Nullable Registrar registrar, @Nullable DateTime deletionTime) {
+    Contact.Builder builder =
+        new Contact.Builder()
+            .setContactId(id)
+            .setRepoId(generateNewContactHostRoid())
+            .setCreationTimeForTest(DateTime.parse("2000-10-08T00:45:00Z"));
     if (registrar != null) {
       builder
           .setCreationRegistrarId(registrar.getRegistrarId())
@@ -258,13 +255,13 @@ public final class FullFieldsTestEntityHelper {
     return builder.build();
   }
 
-  public static ContactResource makeAndPersistContactResource(
+  public static Contact makeAndPersistContact(
       String id,
       String name,
       @Nullable String email,
       @Nullable DateTime creationTime,
       @Nullable Registrar registrar) {
-    return makeAndPersistContactResource(
+    return makeAndPersistContact(
         id,
         name,
         email,
@@ -274,26 +271,26 @@ public final class FullFieldsTestEntityHelper {
         null);
   }
 
-  public static ContactResource makeAndPersistContactResource(
+  public static Contact makeAndPersistContact(
       String id,
       String name,
       @Nullable String email,
       @Nullable List<String> street,
       @Nullable DateTime creationTime) {
-    return makeAndPersistContactResource(id, name, email, street, creationTime, null, null);
+    return makeAndPersistContact(id, name, email, street, creationTime, null, null);
   }
 
-  public static ContactResource makeAndPersistContactResource(
+  public static Contact makeAndPersistContact(
       String id,
       String name,
       @Nullable String email,
       @Nullable List<String> street,
       @Nullable DateTime creationTime,
       @Nullable Registrar registrar) {
-    return makeAndPersistContactResource(id, name, email, street, creationTime, registrar, null);
+    return makeAndPersistContact(id, name, email, street, creationTime, registrar, null);
   }
 
-  public static ContactResource makeAndPersistContactResource(
+  public static Contact makeAndPersistContact(
       String id,
       String name,
       @Nullable String email,
@@ -301,38 +298,36 @@ public final class FullFieldsTestEntityHelper {
       @Nullable DateTime creationTime,
       @Nullable Registrar registrar,
       @Nullable DateTime deletionTime) {
-    ContactResource contactResource =
-        persistResource(makeContactResource(id, name, email, street, registrar, deletionTime));
+    Contact contact =
+        persistResource(makeContact(id, name, email, street, registrar, deletionTime));
     if (creationTime != null) {
-      persistResource(makeHistoryEntry(
-          contactResource, HistoryEntry.Type.CONTACT_CREATE, null, "created", creationTime));
+      persistResource(
+          makeHistoryEntry(
+              contact, HistoryEntry.Type.CONTACT_CREATE, null, "created", creationTime));
     }
     if (deletionTime != null) {
-      persistResource(makeHistoryEntry(
-          contactResource, HistoryEntry.Type.CONTACT_DELETE, null, "deleted", deletionTime));
+      persistResource(
+          makeHistoryEntry(
+              contact, HistoryEntry.Type.CONTACT_DELETE, null, "deleted", deletionTime));
     }
-    return contactResource;
+    return contact;
   }
 
-  public static ContactResource makeAndPersistDeletedContactResource(
-      String id,
-      DateTime creationTime,
-      Registrar registrar,
-      DateTime deletionTime) {
-    ContactResource contactResource =
-        persistResource(makeWipedOutContactResource(id, registrar, deletionTime));
-    persistResource(makeHistoryEntry(
-        contactResource, HistoryEntry.Type.CONTACT_CREATE, null, "created", creationTime));
-    persistResource(makeHistoryEntry(
-        contactResource, HistoryEntry.Type.CONTACT_DELETE, null, "deleted", deletionTime));
-    return contactResource;
+  public static Contact makeAndPersistDeletedContact(
+      String id, DateTime creationTime, Registrar registrar, DateTime deletionTime) {
+    Contact contact = persistResource(makeWipedOutContact(id, registrar, deletionTime));
+    persistResource(
+        makeHistoryEntry(contact, HistoryEntry.Type.CONTACT_CREATE, null, "created", creationTime));
+    persistResource(
+        makeHistoryEntry(contact, HistoryEntry.Type.CONTACT_DELETE, null, "deleted", deletionTime));
+    return contact;
   }
 
   public static Domain makeDomain(
       String domain,
-      @Nullable ContactResource registrant,
-      @Nullable ContactResource admin,
-      @Nullable ContactResource tech,
+      @Nullable Contact registrant,
+      @Nullable Contact admin,
+      @Nullable Contact tech,
       @Nullable Host ns1,
       @Nullable Host ns2,
       Registrar registrar) {

--- a/core/src/test/java/google/registry/tools/GetContactCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetContactCommandTest.java
@@ -15,7 +15,7 @@
 package google.registry.tools;
 
 import static google.registry.testing.DatabaseHelper.createTld;
-import static google.registry.testing.DatabaseHelper.newContactResource;
+import static google.registry.testing.DatabaseHelper.newContact;
 import static google.registry.testing.DatabaseHelper.persistActiveContact;
 import static google.registry.testing.DatabaseHelper.persistDeletedContact;
 import static google.registry.testing.DatabaseHelper.persistResource;
@@ -44,9 +44,9 @@ class GetContactCommandTest extends CommandTestCase<GetContactCommand> {
     assertInStdout("contactId=sh8013");
     assertInStdout(
         "Websafe key: "
-            + "kind:ContactResource"
+            + "kind:Contact"
             + "@sql:rO0ABXQABjItUk9JRA"
-            + "@ofy:agR0ZXN0chsLEg9Db250YWN0UmVzb3VyY2UiBjItUk9JRAw");
+            + "@ofy:agR0ZXN0chMLEgdDb250YWN0IgYyLVJPSUQM");
   }
 
   @Test
@@ -56,9 +56,9 @@ class GetContactCommandTest extends CommandTestCase<GetContactCommand> {
     assertInStdout("contactId=sh8013");
     assertInStdout(
         "Websafe key: "
-            + "kind:ContactResource"
+            + "kind:Contact"
             + "@sql:rO0ABXQABjItUk9JRA"
-            + "@ofy:agR0ZXN0chsLEg9Db250YWN0UmVzb3VyY2UiBjItUk9JRAw");
+            + "@ofy:agR0ZXN0chMLEgdDb250YWN0IgYyLVJPSUQM");
     assertNotInStdout("LiveRef");
   }
 
@@ -71,14 +71,14 @@ class GetContactCommandTest extends CommandTestCase<GetContactCommand> {
     assertInStdout("contactId=jd1234");
     assertInStdout(
         "Websafe key: "
-            + "kind:ContactResource"
+            + "kind:Contact"
             + "@sql:rO0ABXQABjItUk9JRA"
-            + "@ofy:agR0ZXN0chsLEg9Db250YWN0UmVzb3VyY2UiBjItUk9JRAw");
+            + "@ofy:agR0ZXN0chMLEgdDb250YWN0IgYyLVJPSUQM");
     assertInStdout(
         "Websafe key: "
-            + "kind:ContactResource"
-            + "@sql:rO0ABXQABjItUk9JRA"
-            + "@ofy:agR0ZXN0chsLEg9Db250YWN0UmVzb3VyY2UiBjItUk9JRAw");
+            + "kind:Contact"
+            + "@sql:rO0ABXQABjMtUk9JRA"
+            + "@ofy:agR0ZXN0chMLEgdDb250YWN0IgYzLVJPSUQM");
   }
 
   @Test
@@ -101,8 +101,7 @@ class GetContactCommandTest extends CommandTestCase<GetContactCommand> {
 
   @Test
   void testSuccess_contactDeletedInFuture() throws Exception {
-    persistResource(
-        newContactResource("sh8013").asBuilder().setDeletionTime(now.plusDays(1)).build());
+    persistResource(newContact("sh8013").asBuilder().setDeletionTime(now.plusDays(1)).build());
     runCommand("sh8013", "--read_timestamp=" + now.plusMonths(1));
     assertInStdout("Contact 'sh8013' does not exist or is deleted");
   }

--- a/core/src/test/java/google/registry/tools/GetDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetDomainCommandTest.java
@@ -38,7 +38,7 @@ class GetDomainCommandTest extends CommandTestCase<GetDomainCommand> {
     persistActiveDomain("example.tld");
     runCommand("example.tld");
     assertInStdout("fullyQualifiedDomainName=example.tld");
-    assertInStdout("Contact=VKey<ContactResource>(sql:3-ROID");
+    assertInStdout("Contact=VKey<Contact>(sql:3-ROID");
     assertInStdout(
         "Websafe key: "
             + "kind:Domain"

--- a/core/src/test/java/google/registry/tools/UnrenewDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UnrenewDomainCommandTest.java
@@ -37,7 +37,7 @@ import com.google.common.collect.ImmutableSet;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Flag;
 import google.registry.model.billing.BillingEvent.Reason;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.eppcommon.StatusValue;
@@ -59,7 +59,7 @@ public class UnrenewDomainCommandTest extends CommandTestCase<UnrenewDomainComma
 
   @Test
   void test_unrenewTwoDomains_worksSuccessfully() throws Exception {
-    ContactResource contact = persistActiveContact("jd1234");
+    Contact contact = persistActiveContact("jd1234");
     fakeClock.advanceOneMilli();
     persistDomainWithDependentResources(
         "foo",
@@ -94,7 +94,7 @@ public class UnrenewDomainCommandTest extends CommandTestCase<UnrenewDomainComma
 
   @Test
   void test_unrenewDomain_savesDependentEntitiesCorrectly() throws Exception {
-    ContactResource contact = persistActiveContact("jd1234");
+    Contact contact = persistActiveContact("jd1234");
     fakeClock.advanceOneMilli();
     persistDomainWithDependentResources(
         "foo",

--- a/core/src/test/java/google/registry/tools/UpdateDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateDomainCommandTest.java
@@ -20,7 +20,7 @@ import static google.registry.model.eppcommon.StatusValue.PENDING_DELETE;
 import static google.registry.model.eppcommon.StatusValue.SERVER_UPDATE_PROHIBITED;
 import static google.registry.model.reporting.HistoryEntry.Type.DOMAIN_CREATE;
 import static google.registry.testing.DatabaseHelper.createTld;
-import static google.registry.testing.DatabaseHelper.newContactResource;
+import static google.registry.testing.DatabaseHelper.newContact;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistActiveHost;
 import static google.registry.testing.DatabaseHelper.persistResource;
@@ -35,7 +35,7 @@ import com.google.common.collect.ImmutableSet;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingEvent.Flag;
 import google.registry.model.billing.BillingEvent.Reason;
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.domain.DesignatedContact;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainHistory;
@@ -237,10 +237,10 @@ class UpdateDomainCommandTest extends EppToolCommandTestCase<UpdateDomainCommand
 
   @Test
   void testSuccess_setContacts() throws Exception {
-    ContactResource adminContact = persistResource(newContactResource("crr-admin1"));
-    ContactResource techContact = persistResource(newContactResource("crr-tech1"));
-    VKey<ContactResource> adminContactKey = adminContact.createVKey();
-    VKey<ContactResource> techContactKey = techContact.createVKey();
+    Contact adminContact = persistResource(newContact("crr-admin1"));
+    Contact techContact = persistResource(newContact("crr-tech1"));
+    VKey<Contact> adminContactKey = adminContact.createVKey();
+    VKey<Contact> techContactKey = techContact.createVKey();
 
     persistResource(
         DatabaseHelper.newDomain("example.tld")
@@ -364,10 +364,10 @@ class UpdateDomainCommandTest extends EppToolCommandTestCase<UpdateDomainCommand
 
   @Test
   void testSuccess_canUpdatePendingDeleteDomain_whenSuperuserPassesOverrideFlag() throws Exception {
-    ContactResource adminContact = persistResource(newContactResource("crr-admin1"));
-    ContactResource techContact = persistResource(newContactResource("crr-tech1"));
-    VKey<ContactResource> adminContactKey = adminContact.createVKey();
-    VKey<ContactResource> techContactKey = techContact.createVKey();
+    Contact adminContact = persistResource(newContact("crr-admin1"));
+    Contact techContact = persistResource(newContact("crr-tech1"));
+    VKey<Contact> adminContactKey = adminContact.createVKey();
+    VKey<Contact> techContactKey = techContact.createVKey();
 
     persistResource(
         DatabaseHelper.newDomain("example.tld")

--- a/core/src/test/java/google/registry/whois/DomainWhoisResponseTest.java
+++ b/core/src/test/java/google/registry/whois/DomainWhoisResponseTest.java
@@ -23,9 +23,9 @@ import static google.registry.whois.WhoisTestData.loadFile;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactAddress;
 import google.registry.model.contact.ContactPhoneNumber;
-import google.registry.model.contact.ContactResource;
 import google.registry.model.contact.PostalInfo;
 import google.registry.model.domain.DesignatedContact;
 import google.registry.model.domain.Domain;
@@ -54,9 +54,9 @@ class DomainWhoisResponseTest {
   private Host host1;
   private Host host2;
   private RegistrarPoc abuseContact;
-  private ContactResource adminContact;
-  private ContactResource registrant;
-  private ContactResource techContact;
+  private Contact adminContact;
+  private Contact registrant;
+  private Contact techContact;
   private Domain domain;
 
   private final FakeClock clock = new FakeClock(DateTime.parse("2009-05-29T20:15:00Z"));
@@ -100,7 +100,7 @@ class DomainWhoisResponseTest {
 
     registrant =
         persistResource(
-            new ContactResource.Builder()
+            new Contact.Builder()
                 .setContactId("5372808-ERL")
                 .setRepoId("4-ROID")
                 .setCreationRegistrarId("NewRegistrar")
@@ -148,7 +148,7 @@ class DomainWhoisResponseTest {
 
     adminContact =
         persistResource(
-            new ContactResource.Builder()
+            new Contact.Builder()
                 .setContactId("5372809-ERL")
                 .setRepoId("5-ROID")
                 .setCreationRegistrarId("NewRegistrar")
@@ -193,7 +193,7 @@ class DomainWhoisResponseTest {
 
     techContact =
         persistResource(
-            new ContactResource.Builder()
+            new Contact.Builder()
                 .setContactId("5372811-ERL")
                 .setRepoId("6-ROID")
                 .setCreationRegistrarId("NewRegistrar")
@@ -241,9 +241,9 @@ class DomainWhoisResponseTest {
 
     VKey<Host> host1VKey = host1.createVKey();
     VKey<Host> host2VKey = host2.createVKey();
-    VKey<ContactResource> registrantResourceKey = registrant.createVKey();
-    VKey<ContactResource> adminResourceKey = adminContact.createVKey();
-    VKey<ContactResource> techResourceKey = techContact.createVKey();
+    VKey<Contact> registrantResourceKey = registrant.createVKey();
+    VKey<Contact> adminResourceKey = adminContact.createVKey();
+    VKey<Contact> techResourceKey = techContact.createVKey();
 
     String repoId = "3-TLD";
     domain =

--- a/core/src/test/java/google/registry/whois/WhoisHttpActionTest.java
+++ b/core/src/test/java/google/registry/whois/WhoisHttpActionTest.java
@@ -20,10 +20,9 @@ import static google.registry.testing.DatabaseHelper.createTlds;
 import static google.registry.testing.DatabaseHelper.loadRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DatabaseHelper.persistSimpleResources;
-import static google.registry.testing.FullFieldsTestEntityHelper.makeContactResource;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeDomain;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrar;
-import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrarContacts;
+import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrarPocs;
 import static google.registry.whois.WhoisTestData.loadFile;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
@@ -35,7 +34,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import google.registry.model.contact.ContactResource;
+import google.registry.model.contact.Contact;
 import google.registry.model.registrar.Registrar;
 import google.registry.model.tld.Registry;
 import google.registry.testing.AppEngineExtension;
@@ -120,14 +119,19 @@ class WhoisHttpActionTest {
     persistResource(
         makeDomain(
             "cat.lol",
-            persistResource(makeContactResource("5372808-ERL", "Goblin Market", "lol@cat.lol")),
-            persistResource(makeContactResource("5372808-IRL", "Santa Claus", "BOFH@cat.lol")),
-            persistResource(makeContactResource("5372808-TRL", "The Raven", "bog@cat.lol")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact(
+                    "5372808-ERL", "Goblin Market", "lol@cat.lol")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact(
+                    "5372808-IRL", "Santa Claus", "BOFH@cat.lol")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact("5372808-TRL", "The Raven", "bog@cat.lol")),
             persistResource(FullFieldsTestEntityHelper.makeHost("ns1.cat.lol", "1.2.3.4")),
             persistResource(
                 FullFieldsTestEntityHelper.makeHost("ns2.cat.lol", "bad:f00d:cafe::15:beef")),
             registrar));
-    persistSimpleResources(makeRegistrarContacts(registrar));
+    persistSimpleResources(makeRegistrarPocs(registrar));
     newWhoisHttpAction("/domain/cat.lol").run();
     assertThat(response.getStatus()).isEqualTo(404);
     assertThat(response.getContentType()).isEqualTo(PLAIN_TEXT_UTF_8);
@@ -141,14 +145,18 @@ class WhoisHttpActionTest {
     persistResource(
         makeDomain(
             "cat.みんな",
-            persistResource(makeContactResource("5372808-ERL", "(◕‿◕)", "lol@cat.みんな")),
-            persistResource(makeContactResource("5372808-IRL", "Santa Claus", "BOFH@cat.みんな")),
-            persistResource(makeContactResource("5372808-TRL", "The Raven", "bog@cat.みんな")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact("5372808-ERL", "(◕‿◕)", "lol@cat.みんな")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact(
+                    "5372808-IRL", "Santa Claus", "BOFH@cat.みんな")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact("5372808-TRL", "The Raven", "bog@cat.みんな")),
             persistResource(FullFieldsTestEntityHelper.makeHost("ns1.cat.みんな", "1.2.3.4")),
             persistResource(
                 FullFieldsTestEntityHelper.makeHost("ns2.cat.みんな", "bad:f00d:cafe::15:beef")),
             registrar));
-    persistSimpleResources(makeRegistrarContacts(registrar));
+    persistSimpleResources(makeRegistrarPocs(registrar));
     newWhoisHttpAction("/domain/cat.みんな").run();
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.getPayload()).isEqualTo(loadFile("whois_action_idn_utf8.txt"));
@@ -156,7 +164,8 @@ class WhoisHttpActionTest {
 
   @Test
   void testRun_wickedLineFeedForgeryInDatastore_crlfSubstitutedWithSpace() {
-    ContactResource trl = makeContactResource("5372808-TRL", "Eric Schmidt", "bog@cat.みんな");
+    Contact trl =
+        FullFieldsTestEntityHelper.makeContact("5372808-TRL", "Eric Schmidt", "bog@cat.みんな");
     trl =
         persistResource(
             trl.asBuilder()
@@ -186,9 +195,13 @@ class WhoisHttpActionTest {
     persistResource(
         makeDomain(
             "cat.みんな",
-            persistResource(makeContactResource("5372808-ERL", "(◕‿◕)", "lol@cat.みんな")),
-            persistResource(makeContactResource("5372808-IRL", "Operator", "BOFH@cat.みんな")),
-            persistResource(makeContactResource("5372808-TRL", "Eric Schmidt", "bog@cat.みんな")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact("5372808-ERL", "(◕‿◕)", "lol@cat.みんな")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact("5372808-IRL", "Operator", "BOFH@cat.みんな")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact(
+                    "5372808-TRL", "Eric Schmidt", "bog@cat.みんな")),
             persistResource(FullFieldsTestEntityHelper.makeHost("ns1.cat.みんな", "1.2.3.4")),
             persistResource(
                 FullFieldsTestEntityHelper.makeHost("ns2.cat.みんな", "bad:f00d:cafe::15:beef")),
@@ -213,14 +226,18 @@ class WhoisHttpActionTest {
     persistResource(
         makeDomain(
             "cat.みんな",
-            persistResource(makeContactResource("5372808-ERL", "(◕‿◕)", "lol@cat.みんな")),
-            persistResource(makeContactResource("5372808-IRL", "Santa Claus", "BOFH@cat.みんな")),
-            persistResource(makeContactResource("5372808-TRL", "The Raven", "bog@cat.みんな")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact("5372808-ERL", "(◕‿◕)", "lol@cat.みんな")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact(
+                    "5372808-IRL", "Santa Claus", "BOFH@cat.みんな")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact("5372808-TRL", "The Raven", "bog@cat.みんな")),
             persistResource(FullFieldsTestEntityHelper.makeHost("ns1.cat.みんな", "1.2.3.4")),
             persistResource(
                 FullFieldsTestEntityHelper.makeHost("ns2.cat.みんな", "bad:f00d:cafe::15:beef")),
             registrar));
-    persistSimpleResources(makeRegistrarContacts(registrar));
+    persistSimpleResources(makeRegistrarPocs(registrar));
     newWhoisHttpAction("/domain/cat.xn--q9jyb4c").run();
     assertThat(response.getPayload()).isEqualTo(loadFile("whois_action_idn_utf8.txt"));
   }
@@ -280,9 +297,14 @@ class WhoisHttpActionTest {
     persistResource(
         makeDomain(
             "cat.lol",
-            persistResource(makeContactResource("5372808-ERL", "Peter Murphy", "lol@cat.lol")),
-            persistResource(makeContactResource("5372808-IRL", "Operator", "BOFH@cat.lol")),
-            persistResource(makeContactResource("5372808-TRL", "Eric Schmidt", "bog@cat.lol")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact(
+                    "5372808-ERL", "Peter Murphy", "lol@cat.lol")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact("5372808-IRL", "Operator", "BOFH@cat.lol")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact(
+                    "5372808-TRL", "Eric Schmidt", "bog@cat.lol")),
             persistResource(FullFieldsTestEntityHelper.makeHost("ns1.cat.lol", "1.2.3.4")),
             persistResource(
                 FullFieldsTestEntityHelper.makeHost("ns2.cat.lol", "bad:f00d:cafe::15:beef")),
@@ -297,9 +319,14 @@ class WhoisHttpActionTest {
     persistResource(
         makeDomain(
             "cat.lol",
-            persistResource(makeContactResource("5372808-ERL", "Peter Murphy", "lol@cat.lol")),
-            persistResource(makeContactResource("5372808-IRL", "Operator", "BOFH@cat.lol")),
-            persistResource(makeContactResource("5372808-TRL", "Eric Schmidt", "bog@cat.lol")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact(
+                    "5372808-ERL", "Peter Murphy", "lol@cat.lol")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact("5372808-IRL", "Operator", "BOFH@cat.lol")),
+            persistResource(
+                FullFieldsTestEntityHelper.makeContact(
+                    "5372808-TRL", "Eric Schmidt", "bog@cat.lol")),
             persistResource(FullFieldsTestEntityHelper.makeHost("ns1.cat.lol", "1.2.3.4")),
             persistResource(
                 FullFieldsTestEntityHelper.makeHost("ns2.cat.lol", "bad:f00d:cafe::15:beef")),
@@ -314,7 +341,7 @@ class WhoisHttpActionTest {
   void testRun_registrarLookup_works() {
     Registrar registrar = persistResource(
         makeRegistrar("example", "Example Registrar, Inc.", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarContacts(registrar));
+    persistSimpleResources(makeRegistrarPocs(registrar));
     // Notice the partial search without "inc".
     newWhoisHttpAction("/registrar/Example%20Registrar").run();
     assertThat(response.getStatus()).isEqualTo(200);
@@ -325,7 +352,7 @@ class WhoisHttpActionTest {
   void testRun_registrarLookupInPendingState_returnsNotFound() {
     Registrar registrar = persistResource(
         makeRegistrar("example", "Example Registrar, Inc.", Registrar.State.PENDING));
-    persistSimpleResources(makeRegistrarContacts(registrar));
+    persistSimpleResources(makeRegistrarPocs(registrar));
     newWhoisHttpAction("/registrar/Example%20Registrar,%20Inc.").run();
     assertThat(response.getStatus()).isEqualTo(404);
     assertThat(response.getPayload()).isEqualTo(loadFile("whois_action_registrar_not_found.txt"));
@@ -336,7 +363,7 @@ class WhoisHttpActionTest {
     Registrar registrar = persistResource(
         makeRegistrar("example", "Example Registrar, Inc.", Registrar.State.ACTIVE)
             .asBuilder().setType(Registrar.Type.TEST).setIanaIdentifier(null).build());
-    persistSimpleResources(makeRegistrarContacts(registrar));
+    persistSimpleResources(makeRegistrarPocs(registrar));
     newWhoisHttpAction("/registrar/Example%20Registrar,%20Inc.").run();
     assertThat(response.getStatus()).isEqualTo(404);
     assertThat(response.getPayload()).isEqualTo(loadFile("whois_action_registrar_not_found.txt"));

--- a/core/src/test/resources/google/registry/export/backup_kinds.txt
+++ b/core/src/test/resources/google/registry/export/backup_kinds.txt
@@ -1,6 +1,6 @@
 AllocationToken
 Cancellation
-ContactResource
+Contact
 Domain
 EntityGroupRoot
 EppResourceIndex

--- a/core/src/test/resources/google/registry/export/reporting_kinds.txt
+++ b/core/src/test/resources/google/registry/export/reporting_kinds.txt
@@ -1,6 +1,6 @@
 AllocationToken
 Cancellation
-ContactResource
+Contact
 Domain
 EppResourceIndex
 ForeignKeyContactIndex

--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -5,6 +5,24 @@ class google.registry.model.common.GaeUserIdConverter {
   @Id long id;
   com.google.appengine.api.users.User user;
 }
+class google.registry.model.contact.Contact {
+  @Id java.lang.String repoId;
+  google.registry.model.contact.ContactAuthInfo authInfo;
+  google.registry.model.contact.ContactPhoneNumber fax;
+  google.registry.model.contact.ContactPhoneNumber voice;
+  google.registry.model.contact.Disclose disclose;
+  google.registry.model.transfer.ContactTransferData transferData;
+  java.lang.String contactId;
+  java.lang.String creationClientId;
+  java.lang.String currentSponsorClientId;
+  java.lang.String email;
+  java.lang.String lastEppUpdateClientId;
+  java.lang.String searchName;
+  java.util.Set<google.registry.model.eppcommon.StatusValue> status;
+  org.joda.time.DateTime deletionTime;
+  org.joda.time.DateTime lastEppUpdateTime;
+  org.joda.time.DateTime lastTransferTime;
+}
 class google.registry.model.contact.ContactAuthInfo {
   google.registry.model.eppcommon.AuthInfo$PasswordAuth pw;
 }
@@ -46,24 +64,6 @@ class google.registry.model.contact.ContactPhoneNumber {
   java.lang.String extension;
   java.lang.String phoneNumber;
 }
-class google.registry.model.contact.ContactResource {
-  @Id java.lang.String repoId;
-  google.registry.model.contact.ContactAuthInfo authInfo;
-  google.registry.model.contact.ContactPhoneNumber fax;
-  google.registry.model.contact.ContactPhoneNumber voice;
-  google.registry.model.contact.Disclose disclose;
-  google.registry.model.transfer.ContactTransferData transferData;
-  java.lang.String contactId;
-  java.lang.String creationClientId;
-  java.lang.String currentSponsorClientId;
-  java.lang.String email;
-  java.lang.String lastEppUpdateClientId;
-  java.lang.String searchName;
-  java.util.Set<google.registry.model.eppcommon.StatusValue> status;
-  org.joda.time.DateTime deletionTime;
-  org.joda.time.DateTime lastEppUpdateTime;
-  org.joda.time.DateTime lastTransferTime;
-}
 class google.registry.model.contact.Disclose {
   google.registry.model.eppcommon.PresenceMarker email;
   google.registry.model.eppcommon.PresenceMarker fax;
@@ -85,10 +85,10 @@ class google.registry.model.domain.Domain {
   google.registry.model.domain.DomainAuthInfo authInfo;
   google.registry.model.domain.launch.LaunchNotice launchNotice;
   google.registry.model.transfer.DomainTransferData transferData;
-  google.registry.persistence.VKey<google.registry.model.contact.ContactResource> adminContact;
-  google.registry.persistence.VKey<google.registry.model.contact.ContactResource> billingContact;
-  google.registry.persistence.VKey<google.registry.model.contact.ContactResource> registrantContact;
-  google.registry.persistence.VKey<google.registry.model.contact.ContactResource> techContact;
+  google.registry.persistence.VKey<google.registry.model.contact.Contact> adminContact;
+  google.registry.persistence.VKey<google.registry.model.contact.Contact> billingContact;
+  google.registry.persistence.VKey<google.registry.model.contact.Contact> registrantContact;
+  google.registry.persistence.VKey<google.registry.model.contact.Contact> techContact;
   google.registry.persistence.VKey<google.registry.model.domain.token.AllocationToken> currentPackageToken;
   google.registry.persistence.VKey<google.registry.model.poll.PollMessage$Autorenew> autorenewPollMessage;
   google.registry.persistence.VKey<google.registry.model.poll.PollMessage$OneTime> deletePollMessage;
@@ -118,10 +118,10 @@ class google.registry.model.domain.DomainBase {
   google.registry.model.domain.DomainAuthInfo authInfo;
   google.registry.model.domain.launch.LaunchNotice launchNotice;
   google.registry.model.transfer.DomainTransferData transferData;
-  google.registry.persistence.VKey<google.registry.model.contact.ContactResource> adminContact;
-  google.registry.persistence.VKey<google.registry.model.contact.ContactResource> billingContact;
-  google.registry.persistence.VKey<google.registry.model.contact.ContactResource> registrantContact;
-  google.registry.persistence.VKey<google.registry.model.contact.ContactResource> techContact;
+  google.registry.persistence.VKey<google.registry.model.contact.Contact> adminContact;
+  google.registry.persistence.VKey<google.registry.model.contact.Contact> billingContact;
+  google.registry.persistence.VKey<google.registry.model.contact.Contact> registrantContact;
+  google.registry.persistence.VKey<google.registry.model.contact.Contact> techContact;
   google.registry.persistence.VKey<google.registry.model.domain.token.AllocationToken> currentPackageToken;
   google.registry.persistence.VKey<google.registry.model.poll.PollMessage$Autorenew> autorenewPollMessage;
   google.registry.persistence.VKey<google.registry.model.poll.PollMessage$OneTime> deletePollMessage;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -327,7 +327,7 @@ registry codebase:
 *   `ClaimsList`, `ClaimsListShard`, and `ClaimsListSingleton` -- These entities
     store the TMCH claims list, for use in trademark processing.
 *   `CommitLog*` -- These entities store the commit log information.
-*   `ContactResource` -- These hold the ICANN contact information (but not
+*   `Contact` -- These hold the ICANN contact information (but not
     registrar contacts, who have a separate entity type).
 *   `Cursor` -- We use Cursor entities to maintain state about daily processes,
     remembering which dates have been processed. For instance, for the RDE
@@ -373,8 +373,8 @@ registry codebase:
 *   `Recurring` -- A Recurring is a billing event which represents a recurring
     charge to the client (as opposed to OneTime).
 *   `Registrar` -- These hold information about client registrars.
-*   `RegistrarContact` -- Registrars have contacts just as domains do. These are
-    stored in a special RegistrarContact entity.
+*   `RegistrarPoc` -- Registrars have contacts just as domains do. These are
+    stored in a special RegistrarPoc entity.
 *   `Registry` -- These hold information about the TLDs supported by the
     Registry system.
 *   `RegistryCursor` -- These entities are the predecessor to the Cursor

--- a/docs/code-structure.md
+++ b/docs/code-structure.md
@@ -142,14 +142,9 @@ encapsulate related values together.
 The classes that extend `EppResource` (along with the RFCs that define them) are
 as follows:
 
-*   `Domain` ([RFC 5731](https://tools.ietf.org/html/rfc5731)), further
-    broken down into:
-    *   `DomainApplication`, an application for a domain submitted during (e.g.)
-        sunrise or landrush
-    *   `DomainResource`, a domain name allocated following a successful
-        application, or registered during a general availability phase
+*   `Domain` ([RFC 5731](https://tools.ietf.org/html/rfc5731))
 *   `Host` ([RFC 5732](https://tools.ietf.org/html/rfc5732))
-*   `ContactResource` ([RFC 5733](https://tools.ietf.org/html/rfc5733))
+*   `Contact` ([RFC 5733](https://tools.ietf.org/html/rfc5733))
 
 All `EppResource` entities use a Repository Object Identifier (ROID) as its
 unique id, in the format specified by [RFC
@@ -173,7 +168,7 @@ Foreign key indexes provide a means of loading active instances of `EppResource`
 objects by their unique IDs:
 
 *   `Domain`: fully-qualified domain name
-*   `ContactResource`: contact id
+*   `Contact`: contact id
 *   `Host`: fully-qualified host name
 
 Since all `EppResource` entities are indexed on ROID (which is also unique, but

--- a/python/google/registry/scripts/testdata/datastore-indexes.xml
+++ b/python/google/registry/scripts/testdata/datastore-indexes.xml
@@ -1,6 +1,6 @@
 <datastore-indexes autoGenerate="false">
     <!-- For finding contact resources by registrar. -->
-    <datastore-index kind="ContactResource" ancestor="false" source="manual">
+    <datastore-index kind="Contact" ancestor="false" source="manual">
         <property name="currentSponsorClientId" direction="asc"/>
         <property name="deletionTime" direction="asc"/>
     </datastore-index>
@@ -79,7 +79,7 @@
         <property name="deletionTime" direction="asc"/>
         <property name="fullyQualifiedHostName" direction="asc"/>
     </datastore-index>
-    <datastore-index kind="ContactResource" ancestor="false" source="manual">
+    <datastore-index kind="Contact" ancestor="false" source="manual">
         <property name="deletionTime" direction="asc"/>
         <property name="searchName" direction="asc"/>
     </datastore-index>


### PR DESCRIPTION
This is a follow-up to PR #1725 and #1733. Now all EPP resource entity class
names have been rationalized to match with their SQL table names.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1763)
<!-- Reviewable:end -->
