### PR TITLE
Rename AppEngineConnection to ServiceConnection

### DIFF
--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -103,13 +103,13 @@ public final class RegistryConfig {
     @Provides
     @Config("projectId")
     public static String provideProjectId(RegistryConfigSettings config) {
-      return config.appEngine.projectId;
+      return config.gcpProject.projectId;
     }
 
     @Provides
     @Config("locationId")
     public static String provideLocationId(RegistryConfigSettings config) {
-      return config.appEngine.locationId;
+      return config.gcpProject.locationId;
     }
 
     /**
@@ -1325,7 +1325,7 @@ public final class RegistryConfig {
 
   /** Returns the App Engine project ID, which is based off the environment name. */
   public static String getProjectId() {
-    return CONFIG_SETTINGS.get().appEngine.projectId;
+    return CONFIG_SETTINGS.get().gcpProject.projectId;
   }
 
   /**
@@ -1338,7 +1338,7 @@ public final class RegistryConfig {
   }
 
   public static boolean areServersLocal() {
-    return CONFIG_SETTINGS.get().appEngine.isLocal;
+    return CONFIG_SETTINGS.get().gcpProject.isLocal;
   }
 
   /**
@@ -1347,7 +1347,7 @@ public final class RegistryConfig {
    * <p>This is used by the {@code nomulus} tool to connect to the App Engine remote API.
    */
   public static URL getDefaultServer() {
-    return makeUrl(CONFIG_SETTINGS.get().appEngine.defaultServiceUrl);
+    return makeUrl(CONFIG_SETTINGS.get().gcpProject.defaultServiceUrl);
   }
 
   /**
@@ -1356,7 +1356,7 @@ public final class RegistryConfig {
    * <p>This is used by the {@code nomulus} tool to connect to the App Engine remote API.
    */
   public static URL getBackendServer() {
-    return makeUrl(CONFIG_SETTINGS.get().appEngine.backendServiceUrl);
+    return makeUrl(CONFIG_SETTINGS.get().gcpProject.backendServiceUrl);
   }
 
   /**
@@ -1365,7 +1365,7 @@ public final class RegistryConfig {
    * <p>This is used by the {@code nomulus} tool to connect to the App Engine remote API.
    */
   public static URL getToolsServer() {
-    return makeUrl(CONFIG_SETTINGS.get().appEngine.toolsServiceUrl);
+    return makeUrl(CONFIG_SETTINGS.get().gcpProject.toolsServiceUrl);
   }
 
   /**
@@ -1374,7 +1374,7 @@ public final class RegistryConfig {
    * <p>This is used by the {@code nomulus} tool to connect to the App Engine remote API.
    */
   public static URL getPubapiServer() {
-    return makeUrl(CONFIG_SETTINGS.get().appEngine.pubapiServiceUrl);
+    return makeUrl(CONFIG_SETTINGS.get().gcpProject.pubapiServiceUrl);
   }
 
   /** Returns the amount of time a singleton should be cached, before expiring. */

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -21,7 +21,7 @@ import java.util.Set;
 /** The POJO that YAML config files are deserialized into. */
 public class RegistryConfigSettings {
 
-  public AppEngine appEngine;
+  public GcpProject gcpProject;
   public GSuite gSuite;
   public OAuth oAuth;
   public CredentialOAuth credentialOAuth;
@@ -45,8 +45,8 @@ public class RegistryConfigSettings {
   public DnsUpdate dnsUpdate;
   public PackageMonitoring packageMonitoring;
 
-  /** Configuration options that apply to the entire App Engine project. */
-  public static class AppEngine {
+  /** Configuration options that apply to the entire GCP project. */
+  public static class GcpProject {
     public String projectId;
     public String locationId;
     public boolean isLocal;

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -5,12 +5,12 @@
 # to override some of these values to configure and enable some services used in
 # production environments.
 
-appEngine:
-  # Globally unique App Engine project ID
+gcpProject:
+  # Globally unique GCP project ID
   projectId: registry-project-id
-  # Location of the App engine project, note that us-central1 and europe-west1 are special in that
-  # they are used without the trailing number in App Engine commands and Google Cloud Console.
-  # See: https://cloud.google.com/appengine/docs/locations
+  # Location of the GCP project, note that us-central1 and europe-west1 are special in that
+  # they are used without the trailing number in GCP commands and Google Cloud Console.
+  # See: https://cloud.google.com/appengine/docs/locations as an example
   locationId: registry-location-id
 
   # whether to use local/test credentials when connecting to the servers

--- a/core/src/main/java/google/registry/config/files/nomulus-config-production-sample.yaml
+++ b/core/src/main/java/google/registry/config/files/nomulus-config-production-sample.yaml
@@ -2,7 +2,7 @@
 # This is the same as what Google Registry runs in production, except with
 # placeholders for Google-specific settings.
 
-appEngine:
+gcpProject:
   projectId: placeholder
   # Set to true if running against local servers (localhost)
   isLocal: false

--- a/core/src/main/java/google/registry/tools/CommandWithConnection.java
+++ b/core/src/main/java/google/registry/tools/CommandWithConnection.java
@@ -16,5 +16,5 @@ package google.registry.tools;
 
 /** A command that can send HTTP requests to a backend module. */
 public interface CommandWithConnection extends Command {
-  void setConnection(AppEngineConnection connection);
+  void setConnection(ServiceConnection connection);
 }

--- a/core/src/main/java/google/registry/tools/CreateRegistrarCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateRegistrarCommand.java
@@ -51,10 +51,10 @@ final class CreateRegistrarCommand extends CreateOrUpdateRegistrarCommand
       arity = 1)
   boolean createGoogleGroups = true;
 
-  private AppEngineConnection connection;
+  private ServiceConnection connection;
 
   @Override
-  public void setConnection(AppEngineConnection connection) {
+  public void setConnection(ServiceConnection connection) {
     this.connection = connection;
   }
 

--- a/core/src/main/java/google/registry/tools/CreateRegistrarGroupsCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateRegistrarGroupsCommand.java
@@ -39,10 +39,10 @@ public class CreateRegistrarGroupsCommand extends ConfirmingCommand
 
   private List<Registrar> registrars = new ArrayList<>();
 
-  private AppEngineConnection connection;
+  private ServiceConnection connection;
 
   @Override
-  public void setConnection(AppEngineConnection connection) {
+  public void setConnection(ServiceConnection connection) {
     this.connection = connection;
   }
 
@@ -66,7 +66,7 @@ public class CreateRegistrarGroupsCommand extends ConfirmingCommand
   }
 
   /** Calls the server endpoint to create groups for the specified registrar client id. */
-  static void executeOnServer(AppEngineConnection connection, String clientId) throws IOException {
+  static void executeOnServer(ServiceConnection connection, String clientId) throws IOException {
     connection.sendPostRequest(
         CreateGroupsAction.PATH,
         ImmutableMap.of(CreateGroupsAction.CLIENT_ID_PARAM, clientId),

--- a/core/src/main/java/google/registry/tools/CurlCommand.java
+++ b/core/src/main/java/google/registry/tools/CurlCommand.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 @Parameters(separators = " =", commandDescription = "Send an HTTP command to the nomulus server.")
 class CurlCommand implements CommandWithConnection {
-  private AppEngineConnection connection;
+  private ServiceConnection connection;
 
   // HTTP Methods that are acceptable for use as values for --method.
   public enum Method {
@@ -76,7 +76,7 @@ class CurlCommand implements CommandWithConnection {
   private Service service;
 
   @Override
-  public void setConnection(AppEngineConnection connection) {
+  public void setConnection(ServiceConnection connection) {
     this.connection = connection;
   }
 
@@ -90,7 +90,7 @@ class CurlCommand implements CommandWithConnection {
       throw new IllegalArgumentException("You may not specify a body for a get method.");
     }
 
-    AppEngineConnection connectionToService = connection.withService(service);
+    ServiceConnection connectionToService = connection.withService(service);
     String response =
         (method == Method.GET)
             ? connectionToService.sendGetRequest(path, ImmutableMap.<String, String>of())

--- a/core/src/main/java/google/registry/tools/EppToolCommand.java
+++ b/core/src/main/java/google/registry/tools/EppToolCommand.java
@@ -60,7 +60,7 @@ abstract class EppToolCommand extends ConfirmingCommand
 
   private List<XmlEppParameters> commands = new ArrayList<>();
 
-  private AppEngineConnection connection;
+  private ServiceConnection connection;
 
   static class XmlEppParameters {
     final String clientId;
@@ -97,7 +97,7 @@ abstract class EppToolCommand extends ConfirmingCommand
   }
 
   @Override
-  public void setConnection(AppEngineConnection connection) {
+  public void setConnection(ServiceConnection connection) {
     this.connection = connection;
   }
 

--- a/core/src/main/java/google/registry/tools/GenerateZoneFilesCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateZoneFilesCommand.java
@@ -45,10 +45,10 @@ final class GenerateZoneFilesCommand implements CommandWithConnection, CommandWi
       validateWith = DateParameter.class)
   private DateTime exportDate = DateTime.now(UTC).minus(standardMinutes(2)).withTimeAtStartOfDay();
 
-  private AppEngineConnection connection;
+  private ServiceConnection connection;
 
   @Override
-  public void setConnection(AppEngineConnection connection) {
+  public void setConnection(ServiceConnection connection) {
     this.connection = connection;
   }
 

--- a/core/src/main/java/google/registry/tools/ListObjectsCommand.java
+++ b/core/src/main/java/google/registry/tools/ListObjectsCommand.java
@@ -54,10 +54,10 @@ abstract class ListObjectsCommand implements CommandWithConnection, CommandWithR
       description = "Whether to print full field names in header row (as opposed to aliases)")
   private boolean fullFieldNames = false;
 
-  private AppEngineConnection connection;
+  private ServiceConnection connection;
 
   @Override
-  public void setConnection(AppEngineConnection connection) {
+  public void setConnection(ServiceConnection connection) {
     this.connection = connection;
   }
 

--- a/core/src/main/java/google/registry/tools/LoadTestCommand.java
+++ b/core/src/main/java/google/registry/tools/LoadTestCommand.java
@@ -77,10 +77,10 @@ class LoadTestCommand extends ConfirmingCommand
       description = "Time to run the load test in seconds.")
   int runSeconds = DEFAULT_RUN_SECONDS;
 
-  private AppEngineConnection connection;
+  private ServiceConnection connection;
 
   @Override
-  public void setConnection(AppEngineConnection connection) {
+  public void setConnection(ServiceConnection connection) {
     this.connection = connection;
   }
 

--- a/core/src/main/java/google/registry/tools/RegistryCli.java
+++ b/core/src/main/java/google/registry/tools/RegistryCli.java
@@ -80,7 +80,7 @@ final class RegistryCli implements AutoCloseable, CommandRunner {
   RegistryToolComponent component;
 
   // These are created lazily on first use.
-  private AppEngineConnection connection;
+  private ServiceConnection connection;
   private RemoteApiInstaller installer;
 
   // The "shell" command should only exist on first use - so that we can't run "shell" inside
@@ -225,10 +225,10 @@ final class RegistryCli implements AutoCloseable, CommandRunner {
     }
   }
 
-  private AppEngineConnection getConnection() {
+  private ServiceConnection getConnection() {
     // Get the App Engine connection, advise the user if they are not currently logged in..
     if (connection == null) {
-      connection = component.appEngineConnection();
+      connection = component.serviceConnection();
     }
     return connection;
   }

--- a/core/src/main/java/google/registry/tools/RegistryToolComponent.java
+++ b/core/src/main/java/google/registry/tools/RegistryToolComponent.java
@@ -176,7 +176,7 @@ interface RegistryToolComponent {
 
   void inject(WhoisQueryCommand command);
 
-  AppEngineConnection appEngineConnection();
+  ServiceConnection serviceConnection();
 
   @LocalCredentialJson
   String googleCredentialJson();

--- a/core/src/main/java/google/registry/tools/RegistryToolEnvironment.java
+++ b/core/src/main/java/google/registry/tools/RegistryToolEnvironment.java
@@ -106,7 +106,7 @@ public enum RegistryToolEnvironment {
         // XXX: Kludge to stop processing once we reach what is *probably* the command name.
         //      This is necessary in order to allow commands to accept arguments named '-e'.
         //      This code should probably be updated, should any zero arity flags be added to
-        //      RegistryCli, LoggingParameters, or AppEngineConnection.
+        //      RegistryCli, LoggingParameters, or ServiceConnection.
         if (args[i].startsWith("-")) {
           expecting = !args[i].contains("=");
         } else {

--- a/core/src/main/java/google/registry/tools/ServiceConnection.java
+++ b/core/src/main/java/google/registry/tools/ServiceConnection.java
@@ -43,12 +43,12 @@ import javax.inject.Inject;
 import org.json.simple.JSONValue;
 
 /**
- * An http connection to an appengine server.
+ * An HTTP connection to a service.
  *
  * <p>By default - connects to the TOOLS service. To create a Connection to another service, call
  * the {@link #withService} function.
  */
-public class AppEngineConnection {
+public class ServiceConnection {
 
   /** Pattern to heuristically extract title tag contents in HTML responses. */
   private static final Pattern HTML_TITLE_TAG_PATTERN = Pattern.compile("<title>(.*?)</title>");
@@ -57,18 +57,18 @@ public class AppEngineConnection {
   private final Service service;
 
   @Inject
-  AppEngineConnection() {
+  ServiceConnection() {
     service = Service.TOOLS;
   }
 
-  private AppEngineConnection(Service service, HttpRequestFactory requestFactory) {
+  private ServiceConnection(Service service, HttpRequestFactory requestFactory) {
     this.service = service;
     this.requestFactory = requestFactory;
   }
 
   /** Returns a copy of this connection that talks to a different service. */
-  public AppEngineConnection withService(Service service) {
-    return new AppEngineConnection(service, requestFactory);
+  public ServiceConnection withService(Service service) {
+    return new ServiceConnection(service, requestFactory);
   }
 
   /** Returns the contents of the title tag in the given HTML, or null if not found. */

--- a/core/src/main/java/google/registry/tools/VerifyOteCommand.java
+++ b/core/src/main/java/google/registry/tools/VerifyOteCommand.java
@@ -62,10 +62,10 @@ final class VerifyOteCommand implements CommandWithConnection, CommandWithRemote
       description = "Only show a summary of information")
   private boolean summarize;
 
-  private AppEngineConnection connection;
+  private ServiceConnection connection;
 
   @Override
-  public void setConnection(AppEngineConnection connection) {
+  public void setConnection(ServiceConnection connection) {
     this.connection = connection;
   }
 

--- a/core/src/main/java/google/registry/tools/javascrap/CreateSyntheticDomainHistoriesCommand.java
+++ b/core/src/main/java/google/registry/tools/javascrap/CreateSyntheticDomainHistoriesCommand.java
@@ -30,11 +30,11 @@ import google.registry.model.domain.Domain;
 import google.registry.model.ofy.ObjectifyService;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.persistence.VKey;
-import google.registry.tools.AppEngineConnection;
 import google.registry.tools.CommandWithConnection;
 import google.registry.tools.CommandWithRemoteApi;
 import google.registry.tools.ConfirmingCommand;
 import google.registry.tools.RemoteApiOptionsUtil;
+import google.registry.tools.ServiceConnection;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URL;
@@ -88,7 +88,7 @@ public class CreateSyntheticDomainHistoriesCommand extends ConfirmingCommand
   private static final ExecutorService executor = Executors.newFixedThreadPool(20);
   private static final AtomicInteger numDomainsProcessed = new AtomicInteger();
 
-  private AppEngineConnection connection;
+  private ServiceConnection connection;
 
   @Inject
   @Config("registryAdminClientId")
@@ -170,7 +170,7 @@ public class CreateSyntheticDomainHistoriesCommand extends ConfirmingCommand
   }
 
   @Override
-  public void setConnection(AppEngineConnection connection) {
+  public void setConnection(ServiceConnection connection) {
     this.connection = connection;
   }
 

--- a/core/src/test/java/google/registry/tools/CreateRegistrarCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateRegistrarCommandTest.java
@@ -54,8 +54,7 @@ import org.mockito.Mock;
 /** Unit tests for {@link CreateRegistrarCommand}. */
 class CreateRegistrarCommandTest extends CommandTestCase<CreateRegistrarCommand> {
 
-  @Mock private AppEngineConnection connection;
-
+  @Mock private ServiceConnection connection;
 
   @BeforeEach
   void beforeEach() {

--- a/core/src/test/java/google/registry/tools/CreateRegistrarGroupsCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateRegistrarGroupsCommandTest.java
@@ -28,7 +28,7 @@ import org.mockito.Mock;
 /** Unit tests for {@link CreateRegistrarGroupsCommand}. */
 class CreateRegistrarGroupsCommandTest extends CommandTestCase<CreateRegistrarGroupsCommand> {
 
-  @Mock private AppEngineConnection connection;
+  @Mock private ServiceConnection connection;
 
   @BeforeEach
   void beforeEach() {

--- a/core/src/test/java/google/registry/tools/CurlCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CurlCommandTest.java
@@ -40,8 +40,8 @@ import org.mockito.quality.Strictness;
 /** Unit tests for {@link CurlCommand}. */
 class CurlCommandTest extends CommandTestCase<CurlCommand> {
 
-  @Mock private AppEngineConnection connection;
-  @Mock private AppEngineConnection connectionForService;
+  @Mock private ServiceConnection connection;
+  @Mock private ServiceConnection connectionForService;
 
   @BeforeEach
   void beforeEach() {

--- a/core/src/test/java/google/registry/tools/EppToolVerifier.java
+++ b/core/src/test/java/google/registry/tools/EppToolVerifier.java
@@ -36,9 +36,8 @@ import org.mockito.ArgumentCaptor;
 /**
  * Class for verifying EPP commands sent to the server via the tool endpoint.
  *
- * <p>Provides its own (mock) {@link AppEngineConnection} that will be monitored for EPP
- * transmission. This Connection needs to be registered with the tool endpoint - something like
- * this:
+ * <p>Provides its own (mock) {@link ServiceConnection} that will be monitored for EPP transmission.
+ * This Connection needs to be registered with the tool endpoint - something like this:
  *
  * <pre>{@code
  * SomeToolCommand command = ...;
@@ -49,7 +48,7 @@ import org.mockito.ArgumentCaptor;
  */
 public class EppToolVerifier {
 
-  private final AppEngineConnection connection = mock(AppEngineConnection.class);
+  private final ServiceConnection connection = mock(ServiceConnection.class);
 
   private String registrarId;
   private boolean superuser;
@@ -196,7 +195,7 @@ public class EppToolVerifier {
   }
 
   /** Returns the (mock) Connection that is being monitored by this verifier. */
-  private AppEngineConnection getConnection() {
+  private ServiceConnection getConnection() {
     return connection;
   }
 }

--- a/core/src/test/java/google/registry/tools/GcpProjectConnectionTest.java
+++ b/core/src/test/java/google/registry/tools/GcpProjectConnectionTest.java
@@ -33,11 +33,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-/** Unit tests for {@link google.registry.tools.AppEngineConnection}. */
+/** Unit tests for {@link ServiceConnection}. */
 @ExtendWith(MockitoExtension.class)
-final class AppEngineConnectionTest {
+final class GcpProjectConnectionTest {
 
-  private AppEngineConnection connection;
+  private ServiceConnection connection;
   private TestHttpTransport httpTransport;
   private TestLowLevelHttpRequest lowLevelHttpRequest;
   @Mock LowLevelHttpResponse lowLevelHttpResponse;
@@ -84,7 +84,7 @@ final class AppEngineConnectionTest {
         .thenReturn(new ByteArrayInputStream("MyContent".getBytes(UTF_8)));
     when(lowLevelHttpResponse.getStatusCode()).thenReturn(200);
 
-    connection = new AppEngineConnection();
+    connection = new ServiceConnection();
     httpTransport = new TestHttpTransport();
     connection.requestFactory = httpTransport.createRequestFactory();
   }

--- a/core/src/test/java/google/registry/tools/ListObjectsCommandTestCase.java
+++ b/core/src/test/java/google/registry/tools/ListObjectsCommandTestCase.java
@@ -37,7 +37,7 @@ import org.mockito.Mock;
 public abstract class ListObjectsCommandTestCase<C extends ListObjectsCommand>
     extends CommandTestCase<C> {
 
-  @Mock AppEngineConnection connection;
+  @Mock ServiceConnection connection;
 
   /** Where to find the servlet task; set by the subclass. */
   abstract String getTaskPath();

--- a/core/src/test/java/google/registry/tools/LoadTestCommandTest.java
+++ b/core/src/test/java/google/registry/tools/LoadTestCommandTest.java
@@ -30,7 +30,7 @@ import org.mockito.Mock;
 /** Unit tests for {@link LoadTestCommand}. */
 class LoadTestCommandTest extends CommandTestCase<LoadTestCommand> {
 
-  @Mock private AppEngineConnection connection;
+  @Mock private ServiceConnection connection;
 
   @BeforeEach
   void beforeEach() {

--- a/core/src/test/java/google/registry/tools/RequestFactoryModuleTest.java
+++ b/core/src/test/java/google/registry/tools/RequestFactoryModuleTest.java
@@ -53,8 +53,8 @@ public class RequestFactoryModuleTest {
   @Test
   void test_provideHttpRequestFactory_localhost() throws Exception {
     // Make sure that localhost creates a request factory with an initializer.
-    boolean origIsLocal = RegistryConfig.CONFIG_SETTINGS.get().appEngine.isLocal;
-    RegistryConfig.CONFIG_SETTINGS.get().appEngine.isLocal = true;
+    boolean origIsLocal = RegistryConfig.CONFIG_SETTINGS.get().gcpProject.isLocal;
+    RegistryConfig.CONFIG_SETTINGS.get().gcpProject.isLocal = true;
     try {
       HttpRequestFactory factory =
           RequestFactoryModule.provideHttpRequestFactory(credentialsBundle);
@@ -64,7 +64,7 @@ public class RequestFactoryModuleTest {
       initializer.initialize(request);
       verifyNoInteractions(httpRequestInitializer);
     } finally {
-      RegistryConfig.CONFIG_SETTINGS.get().appEngine.isLocal = origIsLocal;
+      RegistryConfig.CONFIG_SETTINGS.get().gcpProject.isLocal = origIsLocal;
     }
   }
 
@@ -72,8 +72,8 @@ public class RequestFactoryModuleTest {
   void test_provideHttpRequestFactory_remote() throws Exception {
     when(credentialsBundle.getHttpRequestInitializer()).thenReturn(httpRequestInitializer);
     // Make sure that example.com creates a request factory with the UNITTEST client id but no
-    boolean origIsLocal = RegistryConfig.CONFIG_SETTINGS.get().appEngine.isLocal;
-    RegistryConfig.CONFIG_SETTINGS.get().appEngine.isLocal = false;
+    boolean origIsLocal = RegistryConfig.CONFIG_SETTINGS.get().gcpProject.isLocal;
+    RegistryConfig.CONFIG_SETTINGS.get().gcpProject.isLocal = false;
     try {
       HttpRequestFactory factory =
           RequestFactoryModule.provideHttpRequestFactory(credentialsBundle);
@@ -86,7 +86,7 @@ public class RequestFactoryModuleTest {
       assertThat(request.getReadTimeout()).isEqualTo(REQUEST_TIMEOUT_MS);
       verifyNoMoreInteractions(httpRequestInitializer);
     } finally {
-      RegistryConfig.CONFIG_SETTINGS.get().appEngine.isLocal = origIsLocal;
+      RegistryConfig.CONFIG_SETTINGS.get().gcpProject.isLocal = origIsLocal;
     }
   }
 }

--- a/core/src/test/java/google/registry/tools/VerifyOteCommandTest.java
+++ b/core/src/test/java/google/registry/tools/VerifyOteCommandTest.java
@@ -36,7 +36,7 @@ import org.mockito.quality.Strictness;
 /** Unit tests for {@link VerifyOteCommand}. */
 class VerifyOteCommandTest extends CommandTestCase<VerifyOteCommand> {
 
-  @Mock private AppEngineConnection connection;
+  @Mock private ServiceConnection connection;
 
   @BeforeEach
   void beforeEach() throws Exception {


### PR DESCRIPTION
It doesn't actually use any App Engine libraries or code -- it's just a generic connection with authentication to a service. This also involves changing that block of config to be "gcpProject" instead of "appEngine" since it's more generic.

Note: this will require an internal PR as well to change the corresponding private config block

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1857)
<!-- Reviewable:end -->
