### PR TITLE
Add a new allowed license string

### DIFF
--- a/config/dependency-license/allowed_licenses.json
+++ b/config/dependency-license/allowed_licenses.json
@@ -207,6 +207,9 @@
     {
       "moduleLicense": "GNU Library General Public License v2.1 or later"
     },
+    {
+      "moduleLicense": "GNU Lesser General Public License v3.0"
+    },
     // This is just 3-clause BSD.
     {
       "moduleLicense": "Go License"


### PR DESCRIPTION
A missing GPL3 string causes sporadic failures when building on local desktop and not using our GCS maven repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1800)
<!-- Reviewable:end -->
