### PR TITLE
Add a second, non-GAE OAuth authentication mechanism

### DIFF
--- a/core/src/main/java/google/registry/request/auth/AuthModule.java
+++ b/core/src/main/java/google/registry/request/auth/AuthModule.java
@@ -26,9 +26,7 @@ import dagger.Provides;
 import google.registry.config.RegistryConfig.Config;
 import javax.inject.Singleton;
 
-/**
- * Dagger module for authentication routines.
- */
+/** Dagger module for authentication routines. */
 @Module
 public class AuthModule {
 
@@ -36,8 +34,12 @@ public class AuthModule {
   @Provides
   ImmutableList<AuthenticationMechanism> provideApiAuthenticationMechanisms(
       OAuthAuthenticationMechanism oauthAuthenticationMechanism,
-      CookieOAuth2AuthenticationMechanism cookieOAuth2AuthenticationMechanism) {
-    return ImmutableList.of(oauthAuthenticationMechanism, cookieOAuth2AuthenticationMechanism);
+      CookieOAuth2AuthenticationMechanism cookieOAuth2AuthenticationMechanism,
+      NonGaeOAuthAuthenticationMechanism nonGaeOAuthAuthenticationMechanism) {
+    return ImmutableList.of(
+        oauthAuthenticationMechanism,
+        cookieOAuth2AuthenticationMechanism,
+        nonGaeOAuthAuthenticationMechanism);
   }
 
   /** Provides the OAuthService instance. */

--- a/core/src/main/java/google/registry/request/auth/NonGaeOAuthAuthenticationMechanism.java
+++ b/core/src/main/java/google/registry/request/auth/NonGaeOAuthAuthenticationMechanism.java
@@ -1,0 +1,131 @@
+// Copyright 2022 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.request.auth;
+
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.flogger.FluentLogger;
+import com.google.common.io.ByteStreams;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import google.registry.config.RegistryConfig.Config;
+import google.registry.model.console.User;
+import google.registry.model.console.UserDao;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * OAuth2 authentication mechanism that uses Google OAuth2, not GAE.
+ *
+ * <p>This authentication mechanism should be used in situations where we require automated OAuth2
+ * authentication. The most important/clear usage of this should be in the Nomulus command-line
+ * tool, which uses the installed-code flow to memoize an access token.
+ *
+ * <p>Note: this is dependent on the client including an OAuth2 access code in the headers of the
+ * request, <b>not</b> an ID token. This access token should be created by e.g. the {@link
+ * google.registry.tools.LoginCommand}. JWT ID tokens may be created and used by other means (e.g.
+ * the GCP Identity-Aware Proxy) but those will use an alternate authentication mechanism.
+ */
+public class NonGaeOAuthAuthenticationMechanism implements AuthenticationMechanism {
+
+  private static final String BEARER_PREFIX = "Bearer ";
+  private static final String TOKEN_INFO_URL = "https://oauth2.googleapis.com/tokeninfo";
+
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
+  /** HttpTransport used to contact Google OAuth. */
+  private final NetHttpTransport httpTransport;
+
+  /** The OAuth scopes which must all be present for authentication to succeed. */
+  private final ImmutableSet<String> requiredOauthScopes;
+
+  /** The only OAuth client IDs allowed for authentication. */
+  private final ImmutableSet<String> allowedOauthClientIds;
+
+  @Inject
+  public NonGaeOAuthAuthenticationMechanism(
+      NetHttpTransport httpTransport,
+      @Config("requiredOauthScopes") ImmutableSet<String> requiredOauthScopes,
+      @Config("allowedOauthClientIds") ImmutableSet<String> allowedOauthClientIds) {
+    this.httpTransport = httpTransport;
+    this.requiredOauthScopes = requiredOauthScopes;
+    this.allowedOauthClientIds = allowedOauthClientIds;
+  }
+
+  @Override
+  public AuthResult authenticate(HttpServletRequest request) {
+    // Only accept Authorization headers in Bearer form.
+    String header = request.getHeader(AUTHORIZATION);
+    if ((header == null) || !header.startsWith(BEARER_PREFIX)) {
+      if (header != null) {
+        logger.atInfo().log("Invalid authorization header.");
+      }
+      return AuthResult.NOT_AUTHENTICATED;
+    }
+    String rawAccessToken = header.substring(BEARER_PREFIX.length());
+    GenericUrl tokenInfoUrl = new GenericUrl(TOKEN_INFO_URL).set("access_token", rawAccessToken);
+    JsonObject responseJson;
+    try {
+      HttpRequest tokenInfoRequest =
+          httpTransport.createRequestFactory().buildGetRequest(tokenInfoUrl);
+      HttpResponse response = tokenInfoRequest.execute();
+      if (response.getStatusCode() == HttpStatusCodes.STATUS_CODE_BAD_REQUEST) {
+        logger.atInfo().log("Invalid or expired token");
+        return AuthResult.NOT_AUTHENTICATED;
+      } else if (response.getStatusCode() == HttpStatusCodes.STATUS_CODE_OK) {
+        responseJson =
+            JsonParser.parseString(
+                    new String(ByteStreams.toByteArray(response.getContent()), UTF_8))
+                .getAsJsonObject();
+      } else {
+        logger.atInfo().log("Unexpected token-check status code %d", response.getStatusCode());
+        return AuthResult.NOT_AUTHENTICATED;
+      }
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    String oauthClientId = responseJson.get("aud").getAsString();
+    // Make sure that the client ID matches, to avoid a confused deputy attack; see:
+    // http://stackoverflow.com/a/17439317/1179226
+    if (!allowedOauthClientIds.contains(oauthClientId)) {
+      logger.atInfo().log("OAuth audience %s is not allowed", oauthClientId);
+      return AuthResult.NOT_AUTHENTICATED;
+    }
+    List<String> providedScopes =
+        Splitter.on(' ').splitToList(responseJson.get("scope").getAsString());
+    if (!providedScopes.containsAll(requiredOauthScopes)) {
+      logger.atInfo().log("Provided scopes %s didn't contain required scopes", providedScopes);
+      return AuthResult.NOT_AUTHENTICATED;
+    }
+    String emailAddress = responseJson.get("email").getAsString();
+    Optional<User> maybeUser = UserDao.loadUser(emailAddress);
+    if (!maybeUser.isPresent()) {
+      logger.atInfo().log("No user with email address %s", emailAddress);
+      return AuthResult.NOT_AUTHENTICATED;
+    }
+    return AuthResult.create(AuthLevel.USER, UserAuthInfo.create(maybeUser.get()));
+  }
+}

--- a/core/src/main/java/google/registry/tools/LoginCommand.java
+++ b/core/src/main/java/google/registry/tools/LoginCommand.java
@@ -24,7 +24,7 @@ import javax.inject.Inject;
 
 /** Authorizes the nomulus tool for OAuth 2.0 access to remote resources. */
 @Parameters(commandDescription = "Create local OAuth credentials")
-final class LoginCommand implements Command {
+public final class LoginCommand implements Command {
 
   @Inject GoogleAuthorizationCodeFlow flow;
   @Inject @AuthModule.ClientScopeQualifier String clientScopeQualifier;

--- a/core/src/test/java/google/registry/request/auth/NonGaeOAuthAuthenticationMechanismTest.java
+++ b/core/src/test/java/google/registry/request/auth/NonGaeOAuthAuthenticationMechanismTest.java
@@ -1,0 +1,167 @@
+// Copyright 2022 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.request.auth;
+
+import static com.google.common.net.HttpHeaders.AUTHORIZATION;
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import google.registry.model.console.RegistrarRole;
+import google.registry.model.console.User;
+import google.registry.model.console.UserDao;
+import google.registry.model.console.UserRoles;
+import google.registry.testing.AppEngineExtension;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import javax.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Tests for {@link NonGaeOAuthAuthenticationMechanism}. */
+public class NonGaeOAuthAuthenticationMechanismTest {
+
+  private static final ImmutableSet<String> REQUIRED_OAUTH_SCOPES =
+      ImmutableSet.of("scope1", "scope2");
+  private static final ImmutableSet<String> OAUTH_CLIENT_IDS =
+      ImmutableSet.of("oauthClientId", "otherOauthClientId");
+
+  @RegisterExtension
+  final AppEngineExtension appEngine = AppEngineExtension.builder().withCloudSql().build();
+
+  private NetHttpTransport httpTransport = mock(NetHttpTransport.class);
+  private HttpServletRequest request = mock(HttpServletRequest.class);
+  private HttpResponse httpResponse = mock(HttpResponse.class);
+
+  private final NonGaeOAuthAuthenticationMechanism authenticationMechanism =
+      new NonGaeOAuthAuthenticationMechanism(
+          httpTransport, REQUIRED_OAUTH_SCOPES, OAUTH_CLIENT_IDS);
+
+  @BeforeEach
+  void beforeEach() throws IOException {
+    when(request.getHeader(AUTHORIZATION)).thenReturn("Bearer token");
+    HttpRequestFactory requestFactory = mock(HttpRequestFactory.class);
+    when(httpTransport.createRequestFactory()).thenReturn(requestFactory);
+    HttpRequest getRequest = mock(HttpRequest.class);
+    when(requestFactory.buildGetRequest(any(GenericUrl.class))).thenReturn(getRequest);
+    when(getRequest.execute()).thenReturn(httpResponse);
+    when(httpResponse.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_OK);
+  }
+
+  @Test
+  void testSuccess_findsUser() throws Exception {
+    User user =
+        new User.Builder()
+            .setEmailAddress("johndoe@theregistrar.com")
+            .setGaiaId("gaiaId")
+            .setUserRoles(
+                new UserRoles.Builder()
+                    .setRegistrarRoles(
+                        ImmutableMap.of("TheRegistrar", RegistrarRole.PRIMARY_CONTACT))
+                    .build())
+            .build();
+    UserDao.saveUser(user);
+    // reload the user to pick up the SQL-created ID
+    user = UserDao.loadUser("johndoe@theregistrar.com").get();
+    setResponseJson(
+        "{'aud': 'oauthClientId', 'scope': 'scope1 scope2', 'email': 'johndoe@theregistrar.com'}");
+    assertThat(authenticationMechanism.authenticate(request))
+        .isEqualTo(AuthResult.create(AuthLevel.USER, UserAuthInfo.create(user)));
+  }
+
+  @Test
+  void testFailure_missingHeader() {
+    when(request.getHeader(AUTHORIZATION)).thenReturn(null);
+    assertThat(authenticationMechanism.authenticate(request))
+        .isEqualTo(AuthResult.NOT_AUTHENTICATED);
+  }
+
+  @Test
+  void testFailure_invalidHeader() {
+    when(request.getHeader(AUTHORIZATION)).thenReturn("invalidHeader");
+    assertThat(authenticationMechanism.authenticate(request))
+        .isEqualTo(AuthResult.NOT_AUTHENTICATED);
+  }
+
+  @Test
+  void testFailure_invalidAuthToken() {
+    when(httpResponse.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
+    assertThat(authenticationMechanism.authenticate(request))
+        .isEqualTo(AuthResult.NOT_AUTHENTICATED);
+  }
+
+  @Test
+  void testFailure_unknownStatusCode() {
+    when(httpResponse.getStatusCode()).thenReturn(HttpStatusCodes.STATUS_CODE_SERVICE_UNAVAILABLE);
+    assertThat(authenticationMechanism.authenticate(request))
+        .isEqualTo(AuthResult.NOT_AUTHENTICATED);
+  }
+
+  @Test
+  void testFailure_ioException() throws Exception {
+    when(httpResponse.getContent()).thenThrow(new IOException("exception"));
+    assertThat(
+            assertThrows(
+                RuntimeException.class, () -> authenticationMechanism.authenticate(request)))
+        .hasCauseThat()
+        .isInstanceOf(IOException.class);
+  }
+
+  @Test
+  void testFailure_invalidOauthClientId() throws Exception {
+    setResponseJson("{'aud': 'badClientId'}");
+    assertThat(authenticationMechanism.authenticate(request))
+        .isEqualTo(AuthResult.NOT_AUTHENTICATED);
+  }
+
+  @Test
+  void testFailure_missingScope() throws Exception {
+    setResponseJson("{'aud': 'oauthClientId', 'scope': 'invalidScope'}");
+    assertThat(authenticationMechanism.authenticate(request))
+        .isEqualTo(AuthResult.NOT_AUTHENTICATED);
+  }
+
+  @Test
+  void testFailure_partialScope() throws Exception {
+    setResponseJson("{'aud': 'oauthClientId', 'scope': 'scope1'}");
+    assertThat(authenticationMechanism.authenticate(request))
+        .isEqualTo(AuthResult.NOT_AUTHENTICATED);
+  }
+
+  @Test
+  void testFailure_noUser() throws Exception {
+    setResponseJson(
+        "{'aud': 'oauthClientId', 'scope': 'scope1 scope2', 'email': 'johndoe@theregistrar.com'}");
+    assertThat(authenticationMechanism.authenticate(request))
+        .isEqualTo(AuthResult.NOT_AUTHENTICATED);
+  }
+
+  private void setResponseJson(String responseJson) throws IOException {
+    when(httpResponse.getContent())
+        .thenReturn(new ByteArrayInputStream(responseJson.getBytes(StandardCharsets.UTF_8)));
+  }
+}


### PR DESCRIPTION
This doesn't use GAE but instead inspects the Authorization header on the request for an access token. It then checks the open-source Google API to find out who this access token belongs to.

If the access token is expired or invalid, it just returns NOT_AUTHENTICATED

TODO: possibly remove the regular OAuth auth mechanism on alpha and see what happens if this is the only auth mechanism when we try to do nomulus commands

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1779)
<!-- Reviewable:end -->
