### PR TITLE
Allow status, crDate, upDate, exDate and ns fields for all Domain Info responses

### DIFF
--- a/core/src/test/resources/google/registry/flows/domain/domain_info_response_superuser_package.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_info_response_superuser_package.xml
@@ -8,8 +8,17 @@
           xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
         <domain:name>example.tld</domain:name>
         <domain:roid>%ROID%</domain:roid>
+        <domain:status s="ok"/>
         <domain:registrant>jd1234</domain:registrant>
+        <domain:ns>
+          <domain:hostObj>ns1.example.net</domain:hostObj>
+          <domain:hostObj>ns1.example.tld</domain:hostObj>
+        </domain:ns>
         <domain:clID>NewRegistrar</domain:clID>
+        <domain:crDate>1999-04-03T22:00:00Z</domain:crDate>
+        <domain:upDate>1999-12-03T09:00:00Z</domain:upDate>
+        <domain:exDate>2005-04-03T22:00:00Z</domain:exDate>
+        <domain:trDate>2000-04-08T09:00:00Z</domain:trDate>
       </domain:infData>
     </resData>
     <extension>

--- a/core/src/test/resources/google/registry/flows/domain/domain_info_response_unauthorized.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_info_response_unauthorized.xml
@@ -8,8 +8,17 @@
        xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
         <domain:name>example.tld</domain:name>
         <domain:roid>%ROID%</domain:roid>
+        <domain:status s="ok"/>
         <domain:registrant>jd1234</domain:registrant>
+        <domain:ns>
+          <domain:hostObj>ns1.example.net</domain:hostObj>
+          <domain:hostObj>ns1.example.tld</domain:hostObj>
+        </domain:ns>
         <domain:clID>NewRegistrar</domain:clID>
+        <domain:crDate>1999-04-03T22:00:00Z</domain:crDate>
+        <domain:upDate>1999-12-03T09:00:00Z</domain:upDate>
+        <domain:exDate>2005-04-03T22:00:00Z</domain:exDate>
+        <domain:trDate>2000-04-08T09:00:00Z</domain:trDate>
       </domain:infData>
     </resData>
     <trID>


### PR DESCRIPTION
Per b/257081445 allows more information in domain info response, makes info command response similar to whois response.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1842)
<!-- Reviewable:end -->
