### PR TITLE
Create pipeline to reset domains in QA prior to bad pipeline

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -711,6 +711,10 @@ createToolTask(
     'createSyntheticDomainHistories',
     'google.registry.tools.javascrap.CreateSyntheticDomainHistoriesPipeline')
 
+createToolTask(
+    'resetDomainsToBeforeResave',
+    'google.registry.tools.javascrap.ResetDomainsToBeforeResavePipeline')
+
 project.tasks.create('generateSqlSchema', JavaExec) {
   classpath = sourceSets.nonprod.runtimeClasspath
   main = 'google.registry.tools.DevTool'

--- a/core/src/main/java/google/registry/tools/javascrap/ResetDomainsToBeforeResavePipeline.java
+++ b/core/src/main/java/google/registry/tools/javascrap/ResetDomainsToBeforeResavePipeline.java
@@ -1,0 +1,124 @@
+// Copyright 2022 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.tools.javascrap;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.util.DateTimeUtils.isBeforeOrAt;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+import google.registry.beam.common.RegistryJpaIO;
+import google.registry.beam.common.RegistryPipelineOptions;
+import google.registry.config.RegistryEnvironment;
+import google.registry.model.domain.Domain;
+import google.registry.model.domain.DomainBase;
+import google.registry.model.domain.DomainHistory;
+import google.registry.model.reporting.HistoryEntryDao;
+import google.registry.persistence.PersistenceModule.TransactionIsolationLevel;
+import google.registry.persistence.VKey;
+import java.io.Serializable;
+import java.util.Optional;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.joda.time.DateTime;
+
+/**
+ * Pipeline that resets domains to their state prior to the buggy pipeline that caused b/245940594.
+ *
+ * <p>The pipeline started at 2022-09-05T09:00:00.000Z. If the domain has any history objects before
+ * that time, we reset the domain to the last one before that time. If not, we reset the domain to
+ * the first time (the creation time). That way, it will be valid to replay all (and only)
+ * DOMAIN_UPDATES after the pipeline start time.
+ *
+ * <p>We will not alter contacts or hosts -- this allows domains created post-2022-09-05 to maintain
+ * their foreign key constraints, and it means that we won't need to replay any contact or host EPP
+ * actions.
+ *
+ * <p>After resetting domains to 2022-09-05, we can replay only the DOMAIN_UPDATE EPP actions that
+ * took place after that point, up until the first DomainHistory post-2022-09-10T12:00:00Z (the end
+ * of the pipeline, roughly). At that point we can compare the fields of our domain object to the
+ * domain object stored in that DomainHistory. If the fields are different, then that means that the
+ * domain was likely affected by the overwrite bug.
+ *
+ * <p>To run the pipeline:
+ *
+ * <p><code>
+ * $ ./nom_build :core:resetDomainsToBeforeResave --args="--region=us-central1
+ *   --runner=DataflowRunner
+ *   --registryEnvironment=QA
+ *   --project={project-id}
+ *   --workerMachineType=n2-standard-4"
+ * </code>
+ */
+public class ResetDomainsToBeforeResavePipeline implements Serializable {
+
+  private static final DateTime BAD_PIPELINE_START_TIME =
+      DateTime.parse("2022-09-05T09:00:00.000Z");
+
+  static void setup(Pipeline pipeline) {
+    pipeline
+        .apply(
+            "Select all domain repo IDs",
+            RegistryJpaIO.read(
+                "SELECT d.repoId FROM Domain d", String.class, r -> VKey.create(Domain.class, r)))
+        .apply("Reset each domain", ParDo.of(new DomainResetFunction()));
+  }
+
+  private static class DomainResetFunction extends DoFn<VKey<Domain>, Void> {
+
+    @ProcessElement
+    public void processElement(
+        @Element VKey<Domain> key, PipelineOptions options, OutputReceiver<Void> outputReceiver) {
+      jpaTm()
+          .transact(
+              () -> {
+                // note: these are already sorted from earliest to latest
+                ImmutableList<DomainHistory> allHistories =
+                    HistoryEntryDao.loadHistoryObjectsForResource(key, DomainHistory.class);
+                // If the domain was created before the pipeline, use the last history before it
+                Optional<DomainBase> possibleDomainBeforePipeline =
+                    Streams.findLast(
+                        allHistories.stream()
+                            .filter(
+                                dh ->
+                                    isBeforeOrAt(dh.getModificationTime(), BAD_PIPELINE_START_TIME))
+                            .map(dh -> dh.getDomainBase().get()));
+                // Otherwise (created after the pipeline), use the first (CREATE) history
+                DomainBase domainToPersist =
+                    possibleDomainBeforePipeline.orElseGet(
+                        () -> allHistories.get(0).getDomainBase().get());
+                jpaTm().put(new Domain.Builder().copyFrom(domainToPersist).build());
+              });
+    }
+  }
+
+  public static void main(String[] args) {
+    RegistryPipelineOptions options =
+        PipelineOptionsFactory.fromArgs(args).withValidation().as(RegistryPipelineOptions.class);
+    checkArgument(
+        options.getRegistryEnvironment().equals(RegistryEnvironment.QA),
+        "This command is only meant to be run against the QA instance");
+    RegistryPipelineOptions.validateRegistryPipelineOptions(options);
+    options.setIsolationOverride(TransactionIsolationLevel.TRANSACTION_REPEATABLE_READ);
+
+    Pipeline pipeline = Pipeline.create(options);
+    setup(pipeline);
+    pipeline.run();
+  }
+}

--- a/core/src/test/java/google/registry/tools/javascrap/ResetDomainsToBeforeResavePipelineTest.java
+++ b/core/src/test/java/google/registry/tools/javascrap/ResetDomainsToBeforeResavePipelineTest.java
@@ -1,0 +1,203 @@
+// Copyright 2022 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.tools.javascrap;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.testing.DatabaseHelper.createTld;
+import static google.registry.testing.DatabaseHelper.loadByEntity;
+import static google.registry.testing.DatabaseHelper.persistActiveContact;
+import static google.registry.testing.DatabaseHelper.persistDomainWithDependentResources;
+import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
+import static google.registry.testing.DatabaseHelper.persistResource;
+
+import google.registry.beam.TestPipelineExtension;
+import google.registry.model.contact.Contact;
+import google.registry.model.domain.Domain;
+import google.registry.model.domain.DomainHistory;
+import google.registry.model.eppcommon.StatusValue;
+import google.registry.model.reporting.HistoryEntry;
+import google.registry.persistence.transaction.JpaTestExtensions;
+import google.registry.testing.DatastoreEntityExtension;
+import google.registry.testing.FakeClock;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Tests for {@link ResetDomainsToBeforeResavePipeline}. */
+public class ResetDomainsToBeforeResavePipelineTest {
+
+  private final FakeClock fakeClock = new FakeClock(DateTime.parse("2022-09-01T00:00:00.000Z"));
+
+  @RegisterExtension
+  JpaTestExtensions.JpaIntegrationTestExtension jpaEextension =
+      new JpaTestExtensions.Builder().withClock(fakeClock).buildIntegrationTestExtension();
+
+  @RegisterExtension
+  DatastoreEntityExtension datastoreEntityExtension =
+      new DatastoreEntityExtension().allThreads(true);
+
+  @RegisterExtension TestPipelineExtension pipeline = TestPipelineExtension.create();
+
+  @BeforeEach
+  void beforeEach() {
+    persistNewRegistrar("TheRegistrar");
+    persistNewRegistrar("NewRegistrar");
+    createTld("tld");
+  }
+
+  @Test
+  void testDomainReset_allCases() {
+    Contact contact = persistActiveContact("contact1234");
+
+    // Three domains persisted before the pipeline. One unmodified, one modified before the
+    // pipeline, one modified during the pipeline
+    Domain beforeNoMods =
+        persistDomainWithDependentResources(
+            "before-no-mods",
+            "tld",
+            contact,
+            fakeClock.nowUtc(),
+            fakeClock.nowUtc(),
+            fakeClock.nowUtc().plusYears(2));
+    Domain beforeWithMods =
+        persistDomainWithDependentResources(
+            "before-with-mods",
+            "tld",
+            contact,
+            fakeClock.nowUtc(),
+            fakeClock.nowUtc(),
+            fakeClock.nowUtc().plusYears(2));
+    Domain beforeModBefore =
+        persistDomainWithDependentResources(
+            "before-mod-before",
+            "tld",
+            contact,
+            fakeClock.nowUtc(),
+            fakeClock.nowUtc(),
+            fakeClock.nowUtc().plusYears(2));
+
+    // Modify one domain prior to the pipeline running
+    fakeClock.setTo(DateTime.parse("2022-09-03T00:00:00.000Z"));
+    beforeModBefore =
+        persistResource(
+            beforeModBefore
+                .asBuilder()
+                .addStatusValue(StatusValue.CLIENT_DELETE_PROHIBITED)
+                .build());
+    persistResource(createHistory(beforeModBefore));
+
+    // Two domains persisted during the pipeline, one will be modified, the other won't be
+    fakeClock.setTo(DateTime.parse("2022-09-06T00:00:00.000Z"));
+
+    Domain duringNoMods =
+        persistDomainWithDependentResources(
+            "during-no-mods",
+            "tld",
+            contact,
+            fakeClock.nowUtc(),
+            fakeClock.nowUtc(),
+            fakeClock.nowUtc().plusYears(2));
+    Domain duringWithMods =
+        persistDomainWithDependentResources(
+            "during-with-mods",
+            "tld",
+            contact,
+            fakeClock.nowUtc(),
+            fakeClock.nowUtc(),
+            fakeClock.nowUtc().plusYears(2));
+
+    // Modify two domains created beforehand
+    beforeWithMods =
+        persistResource(
+            beforeWithMods
+                .asBuilder()
+                .addStatusValue(StatusValue.CLIENT_DELETE_PROHIBITED)
+                .build());
+    persistResource(createHistory(beforeWithMods));
+
+    beforeModBefore =
+        persistResource(
+            beforeModBefore
+                .asBuilder()
+                .addStatusValue(StatusValue.CLIENT_RENEW_PROHIBITED)
+                .build());
+    persistResource(createHistory(beforeModBefore));
+
+    // Modify one of the domains created during
+    fakeClock.setTo(DateTime.parse("2022-09-08T00:00:00.000Z"));
+    duringWithMods =
+        persistResource(
+            duringWithMods
+                .asBuilder()
+                .addStatusValue(StatusValue.CLIENT_DELETE_PROHIBITED)
+                .build());
+    persistResource(createHistory(duringWithMods));
+
+    // After the pipeline, create one domain and modify the two that were modified before
+    fakeClock.setTo(DateTime.parse("2022-09-12T00:00:00.000Z"));
+
+    Domain afterNoMods =
+        persistDomainWithDependentResources(
+            "after-no-mods",
+            "tld",
+            contact,
+            fakeClock.nowUtc(),
+            fakeClock.nowUtc(),
+            fakeClock.nowUtc().plusYears(2));
+
+    beforeWithMods =
+        persistResource(
+            beforeWithMods.asBuilder().addStatusValue(StatusValue.CLIENT_RENEW_PROHIBITED).build());
+    persistResource(createHistory(beforeWithMods));
+
+    duringWithMods =
+        persistResource(
+            duringWithMods.asBuilder().addStatusValue(StatusValue.CLIENT_RENEW_PROHIBITED).build());
+    persistResource(createHistory(duringWithMods));
+
+    fakeClock.setTo(DateTime.parse("2022-09-20T00:00:00.000Z"));
+    ResetDomainsToBeforeResavePipeline.setup(pipeline);
+    pipeline.run().waitUntilFinish();
+
+    // The results should be:
+    // 1. beforeNoMods: unmodified
+    // 2. beforeModBefore: should be the modified state before the pipeline
+    // 3. beforeWithMods: should be the originally-persisted domain
+    // 4. duringNoMods: unmodified
+    // 5. duringWithMods: should be the originally-persisted domain
+    // 6. afterMoMods: unmodified
+    // This washes out to all status values being only INACTIVE except for the domain
+    // (beforeModBefore) that had CLIENT_DELETE_PROHIBITED added before the pipeline
+    assertOnlyInactive(beforeNoMods, beforeWithMods, duringNoMods, duringWithMods, afterNoMods);
+    assertThat(loadByEntity(beforeModBefore).getStatusValues())
+        .containsExactly(StatusValue.INACTIVE, StatusValue.CLIENT_DELETE_PROHIBITED);
+  }
+
+  private void assertOnlyInactive(Domain... domains) {
+    for (Domain domain : domains) {
+      assertThat(loadByEntity(domain).getStatusValues()).containsExactly(StatusValue.INACTIVE);
+    }
+  }
+
+  private DomainHistory createHistory(Domain domain) {
+    return new DomainHistory.Builder()
+        .setDomain(domain)
+        .setType(HistoryEntry.Type.DOMAIN_UPDATE)
+        .setModificationTime(fakeClock.nowUtc())
+        .setRegistrarId(domain.getCurrentSponsorRegistrarId())
+        .build();
+  }
+}


### PR DESCRIPTION
This can only be run against the QA instance. If a domain was created prior to the bad pipeline run (2022-09-05T09:00:00.000Z) then we will reset to the last point before the pipeline run. If a domain was created after that point, we reset to the domain creation point. That way, we can replay all DOMAIN_UPDATE objects at or after the pipeline start.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1797)
<!-- Reviewable:end -->
