### PR TITLE
Fix nomulus GetEppResourceCommand

### DIFF
--- a/core/src/main/java/google/registry/model/ImmutableObject.java
+++ b/core/src/main/java/google/registry/model/ImmutableObject.java
@@ -14,6 +14,7 @@
 
 package google.registry.model;
 
+import static com.google.common.collect.Iterables.transform;
 import static com.google.common.collect.Maps.transformValues;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -21,7 +22,6 @@ import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
 import google.registry.persistence.VKey;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -179,8 +179,7 @@ public abstract class ImmutableObject implements Cloneable {
       return transformValues((Map<?, ?>) value, ImmutableObject::hydrate);
     }
     if (value instanceof Collection) {
-      return ((Collection<?>) value)
-          .stream().map(ImmutableObject::hydrate).collect(ImmutableList.toImmutableList());
+      return transform((Collection<?>) value, ImmutableObject::hydrate);
     }
     if (value instanceof ImmutableObject) {
       return ((ImmutableObject) value).toHydratedString();

--- a/core/src/main/java/google/registry/model/ImmutableObject.java
+++ b/core/src/main/java/google/registry/model/ImmutableObject.java
@@ -21,6 +21,7 @@ import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import google.registry.persistence.VKey;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -178,7 +179,8 @@ public abstract class ImmutableObject implements Cloneable {
       return transformValues((Map<?, ?>) value, ImmutableObject::hydrate);
     }
     if (value instanceof Collection) {
-      return ((Collection<?>) value).stream().map(ImmutableObject::hydrate);
+      return ((Collection<?>) value)
+          .stream().map(ImmutableObject::hydrate).collect(ImmutableList.toImmutableList());
     }
     if (value instanceof ImmutableObject) {
       return ((ImmutableObject) value).toHydratedString();

--- a/core/src/main/java/google/registry/tools/GetEppResourceCommand.java
+++ b/core/src/main/java/google/registry/tools/GetEppResourceCommand.java
@@ -60,11 +60,11 @@ abstract class GetEppResourceCommand implements CommandWithRemoteApi {
 
   @Override
   public void run() {
+    DateTime now = clock.nowUtc();
     if (readTimestamp == null) {
-      readTimestamp = clock.nowUtc();
+      readTimestamp = now;
     }
-    checkArgument(
-        !readTimestamp.isBefore(clock.nowUtc()), "--read_timestamp may not be in the past");
+    checkArgument(!readTimestamp.isBefore(now), "--read_timestamp may not be in the past");
     runAndPrint();
   }
 }

--- a/core/src/test/java/google/registry/tools/GetEppResourceCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetEppResourceCommandTest.java
@@ -45,7 +45,7 @@ public class GetEppResourceCommandTest {
   }
 
   @Test
-  public void readTimestampBeforeNow_noException() {
+  public void readTimestampBeforeNow_throwsException() {
     commandUnderTest.readTimestamp = clock.nowUtc().minusMillis(1);
     assertThrows(IllegalArgumentException.class, () -> commandUnderTest.run());
   }

--- a/core/src/test/java/google/registry/tools/GetEppResourceCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetEppResourceCommandTest.java
@@ -1,0 +1,57 @@
+// Copyright 2022 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.tools;
+
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.truth.Truth;
+import google.registry.testing.FakeClock;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/** Unit tests for {@link GetEppResourceCommand}. */
+public class GetEppResourceCommandTest {
+
+  private static final DateTime TEST_TIME = DateTime.now();
+
+  private final FakeClock clock = new FakeClock(TEST_TIME);
+  private GetEppResourceCommand commandUnderTest;
+
+  @BeforeEach
+  public void setup() {
+    commandUnderTest = Mockito.spy(GetEppResourceCommand.class);
+    commandUnderTest.clock = clock;
+  }
+
+  @Test
+  public void readTimestampAfterNow_noException() {
+    commandUnderTest.readTimestamp = clock.nowUtc().plusMillis(1);
+    commandUnderTest.run();
+  }
+
+  @Test
+  public void readTimestampBeforeNow_noException() {
+    commandUnderTest.readTimestamp = clock.nowUtc().minusMillis(1);
+    assertThrows(IllegalArgumentException.class, () -> commandUnderTest.run());
+  }
+
+  @Test
+  public void readTimestampNotProvided_setToNow_noException() {
+    commandUnderTest.run();
+    Truth.assertThat(commandUnderTest.readTimestamp).isEqualTo(clock.nowUtc());
+  }
+}

--- a/core/src/test/java/google/registry/tools/GetEppResourceCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetEppResourceCommandTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertThrows;
 import com.google.common.truth.Truth;
 import google.registry.testing.FakeClock;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -26,7 +27,7 @@ import org.mockito.Mockito;
 /** Unit tests for {@link GetEppResourceCommand}. */
 public class GetEppResourceCommandTest {
 
-  private static final DateTime TEST_TIME = DateTime.now();
+  private static final DateTime TEST_TIME = DateTime.now(DateTimeZone.UTC);
 
   private final FakeClock clock = new FakeClock(TEST_TIME);
   private GetEppResourceCommand commandUnderTest;


### PR DESCRIPTION
Fixes a bug in read_timestamp validation.

Fixes string representation of Collection fields in Epp Resources.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1865)
<!-- Reviewable:end -->
