### PR TITLE
Switch MetricReporter to App default credential

### DIFF
--- a/core/src/main/java/google/registry/monitoring/whitebox/StackdriverModule.java
+++ b/core/src/main/java/google/registry/monitoring/whitebox/StackdriverModule.java
@@ -24,7 +24,7 @@ import com.google.monitoring.metrics.MetricWriter;
 import com.google.monitoring.metrics.stackdriver.StackdriverWriter;
 import dagger.Module;
 import dagger.Provides;
-import google.registry.config.CredentialModule.JsonCredential;
+import google.registry.config.CredentialModule.ApplicationDefaultCredential;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.util.GoogleCredentialsBundle;
 import org.joda.time.Duration;
@@ -39,7 +39,7 @@ public final class StackdriverModule {
 
   @Provides
   static Monitoring provideMonitoring(
-      @JsonCredential GoogleCredentialsBundle credentialsBundle,
+      @ApplicationDefaultCredential GoogleCredentialsBundle credentialsBundle,
       @Config("projectId") String projectId) {
     return new Monitoring.Builder(
             credentialsBundle.getHttpTransport(),


### PR DESCRIPTION
Switch MetricReporter in Appengine to the app default credential.

Verified in Alpha that MetricReporter successfully started and sent metrics to stackdriver.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1837)
<!-- Reviewable:end -->
