### PR TITLE
Remove ofy support from ForeignKeyIndex

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -61,12 +61,6 @@ by Joshua Bloch in his book Effective Java -->
     <property name="message" value="Use assertThrows and expectThrows from JUnitBackports instead of the deprecated methods on ExpectedException."/>
   </module>
 
-  <!-- Checks that the deprecated MockitoJUnitRunner is not used. -->
-  <module name="RegexpSingleline">
-    <property name="format" value="MockitoJUnitRunner"/>
-    <property name="message" value="MockitoJUnitRunner is deprecated. Use @RunWith(JUnit4.class) and MockitoRule instead."/>
-  </module>
-
   <module name="LineLength">
     <!-- Checks if a line is too long. -->
     <property name="max" value="${com.puppycrawl.tools.checkstyle.checks.sizes.LineLength.max}" default="100"/>

--- a/core/src/main/java/google/registry/batch/DeleteProberDataAction.java
+++ b/core/src/main/java/google/registry/batch/DeleteProberDataAction.java
@@ -19,7 +19,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static google.registry.batch.BatchModule.PARAM_DRY_RUN;
 import static google.registry.config.RegistryEnvironment.PRODUCTION;
-import static google.registry.model.ResourceTransferUtils.updateForeignKeyIndexDeletionTime;
 import static google.registry.model.reporting.HistoryEntry.Type.DOMAIN_DELETE;
 import static google.registry.model.tld.Registries.getTldsOfType;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
@@ -267,8 +266,6 @@ public class DeleteProberDataAction implements Runnable {
     // messages, or auto-renews because those will all be hard-deleted the next time the job runs
     // anyway.
     tm().putAll(ImmutableList.of(deletedDomain, historyEntry));
-    // updating foreign keys is a no-op in SQL
-    updateForeignKeyIndexDeletionTime(deletedDomain);
     dnsQueue.addDomainRefreshTask(deletedDomain.getDomainName());
   }
 }

--- a/core/src/main/java/google/registry/flows/contact/ContactCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactCreateFlow.java
@@ -41,7 +41,6 @@ import google.registry.model.eppinput.ResourceCommand;
 import google.registry.model.eppoutput.CreateData.ContactCreateData;
 import google.registry.model.eppoutput.EppResponse;
 import google.registry.model.index.EppResourceIndex;
-import google.registry.model.index.ForeignKeyIndex;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.reporting.IcannReportingTypes.ActivityReportField;
 import javax.inject.Inject;
@@ -100,7 +99,6 @@ public final class ContactCreateFlow implements TransactionalFlow {
             ImmutableSet.of(
                 newContact,
                 historyBuilder.build(),
-                ForeignKeyIndex.create(newContact, newContact.getDeletionTime()),
                 EppResourceIndex.create(Key.create(newContact))));
     return responseBuilder
         .setResData(ContactCreateData.create(newContact.getContactId(), now))

--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -106,7 +106,6 @@ import google.registry.model.eppinput.ResourceCommand;
 import google.registry.model.eppoutput.CreateData.DomainCreateData;
 import google.registry.model.eppoutput.EppResponse;
 import google.registry.model.index.EppResourceIndex;
-import google.registry.model.index.ForeignKeyIndex;
 import google.registry.model.poll.PendingActionNotificationResponse.DomainPendingActionNotificationResponse;
 import google.registry.model.poll.PollMessage;
 import google.registry.model.poll.PollMessage.Autorenew;
@@ -404,7 +403,6 @@ public final class DomainCreateFlow implements TransactionalFlow {
     entitiesToSave.add(
         domain,
         domainHistory,
-        ForeignKeyIndex.create(domain, domain.getDeletionTime()),
         EppResourceIndex.create(Key.create(domain)));
     if (allocationToken.isPresent()
         && TokenType.SINGLE_USE.equals(allocationToken.get().getTokenType())) {

--- a/core/src/main/java/google/registry/flows/domain/DomainDeleteFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainDeleteFlow.java
@@ -29,7 +29,6 @@ import static google.registry.flows.domain.DomainFlowUtils.updateAutorenewRecurr
 import static google.registry.flows.domain.DomainFlowUtils.verifyNotInPredelegation;
 import static google.registry.model.ResourceTransferUtils.denyPendingTransfer;
 import static google.registry.model.ResourceTransferUtils.handlePendingTransferOnDelete;
-import static google.registry.model.ResourceTransferUtils.updateForeignKeyIndexDeletionTime;
 import static google.registry.model.eppoutput.Result.Code.SUCCESS;
 import static google.registry.model.eppoutput.Result.Code.SUCCESS_WITH_ACTION_PENDING;
 import static google.registry.model.reporting.DomainTransactionRecord.TransactionReportField.ADD_FIELDS;
@@ -257,7 +256,6 @@ public final class DomainDeleteFlow implements TransactionalFlow {
     Domain newDomain = builder.build();
     DomainHistory domainHistory =
         buildDomainHistory(newDomain, registry, now, durationUntilDelete, inAddGracePeriod);
-    updateForeignKeyIndexDeletionTime(newDomain);
     handlePendingTransferOnDelete(existingDomain, newDomain, now, domainHistory);
     // Close the autorenew billing event and poll message. This may delete the poll message.  Store
     // the updated recurring billing event, we'll need it later and can't reload it.

--- a/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
@@ -27,7 +27,6 @@ import static google.registry.flows.domain.DomainFlowUtils.validateFeeChallenge;
 import static google.registry.flows.domain.DomainFlowUtils.verifyNotReserved;
 import static google.registry.flows.domain.DomainFlowUtils.verifyPremiumNameIsNotBlocked;
 import static google.registry.flows.domain.DomainFlowUtils.verifyRegistrarIsActive;
-import static google.registry.model.ResourceTransferUtils.updateForeignKeyIndexDeletionTime;
 import static google.registry.model.reporting.HistoryEntry.Type.DOMAIN_RESTORE;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
@@ -188,7 +187,6 @@ public final class DomainRestoreRequestFlow implements TransactionalFlow {
             autorenewPollMessage,
             now,
             registrarId);
-    updateForeignKeyIndexDeletionTime(newDomain);
     DomainHistory domainHistory = buildDomainHistory(newDomain, now);
     entitiesToSave.add(newDomain, domainHistory, autorenewEvent, autorenewPollMessage);
     tm().putAll(entitiesToSave.build());

--- a/core/src/main/java/google/registry/flows/host/HostCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostCreateFlow.java
@@ -50,7 +50,6 @@ import google.registry.model.host.Host;
 import google.registry.model.host.HostCommand.Create;
 import google.registry.model.host.HostHistory;
 import google.registry.model.index.EppResourceIndex;
-import google.registry.model.index.ForeignKeyIndex;
 import google.registry.model.reporting.IcannReportingTypes.ActivityReportField;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -135,7 +134,6 @@ public final class HostCreateFlow implements TransactionalFlow {
         ImmutableSet.of(
             newHost,
             historyBuilder.build(),
-            ForeignKeyIndex.create(newHost, newHost.getDeletionTime()),
             EppResourceIndex.create(Key.create(newHost)));
     if (superordinateDomain.isPresent()) {
       tm().update(

--- a/core/src/main/java/google/registry/flows/host/HostUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostUpdateFlow.java
@@ -57,7 +57,6 @@ import google.registry.model.host.HostCommand.Update;
 import google.registry.model.host.HostCommand.Update.AddRemove;
 import google.registry.model.host.HostCommand.Update.Change;
 import google.registry.model.host.HostHistory;
-import google.registry.model.index.ForeignKeyIndex;
 import google.registry.model.reporting.IcannReportingTypes.ActivityReportField;
 import google.registry.persistence.VKey;
 import java.util.Objects;
@@ -194,11 +193,7 @@ public final class HostUpdateFlow implements TransactionalFlow {
     ImmutableSet.Builder<ImmutableObject> entitiesToInsert = new ImmutableSet.Builder<>();
     ImmutableSet.Builder<ImmutableObject> entitiesToUpdate = new ImmutableSet.Builder<>();
     entitiesToUpdate.add(newHost);
-    // Keep the {@link ForeignKeyIndex} for this host up to date.
     if (isHostRename) {
-      // Update the foreign key for the old host name and save one for the new host name.
-      entitiesToUpdate.add(ForeignKeyIndex.create(existingHost, now));
-      entitiesToUpdate.add(ForeignKeyIndex.create(newHost, newHost.getDeletionTime()));
       updateSuperordinateDomains(existingHost, newHost);
     }
     enqueueTasks(existingHost, newHost);

--- a/core/src/main/java/google/registry/model/EntityClasses.java
+++ b/core/src/main/java/google/registry/model/EntityClasses.java
@@ -26,7 +26,6 @@ import google.registry.model.host.Host;
 import google.registry.model.host.HostHistory;
 import google.registry.model.index.EppResourceIndex;
 import google.registry.model.index.EppResourceIndexBucket;
-import google.registry.model.index.ForeignKeyIndex;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.server.ServerSecret;
 
@@ -44,9 +43,6 @@ public final class EntityClasses {
           EntityGroupRoot.class,
           EppResourceIndex.class,
           EppResourceIndexBucket.class,
-          ForeignKeyIndex.ForeignKeyContactIndex.class,
-          ForeignKeyIndex.ForeignKeyDomainIndex.class,
-          ForeignKeyIndex.ForeignKeyHostIndex.class,
           GaeUserIdConverter.class,
           HistoryEntry.class,
           Host.class,

--- a/core/src/main/java/google/registry/model/ResourceTransferUtils.java
+++ b/core/src/main/java/google/registry/model/ResourceTransferUtils.java
@@ -23,13 +23,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import google.registry.model.EppResource.BuilderWithTransferData;
-import google.registry.model.EppResource.ForeignKeyedEppResource;
 import google.registry.model.EppResource.ResourceWithTransferData;
 import google.registry.model.contact.Contact;
 import google.registry.model.domain.Domain;
 import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.eppcommon.Trid;
-import google.registry.model.index.ForeignKeyIndex;
 import google.registry.model.poll.PendingActionNotificationResponse;
 import google.registry.model.poll.PendingActionNotificationResponse.ContactPendingActionNotificationResponse;
 import google.registry.model.poll.PendingActionNotificationResponse.DomainPendingActionNotificationResponse;
@@ -102,13 +100,6 @@ public final class ResourceTransferUtils {
 
   private static void assertIsContactOrDomain(EppResource eppResource) {
     checkState(eppResource instanceof Contact || eppResource instanceof Domain);
-  }
-
-  /** Update the relevant {@link ForeignKeyIndex} to cache the new deletion time. */
-  public static <R extends EppResource> void updateForeignKeyIndexDeletionTime(R resource) {
-    if (resource instanceof ForeignKeyedEppResource) {
-      tm().insert(ForeignKeyIndex.create(resource, resource.getDeletionTime()));
-    }
   }
 
   /** If there is a transfer out, delete the server-approve entities and enqueue a poll message. */

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -31,9 +31,6 @@ import com.google.common.collect.Streams;
 import com.google.common.flogger.FluentLogger;
 import google.registry.model.ImmutableObject;
 import google.registry.model.index.EppResourceIndex;
-import google.registry.model.index.ForeignKeyIndex.ForeignKeyContactIndex;
-import google.registry.model.index.ForeignKeyIndex.ForeignKeyDomainIndex;
-import google.registry.model.index.ForeignKeyIndex.ForeignKeyHostIndex;
 import google.registry.persistence.JpaRetries;
 import google.registry.persistence.VKey;
 import google.registry.util.Clock;
@@ -83,11 +80,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   // to exclude the Datastore specific entities when the underlying tm() is jpaTm().
   // TODO(b/176108270): Remove this property after database migration.
   private static final ImmutableSet<Class<? extends ImmutableObject>> IGNORED_ENTITY_CLASSES =
-      ImmutableSet.of(
-          EppResourceIndex.class,
-          ForeignKeyContactIndex.class,
-          ForeignKeyDomainIndex.class,
-          ForeignKeyHostIndex.class);
+      ImmutableSet.of(EppResourceIndex.class);
 
   // EntityManagerFactory is thread safe.
   private final EntityManagerFactory emf;

--- a/core/src/test/java/google/registry/flows/host/HostUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostUpdateFlowTest.java
@@ -106,7 +106,7 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
   }
 
   /**
-   * Setup a domain with a transfer that should have been server approved a day ago.
+   * Set up a domain with a transfer that should have been server approved a day ago.
    *
    * <p>The transfer is from "TheRegistrar" to "NewRegistrar".
    */
@@ -508,7 +508,7 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
                 .asBuilder()
                 .setLastTransferTime(lastTransferTime)
                 .build());
-    // Set the new domain to have a last transfer time that is different than the last transfer
+    // Set the new domain to have a last transfer time that is different from the last transfer
     // time on the host in question.
     persistResource(
         DatabaseHelper.newDomain("example.tld")
@@ -546,7 +546,7 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
                 .asBuilder()
                 .setLastTransferTime(clock.nowUtc().minusDays(5))
                 .build());
-    // Set the new domain to have a last transfer time that is different than the last transfer
+    // Set the new domain to have a last transfer time that is different from the last transfer
     // time on the host in question.
     persistResource(
         DatabaseHelper.newDomain("example.tld")
@@ -814,7 +814,7 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
         clock.nowUtc().minusDays(2), clock.nowUtc().minusDays(3));
   }
 
-  /** Test when the new superdordinate domain has never been transferred before. */
+  /** Test when the new superordinate domain has never been transferred before. */
   @Test
   void testSuccess_externalToSubord_lastTransferTimeNotOverridden_whenNull() throws Exception {
     doExternalToInternalLastTransferTimeTest(clock.nowUtc().minusDays(2), null);

--- a/core/src/test/java/google/registry/model/common/ClassPathManagerTest.java
+++ b/core/src/test/java/google/registry/model/common/ClassPathManagerTest.java
@@ -23,9 +23,6 @@ import google.registry.model.domain.DomainHistory;
 import google.registry.model.host.Host;
 import google.registry.model.index.EppResourceIndex;
 import google.registry.model.index.EppResourceIndexBucket;
-import google.registry.model.index.ForeignKeyIndex.ForeignKeyContactIndex;
-import google.registry.model.index.ForeignKeyIndex.ForeignKeyDomainIndex;
-import google.registry.model.index.ForeignKeyIndex.ForeignKeyHostIndex;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.server.ServerSecret;
 import google.registry.testing.TestObject;
@@ -44,8 +41,6 @@ public class ClassPathManagerTest {
      * below are all classes supported in CLASS_REGISTRY. This test breaks if someone changes a
      * classname without preserving the original name.
      */
-    assertThat(ClassPathManager.getClass("ForeignKeyContactIndex"))
-        .isEqualTo(ForeignKeyContactIndex.class);
     assertThat(ClassPathManager.getClass("Host")).isEqualTo(Host.class);
     assertThat(ClassPathManager.getClass("Contact")).isEqualTo(Contact.class);
     assertThat(ClassPathManager.getClass("GaeUserIdConverter")).isEqualTo(GaeUserIdConverter.class);
@@ -54,12 +49,8 @@ public class ClassPathManagerTest {
     assertThat(ClassPathManager.getClass("EntityGroupRoot")).isEqualTo(EntityGroupRoot.class);
     assertThat(ClassPathManager.getClass("Domain")).isEqualTo(Domain.class);
     assertThat(ClassPathManager.getClass("HistoryEntry")).isEqualTo(HistoryEntry.class);
-    assertThat(ClassPathManager.getClass("ForeignKeyHostIndex"))
-        .isEqualTo(ForeignKeyHostIndex.class);
     assertThat(ClassPathManager.getClass("ServerSecret")).isEqualTo(ServerSecret.class);
     assertThat(ClassPathManager.getClass("EppResourceIndex")).isEqualTo(EppResourceIndex.class);
-    assertThat(ClassPathManager.getClass("ForeignKeyDomainIndex"))
-        .isEqualTo(ForeignKeyDomainIndex.class);
   }
 
   @Test
@@ -92,8 +83,6 @@ public class ClassPathManagerTest {
      * The classes below are all classes supported in CLASS_NAME_REGISTRY. This test breaks if
      * someone changes a classname without preserving the original name.
      */
-    assertThat(ClassPathManager.getClassName(ForeignKeyContactIndex.class))
-        .isEqualTo("ForeignKeyContactIndex");
     assertThat(ClassPathManager.getClassName(Host.class)).isEqualTo("Host");
     assertThat(ClassPathManager.getClassName(Contact.class)).isEqualTo("Contact");
     assertThat(ClassPathManager.getClassName(GaeUserIdConverter.class))
@@ -103,12 +92,8 @@ public class ClassPathManagerTest {
     assertThat(ClassPathManager.getClassName(EntityGroupRoot.class)).isEqualTo("EntityGroupRoot");
     assertThat(ClassPathManager.getClassName(Domain.class)).isEqualTo("Domain");
     assertThat(ClassPathManager.getClassName(HistoryEntry.class)).isEqualTo("HistoryEntry");
-    assertThat(ClassPathManager.getClassName(ForeignKeyHostIndex.class))
-        .isEqualTo("ForeignKeyHostIndex");
     assertThat(ClassPathManager.getClassName(ServerSecret.class)).isEqualTo("ServerSecret");
     assertThat(ClassPathManager.getClassName(EppResourceIndex.class)).isEqualTo("EppResourceIndex");
-    assertThat(ClassPathManager.getClassName(ForeignKeyDomainIndex.class))
-        .isEqualTo("ForeignKeyDomainIndex");
   }
 
   @Test

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -63,7 +63,6 @@ import com.googlecode.objectify.Key;
 import google.registry.dns.writer.VoidDnsWriter;
 import google.registry.model.Buildable;
 import google.registry.model.EppResource;
-import google.registry.model.EppResource.ForeignKeyedEppResource;
 import google.registry.model.EppResourceUtils;
 import google.registry.model.ImmutableObject;
 import google.registry.model.billing.BillingEvent;
@@ -91,7 +90,6 @@ import google.registry.model.eppcommon.Trid;
 import google.registry.model.host.Host;
 import google.registry.model.index.EppResourceIndex;
 import google.registry.model.index.EppResourceIndexBucket;
-import google.registry.model.index.ForeignKeyIndex;
 import google.registry.model.poll.PollMessage;
 import google.registry.model.pricing.StaticPremiumListPricingEngine;
 import google.registry.model.registrar.Registrar;
@@ -1011,9 +1009,6 @@ public class DatabaseHelper {
         .that(resource.getRepoId())
         .isNotEmpty();
     saver.accept(index);
-    if (resource instanceof ForeignKeyedEppResource) {
-      saver.accept(ForeignKeyIndex.create(resource, resource.getDeletionTime()));
-    }
   }
 
   /** Persists an object in the DB for tests. */

--- a/core/src/test/resources/google/registry/model/schema.txt
+++ b/core/src/test/resources/google/registry/model/schema.txt
@@ -297,21 +297,6 @@ class google.registry.model.index.EppResourceIndex {
 class google.registry.model.index.EppResourceIndexBucket {
   @Id long bucketId;
 }
-class google.registry.model.index.ForeignKeyIndex$ForeignKeyContactIndex {
-  @Id java.lang.String foreignKey;
-  google.registry.persistence.VKey<E> topReference;
-  org.joda.time.DateTime deletionTime;
-}
-class google.registry.model.index.ForeignKeyIndex$ForeignKeyDomainIndex {
-  @Id java.lang.String foreignKey;
-  google.registry.persistence.VKey<E> topReference;
-  org.joda.time.DateTime deletionTime;
-}
-class google.registry.model.index.ForeignKeyIndex$ForeignKeyHostIndex {
-  @Id java.lang.String foreignKey;
-  google.registry.persistence.VKey<E> topReference;
-  org.joda.time.DateTime deletionTime;
-}
 class google.registry.model.reporting.DomainTransactionRecord {
   google.registry.model.reporting.DomainTransactionRecord$TransactionReportField reportField;
   java.lang.Integer reportAmount;

--- a/util/src/main/java/google/registry/util/TypeUtils.java
+++ b/util/src/main/java/google/registry/util/TypeUtils.java
@@ -28,7 +28,9 @@ import java.lang.reflect.Modifier;
 import java.util.function.Predicate;
 
 /** Utilities methods related to reflection. */
-public class TypeUtils {
+public final class TypeUtils {
+
+  private TypeUtils() {}
 
   /** A {@code TypeToken} that removes an ugly cast in the common cases of getting a known type. */
   public static class TypeInstantiator<T> extends TypeToken<T> {
@@ -47,7 +49,8 @@ public class TypeUtils {
   }
 
   public static <T> T instantiate(Class<? extends T> clazz) {
-    checkArgument(Modifier.isPublic(clazz.getModifiers()),
+    checkArgument(
+        Modifier.isPublic(clazz.getModifiers()),
         "AppEngine's custom security manager won't let us reflectively access non-public types");
     try {
       return clazz.getConstructor().newInstance();
@@ -59,14 +62,15 @@ public class TypeUtils {
   /**
    * Instantiate a class with the specified constructor argument.
    *
-   * <p>Because we use arg1's type to lookup the constructor, this only works if arg1's class is
-   * exactly the same type as the constructor argument. Subtypes are not allowed.
+   * <p>Because we use {@code arg}'s type to look up the constructor, this only works if arg1's
+   * class is exactly the same type as the constructor argument. Subtypes are not allowed.
    */
-  public static <T, U> T instantiate(Class<? extends T> clazz, U arg1) {
-    checkArgument(Modifier.isPublic(clazz.getModifiers()),
+  public static <T, U> T instantiate(Class<? extends T> clazz, U arg) {
+    checkArgument(
+        Modifier.isPublic(clazz.getModifiers()),
         "AppEngine's custom security manager won't let us reflectively access non-public types");
     try {
-      return clazz.getConstructor(arg1.getClass()).newInstance(arg1);
+      return clazz.getConstructor(arg.getClass()).newInstance(arg);
     } catch (ReflectiveOperationException e) {
       throw new RuntimeException(e);
     }
@@ -106,8 +110,10 @@ public class TypeUtils {
           T enumField = (T) field.get(null);
           builder.put(field.getName(), enumField);
         } catch (IllegalArgumentException | IllegalAccessException e) {
-          throw new RuntimeException(String.format(
-              "Could not retrieve static final field mapping for %s", clazz.getName()), e);
+          throw new RuntimeException(
+              String.format(
+                  "Could not retrieve static final field mapping for %s", clazz.getName()),
+              e);
         }
       }
     }
@@ -115,8 +121,7 @@ public class TypeUtils {
   }
 
   /** Returns a predicate that tests whether classes are annotated with the given annotation. */
-  public static Predicate<Class<?>> hasAnnotation(
-      final Class<? extends Annotation> annotation) {
+  public static Predicate<Class<?>> hasAnnotation(final Class<? extends Annotation> annotation) {
     return clazz -> clazz.isAnnotationPresent(annotation);
   }
 


### PR DESCRIPTION
FKI used to be persisted in datastore to help speed up loading by foreign key.
Now it is just a helper class to do the same thing in SQL because
indexing is natively supported in SQL.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1777)
<!-- Reviewable:end -->
