### PR TITLE
Add fallback for Spec11 ThreatMatch parser

### DIFF
--- a/core/src/main/java/google/registry/beam/spec11/ThreatMatch.java
+++ b/core/src/main/java/google/registry/beam/spec11/ThreatMatch.java
@@ -26,6 +26,7 @@ public abstract class ThreatMatch implements Serializable {
 
   private static final String THREAT_TYPE_FIELD = "threatType";
   private static final String DOMAIN_NAME_FIELD = "domainName";
+  private static final String OUTDATED_NAME_FIELD = "fullyQualifiedDomainName";
 
   /** Returns what kind of threat it is (malware, phishing etc.) */
   public abstract String threatType();
@@ -46,7 +47,12 @@ public abstract class ThreatMatch implements Serializable {
 
   /** Parses a {@link JSONObject} and returns an equivalent {@link ThreatMatch}. */
   public static ThreatMatch fromJSON(JSONObject threatMatch) throws JSONException {
+    // TODO: delete OUTDATED_NAME_FIELD once we no longer process reports saved with
+    // fullyQualifiedDomainName in them, likely 2023
     return new AutoValue_ThreatMatch(
-        threatMatch.getString(THREAT_TYPE_FIELD), threatMatch.getString(DOMAIN_NAME_FIELD));
+        threatMatch.getString(THREAT_TYPE_FIELD),
+        threatMatch.has(OUTDATED_NAME_FIELD)
+            ? threatMatch.getString(OUTDATED_NAME_FIELD)
+            : threatMatch.getString(DOMAIN_NAME_FIELD));
   }
 }

--- a/core/src/test/java/google/registry/reporting/spec11/Spec11RegistrarThreatMatchesParserTest.java
+++ b/core/src/test/java/google/registry/reporting/spec11/Spec11RegistrarThreatMatchesParserTest.java
@@ -100,6 +100,24 @@ public class Spec11RegistrarThreatMatchesParserTest {
     assertThat(objectWithExtraFields).isEqualTo(objectWithoutExtraFields);
   }
 
+  @Test
+  void testSuccess_worksWithOutdatedField() throws Exception {
+    ThreatMatch objectWithOutdatedField =
+        ThreatMatch.fromJSON(
+            new JSONObject(
+                ImmutableMap.of(
+                    "threatType", "MALWARE",
+                    "fullyQualifiedDomainName", "c.com")));
+    ThreatMatch objectWithoutOutdatedFields =
+        ThreatMatch.fromJSON(
+            new JSONObject(
+                ImmutableMap.of(
+                    "threatType", "MALWARE",
+                    "domainName", "c.com")));
+
+    assertThat(objectWithOutdatedField).isEqualTo(objectWithoutOutdatedFields);
+  }
+
   /** The expected contents of the sample spec11 report file */
   public static ImmutableSet<RegistrarThreatMatches> sampleThreatMatches() throws Exception {
     return ImmutableSet.of(getMatchA(), getMatchB());


### PR DESCRIPTION
The issue we encountered with Spec11 failing to publish reports on 09/29/2022 is a side effect of https://github.com/google/nomulus/pull/1784 change. 
In nutshell the root cause is that Spec11 parser processes data with 1 day lag, so at the time release went through it went on processing data saved with ```fullyQualifiedDomainName```, the next day it autocorrected itself due to saved files usage of ```domainName``` as a field name. 

However we still want to be able to parse older files stored in a cloud, so this change adds a support for both older field and newer field.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1806)
<!-- Reviewable:end -->
