### PR TITLE
Fix javadoc build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -528,6 +528,7 @@ task javaIncrementalFormatApply {
 
 task javadoc(type: Javadoc) {
   source javadocSource
+  exclude "**/package-info.java"
   classpath = files(javadocClasspath)
   destinationDir = file("${buildDir}/docs/javadoc")
   options.encoding = "UTF-8"

--- a/build.gradle
+++ b/build.gradle
@@ -528,6 +528,9 @@ task javaIncrementalFormatApply {
 
 task javadoc(type: Javadoc) {
   source javadocSource
+  // Java 11.0.17 has the following bug that affects annotation handling on
+  // package-info.java:
+  // https://bugs.openjdk.org/browse/JDK-8222091
   exclude "**/package-info.java"
   classpath = files(javadocClasspath)
   destinationDir = file("${buildDir}/docs/javadoc")


### PR DESCRIPTION
With newer versions of Java 11, javadoc fails to build due to unknown
tags in package-info.java files. These files are not important so we
exclude them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1866)
<!-- Reviewable:end -->
