### PR TITLE
Re-add parenthesis

### DIFF
--- a/core/src/main/java/google/registry/tools/RegistrarPocCommand.java
+++ b/core/src/main/java/google/registry/tools/RegistrarPocCommand.java
@@ -182,8 +182,9 @@ final class RegistrarPocCommand extends MutatingCommand {
       // strange, but we need to handle this by setting the contact types to the empty set. Also do
       // this if contactTypeNames is empty, which is what I would hope JCommander would return in
       // some future, better world.
-    } else if (contactTypeNames.isEmpty()
-        || contactTypeNames.size() == 1 && contactTypeNames.get(0).isEmpty()) {
+    } else //noinspection UnnecessaryParentheses
+    if (contactTypeNames.isEmpty()
+        || (contactTypeNames.size() == 1 && contactTypeNames.get(0).isEmpty())) {
       contactTypes = ImmutableSet.of();
     } else {
       contactTypes =


### PR DESCRIPTION
Apparently IntelliJ doesn't like the extra parens, but our own
ErrorProne checks want it for clarity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1862)
<!-- Reviewable:end -->
