### PR TITLE
Fix nomulus command

### DIFF
--- a/core/src/main/java/google/registry/tools/RegistryToolComponent.java
+++ b/core/src/main/java/google/registry/tools/RegistryToolComponent.java
@@ -118,6 +118,14 @@ interface RegistryToolComponent {
 
   void inject(GenerateEscrowDepositCommand command);
 
+  void inject(GetContactCommand command);
+
+  void inject(GetDomainCommand command);
+
+  void inject(GetHostCommand command);
+
+  void inject(GetPackagePromotionCommand command);
+
   void inject(GetKeyringSecretCommand command);
 
   void inject(GetSqlCredentialCommand command);
@@ -143,6 +151,8 @@ interface RegistryToolComponent {
   void inject(SetNumInstancesCommand command);
 
   void inject(SetupOteCommand command);
+
+  void inject(UniformRapidSuspensionCommand command);
 
   void inject(UnlockDomainCommand command);
 


### PR DESCRIPTION
go/r3pr/1805 introduced an injectable clock in a few commands, but we
forgot to add the corresponding injector in the component. This PR fixes
it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1812)
<!-- Reviewable:end -->
