### PR TITLE
Delete unused queues 

### DIFF
--- a/core/src/main/java/google/registry/batch/AsyncTaskEnqueuer.java
+++ b/core/src/main/java/google/registry/batch/AsyncTaskEnqueuer.java
@@ -17,25 +17,16 @@ package google.registry.batch;
 import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.util.DateTimeUtils.isBeforeOrAt;
 
-import com.google.appengine.api.taskqueue.Queue;
-import com.google.appengine.api.taskqueue.TaskOptions;
-import com.google.appengine.api.taskqueue.TaskOptions.Method;
-import com.google.appengine.api.taskqueue.TransientFailureException;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Multimap;
 import com.google.common.flogger.FluentLogger;
-import google.registry.config.RegistryConfig.Config;
 import google.registry.model.EppResource;
-import google.registry.model.eppcommon.Trid;
-import google.registry.model.host.Host;
 import google.registry.persistence.VKey;
 import google.registry.request.Action.Service;
 import google.registry.util.CloudTasksUtils;
-import google.registry.util.Retrier;
 import javax.inject.Inject;
-import javax.inject.Named;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
 
@@ -44,41 +35,23 @@ public final class AsyncTaskEnqueuer {
 
   /** The HTTP parameter names used by async flows. */
   public static final String PARAM_RESOURCE_KEY = "resourceKey";
-  public static final String PARAM_REQUESTING_CLIENT_ID = "requestingClientId";
-  public static final String PARAM_CLIENT_TRANSACTION_ID = "clientTransactionId";
-  public static final String PARAM_SERVER_TRANSACTION_ID = "serverTransactionId";
-  public static final String PARAM_IS_SUPERUSER = "isSuperuser";
   public static final String PARAM_HOST_KEY = "hostKey";
   public static final String PARAM_REQUESTED_TIME = "requestedTime";
   public static final String PARAM_RESAVE_TIMES = "resaveTimes";
 
   /** The task queue names used by async flows. */
   public static final String QUEUE_ASYNC_ACTIONS = "async-actions";
-  public static final String QUEUE_ASYNC_DELETE = "async-delete-pull";
+
   public static final String QUEUE_ASYNC_HOST_RENAME = "async-host-rename-pull";
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
   private static final Duration MAX_ASYNC_ETA = Duration.standardDays(30);
 
-  private final Duration asyncDeleteDelay;
-  private final Queue asyncDeletePullQueue;
-  private final Queue asyncDnsRefreshPullQueue;
-  private final Retrier retrier;
-
   private final CloudTasksUtils cloudTasksUtils;
 
   @Inject
-  public AsyncTaskEnqueuer(
-      @Named(QUEUE_ASYNC_DELETE) Queue asyncDeletePullQueue,
-      @Named(QUEUE_ASYNC_HOST_RENAME) Queue asyncDnsRefreshPullQueue,
-      @Config("asyncDeleteDelay") Duration asyncDeleteDelay,
-      CloudTasksUtils cloudTasksUtils,
-      Retrier retrier) {
-    this.asyncDeletePullQueue = asyncDeletePullQueue;
-    this.asyncDnsRefreshPullQueue = asyncDnsRefreshPullQueue;
-    this.asyncDeleteDelay = asyncDeleteDelay;
+  public AsyncTaskEnqueuer(CloudTasksUtils cloudTasksUtils) {
     this.cloudTasksUtils = cloudTasksUtils;
-    this.retrier = retrier;
   }
 
   /** Enqueues a task to asynchronously re-save an entity at some point in the future. */
@@ -117,47 +90,5 @@ public final class AsyncTaskEnqueuer {
         QUEUE_ASYNC_ACTIONS,
         cloudTasksUtils.createPostTaskWithDelay(
             ResaveEntityAction.PATH, Service.BACKEND.toString(), params, etaDuration));
-  }
-
-  /** Enqueues a task to asynchronously delete a contact or host, by key. */
-  public void enqueueAsyncDelete(
-      EppResource resourceToDelete,
-      DateTime now,
-      String requestingRegistrarId,
-      Trid trid,
-      boolean isSuperuser) {
-    logger.atInfo().log(
-        "Enqueuing async deletion of %s on behalf of registrar %s.",
-        resourceToDelete.getRepoId(), requestingRegistrarId);
-    TaskOptions task =
-        TaskOptions.Builder.withMethod(Method.PULL)
-            .countdownMillis(asyncDeleteDelay.getMillis())
-            .param(PARAM_RESOURCE_KEY, resourceToDelete.createVKey().stringify())
-            .param(PARAM_REQUESTING_CLIENT_ID, requestingRegistrarId)
-            .param(PARAM_SERVER_TRANSACTION_ID, trid.getServerTransactionId())
-            .param(PARAM_IS_SUPERUSER, Boolean.toString(isSuperuser))
-            .param(PARAM_REQUESTED_TIME, now.toString());
-    trid.getClientTransactionId()
-        .ifPresent(clTrid -> task.param(PARAM_CLIENT_TRANSACTION_ID, clTrid));
-    addTaskToQueueWithRetry(asyncDeletePullQueue, task);
-  }
-
-  /** Enqueues a task to asynchronously refresh DNS for a renamed host. */
-  public void enqueueAsyncDnsRefresh(Host host, DateTime now) {
-    VKey<Host> hostKey = host.createVKey();
-    logger.atInfo().log("Enqueuing async DNS refresh for renamed host %s.", hostKey);
-    addTaskToQueueWithRetry(
-        asyncDnsRefreshPullQueue,
-        TaskOptions.Builder.withMethod(Method.PULL)
-            .param(PARAM_HOST_KEY, hostKey.stringify())
-            .param(PARAM_REQUESTED_TIME, now.toString()));
-  }
-
-  /**
-   * Adds a task to a queue with retrying, to avoid aborting the entire flow over a transient issue
-   * enqueuing a task.
-   */
-  private void addTaskToQueueWithRetry(final Queue queue, final TaskOptions task) {
-    retrier.callWithRetry(() -> queue.add(task), TransientFailureException.class);
   }
 }

--- a/core/src/main/java/google/registry/batch/BatchModule.java
+++ b/core/src/main/java/google/registry/batch/BatchModule.java
@@ -14,13 +14,9 @@
 
 package google.registry.batch;
 
-import static com.google.appengine.api.taskqueue.QueueFactory.getQueue;
 import static google.registry.batch.AsyncTaskEnqueuer.PARAM_REQUESTED_TIME;
 import static google.registry.batch.AsyncTaskEnqueuer.PARAM_RESAVE_TIMES;
 import static google.registry.batch.AsyncTaskEnqueuer.PARAM_RESOURCE_KEY;
-import static google.registry.batch.AsyncTaskEnqueuer.QUEUE_ASYNC_ACTIONS;
-import static google.registry.batch.AsyncTaskEnqueuer.QUEUE_ASYNC_DELETE;
-import static google.registry.batch.AsyncTaskEnqueuer.QUEUE_ASYNC_HOST_RENAME;
 import static google.registry.batch.CannedScriptExecutionAction.SCRIPT_PARAM;
 import static google.registry.request.RequestParameters.extractBooleanParameter;
 import static google.registry.request.RequestParameters.extractIntParameter;
@@ -33,13 +29,11 @@ import static google.registry.request.RequestParameters.extractRequiredDatetimeP
 import static google.registry.request.RequestParameters.extractRequiredParameter;
 import static google.registry.request.RequestParameters.extractSetOfDatetimeParameters;
 
-import com.google.appengine.api.taskqueue.Queue;
 import com.google.common.collect.ImmutableSet;
 import dagger.Module;
 import dagger.Provides;
 import google.registry.request.Parameter;
 import java.util.Optional;
-import javax.inject.Named;
 import javax.servlet.http.HttpServletRequest;
 import org.joda.time.DateTime;
 
@@ -127,24 +121,6 @@ public class BatchModule {
   @Parameter(PARAM_DRY_RUN)
   static boolean provideIsDryRun(HttpServletRequest req) {
     return extractBooleanParameter(req, PARAM_DRY_RUN);
-  }
-
-  @Provides
-  @Named(QUEUE_ASYNC_ACTIONS)
-  static Queue provideAsyncActionsPushQueue() {
-    return getQueue(QUEUE_ASYNC_ACTIONS);
-  }
-
-  @Provides
-  @Named(QUEUE_ASYNC_DELETE)
-  static Queue provideAsyncDeletePullQueue() {
-    return getQueue(QUEUE_ASYNC_DELETE);
-  }
-
-  @Provides
-  @Named(QUEUE_ASYNC_HOST_RENAME)
-  static Queue provideAsyncHostRenamePullQueue() {
-    return getQueue(QUEUE_ASYNC_HOST_RENAME);
   }
 
   // TODO(b/234424397): remove method after credential changes are rolled out.

--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -1028,38 +1028,6 @@ public final class RegistryConfig {
     }
 
     /**
-     * Returns the delay before executing async delete flow mapreduces.
-     *
-     * <p>This delay should be sufficiently longer than a transaction, to solve the following
-     * problem:
-     *
-     * <ul>
-     *   <li>a domain mutation flow starts a transaction
-     *   <li>the domain flow non-transactionally reads a resource and sees that it's not in
-     *       PENDING_DELETE
-     *   <li>the domain flow creates a new reference to this resource
-     *   <li>a contact/host delete flow runs and marks the resource PENDING_DELETE and commits
-     *   <li>the domain flow commits
-     * </ul>
-     *
-     * <p>Although we try not to add references to a PENDING_DELETE resource, strictly speaking that
-     * is ok as long as the mapreduce eventually sees the new reference (and therefore
-     * asynchronously fails the delete). Without this delay, the mapreduce might have started before
-     * the domain flow committed, and could potentially miss the reference.
-     *
-     * <p>If you are using EPP resource caching (eppResourceCachingEnabled in YAML), then this
-     * duration should also be longer than that cache duration (eppResourceCachingSeconds).
-     *
-     * @see google.registry.config.RegistryConfigSettings.Caching
-     * @see google.registry.batch.AsyncTaskEnqueuer
-     */
-    @Provides
-    @Config("asyncDeleteDelay")
-    public static Duration provideAsyncDeleteDelay(RegistryConfigSettings config) {
-      return Duration.standardSeconds(config.misc.asyncDeleteDelaySeconds);
-    }
-
-    /**
      * The server ID used in the 'svID' element of an EPP 'greeting'.
      *
      * @see <a href="https://tools.ietf.org/html/rfc5730">RFC 7530</a>

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -207,7 +207,6 @@ public class RegistryConfigSettings {
     public String alertRecipientEmailAddress;
     public String spec11OutgoingEmailAddress;
     public List<String> spec11BccEmailAddresses;
-    public int asyncDeleteDelaySeconds;
     public int transientFailureRetries;
   }
 

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -421,11 +421,6 @@ misc:
   spec11BccEmailAddresses:
     - abuse@example.com
 
-  # How long to delay processing of asynchronous deletions. This should always
-  # be longer than eppResourceCachingSeconds, to prevent deleted contacts or
-  # hosts from being used on domains.
-  asyncDeleteDelaySeconds: 90
-
   # Number of times to retry a GAE operation when a transient exception is thrown.
   # The number of milliseconds it'll sleep before giving up is (2^n - 2) * 100.
   transientFailureRetries: 12

--- a/core/src/main/java/google/registry/env/common/default/WEB-INF/queue.xml
+++ b/core/src/main/java/google/registry/env/common/default/WEB-INF/queue.xml
@@ -19,86 +19,6 @@
   </queue>
 
   <queue>
-    <name>async-delete-pull</name>
-    <mode>pull</mode>
-  </queue>
-
-  <queue>
-    <name>async-host-rename-pull</name>
-    <mode>pull</mode>
-  </queue>
-
-  <queue>
-    <name>export-commits</name>
-    <rate>10/s</rate>
-    <bucket-size>100</bucket-size>
-    <retry-parameters>
-      <!-- Retry aggressively since a single delayed export increases our time window of
-           unrecoverable data loss in the event of a Datastore failure. -->
-      <min-backoff-seconds>1</min-backoff-seconds>
-      <max-backoff-seconds>60</max-backoff-seconds>
-      <!-- No age limit; a failed export should be retried as long as possible to avoid
-           having data missing from our exported commit log record. -->
-    </retry-parameters>
-  </queue>
-
-  <!-- Queue for polling export BigQuery jobs for completion. -->
-  <queue>
-    <name>export-bigquery-poll</name>
-    <!-- Limit queue to 5 concurrent tasks and 5 per second to avoid hitting BigQuery quotas. -->
-    <rate>5/s</rate>
-    <bucket-size>5</bucket-size>
-    <max-concurrent-requests>5</max-concurrent-requests>
-    <!-- Check every 20s and increase interval to every 5 minutes. -->
-    <retry-parameters>
-      <min-backoff-seconds>20</min-backoff-seconds>
-      <max-backoff-seconds>300</max-backoff-seconds>
-      <max-doublings>2</max-doublings>
-    </retry-parameters>
-  </queue>
-
-  <!-- Queue for launching new snapshots and for triggering the initial BigQuery load jobs. -->
-  <queue>
-    <name>export-snapshot</name>
-    <rate>1/s</rate>
-    <retry-parameters>
-      <!-- Should be less than the exportSnapshot cron interval; see cron.xml. -->
-      <task-age-limit>22h</task-age-limit>
-      <!-- Retry starting at a 5m interval and increasing up to a 30m interval. -->
-      <min-backoff-seconds>300</min-backoff-seconds>
-      <max-backoff-seconds>1800</max-backoff-seconds>
-      <task-retry-limit>10</task-retry-limit>
-    </retry-parameters>
-  </queue>
-
-  <!-- Queue for polling managed backup snapshots for completion. -->
-  <queue>
-    <name>export-snapshot-poll</name>
-    <rate>5/m</rate>
-    <retry-parameters>
-      <!-- Should be less than the exportSnapshot cron interval; see cron.xml. -->
-      <task-age-limit>22h</task-age-limit>
-      <!-- Retry starting at a 1m interval and increasing up to a 5m interval. -->
-      <min-backoff-seconds>60</min-backoff-seconds>
-      <max-backoff-seconds>300</max-backoff-seconds>
-    </retry-parameters>
-  </queue>
-
-  <!-- Queue for updating BigQuery views after a snapshot kind's load job completes. -->
-  <queue>
-    <name>export-snapshot-update-view</name>
-    <rate>1/s</rate>
-    <retry-parameters>
-      <!-- Should be less than the exportSnapshot cron interval; see cron.xml. -->
-      <task-age-limit>22h</task-age-limit>
-      <!-- Retry starting at a 10s interval and increasing up to a 1m interval. -->
-      <min-backoff-seconds>10</min-backoff-seconds>
-      <max-backoff-seconds>60</max-backoff-seconds>
-      <task-retry-limit>10</task-retry-limit>
-    </retry-parameters>
-  </queue>
-
-  <queue>
     <name>rde-upload</name>
     <rate>10/m</rate>
     <bucket-size>50</bucket-size>
@@ -149,7 +69,7 @@
     </retry-parameters>
   </queue>
 
-  <!-- Queue for tasks to produce LORDN CSV reports, either by by the query or queue method. -->
+  <!-- Queue for tasks to produce LORDN CSV reports, either by the query or queue method. -->
   <queue>
     <name>nordn</name>
     <rate>1/s</rate>
@@ -169,17 +89,6 @@
   <queue>
     <name>lordn-sunrise</name>
     <mode>pull</mode>
-  </queue>
-
-  <!-- Queue used by the MapReduce library for running tasks.
-
-       Do not re-use this queue for tasks that our code creates (e.g. tasks to launch MapReduces
-       that aren't themselves part of a running MapReduce).-->
-  <queue>
-    <name>mapreduce</name>
-    <!-- Warning: DO NOT SET A <target> parameter for this queue.  See b/24782801 for why. -->
-    <rate>500/s</rate>
-    <bucket-size>100</bucket-size>
   </queue>
 
   <!-- Queue for tasks that sync data to Google Spreadsheets. -->
@@ -208,71 +117,4 @@
     <max-concurrent-requests>5</max-concurrent-requests>
   </queue>
 
-  <!-- Queue for replaying commit logs to SQL during the transition from Datastore -> SQL. -->
-  <queue>
-    <name>replay-commit-logs-to-sql</name>
-    <rate>1/s</rate>
-  </queue>
-
-  <!-- The load[0-9] queues are used for load-testing, and can be safely deleted
-       in any environment that doesn't require load-testing. -->
-  <queue>
-    <name>load0</name>
-    <rate>500/s</rate>
-    <bucket-size>500</bucket-size>
-  </queue>
-
-  <queue>
-    <name>load1</name>
-    <rate>500/s</rate>
-    <bucket-size>500</bucket-size>
-  </queue>
-
-  <queue>
-    <name>load2</name>
-    <rate>500/s</rate>
-    <bucket-size>500</bucket-size>
-  </queue>
-
-  <queue>
-    <name>load3</name>
-    <rate>500/s</rate>
-    <bucket-size>500</bucket-size>
-  </queue>
-
-  <queue>
-    <name>load4</name>
-    <rate>500/s</rate>
-    <bucket-size>500</bucket-size>
-  </queue>
-
-  <queue>
-    <name>load5</name>
-    <rate>500/s</rate>
-    <bucket-size>500</bucket-size>
-  </queue>
-
-  <queue>
-    <name>load6</name>
-    <rate>500/s</rate>
-    <bucket-size>500</bucket-size>
-  </queue>
-
-  <queue>
-    <name>load7</name>
-    <rate>500/s</rate>
-    <bucket-size>500</bucket-size>
-  </queue>
-
-  <queue>
-    <name>load8</name>
-    <rate>500/s</rate>
-    <bucket-size>500</bucket-size>
-  </queue>
-
-  <queue>
-    <name>load9</name>
-    <rate>500/s</rate>
-    <bucket-size>500</bucket-size>
-  </queue>
 </queue-entries>

--- a/core/src/main/java/google/registry/flows/host/HostUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostUpdateFlow.java
@@ -268,7 +268,7 @@ public final class HostUpdateFlow implements TransactionalFlow {
       }
       // We must also enqueue updates for all domains that use this host as their nameserver so
       // that their NS records can be updated to point at the new name.
-      asyncTaskEnqueuer.enqueueAsyncDnsRefresh(existingHost, tm().getTransactionTime());
+      // TODO(jianglai): implement a SQL based solution.
     }
   }
 

--- a/core/src/test/java/google/registry/batch/AsyncTaskEnqueuerTest.java
+++ b/core/src/test/java/google/registry/batch/AsyncTaskEnqueuerTest.java
@@ -14,16 +14,12 @@
 
 package google.registry.batch;
 
-import static com.google.appengine.api.taskqueue.QueueFactory.getQueue;
 import static google.registry.batch.AsyncTaskEnqueuer.PARAM_REQUESTED_TIME;
 import static google.registry.batch.AsyncTaskEnqueuer.PARAM_RESAVE_TIMES;
 import static google.registry.batch.AsyncTaskEnqueuer.PARAM_RESOURCE_KEY;
 import static google.registry.batch.AsyncTaskEnqueuer.QUEUE_ASYNC_ACTIONS;
-import static google.registry.batch.AsyncTaskEnqueuer.QUEUE_ASYNC_DELETE;
-import static google.registry.batch.AsyncTaskEnqueuer.QUEUE_ASYNC_HOST_RENAME;
 import static google.registry.testing.DatabaseHelper.persistActiveContact;
 import static google.registry.testing.TestLogHandlerUtils.assertLogMessage;
-import static org.joda.time.Duration.standardSeconds;
 
 import com.google.cloud.tasks.v2.HttpMethod;
 import com.google.common.collect.ImmutableSortedSet;
@@ -32,11 +28,9 @@ import google.registry.testing.AppEngineExtension;
 import google.registry.testing.CloudTasksHelper;
 import google.registry.testing.CloudTasksHelper.TaskMatcher;
 import google.registry.testing.FakeClock;
-import google.registry.testing.FakeSleeper;
 import google.registry.util.CapturingLogHandler;
 import google.registry.util.CloudTasksUtils;
 import google.registry.util.JdkLoggerConfig;
-import google.registry.util.Retrier;
 import java.util.logging.Level;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
@@ -64,18 +58,11 @@ public class AsyncTaskEnqueuerTest {
   @BeforeEach
   void beforeEach() {
     JdkLoggerConfig.getConfig(AsyncTaskEnqueuer.class).addHandler(logHandler);
-    asyncTaskEnqueuer =
-        createForTesting(cloudTasksHelper.getTestCloudTasksUtils(), clock, standardSeconds(90));
+    asyncTaskEnqueuer = createForTesting(cloudTasksHelper.getTestCloudTasksUtils());
   }
 
-  public static AsyncTaskEnqueuer createForTesting(
-      CloudTasksUtils cloudTasksUtils, FakeClock clock, Duration asyncDeleteDelay) {
-    return new AsyncTaskEnqueuer(
-        getQueue(QUEUE_ASYNC_DELETE),
-        getQueue(QUEUE_ASYNC_HOST_RENAME),
-        asyncDeleteDelay,
-        cloudTasksUtils,
-        new Retrier(new FakeSleeper(clock), 1));
+  public static AsyncTaskEnqueuer createForTesting(CloudTasksUtils cloudTasksUtils) {
+    return new AsyncTaskEnqueuer(cloudTasksUtils);
   }
 
   @Test

--- a/core/src/test/java/google/registry/batch/ResaveEntityActionTest.java
+++ b/core/src/test/java/google/registry/batch/ResaveEntityActionTest.java
@@ -41,7 +41,6 @@ import google.registry.testing.CloudTasksHelper.TaskMatcher;
 import google.registry.testing.DatabaseHelper;
 import google.registry.testing.FakeClock;
 import org.joda.time.DateTime;
-import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -67,8 +66,7 @@ public class ResaveEntityActionTest {
   @BeforeEach
   void beforeEach() {
     asyncTaskEnqueuer =
-        AsyncTaskEnqueuerTest.createForTesting(
-            cloudTasksHelper.getTestCloudTasksUtils(), clock, Duration.ZERO);
+        AsyncTaskEnqueuerTest.createForTesting(cloudTasksHelper.getTestCloudTasksUtils());
     createTld("tld");
   }
 

--- a/core/src/test/java/google/registry/flows/EppTestComponent.java
+++ b/core/src/test/java/google/registry/flows/EppTestComponent.java
@@ -14,8 +14,6 @@
 
 package google.registry.flows;
 
-import static org.joda.time.Duration.standardSeconds;
-
 import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
@@ -73,8 +71,7 @@ public interface EppTestComponent {
       FakesAndMocksModule instance = new FakesAndMocksModule();
       CloudTasksHelper cloudTasksHelper = new CloudTasksHelper(clock);
       instance.asyncTaskEnqueuer =
-          AsyncTaskEnqueuerTest.createForTesting(
-              cloudTasksHelper.getTestCloudTasksUtils(), clock, standardSeconds(90));
+          AsyncTaskEnqueuerTest.createForTesting(cloudTasksHelper.getTestCloudTasksUtils());
       instance.clock = clock;
       instance.domainFlowTmchUtils =
           new DomainFlowTmchUtils(

--- a/core/src/test/java/google/registry/flows/contact/ContactDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactDeleteFlowTest.java
@@ -16,7 +16,6 @@ package google.registry.flows.contact;
 
 import static com.google.common.collect.MoreCollectors.onlyElement;
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.batch.AsyncTaskEnqueuer.QUEUE_ASYNC_DELETE;
 import static google.registry.testing.ContactSubject.assertAboutContacts;
 import static google.registry.testing.DatabaseHelper.assertNoBillingEvents;
 import static google.registry.testing.DatabaseHelper.createTld;
@@ -27,7 +26,6 @@ import static google.registry.testing.DatabaseHelper.persistContactWithPendingTr
 import static google.registry.testing.DatabaseHelper.persistDeletedContact;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
-import static google.registry.testing.TaskQueueHelper.assertNoTasksEnqueued;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableSet;
@@ -238,7 +236,6 @@ class ContactDeleteFlowTest extends ResourceFlowTestCase<ContactDeleteFlow, Cont
         .hasExactlyStatusValues(StatusValue.OK)
         .and()
         .hasOneHistoryEntryEachOfTypes(historyEntryTypes);
-    assertNoTasksEnqueued(QUEUE_ASYNC_DELETE);
     assertNoBillingEvents();
   }
 

--- a/core/src/test/java/google/registry/flows/host/HostDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostDeleteFlowTest.java
@@ -15,7 +15,6 @@
 package google.registry.flows.host;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.batch.AsyncTaskEnqueuer.QUEUE_ASYNC_DELETE;
 import static google.registry.testing.DatabaseHelper.assertNoBillingEvents;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.loadByKey;
@@ -27,7 +26,6 @@ import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptio
 import static google.registry.testing.HostSubject.assertAboutHosts;
 import static google.registry.testing.TaskQueueHelper.assertDnsTasksEnqueued;
 import static google.registry.testing.TaskQueueHelper.assertNoDnsTasksEnqueued;
-import static google.registry.testing.TaskQueueHelper.assertNoTasksEnqueued;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
@@ -324,7 +322,6 @@ class HostDeleteFlowTest extends ResourceFlowTestCase<HostDeleteFlow, Host> {
       assertNoDnsTasksEnqueued();
     }
     assertLastHistoryContainsResource(deletedHost);
-    assertNoTasksEnqueued(QUEUE_ASYNC_DELETE);
   }
 
   private void assertSqlDeleteSuccess() throws Exception {

--- a/core/src/test/java/google/registry/flows/host/HostUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostUpdateFlowTest.java
@@ -16,8 +16,6 @@ package google.registry.flows.host;
 
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.batch.AsyncTaskEnqueuer.PARAM_HOST_KEY;
-import static google.registry.batch.AsyncTaskEnqueuer.QUEUE_ASYNC_HOST_RENAME;
 import static google.registry.model.EppResourceUtils.loadByForeignKey;
 import static google.registry.testing.DatabaseHelper.assertNoBillingEvents;
 import static google.registry.testing.DatabaseHelper.createTld;
@@ -37,7 +35,6 @@ import static google.registry.testing.HistoryEntrySubject.assertAboutHistoryEntr
 import static google.registry.testing.HostSubject.assertAboutHosts;
 import static google.registry.testing.TaskQueueHelper.assertDnsTasksEnqueued;
 import static google.registry.testing.TaskQueueHelper.assertNoDnsTasksEnqueued;
-import static google.registry.testing.TaskQueueHelper.assertTasksEnqueued;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -79,7 +76,6 @@ import google.registry.model.transfer.DomainTransferData;
 import google.registry.model.transfer.TransferStatus;
 import google.registry.persistence.VKey;
 import google.registry.testing.DatabaseHelper;
-import google.registry.testing.TaskQueueHelper.TaskMatcher;
 import javax.annotation.Nullable;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
@@ -203,11 +199,12 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
     Host renamedHost = doSuccessfulTest();
     assertThat(renamedHost.isSubordinate()).isTrue();
     // Task enqueued to change the NS record of the referencing domain.
-    assertTasksEnqueued(
-        QUEUE_ASYNC_HOST_RENAME,
-        new TaskMatcher()
-            .param(PARAM_HOST_KEY, renamedHost.createVKey().stringify())
-            .param("requestedTime", clock.nowUtc().toString()));
+    // TODO(jianglai): add assertion on host rename refresh based on SQL impementation.
+    // assertTasksEnqueued(
+    //    QUEUE_ASYNC_HOST_RENAME,
+    //    new TaskMatcher()
+    //        .param(PARAM_HOST_KEY, renamedHost.createVKey().stringify())
+    //        .param("requestedTime", clock.nowUtc().toString()));
   }
 
   @Test

--- a/core/src/test/java/google/registry/testing/CloudTasksHelper.java
+++ b/core/src/test/java/google/registry/testing/CloudTasksHelper.java
@@ -227,7 +227,7 @@ public class CloudTasksHelper implements Serializable {
     String service;
     // App Engine TaskOption methods default to "POST".  This isn't obvious from the code, so we
     // default it to POST here so that we don't accidentally create an entry with a GET method when
-    // converting to CloudTaskUtils, which requires that the method be specified explicitly.
+    // converting to CloudTasksUtils, which requires that the method be specified explicitly.
     // Should we ever actually want to do a GET, we'll likewise have to set this explicitly for the
     // tests.
     HttpMethod method = HttpMethod.POST;


### PR DESCRIPTION
Note that the async-host-rename-pull queue were still being populated prior to this PR, but the queue hasn't been processed for several months. There is no point in keeping enqueuing to it. We will implement a SQL-based DNS refresh solution and run RefreshDnsForAllDomainAction action once to catch up on all stale changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1841)
<!-- Reviewable:end -->
