### PR TITLE
Do not enqueue DNS updates when flow doesn't affect nameservers

### DIFF
--- a/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
@@ -47,6 +47,7 @@ import static google.registry.testing.DomainSubject.assertAboutDomains;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
 import static google.registry.testing.HistoryEntrySubject.assertAboutHistoryEntries;
 import static google.registry.testing.TaskQueueHelper.assertDnsTasksEnqueued;
+import static google.registry.testing.TaskQueueHelper.assertNoDnsTasksEnqueued;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.joda.money.CurrencyUnit.USD;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -1726,5 +1727,11 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     clock.advanceOneMilli();
     runFlowAsSuperuser();
     assertAboutDomains().that(reloadResourceByForeignKey()).hasNoAutorenewEndTime();
+  }
+
+  @Test
+  void testDnsTaskIsNotTriggeredWhenNoDSChangeSubmitted() throws Exception {
+    setEppInput("domain_update_no_ds_change.xml");
+    assertNoDnsTasksEnqueued();
   }
 }

--- a/core/src/test/resources/google/registry/flows/domain/domain_update_no_ds_change.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_update_no_ds_change.xml
@@ -1,0 +1,18 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <command>
+    <update>
+      <domain:update
+       xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>example.tld</domain:name>
+        <domain:add>
+          <domain:contact type="admin">mak21</domain:contact>
+          <domain:contact type="billing">mak21</domain:contact>
+          <domain:contact type="tech">mak21</domain:contact>
+          <domain:status s="serverHold"
+              lang="en">Server hold.</domain:status>
+        </domain:add>
+      </domain:update>
+    </update>
+    <clTRID>ABC-12345</clTRID>
+  </command>
+</epp>


### PR DESCRIPTION
I believe this should safely fix the issue with triggering dns publish tasks for when they are not required. As far as I understand this process only **nameservers** and **ds data** change should trigger dns publish task.

I removed ```assertDnsTasksEnqueued``` from ```doSuccessfulTest``` as evidentaly it's not expected. Added the test for the this particular use case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1785)
<!-- Reviewable:end -->
