### PR TITLE
Modify the CreateSynthetic pipeline to run over all non-deleted domains

### DIFF
--- a/core/src/main/java/google/registry/tools/javascrap/CreateSyntheticDomainHistoriesPipeline.java
+++ b/core/src/main/java/google/registry/tools/javascrap/CreateSyntheticDomainHistoriesPipeline.java
@@ -61,21 +61,14 @@ public class CreateSyntheticDomainHistoriesPipeline implements Serializable {
       "Create synthetic domain histories to fix RDE for b/248112997";
   private static final DateTime BAD_PIPELINE_START_TIME =
       DateTime.parse("2022-09-05T09:00:00.000Z");
-  private static final DateTime BAD_PIPELINE_END_TIME = DateTime.parse("2022-09-10T12:00:00.000Z");
 
   static void setup(Pipeline pipeline, String registryAdminRegistrarId) {
     pipeline
         .apply(
             "Read all domain repo IDs",
             RegistryJpaIO.read(
-                "SELECT d.repoId FROM Domain d WHERE deletionTime > :badPipelineStartTime AND NOT"
-                    + " EXISTS (SELECT 1 FROM DomainHistory dh WHERE dh.domainRepoId = d.repoId"
-                    + " AND dh.modificationTime > :badPipelineEndTime)",
-                ImmutableMap.of(
-                    "badPipelineStartTime",
-                    BAD_PIPELINE_START_TIME,
-                    "badPipelineEndTime",
-                    BAD_PIPELINE_END_TIME),
+                "SELECT d.repoId FROM Domain d WHERE deletionTime > :badPipelineStartTime",
+                ImmutableMap.of("badPipelineStartTime", BAD_PIPELINE_START_TIME),
                 String.class,
                 repoId -> VKey.createSql(Domain.class, repoId)))
         .apply(

--- a/core/src/test/java/google/registry/tools/javascrap/CreateSyntheticDomainHistoriesPipelineTest.java
+++ b/core/src/test/java/google/registry/tools/javascrap/CreateSyntheticDomainHistoriesPipelineTest.java
@@ -98,11 +98,13 @@ public class CreateSyntheticDomainHistoriesPipelineTest {
     assertAboutImmutableObjects()
         .that(syntheticHistory.getDomainBase().get())
         .isEqualExceptFields(domain, "updateTimestamp");
+    // four total histories, two CREATE and two SYNTHETIC
+    assertThat(loadAllOf(DomainHistory.class)).hasSize(4);
 
-    // shouldn't create any entries on re-run
+    // can create multiple entries if we run it multiple times
     pipeline.run().waitUntilFinish();
-    assertThat(HistoryEntryDao.loadHistoryObjectsForResource(domain.createVKey())).hasSize(2);
-    // three total histories, two CREATE and one SYNTHETIC
-    assertThat(loadAllOf(DomainHistory.class)).hasSize(3);
+    assertThat(HistoryEntryDao.loadHistoryObjectsForResource(domain.createVKey())).hasSize(3);
+    // six total histories, two CREATE and four SYNTHETIC
+    assertThat(loadAllOf(DomainHistory.class)).hasSize(6);
   }
 }


### PR DESCRIPTION
We're seeing some discrepancies with the history objects created with the previous READ_COMMITTED pipeline so we can make this change to create a new set of history objects in QA now that it's set to REPEATABLE_READ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1803)
<!-- Reviewable:end -->
