### PR TITLE
Restore log4j exclusion in gradle build

### DIFF
--- a/java_common.gradle
+++ b/java_common.gradle
@@ -62,6 +62,12 @@ configurations {
     // See https://issues.apache.org/jira/browse/BEAM-8862
     it.exclude group: 'org.mockito', module: 'mockito-core'
   }
+  all.each {
+    // log4j has high-profile security vulnerabilities. It's a transitive
+    // dependency used by some Apache Beam packages. Excluding it does not
+    // impact our troubleshooting needs.
+    it.exclude group: 'org.apache.logging.log4j'
+  }
 }
 
 dependencies {


### PR DESCRIPTION
This was added in go/r3pr/1466 but accidentally overwritten in go/r3pr/1472.

Log4j is not in the current releases though. Our dependencies must have removed them too.
Still good to keep.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1801)
<!-- Reviewable:end -->
