### PR TITLE
Make it possible to persist multiple entities together in Beam.

### DIFF
--- a/core/src/test/java/google/registry/beam/common/RegistryJpaWriteTest.java
+++ b/core/src/test/java/google/registry/beam/common/RegistryJpaWriteTest.java
@@ -14,24 +14,31 @@
 
 package google.registry.beam.common;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.immutableObjectCorrespondence;
 import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.testing.DatabaseHelper.loadAllOf;
 import static google.registry.testing.DatabaseHelper.newContact;
+import static google.registry.testing.DatabaseHelper.newHost;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import google.registry.beam.TestPipelineExtension;
+import google.registry.beam.common.RegistryJpaIO.ExistingEntityException;
 import google.registry.model.contact.Contact;
+import google.registry.model.host.Host;
 import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationTestExtension;
-import google.registry.testing.AppEngineExtension;
 import google.registry.testing.FakeClock;
 import java.io.Serializable;
 import org.apache.beam.sdk.Pipeline.PipelineExecutionException;
+import org.apache.beam.sdk.coders.SerializableCoder;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.values.KV;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -47,11 +54,12 @@ class RegistryJpaWriteTest implements Serializable {
 
   @RegisterExtension
   final transient TestPipelineExtension testPipeline =
-      TestPipelineExtension.create().enableAbandonedNodeEnforcement(true);
+      TestPipelineExtension.fromOptions(
+              PipelineOptionsFactory.fromArgs("--targetParallelism=1").create())
+          .enableAbandonedNodeEnforcement(true);
 
   @Test
   void writeToSql_twoWriters() {
-    jpaTm().transact(() -> jpaTm().put(AppEngineExtension.makeRegistrar2()));
     ImmutableList.Builder<Contact> contactsBuilder = new ImmutableList.Builder<>();
     for (int i = 0; i < 3; i++) {
       contactsBuilder.add(newContact("contact_" + i));
@@ -63,8 +71,54 @@ class RegistryJpaWriteTest implements Serializable {
     testPipeline.run().waitUntilFinish();
 
     assertThat(loadAllOf(Contact.class))
-        .comparingElementsUsing(immutableObjectCorrespondence("revisions", "updateTimestamp"))
+        .comparingElementsUsing(immutableObjectCorrespondence("updateTimestamp"))
         .containsExactlyElementsIn(contacts);
+  }
+
+  @Test
+  void writeToSql_iterableEntities() {
+    ImmutableList.Builder<KV<Contact, Host>> kvBuilder = new ImmutableList.Builder<>();
+    for (int i = 0; i < 3; i++) {
+      kvBuilder.add(KV.of(newContact("contact_" + i), newHost("host_" + i + ".external")));
+    }
+    ImmutableList<KV<Contact, Host>> kvs = kvBuilder.build();
+    testPipeline
+        .apply(Create.of(kvs))
+        .apply(
+            RegistryJpaIO.<KV<Contact, Host>>write()
+                .withName("Contact and Host")
+                .withJpaConverter(kv -> ImmutableList.of(kv.getKey(), kv.getValue()))
+                .withBatchSize(4)
+                .withShards(2));
+    testPipeline.run().waitUntilFinish();
+    assertThat(loadAllOf(Contact.class))
+        .comparingElementsUsing(immutableObjectCorrespondence("updateTimestamp"))
+        .containsExactlyElementsIn(kvs.stream().map(KV::getKey).collect(toImmutableSet()));
+    assertThat(loadAllOf(Host.class))
+        .comparingElementsUsing(immutableObjectCorrespondence("updateTimestamp"))
+        .containsExactlyElementsIn(kvs.stream().map(KV::getValue).collect(toImmutableSet()));
+  }
+
+  @Test
+  void testFailure_noRetrySingly() {
+    ImmutableList.Builder<Serializable> entityBuilder = new ImmutableList.Builder<>();
+    for (int i = 0; i < 3; i++) {
+      entityBuilder.add(newContact("contact_" + i));
+    }
+    entityBuilder.add(new Serializable() {});
+    ImmutableList<Serializable> entities = entityBuilder.build();
+    testPipeline
+        .apply(Create.of(entities).withCoder(SerializableCoder.of(Serializable.class)))
+        .apply(
+            RegistryJpaIO.<Serializable>write()
+                .withName("Contact")
+                // Because there is only one worker thread (see testPipeline construction), all four
+                // elements must be grouped into one batch.
+                .withBatchSize(4)
+                .withRetrySingly(false));
+    assertThrows(PipelineExecutionException.class, () -> testPipeline.run().waitUntilFinish());
+    // All three contacts are in the same batch, and none should have been persisted.
+    assertThat(loadAllOf(Contact.class)).isEmpty();
   }
 
   @Test
@@ -75,19 +129,18 @@ class RegistryJpaWriteTest implements Serializable {
     jpaTm()
         .transact(
             () -> {
-              jpaTm().put(AppEngineExtension.makeRegistrar2());
+              jpaTm().put(newHost("blah.external"));
               jpaTm().put(newContact("contact"));
             });
     Contact contact = Iterables.getOnlyElement(loadAllOf(Contact.class));
     testPipeline
         .apply(Create.of(contact))
         .apply(RegistryJpaIO.<Contact>write().withName("Contact"));
-    // PipelineExecutionException caused by a RuntimeException caused by an IllegalArgumentException
+    // PipelineExecutionException caused by an ExistingEntityException ultimately.
     assertThat(
-            assertThrows(
-                PipelineExecutionException.class, () -> testPipeline.run().waitUntilFinish()))
-        .hasCauseThat()
-        .hasCauseThat()
-        .isInstanceOf(IllegalArgumentException.class);
+            Throwables.getRootCause(
+                assertThrows(
+                    PipelineExecutionException.class, () -> testPipeline.run().waitUntilFinish())))
+        .isInstanceOf(ExistingEntityException.class);
   }
 }


### PR DESCRIPTION
There might be future cases where one would like to write several
entities together in a transaction with the SqlWriter, for entities that
must be persisted or rolled back together. This PR adds such a
functionality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1882)
<!-- Reviewable:end -->
