### PR TITLE
Use injected times in URSC and CommandTestCase

### DIFF
--- a/core/src/main/java/google/registry/tools/UniformRapidSuspensionCommand.java
+++ b/core/src/main/java/google/registry/tools/UniformRapidSuspensionCommand.java
@@ -21,7 +21,6 @@ import static google.registry.model.EppResourceUtils.checkResourcesExist;
 import static google.registry.model.EppResourceUtils.loadByForeignKey;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.PreconditionsUtils.checkArgumentPresent;
-import static org.joda.time.DateTimeZone.UTC;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
@@ -38,11 +37,13 @@ import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.host.Host;
 import google.registry.tools.soy.DomainRenewSoyInfo;
 import google.registry.tools.soy.UniformRapidSuspensionSoyInfo;
+import google.registry.util.Clock;
 import google.registry.util.DomainNameUtils;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import javax.inject.Inject;
 import javax.xml.bind.annotation.adapters.HexBinaryAdapter;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
@@ -119,10 +120,12 @@ final class UniformRapidSuspensionCommand extends MutatingEppToolCommand {
   /** Set of status values to remove. */
   ImmutableSet<String> removeStatuses;
 
+  @Inject Clock clock;
+
   @Override
   protected void initMutatingEppToolCommand() {
     superuser = true;
-    DateTime now = DateTime.now(UTC);
+    DateTime now = clock.nowUtc();
     ImmutableList<String> newCanonicalHosts =
         newHosts.stream().map(DomainNameUtils::canonicalizeHostname).collect(toImmutableList());
     ImmutableSet<String> newHostsSet = ImmutableSet.copyOf(newCanonicalHosts);

--- a/core/src/test/java/google/registry/tools/CommandTestCase.java
+++ b/core/src/test/java/google/registry/tools/CommandTestCase.java
@@ -19,7 +19,6 @@ import static com.google.common.collect.Iterables.toArray;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.joda.time.DateTimeZone.UTC;
 
 import com.beust.jcommander.JCommander;
 import com.google.common.base.Joiner;
@@ -63,7 +62,7 @@ public abstract class CommandTestCase<C extends Command> {
 
   protected C command;
 
-  protected final FakeClock fakeClock = new FakeClock(DateTime.now(UTC));
+  protected final FakeClock fakeClock = new FakeClock(DateTime.parse("2022-09-01T00:00:00.000Z"));
 
   @RegisterExtension
   public final AppEngineExtension appEngine =

--- a/core/src/test/java/google/registry/tools/GetContactCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetContactCommandTest.java
@@ -19,22 +19,19 @@ import static google.registry.testing.DatabaseHelper.newContact;
 import static google.registry.testing.DatabaseHelper.persistActiveContact;
 import static google.registry.testing.DatabaseHelper.persistDeletedContact;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.beust.jcommander.ParameterException;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link GetContactCommand}. */
 class GetContactCommandTest extends CommandTestCase<GetContactCommand> {
 
-  private DateTime now = DateTime.now(UTC);
-
   @BeforeEach
   void beforeEach() {
     createTld("tld");
+    command.clock = fakeClock;
   }
 
   @Test
@@ -67,7 +64,7 @@ class GetContactCommandTest extends CommandTestCase<GetContactCommand> {
 
   @Test
   void testSuccess_deletedContact() throws Exception {
-    persistDeletedContact("sh8013", now.minusDays(1));
+    persistDeletedContact("sh8013", fakeClock.nowUtc().minusDays(1));
     runCommand("sh8013");
     assertInStdout("Contact 'sh8013' does not exist or is deleted");
   }
@@ -85,8 +82,9 @@ class GetContactCommandTest extends CommandTestCase<GetContactCommand> {
 
   @Test
   void testSuccess_contactDeletedInFuture() throws Exception {
-    persistResource(newContact("sh8013").asBuilder().setDeletionTime(now.plusDays(1)).build());
-    runCommand("sh8013", "--read_timestamp=" + now.plusMonths(1));
+    persistResource(
+        newContact("sh8013").asBuilder().setDeletionTime(fakeClock.nowUtc().plusDays(1)).build());
+    runCommand("sh8013", "--read_timestamp=" + fakeClock.nowUtc().plusMonths(1));
     assertInStdout("Contact 'sh8013' does not exist or is deleted");
   }
 }

--- a/core/src/test/java/google/registry/tools/GetDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetDomainCommandTest.java
@@ -31,6 +31,7 @@ class GetDomainCommandTest extends CommandTestCase<GetDomainCommand> {
   @BeforeEach
   void beforeEach() {
     createTld("tld");
+    command.clock = fakeClock;
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/GetPackagePromotionCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetPackagePromotionCommandTest.java
@@ -28,10 +28,16 @@ import google.registry.model.domain.token.PackagePromotion;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link GetPackagePromotionCommand}. */
 public class GetPackagePromotionCommandTest extends CommandTestCase<GetPackagePromotionCommand> {
+
+  @BeforeEach
+  void beforeEach() {
+    command.clock = fakeClock;
+  }
 
   @Test
   void testSuccess() throws Exception {

--- a/core/src/test/java/google/registry/tools/UniformRapidSuspensionCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UniformRapidSuspensionCommandTest.java
@@ -48,6 +48,7 @@ class UniformRapidSuspensionCommandTest
 
   @BeforeEach
   void beforeEach() {
+    command.clock = fakeClock;
     // Since the command's history client ID must be CharlestonRoad, resave TheRegistrar that way.
     persistResource(
         loadRegistrar("TheRegistrar").asBuilder().setRegistrarId("CharlestonRoad").build());


### PR DESCRIPTION
We started getting failures because some of the tests used October. In general we should freeze the clock for testing as much as possible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1805)
<!-- Reviewable:end -->
