### PR TITLE
Change some READ_COMMITTED levels to REPEATABLE_READ

### DIFF
--- a/core/src/main/java/google/registry/beam/resave/ResaveAllEppResourcesPipeline.java
+++ b/core/src/main/java/google/registry/beam/resave/ResaveAllEppResourcesPipeline.java
@@ -91,7 +91,6 @@ public class ResaveAllEppResourcesPipeline implements Serializable {
   }
 
   void setupPipeline(Pipeline pipeline) {
-    options.setIsolationOverride(TransactionIsolationLevel.TRANSACTION_READ_COMMITTED);
     if (options.getFast()) {
       fastResaveContacts(pipeline);
       fastResaveDomains(pipeline);
@@ -194,6 +193,7 @@ public class ResaveAllEppResourcesPipeline implements Serializable {
         PipelineOptionsFactory.fromArgs(args)
             .withValidation()
             .as(ResaveAllEppResourcesPipelineOptions.class);
+    options.setIsolationOverride(TransactionIsolationLevel.TRANSACTION_REPEATABLE_READ);
     new ResaveAllEppResourcesPipeline(options).run();
   }
 }

--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -278,7 +278,7 @@ public abstract class PersistenceModule {
     replicaInstanceConnectionName.ifPresent(
         name -> overrides.put(HIKARI_DS_CLOUD_SQL_INSTANCE, name));
     overrides.put(
-        Environment.ISOLATION, TransactionIsolationLevel.TRANSACTION_READ_COMMITTED.name());
+        Environment.ISOLATION, TransactionIsolationLevel.TRANSACTION_REPEATABLE_READ.name());
     return new JpaTransactionManagerImpl(create(overrides), clock);
   }
 
@@ -294,7 +294,7 @@ public abstract class PersistenceModule {
     replicaInstanceConnectionName.ifPresent(
         name -> overrides.put(HIKARI_DS_CLOUD_SQL_INSTANCE, name));
     overrides.put(
-        Environment.ISOLATION, TransactionIsolationLevel.TRANSACTION_READ_COMMITTED.name());
+        Environment.ISOLATION, TransactionIsolationLevel.TRANSACTION_REPEATABLE_READ.name());
     return new JpaTransactionManagerImpl(create(overrides), clock);
   }
 

--- a/core/src/main/java/google/registry/tools/javascrap/CreateSyntheticDomainHistoriesPipeline.java
+++ b/core/src/main/java/google/registry/tools/javascrap/CreateSyntheticDomainHistoriesPipeline.java
@@ -117,7 +117,7 @@ public class CreateSyntheticDomainHistoriesPipeline implements Serializable {
     RegistryPipelineOptions options =
         PipelineOptionsFactory.fromArgs(args).withValidation().as(RegistryPipelineOptions.class);
     RegistryPipelineOptions.validateRegistryPipelineOptions(options);
-    options.setIsolationOverride(TransactionIsolationLevel.TRANSACTION_READ_COMMITTED);
+    options.setIsolationOverride(TransactionIsolationLevel.TRANSACTION_REPEATABLE_READ);
     String registryAdminRegistrarId =
         DaggerCreateSyntheticDomainHistoriesPipeline_ConfigComponent.create()
             .getRegistryAdminRegistrarId();


### PR DESCRIPTION
Basically, any time we're loading a bunch of linked objects that might change, we want to have REPEATABLE_READ so that another transaction doesn't come along and smush whatever we think we're loading.

The following instances of READ_COMMITTED haven't changed:
- RdePipeline (it only loads immutable objects like histories)
- Invoicing pipeline (only immutable objects like BillingEvents)
- Spec11 (doesn't use any linked info from Domain)

This also changes the PersistenceModule to use REPEATABLE_READ by default on the replica JPA TM, for the standard reasoning.