### PR TITLE
Use keyless delegated credential

### DIFF
--- a/core/src/main/java/google/registry/groups/DirectoryModule.java
+++ b/core/src/main/java/google/registry/groups/DirectoryModule.java
@@ -17,7 +17,7 @@ package google.registry.groups;
 import com.google.api.services.admin.directory.Directory;
 import dagger.Module;
 import dagger.Provides;
-import google.registry.config.CredentialModule.DelegatedCredential;
+import google.registry.config.CredentialModule.AdcDelegatedCredential;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.util.GoogleCredentialsBundle;
 
@@ -27,7 +27,7 @@ public final class DirectoryModule {
 
   @Provides
   static Directory provideDirectory(
-      @DelegatedCredential GoogleCredentialsBundle credentialsBundle,
+      @AdcDelegatedCredential GoogleCredentialsBundle credentialsBundle,
       @Config("projectId") String projectId) {
     return new Directory.Builder(
             credentialsBundle.getHttpTransport(),

--- a/core/src/main/java/google/registry/groups/GroupssettingsModule.java
+++ b/core/src/main/java/google/registry/groups/GroupssettingsModule.java
@@ -17,7 +17,7 @@ package google.registry.groups;
 import com.google.api.services.groupssettings.Groupssettings;
 import dagger.Module;
 import dagger.Provides;
-import google.registry.config.CredentialModule.DelegatedCredential;
+import google.registry.config.CredentialModule.AdcDelegatedCredential;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.util.GoogleCredentialsBundle;
 
@@ -27,7 +27,7 @@ public final class GroupssettingsModule {
 
   @Provides
   static Groupssettings provideDirectory(
-      @DelegatedCredential GoogleCredentialsBundle credentialsBundle,
+      @AdcDelegatedCredential GoogleCredentialsBundle credentialsBundle,
       @Config("projectId") String projectId) {
     return new Groupssettings.Builder(
             credentialsBundle.getHttpTransport(),

--- a/core/src/main/java/google/registry/keyring/api/KeyModule.java
+++ b/core/src/main/java/google/registry/keyring/api/KeyModule.java
@@ -120,10 +120,4 @@ public final class KeyModule {
   static String provideSafeBrowsingAPIKey(Keyring keyring) {
     return keyring.getSafeBrowsingAPIKey();
   }
-
-  @Provides
-  @Key("jsonCredential")
-  static String provideJsonCredential(Keyring keyring) {
-    return keyring.getJsonCredential();
-  }
 }

--- a/core/src/main/java/google/registry/keyring/secretmanager/SecretManagerKeyring.java
+++ b/core/src/main/java/google/registry/keyring/secretmanager/SecretManagerKeyring.java
@@ -143,6 +143,7 @@ public class SecretManagerKeyring implements Keyring {
     return getString(StringKeyLabel.MARKSDB_SMDRL_LOGIN_STRING);
   }
 
+  // TODO(b/237305940): remove this method and all supports, including entry in secretmanager
   @Override
   public String getJsonCredential() {
     return getString(StringKeyLabel.JSON_CREDENTIAL_STRING);


### PR DESCRIPTION
Use the new keyless delegated credential with `AdcDelegatedCredential` annotation for accessing Google Workspace APIs. This new cred is verified in production.

Removed everything related to @JsonCredential

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1847)
<!-- Reviewable:end -->
