### PR TITLE
Take anchor tenant tokens into account in domain check flows

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -682,7 +682,13 @@ public class DomainFlowUtils {
           builder.setAvailIfSupported(true);
           fees =
               pricingLogic
-                  .getCreatePrice(registry, domainNameString, now, years, false, allocationToken)
+                  .getCreatePrice(
+                      registry,
+                      domainNameString,
+                      now,
+                      years,
+                      isAnchorTenant(domainName, allocationToken, Optional.empty()),
+                      allocationToken)
                   .getFees();
         }
         break;

--- a/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
@@ -189,6 +189,25 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
   }
 
   @Test
+  void testSuccess_allocationToken_premiumAnchorTenant_noFee() throws Exception {
+    createTld("example");
+    persistResource(
+        Registry.get("tld")
+            .asBuilder()
+            .setPremiumList(persistPremiumList("example1", USD, "example1,USD 100"))
+            .build());
+    persistResource(
+        new AllocationToken.Builder()
+            .setToken("abc123")
+            .setTokenType(SINGLE_USE)
+            .setRegistrationBehavior(AllocationToken.RegistrationBehavior.ANCHOR_TENANT)
+            .setDomainName("example1.tld")
+            .build());
+    setEppInput("domain_check_allocationtoken_fee.xml");
+    runFlowAssertResponse(loadFile("domain_check_allocationtoken_fee_anchor_response.xml"));
+  }
+
+  @Test
   void testSuccess_oneExists_allocationTokenIsRedeemed() throws Exception {
     setEppInput("domain_check_allocationtoken.xml");
     Domain domain = persistActiveDomain("example1.tld");

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee_anchor_response.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee_anchor_response.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<epp xmlns:launch="urn:ietf:params:xml:ns:launch-1.0" xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1" xmlns:host="urn:ietf:params:xml:ns:host-1.0" xmlns:fee11="urn:ietf:params:xml:ns:fee-0.11" xmlns:fee12="urn:ietf:params:xml:ns:fee-0.12" xmlns:fee="urn:ietf:params:xml:ns:fee-0.6" xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0" xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xmlns:contact="urn:ietf:params:xml:ns:contact-1.0">
+  <response>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
+    </result>
+    <resData>
+      <domain:chkData>
+        <domain:cd>
+          <domain:name avail="true">example1.tld</domain:name>
+        </domain:cd>
+        <domain:cd>
+            <domain:name avail="false">example2.example</domain:name>
+            <domain:reason>Alloc token invalid for domain</domain:reason>
+        </domain:cd>
+        <domain:cd>
+            <domain:name avail="false">reserved.tld</domain:name>
+            <domain:reason>Alloc token invalid for domain</domain:reason>
+        </domain:cd>
+      </domain:chkData>
+    </resData>
+    <extension>
+      <fee:chkData>
+        <fee:cd>
+          <fee:name>example2.example</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:fee description="create">0.00</fee:fee>
+        </fee:cd>
+        <fee:cd>
+          <fee:name>example1.tld</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:fee description="create">0.00</fee:fee>
+        </fee:cd>
+        <fee:cd>
+          <fee:name>reserved.tld</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:class>reserved</fee:class>
+        </fee:cd>
+      </fee:chkData>
+    </extension>
+    <trID>
+      <clTRID>ABC-12345</clTRID>
+      <svTRID>server-trid</svTRID>
+    </trID>
+  </response>
+</epp>


### PR DESCRIPTION
These were always properly reflected in the actual creations, but when running a check flow it would still show a non-zero cost even when using an ANCHOR_TENANT allocation token. This changes it so that we accurately show the $0.00 cost.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1868)
<!-- Reviewable:end -->
