### PR TITLE
Remove TransactionManagerFactory.jpaTm()

### DIFF
--- a/core/src/main/java/google/registry/batch/CheckPackagesComplianceAction.java
+++ b/core/src/main/java/google/registry/batch/CheckPackagesComplianceAction.java
@@ -14,7 +14,6 @@
 package google.registry.batch;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.google.common.collect.ImmutableList;
@@ -25,6 +24,7 @@ import google.registry.model.domain.token.AllocationToken;
 import google.registry.model.domain.token.PackagePromotion;
 import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.RegistrarPoc;
+import google.registry.persistence.transaction.TransactionManagerFactory;
 import google.registry.request.Action;
 import google.registry.request.Action.Service;
 import google.registry.request.auth.Auth;
@@ -71,7 +71,7 @@ public class CheckPackagesComplianceAction implements Runnable {
               for (PackagePromotion packagePromo : packages) {
                 Long creates =
                     (Long)
-                        jpaTm()
+                        TransactionManagerFactory.tm()
                             .query(
                                 "SELECT COUNT(*) FROM DomainHistory WHERE current_package_token ="
                                     + " :token AND modificationTime >= :lastBilling AND type ="

--- a/core/src/main/java/google/registry/batch/ExpandRecurringBillingEventsAction.java
+++ b/core/src/main/java/google/registry/batch/ExpandRecurringBillingEventsAction.java
@@ -23,7 +23,6 @@ import static google.registry.model.common.Cursor.CursorType.RECURRING_BILLING;
 import static google.registry.model.domain.Period.Unit.YEARS;
 import static google.registry.model.reporting.HistoryEntry.Type.DOMAIN_AUTORENEW;
 import static google.registry.persistence.transaction.QueryComposer.Comparator.EQ;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.CollectionUtils.union;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
@@ -50,6 +49,7 @@ import google.registry.model.reporting.DomainTransactionRecord;
 import google.registry.model.reporting.DomainTransactionRecord.TransactionReportField;
 import google.registry.model.tld.Registry;
 import google.registry.persistence.VKey;
+import google.registry.persistence.transaction.TransactionManagerFactory;
 import google.registry.request.Action;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
@@ -118,14 +118,14 @@ public class ExpandRecurringBillingEventsAction implements Runnable {
     do {
       final long prevMaxProcessedRecurrenceId = maxProcessedRecurrenceId;
       sqlBatchResults =
-          jpaTm()
+          TransactionManagerFactory.tm()
               .transact(
                   () -> {
                     Set<String> expandedDomains = newHashSet();
                     int batchBillingEventsSaved = 0;
                     long maxRecurrenceId = prevMaxProcessedRecurrenceId;
                     List<Recurring> recurrings =
-                        jpaTm()
+                        TransactionManagerFactory.tm()
                             .query(
                                 "FROM BillingRecurrence "
                                     + "WHERE eventTime <= :executeTime "

--- a/core/src/main/java/google/registry/batch/RelockDomainAction.java
+++ b/core/src/main/java/google/registry/batch/RelockDomainAction.java
@@ -16,7 +16,6 @@ package google.registry.batch;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.Action.Method.POST;
 import static google.registry.tools.LockOrUnlockDomainCommand.REGISTRY_LOCK_STATUSES;
@@ -34,6 +33,7 @@ import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.RegistrarPoc;
 import google.registry.model.tld.RegistryLockDao;
 import google.registry.persistence.VKey;
+import google.registry.persistence.transaction.TransactionManagerFactory;
 import google.registry.request.Action;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
@@ -189,7 +189,8 @@ public class RelockDomainAction implements Runnable {
         "Domain %s has a pending delete.",
         domainName);
     checkArgument(
-        !DateTimeUtils.isAtOrAfter(jpaTm().getTransactionTime(), domain.getDeletionTime()),
+        !DateTimeUtils.isAtOrAfter(
+            TransactionManagerFactory.tm().getTransactionTime(), domain.getDeletionTime()),
         "Domain %s has been deleted.",
         domainName);
     checkArgument(

--- a/core/src/main/java/google/registry/beam/common/DatabaseSnapshot.java
+++ b/core/src/main/java/google/registry/beam/common/DatabaseSnapshot.java
@@ -15,7 +15,7 @@
 package google.registry.beam.common;
 
 import static com.google.common.base.Preconditions.checkState;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.google.common.flogger.FluentLogger;
 import java.util.List;
@@ -52,7 +52,7 @@ public class DatabaseSnapshot implements AutoCloseable {
   }
 
   private DatabaseSnapshot open() {
-    entityManager = jpaTm().getStandaloneEntityManager();
+    entityManager = tm().getStandaloneEntityManager();
     transaction = entityManager.getTransaction();
     transaction.setRollbackOnly();
     transaction.begin();

--- a/core/src/main/java/google/registry/beam/common/RegistryQuery.java
+++ b/core/src/main/java/google/registry/beam/common/RegistryQuery.java
@@ -14,7 +14,7 @@
 
 package google.registry.beam.common;
 
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import google.registry.persistence.transaction.JpaTransactionManager;
 import java.io.Serializable;
@@ -53,7 +53,7 @@ public interface RegistryQuery<T> extends Serializable {
   static <T> RegistryQuery<T> createQuery(
       String sql, @Nullable Map<String, Object> parameters, boolean nativeQuery) {
     return () -> {
-      EntityManager entityManager = jpaTm().getEntityManager();
+      EntityManager entityManager = tm().getEntityManager();
       Query query =
           nativeQuery ? entityManager.createNativeQuery(sql) : entityManager.createQuery(sql);
       if (parameters != null) {
@@ -76,7 +76,7 @@ public interface RegistryQuery<T> extends Serializable {
       String jpql, @Nullable Map<String, Object> parameters, Class<T> clazz) {
     return () -> {
       // TODO(b/193662898): switch to jpaTm().query() when it can properly detach loaded entities.
-      EntityManager entityManager = jpaTm().getEntityManager();
+      EntityManager entityManager = tm().getEntityManager();
       TypedQuery<T> query = entityManager.createQuery(jpql, clazz);
       if (parameters != null) {
         parameters.forEach(query::setParameter);
@@ -98,7 +98,7 @@ public interface RegistryQuery<T> extends Serializable {
   static <T> RegistryQuery<T> createQuery(CriteriaQuerySupplier<T> criteriaQuery) {
     return () -> {
       // TODO(b/193662898): switch to jpaTm().query() when it can properly detach loaded entities.
-      EntityManager entityManager = jpaTm().getEntityManager();
+      EntityManager entityManager = tm().getEntityManager();
       TypedQuery<T> query = entityManager.createQuery(criteriaQuery.get());
       JpaTransactionManager.setQueryFetchSize(query, QUERY_FETCH_SIZE);
       return query.getResultStream().map(e -> detach(entityManager, e));

--- a/core/src/main/java/google/registry/beam/resave/ResaveAllEppResourcesPipeline.java
+++ b/core/src/main/java/google/registry/beam/resave/ResaveAllEppResourcesPipeline.java
@@ -15,7 +15,7 @@
 package google.registry.beam.resave;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static org.apache.beam.sdk.values.TypeDescriptors.integers;
 
 import com.google.common.collect.ImmutableList;
@@ -174,19 +174,18 @@ public class ResaveAllEppResourcesPipeline implements Serializable {
     public void processElement(
         @Element KV<ShardedKey<Integer>, Iterable<String>> element,
         OutputReceiver<Void> outputReceiver) {
-      jpaTm()
-          .transact(
+      tm().transact(
               () -> {
-                DateTime now = jpaTm().getTransactionTime();
+                DateTime now = tm().getTransactionTime();
                 ImmutableList<VKey<? extends EppResource>> keys =
                     Streams.stream(element.getValue())
                         .map(repoId -> VKey.create(clazz, repoId))
                         .collect(toImmutableList());
                 ImmutableList<EppResource> mappedResources =
-                    jpaTm().loadByKeys(keys).values().stream()
+                    tm().loadByKeys(keys).values().stream()
                         .map(r -> r.cloneProjectedAtTime(now))
                         .collect(toImmutableList());
-                jpaTm().putAll(mappedResources);
+                tm().putAll(mappedResources);
               });
     }
   }

--- a/core/src/main/java/google/registry/beam/spec11/Spec11Pipeline.java
+++ b/core/src/main/java/google/registry/beam/spec11/Spec11Pipeline.java
@@ -15,7 +15,7 @@
 package google.registry.beam.spec11;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
@@ -131,9 +131,8 @@ public class Spec11Pipeline implements Serializable {
                   public void processElement(
                       @Element KV<String, String> input, OutputReceiver<DomainNameInfo> output) {
                     Domain domain =
-                        jpaTm()
-                            .transact(
-                                () -> jpaTm().loadByKey(VKey.create(Domain.class, input.getKey())));
+                        tm().transact(
+                                () -> tm().loadByKey(VKey.create(Domain.class, input.getKey())));
                     String emailAddress = input.getValue();
                     if (emailAddress == null) {
                       emailAddress = "";

--- a/core/src/main/java/google/registry/export/ExportDomainListsAction.java
+++ b/core/src/main/java/google/registry/export/ExportDomainListsAction.java
@@ -16,7 +16,6 @@ package google.registry.export;
 
 import static com.google.common.base.Verify.verifyNotNull;
 import static google.registry.model.tld.Registries.getTldsOfType;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.Action.Method.POST;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -30,6 +29,7 @@ import google.registry.config.RegistryConfig.Config;
 import google.registry.gcs.GcsUtils;
 import google.registry.model.tld.Registry;
 import google.registry.model.tld.Registry.TldType;
+import google.registry.persistence.transaction.TransactionManagerFactory;
 import google.registry.request.Action;
 import google.registry.request.auth.Auth;
 import google.registry.storage.drive.DriveConnection;
@@ -89,7 +89,7 @@ public class ExportDomainListsAction implements Runnable {
                           // DateTime are persisted as timestamp_z in SQL. It is only the
                           // validation that compares the Java types, and only with the first
                           // field that compares with the substituted value.
-                          jpaTm()
+                          TransactionManagerFactory.tm()
                               .query(
                                   "SELECT domainName FROM Domain "
                                       + "WHERE tld = :tld "

--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -37,7 +37,6 @@ import static google.registry.model.tld.label.ReservationType.FULLY_BLOCKED;
 import static google.registry.model.tld.label.ReservationType.NAME_COLLISION;
 import static google.registry.model.tld.label.ReservationType.RESERVED_FOR_ANCHOR_TENANT;
 import static google.registry.model.tld.label.ReservationType.RESERVED_FOR_SPECIFIC_USE;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.pricing.PricingEngineProxy.isDomainPremium;
 import static google.registry.util.CollectionUtils.nullToEmpty;
@@ -128,6 +127,7 @@ import google.registry.model.tld.label.ReservationType;
 import google.registry.model.tld.label.ReservedList;
 import google.registry.model.tmch.ClaimsList;
 import google.registry.persistence.VKey;
+import google.registry.persistence.transaction.TransactionManagerFactory;
 import google.registry.tldconfig.idn.IdnLabelValidator;
 import google.registry.tools.DigestType;
 import google.registry.util.Idn;
@@ -1179,7 +1179,7 @@ public class DomainFlowUtils {
 
   private static List<DomainHistory> findRecentHistoryEntries(
       Domain domain, DateTime now, Duration maxSearchPeriod) {
-    return jpaTm()
+    return TransactionManagerFactory.tm()
         .query(
             "FROM DomainHistory WHERE modificationTime >= :beginning AND repoId = "
                 + ":repoId ORDER BY modificationTime ASC",

--- a/core/src/main/java/google/registry/flows/domain/token/AllocationTokenFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/token/AllocationTokenFlowUtils.java
@@ -15,7 +15,6 @@
 package google.registry.flows.domain.token;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.google.common.base.Strings;
@@ -39,6 +38,7 @@ import google.registry.model.domain.token.AllocationTokenExtension;
 import google.registry.model.reporting.HistoryEntry.HistoryEntryId;
 import google.registry.model.tld.Registry;
 import google.registry.persistence.VKey;
+import google.registry.persistence.transaction.TransactionManagerFactory;
 import java.util.List;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -229,8 +229,8 @@ public class AllocationTokenFlowUtils {
     // the Recurring billing event is reloaded later in the renew flow, so we synchronize changed
     // RecurringBillingEvent with storage manually
     tm().put(newRecurringBillingEvent);
-    jpaTm().getEntityManager().flush();
-    jpaTm().getEntityManager().clear();
+    TransactionManagerFactory.tm().getEntityManager().flush();
+    TransactionManagerFactory.tm().getEntityManager().clear();
 
     // Remove current package token
     return domain

--- a/core/src/main/java/google/registry/model/CreateAutoTimestamp.java
+++ b/core/src/main/java/google/registry/model/CreateAutoTimestamp.java
@@ -14,7 +14,7 @@
 
 package google.registry.model;
 
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import javax.annotation.Nullable;
 import javax.persistence.Column;
@@ -34,7 +34,7 @@ public class CreateAutoTimestamp extends ImmutableObject implements UnsafeSerial
   @PreUpdate
   void setTimestamp() {
     if (creationTime == null) {
-      creationTime = jpaTm().getTransactionTime();
+      creationTime = tm().getTransactionTime();
     }
   }
 

--- a/core/src/main/java/google/registry/model/EppResourceUtils.java
+++ b/core/src/main/java/google/registry/model/EppResourceUtils.java
@@ -16,7 +16,6 @@ package google.registry.model;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static google.registry.util.DateTimeUtils.isAtOrAfter;
@@ -41,6 +40,7 @@ import google.registry.model.transfer.DomainTransferData;
 import google.registry.model.transfer.TransferData;
 import google.registry.model.transfer.TransferStatus;
 import google.registry.persistence.VKey;
+import google.registry.persistence.transaction.TransactionManagerFactory;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -349,13 +349,13 @@ public final class EppResourceUtils {
               Query query;
               if (isContactKey) {
                 query =
-                    jpaTm()
+                    TransactionManagerFactory.tm()
                         .query(CONTACT_LINKED_DOMAIN_QUERY, String.class)
                         .setParameter("fkRepoId", key)
                         .setParameter("now", now);
               } else {
                 query =
-                    jpaTm()
+                    TransactionManagerFactory.tm()
                         .getEntityManager()
                         .createNativeQuery(HOST_LINKED_DOMAIN_QUERY)
                         .setParameter("fkRepoId", key.getKey())

--- a/core/src/main/java/google/registry/model/ForeignKeyUtils.java
+++ b/core/src/main/java/google/registry/model/ForeignKeyUtils.java
@@ -18,8 +18,8 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static google.registry.config.RegistryConfig.getEppResourceCachingDuration;
 import static google.registry.config.RegistryConfig.getEppResourceMaxCachedEntries;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.replicaJpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.LoadingCache;
@@ -108,7 +108,7 @@ public final class ForeignKeyUtils {
   private static <E extends EppResource> ImmutableMap<String, MostRecentResource> load(
       Class<E> clazz, Collection<String> foreignKeys, boolean useReplicaJpaTm) {
     String fkProperty = RESOURCE_TYPE_TO_FK_PROPERTY.get(clazz);
-    JpaTransactionManager jpaTmToUse = useReplicaJpaTm ? replicaJpaTm() : jpaTm();
+    JpaTransactionManager jpaTmToUse = useReplicaJpaTm ? replicaJpaTm() : tm();
     return jpaTmToUse.transact(
         () ->
             jpaTmToUse

--- a/core/src/main/java/google/registry/model/IdService.java
+++ b/core/src/main/java/google/registry/model/IdService.java
@@ -15,7 +15,7 @@
 package google.registry.model;
 
 import static com.google.common.base.Preconditions.checkState;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static org.joda.time.DateTimeZone.UTC;
 
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -70,12 +70,10 @@ public final class IdService {
    * <p>The generated IDs are project-wide unique
    */
   private static Long getSequenceBasedId() {
-    return jpaTm()
-        .transact(
+    return tm().transact(
             () ->
                 (BigInteger)
-                    jpaTm()
-                        .getEntityManager()
+                    tm().getEntityManager()
                         .createNativeQuery("SELECT nextval('project_wide_unique_id_seq')")
                         .getSingleResult())
         .longValue();

--- a/core/src/main/java/google/registry/model/UpdateAutoTimestamp.java
+++ b/core/src/main/java/google/registry/model/UpdateAutoTimestamp.java
@@ -14,7 +14,7 @@
 
 package google.registry.model;
 
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
 import java.util.Optional;
@@ -38,7 +38,7 @@ public class UpdateAutoTimestamp extends ImmutableObject implements UnsafeSerial
   @PrePersist
   @PreUpdate
   void setTimestamp() {
-    lastUpdateTime = jpaTm().getTransactionTime();
+    lastUpdateTime = tm().getTransactionTime();
   }
 
   /** Returns the timestamp, or {@code START_OF_TIME} if it's null. */

--- a/core/src/main/java/google/registry/model/console/UserDao.java
+++ b/core/src/main/java/google/registry/model/console/UserDao.java
@@ -15,7 +15,7 @@
 package google.registry.model.console;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import java.util.Optional;
 
@@ -24,11 +24,9 @@ public class UserDao {
 
   /** Retrieves the one user with this email address if it exists. */
   public static Optional<User> loadUser(String emailAddress) {
-    return jpaTm()
-        .transact(
+    return tm().transact(
             () ->
-                jpaTm()
-                    .query("FROM User WHERE emailAddress = :emailAddress", User.class)
+                tm().query("FROM User WHERE emailAddress = :emailAddress", User.class)
                     .setParameter("emailAddress", emailAddress)
                     .getResultStream()
                     .findFirst());
@@ -36,8 +34,7 @@ public class UserDao {
 
   /** Saves the given user, checking that no existing user already exists with this email. */
   public static void saveUser(User user) {
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
               // Check for an existing user (the unique constraint protects us, but this gives a
               // nicer exception)
@@ -51,7 +48,7 @@ public class UserDao {
                             + " email already exists with ID %s",
                         user.getEmailAddress(), user.getId(), savedUser.getId()));
               }
-              jpaTm().put(user);
+              tm().put(user);
             });
   }
 }

--- a/core/src/main/java/google/registry/model/domain/token/PackagePromotion.java
+++ b/core/src/main/java/google/registry/model/domain/token/PackagePromotion.java
@@ -15,7 +15,6 @@
 package google.registry.model.domain.token;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
@@ -25,6 +24,7 @@ import google.registry.model.ImmutableObject;
 import google.registry.model.domain.token.AllocationToken.TokenType;
 import google.registry.persistence.VKey;
 import google.registry.persistence.converter.JodaMoneyType;
+import google.registry.persistence.transaction.TransactionManagerFactory;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.persistence.Column;
@@ -101,8 +101,8 @@ public class PackagePromotion extends ImmutableObject implements Buildable {
 
   /** Loads and returns a PackagePromotion entity by its token string directly from Cloud SQL. */
   public static Optional<PackagePromotion> loadByTokenString(String tokenString) {
-    jpaTm().assertInTransaction();
-    return jpaTm()
+    TransactionManagerFactory.tm().assertInTransaction();
+    return TransactionManagerFactory.tm()
         .query("FROM PackagePromotion WHERE token = :token", PackagePromotion.class)
         .setParameter("token", VKey.create(AllocationToken.class, tokenString))
         .getResultStream()

--- a/core/src/main/java/google/registry/model/registrar/Registrar.java
+++ b/core/src/main/java/google/registry/model/registrar/Registrar.java
@@ -27,7 +27,6 @@ import static com.google.common.io.BaseEncoding.base64;
 import static google.registry.config.RegistryConfig.getDefaultRegistrarWhoisServer;
 import static google.registry.model.CacheUtils.memoizeWithShortExpiration;
 import static google.registry.model.tld.Registries.assertTldsExist;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.CollectionUtils.nullToEmptyImmutableCopy;
 import static google.registry.util.CollectionUtils.nullToEmptyImmutableSortedCopy;
@@ -61,6 +60,7 @@ import google.registry.model.UpdateAutoTimestampEntity;
 import google.registry.model.tld.Registry;
 import google.registry.model.tld.Registry.TldType;
 import google.registry.persistence.VKey;
+import google.registry.persistence.transaction.TransactionManagerFactory;
 import google.registry.util.CidrAddressBlock;
 import java.security.cert.CertificateParsingException;
 import java.util.Comparator;
@@ -580,7 +580,7 @@ public class Registrar extends UpdateAutoTimestampEntity implements Buildable, J
   private Iterable<RegistrarPoc> getContactsIterable() {
     return tm().transact(
             () ->
-                jpaTm()
+                TransactionManagerFactory.tm()
                     .query("FROM RegistrarPoc WHERE registrarId = :registrarId", RegistrarPoc.class)
                     .setParameter("registrarId", registrarId)
                     .getResultStream()

--- a/core/src/main/java/google/registry/model/registrar/RegistrarPoc.java
+++ b/core/src/main/java/google/registry/model/registrar/RegistrarPoc.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.io.BaseEncoding.base64;
 import static google.registry.model.registrar.Registrar.checkValidEmail;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.CollectionUtils.nullToEmptyImmutableSortedCopy;
 import static google.registry.util.PasswordUtils.SALT_SUPPLIER;
@@ -37,6 +36,7 @@ import google.registry.model.Jsonifiable;
 import google.registry.model.UnsafeSerializable;
 import google.registry.model.registrar.RegistrarPoc.RegistrarPocId;
 import google.registry.persistence.VKey;
+import google.registry.persistence.transaction.TransactionManagerFactory;
 import java.io.Serializable;
 import java.util.Map;
 import java.util.Optional;
@@ -185,7 +185,7 @@ public class RegistrarPoc extends ImmutableObject implements Jsonifiable, Unsafe
             () -> {
               ImmutableSet<String> emailAddressesToKeep =
                   contacts.stream().map(RegistrarPoc::getEmailAddress).collect(toImmutableSet());
-              jpaTm()
+              TransactionManagerFactory.tm()
                   .query(
                       "DELETE FROM RegistrarPoc WHERE registrarId = :registrarId AND "
                           + "emailAddress NOT IN :emailAddressesToKeep")

--- a/core/src/main/java/google/registry/model/smd/SignedMarkRevocationListDao.java
+++ b/core/src/main/java/google/registry/model/smd/SignedMarkRevocationListDao.java
@@ -14,7 +14,7 @@
 
 package google.registry.model.smd;
 
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
 import com.google.common.collect.ImmutableMap;
@@ -28,15 +28,12 @@ public class SignedMarkRevocationListDao {
   /** Loads the {@link SignedMarkRevocationList}. */
   static SignedMarkRevocationList load() {
     Optional<SignedMarkRevocationList> smdrl =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () -> {
                   Long revisionId =
-                      jpaTm()
-                          .query("SELECT MAX(revisionId) FROM SignedMarkRevocationList", Long.class)
+                      tm().query("SELECT MAX(revisionId) FROM SignedMarkRevocationList", Long.class)
                           .getSingleResult();
-                  return jpaTm()
-                      .query(
+                  return tm().query(
                           "FROM SignedMarkRevocationList smrl LEFT JOIN FETCH smrl.revokes "
                               + "WHERE smrl.revisionId = :revisionId",
                           SignedMarkRevocationList.class)
@@ -49,7 +46,7 @@ public class SignedMarkRevocationListDao {
 
   /** Save the given {@link SignedMarkRevocationList} */
   static void save(SignedMarkRevocationList signedMarkRevocationList) {
-    jpaTm().transact(() -> jpaTm().insert(signedMarkRevocationList));
+    tm().transact(() -> tm().insert(signedMarkRevocationList));
     logger.atInfo().log(
         "Inserted %,d signed mark revocations into Cloud SQL.",
         signedMarkRevocationList.revokes.size());

--- a/core/src/main/java/google/registry/model/tld/Registries.java
+++ b/core/src/main/java/google/registry/model/tld/Registries.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Strings.emptyToNull;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Maps.filterValues;
 import static google.registry.model.CacheUtils.memoizeWithShortExpiration;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.CollectionUtils.entriesToImmutableMap;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
@@ -34,6 +33,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Streams;
 import com.google.common.net.InternetDomainName;
 import google.registry.model.tld.Registry.TldType;
+import google.registry.persistence.transaction.TransactionManagerFactory;
 import google.registry.util.DomainNameUtils;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -59,7 +59,8 @@ public final class Registries {
         () ->
             tm().transact(
                     () -> {
-                      EntityManager entityManager = jpaTm().getEntityManager();
+                      EntityManager entityManager =
+                          TransactionManagerFactory.tm().getEntityManager();
                       Stream<?> resultStream =
                           entityManager
                               .createQuery("SELECT tldStr, tldType FROM Tld")

--- a/core/src/main/java/google/registry/model/tld/label/ReservedListDao.java
+++ b/core/src/main/java/google/registry/model/tld/label/ReservedListDao.java
@@ -14,7 +14,7 @@
 
 package google.registry.model.tld.label;
 
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
 import com.google.common.flogger.FluentLogger;
@@ -31,7 +31,7 @@ public class ReservedListDao {
   public static void save(ReservedList reservedList) {
     checkArgumentNotNull(reservedList, "Must specify reservedList");
     logger.atInfo().log("Saving reserved list %s to Cloud SQL.", reservedList.getName());
-    jpaTm().transact(() -> jpaTm().insert(reservedList));
+    tm().transact(() -> tm().insert(reservedList));
     logger.atInfo().log(
         "Saved reserved list %s with %d entries to Cloud SQL.",
         reservedList.getName(), reservedList.getReservedListEntries().size());
@@ -39,7 +39,7 @@ public class ReservedListDao {
 
   /** Deletes a reserved list from Cloud SQL. */
   public static void delete(ReservedList reservedList) {
-    jpaTm().transact(() -> jpaTm().delete(reservedList));
+    tm().transact(() -> tm().delete(reservedList));
   }
 
   /**
@@ -47,11 +47,9 @@ public class ReservedListDao {
    * exists.
    */
   public static Optional<ReservedList> getLatestRevision(String reservedListName) {
-    return jpaTm()
-        .transact(
+    return tm().transact(
             () ->
-                jpaTm()
-                    .query(
+                tm().query(
                         "FROM ReservedList WHERE revisionId IN "
                             + "(SELECT MAX(revisionId) FROM ReservedList WHERE name = :name)",
                         ReservedList.class)
@@ -66,11 +64,9 @@ public class ReservedListDao {
    * <p>This means that at least one reserved list revision must exist for the given name.
    */
   public static boolean checkExists(String reservedListName) {
-    return jpaTm()
-        .transact(
+    return tm().transact(
             () ->
-                jpaTm()
-                        .query("SELECT 1 FROM ReservedList WHERE name = :name", Integer.class)
+                tm().query("SELECT 1 FROM ReservedList WHERE name = :name", Integer.class)
                         .setParameter("name", reservedListName)
                         .setMaxResults(1)
                         .getResultList()

--- a/core/src/main/java/google/registry/model/tmch/ClaimsListDao.java
+++ b/core/src/main/java/google/registry/model/tmch/ClaimsListDao.java
@@ -16,7 +16,7 @@ package google.registry.model.tmch;
 
 import static google.registry.config.RegistryConfig.getClaimsListCacheDuration;
 import static google.registry.persistence.transaction.QueryComposer.Comparator.EQ;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
 import com.github.benmanes.caffeine.cache.LoadingCache;
@@ -51,7 +51,7 @@ public class ClaimsListDao {
 
   /** Saves the given {@link ClaimsList} to Cloud SQL. */
   public static void save(ClaimsList claimsList) {
-    jpaTm().transact(() -> jpaTm().insert(claimsList));
+    tm().transact(() -> tm().insert(claimsList));
     CACHE.put(ClaimsListDao.class, claimsList);
   }
 
@@ -65,15 +65,12 @@ public class ClaimsListDao {
    * doesn't exist.
    */
   private static ClaimsList getUncached() {
-    return jpaTm()
-        .transact(
+    return tm().transact(
             () -> {
               Long revisionId =
-                  jpaTm()
-                      .query("SELECT MAX(revisionId) FROM ClaimsList", Long.class)
+                  tm().query("SELECT MAX(revisionId) FROM ClaimsList", Long.class)
                       .getSingleResult();
-              return jpaTm()
-                  .createQueryComposer(ClaimsList.class)
+              return tm().createQueryComposer(ClaimsList.class)
                   .where("revisionId", EQ, revisionId)
                   .first();
             })

--- a/core/src/main/java/google/registry/model/tmch/TmchCrl.java
+++ b/core/src/main/java/google/registry/model/tmch/TmchCrl.java
@@ -15,7 +15,7 @@
 package google.registry.model.tmch;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import google.registry.model.common.CrossTldSingleton;
 import java.util.Optional;
@@ -39,7 +39,7 @@ public final class TmchCrl extends CrossTldSingleton {
 
   /** Returns the singleton instance of this entity, without memoization. */
   public static Optional<TmchCrl> get() {
-    return jpaTm().transact(() -> jpaTm().loadSingleton(TmchCrl.class));
+    return tm().transact(() -> tm().loadSingleton(TmchCrl.class));
   }
 
   /**
@@ -49,14 +49,13 @@ public final class TmchCrl extends CrossTldSingleton {
    * and actually newer than the one currently in the database.
    */
   public static void set(final String crl, final String url) {
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
               TmchCrl tmchCrl = new TmchCrl();
-              tmchCrl.updated = jpaTm().getTransactionTime();
+              tmchCrl.updated = tm().getTransactionTime();
               tmchCrl.crl = checkNotNull(crl, "crl");
               tmchCrl.url = checkNotNull(url, "url");
-              jpaTm().put(tmchCrl);
+              tm().put(tmchCrl);
             });
   }
 

--- a/core/src/main/java/google/registry/persistence/transaction/CriteriaQueryBuilder.java
+++ b/core/src/main/java/google/registry/persistence/transaction/CriteriaQueryBuilder.java
@@ -14,7 +14,7 @@
 
 package google.registry.persistence.transaction;
 
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Collection;
@@ -104,7 +104,7 @@ public class CriteriaQueryBuilder<T> {
 
   /** Creates a query builder that will SELECT from the given class. */
   public static <T> CriteriaQueryBuilder<T> create(Class<T> clazz) {
-    return create(jpaTm(), clazz);
+    return create(tm(), clazz);
   }
 
   /** Creates a query builder for the given entity manager. */

--- a/core/src/main/java/google/registry/persistence/transaction/DummyJpaTransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/DummyJpaTransactionManager.java
@@ -20,8 +20,8 @@ import java.lang.reflect.Proxy;
  * A dummy implementation for {@link JpaTransactionManager} which throws exception when any of its
  * method is invoked.
  *
- * <p>This is used to initialize the {@link TransactionManagerFactory#jpaTm()} when running unit
- * tests, because obviously we cannot connect to the actual Cloud SQL backend in a unit test.
+ * <p>This is used to initialize the {@link TransactionManagerFactory#tm()} when running unit tests,
+ * because obviously we cannot connect to the actual Cloud SQL backend in a unit test.
  *
  * <p>If a unit test needs to access the Cloud SQL database, it must add {@code
  * JpaTransactionManagerExtension} as a JUnit extension in the test class.

--- a/core/src/main/java/google/registry/persistence/transaction/QueryComposer.java
+++ b/core/src/main/java/google/registry/persistence/transaction/QueryComposer.java
@@ -14,7 +14,7 @@
 
 package google.registry.persistence.transaction;
 
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
@@ -210,7 +210,7 @@ public abstract class QueryComposer<T> {
     }
 
     public void addToCriteriaQueryBuilder(CriteriaQueryBuilder queryBuilder) {
-      CriteriaBuilder criteriaBuilder = jpaTm().getEntityManager().getCriteriaBuilder();
+      CriteriaBuilder criteriaBuilder = tm().getEntityManager().getCriteriaBuilder();
       queryBuilder.where(
           fieldName, comparator.getComparisonFactory().apply(criteriaBuilder), value);
     }

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionManagerFactory.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionManagerFactory.java
@@ -19,21 +19,15 @@ import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
 import com.google.appengine.api.utils.SystemProperty;
 import com.google.appengine.api.utils.SystemProperty.Environment.Value;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Suppliers;
 import google.registry.config.RegistryEnvironment;
 import google.registry.persistence.DaggerPersistenceComponent;
 import google.registry.tools.RegistryToolEnvironment;
 import google.registry.util.NonFinalForTesting;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 /** Factory class to create {@link TransactionManager} instance. */
-// TODO: Rename this to PersistenceFactory and move to persistence package.
 public final class TransactionManagerFactory {
-
-  /** Optional override to manually set the transaction manager per-test. */
-  private static Optional<TransactionManager> tmForTest = Optional.empty();
 
   /** Supplier for jpaTm so that it is initialized only once, upon first usage. */
   @NonFinalForTesting
@@ -78,22 +72,12 @@ public final class TransactionManagerFactory {
   }
 
   /**
-   * Returns the {@link TransactionManager} instance.
-   *
-   * <p>Returns the {@link JpaTransactionManager} or replica based on the possible manually
-   * specified per-test transaction manager.
-   */
-  public static TransactionManager tm() {
-    return tmForTest.orElseGet(TransactionManagerFactory::jpaTm);
-  }
-
-  /**
    * Returns {@link JpaTransactionManager} instance.
    *
    * <p>Between invocations of {@link TransactionManagerFactory#setJpaTm} every call to this method
    * returns the same instance.
    */
-  public static JpaTransactionManager jpaTm() {
+  public static JpaTransactionManager tm() {
     return jpaTm.get();
   }
 
@@ -112,7 +96,7 @@ public final class TransactionManagerFactory {
     return replicaJpaTm();
   }
 
-  /** Sets the return of {@link #jpaTm()} to the given instance of {@link JpaTransactionManager}. */
+  /** Sets the return of {@link #tm()} to the given instance of {@link JpaTransactionManager}. */
   public static void setJpaTm(Supplier<JpaTransactionManager> jpaTmSupplier) {
     checkArgumentNotNull(jpaTmSupplier, "jpaTmSupplier");
     checkState(
@@ -133,32 +117,12 @@ public final class TransactionManagerFactory {
   }
 
   /**
-   * Makes {@link #jpaTm()} return the {@link JpaTransactionManager} instance provided by {@code
+   * Makes {@link #tm()} return the {@link JpaTransactionManager} instance provided by {@code
    * jpaTmSupplier} from now on. This method should only be called by an implementor of {@link
    * org.apache.beam.sdk.harness.JvmInitializer}.
    */
   public static void setJpaTmOnBeamWorker(Supplier<JpaTransactionManager> jpaTmSupplier) {
     checkArgumentNotNull(jpaTmSupplier, "jpaTmSupplier");
     jpaTm = Suppliers.memoize(jpaTmSupplier::get);
-  }
-
-  /**
-   * Sets the return of {@link #tm()} to the given instance of {@link TransactionManager}.
-   *
-   * <p>DO NOT CALL THIS DIRECTLY IF POSSIBLE. Strongly prefer the use of <code>TmOverrideExtension
-   * </code> in test code instead.
-   *
-   * <p>Used when overriding the per-test transaction manager for dual-database tests. Should be
-   * matched with a corresponding invocation of {@link #removeTmOverrideForTest()} either at the end
-   * of the test or in an <code>@AfterEach</code> handler.
-   */
-  @VisibleForTesting
-  public static void setTmOverrideForTest(TransactionManager newTmOverride) {
-    tmForTest = Optional.of(newTmOverride);
-  }
-
-  /** Resets the overridden transaction manager post-test. */
-  public static void removeTmOverrideForTest() {
-    tmForTest = Optional.empty();
   }
 }

--- a/core/src/main/java/google/registry/request/auth/AuthenticatedRegistrarAccessor.java
+++ b/core/src/main/java/google/registry/request/auth/AuthenticatedRegistrarAccessor.java
@@ -16,7 +16,6 @@ package google.registry.request.auth;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.google.appengine.api.users.User;
@@ -31,6 +30,7 @@ import google.registry.groups.GroupsConnection;
 import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.Registrar.State;
 import google.registry.model.registrar.RegistrarPoc;
+import google.registry.persistence.transaction.TransactionManagerFactory;
 import java.util.Optional;
 import javax.annotation.concurrent.Immutable;
 import javax.inject.Inject;
@@ -311,10 +311,10 @@ public class AuthenticatedRegistrarAccessor {
       logger.atInfo().log("Checking registrar contacts for user ID %s.", user.getEmail());
 
       // Find all registrars that have a registrar contact with this user's ID.
-      jpaTm()
+      TransactionManagerFactory.tm()
           .transact(
               () ->
-                  jpaTm()
+                  TransactionManagerFactory.tm()
                       .query(
                           "SELECT r FROM Registrar r INNER JOIN RegistrarPoc rp ON r.registrarId ="
                               + " rp.registrarId WHERE lower(rp.loginEmailAddress) = :email AND"

--- a/core/src/main/java/google/registry/tools/AckPollMessagesCommand.java
+++ b/core/src/main/java/google/registry/tools/AckPollMessagesCommand.java
@@ -18,7 +18,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static google.registry.flows.poll.PollFlowUtils.createPollMessageQuery;
 import static google.registry.model.poll.PollMessageExternalKeyConverter.makePollMessageExternalId;
 import static google.registry.persistence.transaction.QueryComposer.Comparator.LIKE;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
@@ -81,8 +81,7 @@ final class AckPollMessagesCommand implements Command {
 
   /** Loads and acks all matching poll messages from SQL in one transaction. */
   private void ackPollMessagesSql() {
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
               QueryComposer<PollMessage> query = createPollMessageQuery(clientId, clock.nowUtc());
               if (!isNullOrEmpty(message)) {

--- a/core/src/main/java/google/registry/tools/CreateOrUpdatePackagePromotionCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdatePackagePromotionCommand.java
@@ -15,7 +15,6 @@
 package google.registry.tools;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.beust.jcommander.Parameter;
@@ -23,6 +22,7 @@ import google.registry.model.domain.token.AllocationToken;
 import google.registry.model.domain.token.AllocationToken.TokenType;
 import google.registry.model.domain.token.PackagePromotion;
 import google.registry.persistence.VKey;
+import google.registry.persistence.transaction.TransactionManagerFactory;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -87,7 +87,7 @@ abstract class CreateOrUpdatePackagePromotionCommand extends MutatingCommand {
   @Override
   protected final void init() throws Exception {
     for (String token : mainParameters) {
-      jpaTm()
+      TransactionManagerFactory.tm()
           .transact(
               () -> {
                 PackagePromotion oldPackage = getOldPackagePromotion(token);

--- a/core/src/main/java/google/registry/tools/GetPackagePromotionCommand.java
+++ b/core/src/main/java/google/registry/tools/GetPackagePromotionCommand.java
@@ -14,7 +14,7 @@
 
 package google.registry.tools;
 
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.PreconditionsUtils.checkArgumentPresent;
 
 import com.beust.jcommander.Parameter;
@@ -32,8 +32,7 @@ public class GetPackagePromotionCommand extends GetEppResourceCommand {
   @Override
   void runAndPrint() {
     for (String token : mainParameters) {
-      jpaTm()
-          .transact(
+      tm().transact(
               () -> {
                 PackagePromotion packagePromotion =
                     checkArgumentPresent(

--- a/core/src/main/java/google/registry/tools/LockOrUnlockDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/LockOrUnlockDomainCommand.java
@@ -20,7 +20,6 @@ import static com.google.common.collect.Iterables.partition;
 import static google.registry.model.eppcommon.StatusValue.SERVER_DELETE_PROHIBITED;
 import static google.registry.model.eppcommon.StatusValue.SERVER_TRANSFER_PROHIBITED;
 import static google.registry.model.eppcommon.StatusValue.SERVER_UPDATE_PROHIBITED;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.CollectionUtils.findDuplicates;
 
@@ -31,6 +30,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.FluentLogger;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.model.eppcommon.StatusValue;
+import google.registry.persistence.transaction.TransactionManagerFactory;
 import java.util.List;
 import javax.inject.Inject;
 
@@ -84,7 +84,7 @@ public abstract class LockOrUnlockDomainCommand extends ConfirmingCommand {
         .forEach(
             batch ->
                 // we require that the jpaTm is the outer transaction in DomainLockUtils
-                jpaTm()
+                TransactionManagerFactory.tm()
                     .transact(
                         () ->
                             tm().transact(

--- a/core/src/main/java/google/registry/tools/RegistryCli.java
+++ b/core/src/main/java/google/registry/tools/RegistryCli.java
@@ -15,7 +15,7 @@
 package google.registry.tools;
 
 import static com.google.common.base.Preconditions.checkState;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.tools.Injector.injectReflectively;
 
 import com.beust.jcommander.JCommander;
@@ -218,7 +218,7 @@ final class RegistryCli implements CommandRunner {
 
     // Reset the JPA transaction manager after every command to avoid a situation where a test can
     // interfere with other tests
-    JpaTransactionManager cachedJpaTm = jpaTm();
+    JpaTransactionManager cachedJpaTm = tm();
     TransactionManagerFactory.setJpaTm(() -> component.nomulusToolJpaTransactionManager().get());
     TransactionManagerFactory.setReplicaJpaTm(
         () -> component.nomulusToolReplicaJpaTransactionManager().get());

--- a/core/src/main/java/google/registry/tools/SetDatabaseMigrationStateCommand.java
+++ b/core/src/main/java/google/registry/tools/SetDatabaseMigrationStateCommand.java
@@ -14,7 +14,7 @@
 
 package google.registry.tools;
 
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
@@ -48,11 +48,10 @@ public class SetDatabaseMigrationStateCommand extends ConfirmingCommand {
 
   @Override
   protected String prompt() {
-    return jpaTm()
-        .transact(
+    return tm().transact(
             () -> {
               StringBuilder result = new StringBuilder();
-              DateTime now = jpaTm().getTransactionTime();
+              DateTime now = tm().getTransactionTime();
               DateTime nextTransition = transitionSchedule.ceilingKey(now);
               if (nextTransition != null && nextTransition.isBefore(now.plusMinutes(10))) {
                 result.append(WARNING_MESSAGE);
@@ -65,7 +64,7 @@ public class SetDatabaseMigrationStateCommand extends ConfirmingCommand {
 
   @Override
   protected String execute() {
-    jpaTm().transact(() -> DatabaseMigrationStateSchedule.set(transitionSchedule));
+    tm().transact(() -> DatabaseMigrationStateSchedule.set(transitionSchedule));
     return String.format("Successfully set new migration state schedule %s", transitionSchedule);
   }
 }

--- a/core/src/main/java/google/registry/tools/server/ListDomainsAction.java
+++ b/core/src/main/java/google/registry/tools/server/ListDomainsAction.java
@@ -17,7 +17,7 @@ package google.registry.tools.server;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static google.registry.model.tld.Registries.assertTldsExist;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.Action.Method.GET;
 import static google.registry.request.Action.Method.POST;
 import static google.registry.request.RequestParameters.PARAM_TLDS;
@@ -74,18 +74,16 @@ public final class ListDomainsAction extends ListObjectsAction<Domain> {
   }
 
   private ImmutableList<Domain> loadDomains() {
-    return jpaTm()
-        .transact(
+    return tm().transact(
             () ->
-                jpaTm()
-                    .query(
+                tm().query(
                         "FROM Domain WHERE tld IN (:tlds) AND deletionTime > "
                             + "current_timestamp() ORDER BY creationTime DESC",
                         Domain.class)
                     .setParameter("tlds", tlds)
                     .setMaxResults(limit)
                     .getResultStream()
-                    .map(EppResourceUtils.transformAtTime(jpaTm().getTransactionTime()))
+                    .map(EppResourceUtils.transformAtTime(tm().getTransactionTime()))
                     .collect(toImmutableList()));
   }
 }

--- a/core/src/main/java/google/registry/tools/server/ListPremiumListsAction.java
+++ b/core/src/main/java/google/registry/tools/server/ListPremiumListsAction.java
@@ -15,7 +15,7 @@
 package google.registry.tools.server;
 
 import static com.google.common.collect.ImmutableSortedSet.toImmutableSortedSet;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.Action.Method.GET;
 import static google.registry.request.Action.Method.POST;
 
@@ -49,10 +49,9 @@ public final class ListPremiumListsAction extends ListObjectsAction<PremiumList>
 
   @Override
   public ImmutableSet<PremiumList> loadObjects() {
-    return jpaTm()
-        .transact(
+    return tm().transact(
             () ->
-                jpaTm().loadAllOf(PremiumList.class).stream()
+                tm().loadAllOf(PremiumList.class).stream()
                     .map(PremiumList::getName)
                     .map(PremiumListDao::getLatestRevision)
                     .filter(Optional::isPresent)

--- a/core/src/main/java/google/registry/tools/server/ListReservedListsAction.java
+++ b/core/src/main/java/google/registry/tools/server/ListReservedListsAction.java
@@ -15,7 +15,7 @@
 package google.registry.tools.server;
 
 import static com.google.common.collect.ImmutableSortedSet.toImmutableSortedSet;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.Action.Method.GET;
 import static google.registry.request.Action.Method.POST;
 
@@ -47,10 +47,9 @@ public final class ListReservedListsAction extends ListObjectsAction<ReservedLis
 
   @Override
   public ImmutableSet<ReservedList> loadObjects() {
-    return jpaTm()
-        .transact(
+    return tm().transact(
             () ->
-                jpaTm().loadAllOf(ReservedList.class).stream()
+                tm().loadAllOf(ReservedList.class).stream()
                     .map(ReservedList::getName)
                     .map(ReservedListDao::getLatestRevision)
                     .filter(Optional::isPresent)

--- a/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
+++ b/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
@@ -16,13 +16,13 @@ package google.registry.tools.server;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.model.tld.Registries.assertTldsExist;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.RequestParameters.PARAM_TLDS;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.FluentLogger;
 import google.registry.dns.DnsQueue;
+import google.registry.persistence.transaction.TransactionManagerFactory;
 import google.registry.request.Action;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
@@ -80,7 +80,7 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
     checkArgument(smearMinutes > 0, "Must specify a positive number of smear minutes");
     tm().transact(
             () ->
-                jpaTm()
+                TransactionManagerFactory.tm()
                     .query(
                         "SELECT domainName FROM Domain "
                             + "WHERE tld IN (:tlds) "

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
@@ -19,7 +19,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Sets.difference;
 import static google.registry.config.RegistryEnvironment.PRODUCTION;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.security.JsonResponseHelper.Status.ERROR;
 import static google.registry.security.JsonResponseHelper.Status.SUCCESS;
@@ -44,6 +43,7 @@ import google.registry.flows.certs.CertificateChecker.InsecureCertificateExcepti
 import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.RegistrarPoc;
 import google.registry.model.registrar.RegistrarPoc.Type;
+import google.registry.persistence.transaction.TransactionManagerFactory;
 import google.registry.request.Action;
 import google.registry.request.Action.Service;
 import google.registry.request.HttpException.BadRequestException;
@@ -243,7 +243,7 @@ public class RegistrarSettingsAction implements Runnable, JsonActionRunner.JsonA
     Registrar registrar = loadRegistrarUnchecked(registrarId);
     // Detach the registrar to avoid Hibernate object-updates, since we wish to email
     // out the diffs between the existing and updated registrar objects
-    jpaTm().getEntityManager().detach(registrar);
+    TransactionManagerFactory.tm().getEntityManager().detach(registrar);
     // Verify that the registrar hasn't been changed.
     // To do that - we find the latest update time (or null if the registrar has been
     // deleted) and compare to the update time from the args. The update time in the args

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistryLockPostAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistryLockPostAction.java
@@ -16,7 +16,7 @@ package google.registry.ui.server.registrar;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.security.JsonResponseHelper.Status.ERROR;
 import static google.registry.security.JsonResponseHelper.Status.SUCCESS;
 import static google.registry.ui.server.registrar.RegistryLockGetAction.getContactMatchingLogin;
@@ -127,8 +127,7 @@ public class RegistryLockPostAction implements Runnable, JsonActionRunner.JsonAc
               .orElseThrow(() -> new ForbiddenException("User is not logged in"));
 
       String userEmail = verifyPasswordAndGetEmail(userAuthInfo, postInput);
-      jpaTm()
-          .transact(
+      tm().transact(
               () -> {
                 RegistryLock registryLock =
                     postInput.isLock

--- a/core/src/main/java/google/registry/whois/NameserverLookupByIpCommand.java
+++ b/core/src/main/java/google/registry/whois/NameserverLookupByIpCommand.java
@@ -16,7 +16,7 @@ package google.registry.whois;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -51,12 +51,10 @@ final class NameserverLookupByIpCommand implements WhoisCommand {
   public WhoisResponse executeQuery(DateTime now) throws WhoisException {
     Iterable<Host> hostsFromDb;
     hostsFromDb =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () ->
                     // We cannot query @Convert-ed fields in HQL, so we must use native Postgres.
-                    jpaTm()
-                        .getEntityManager()
+                    tm().getEntityManager()
                         /*
                          * Using array_operator <@ (contained-by) with gin index on inet_address.
                          * Without gin index, this is slightly slower than the alternative form of

--- a/core/src/test/java/google/registry/batch/CheckPackagesComplianceActionTest.java
+++ b/core/src/test/java/google/registry/batch/CheckPackagesComplianceActionTest.java
@@ -14,7 +14,7 @@
 package google.registry.batch;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistActiveContact;
 import static google.registry.testing.DatabaseHelper.persistEppResource;
@@ -110,7 +110,7 @@ public class CheckPackagesComplianceActionTest {
             .setLastNotificationSent(DateTime.parse("2010-11-12T05:00:00Z"))
             .build();
 
-    jpaTm().transact(() -> jpaTm().put(packagePromotion));
+    tm().transact(() -> tm().put(packagePromotion));
     contact = persistActiveContact("contact1234");
   }
 
@@ -199,7 +199,7 @@ public class CheckPackagesComplianceActionTest {
             .setPackagePrice(Money.of(CurrencyUnit.USD, 1000))
             .setNextBillingDate(DateTime.parse("2012-11-12T05:00:00Z"))
             .build();
-    jpaTm().transact(() -> jpaTm().put(packagePromotion2));
+    tm().transact(() -> tm().put(packagePromotion2));
 
     persistEppResource(
         DatabaseHelper.newDomain("foo2.tld", contact)
@@ -253,7 +253,7 @@ public class CheckPackagesComplianceActionTest {
             .setPackagePrice(Money.of(CurrencyUnit.USD, 1000))
             .setNextBillingDate(DateTime.parse("2015-11-12T05:00:00Z"))
             .build();
-    jpaTm().transact(() -> jpaTm().put(packagePromotion2));
+    tm().transact(() -> tm().put(packagePromotion2));
 
     // Create limit is 1, creating 2 domains to go over the limit
     persistEppResource(

--- a/core/src/test/java/google/registry/batch/WipeOutContactHistoryPiiActionTest.java
+++ b/core/src/test/java/google/registry/batch/WipeOutContactHistoryPiiActionTest.java
@@ -17,7 +17,7 @@ package google.registry.batch;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.common.truth.Truth8.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.apache.http.HttpStatus.SC_OK;
 
@@ -118,8 +118,7 @@ class WipeOutContactHistoryPiiActionTest {
   void getAllHistoryEntitiesOlderThan_returnsAllPersistedEntities() {
     ImmutableList<ContactHistory> expectedToBeWipedOut =
         persistLotsOfContactHistoryEntities(20, MIN_MONTHS_BEFORE_WIPE_OUT + 1, 0, DEFAULT_CONTACT);
-    jpaTm()
-        .transact(
+    tm().transact(
             () ->
                 assertThat(
                         action.getNextContactHistoryEntitiesWithPiiBatch(
@@ -135,8 +134,7 @@ class WipeOutContactHistoryPiiActionTest {
     // persisted entities that should not be part of the actual result
     persistLotsOfContactHistoryEntities(15, 17, MIN_MONTHS_BEFORE_WIPE_OUT - 1, DEFAULT_CONTACT);
 
-    jpaTm()
-        .transact(
+    tm().transact(
             () ->
                 assertThat(
                         action.getNextContactHistoryEntitiesWithPiiBatch(
@@ -147,8 +145,7 @@ class WipeOutContactHistoryPiiActionTest {
   @Test
   void run_withNoEntitiesToWipeOut_success() {
     assertThat(
-            jpaTm()
-                .transact(
+            tm().transact(
                     () ->
                         action
                             .getNextContactHistoryEntitiesWithPiiBatch(
@@ -158,8 +155,7 @@ class WipeOutContactHistoryPiiActionTest {
     action.run();
 
     assertThat(
-            jpaTm()
-                .transact(
+            tm().transact(
                     () ->
                         action
                             .getNextContactHistoryEntitiesWithPiiBatch(
@@ -180,8 +176,7 @@ class WipeOutContactHistoryPiiActionTest {
 
     // The query should return a stream of all persisted entities.
     assertThat(
-            jpaTm()
-                .transact(
+            tm().transact(
                     () ->
                         action
                             .getNextContactHistoryEntitiesWithPiiBatch(
@@ -197,8 +192,7 @@ class WipeOutContactHistoryPiiActionTest {
 
     // The query should return an empty stream after the wipe out action.
     assertThat(
-            jpaTm()
-                .transact(
+            tm().transact(
                     () ->
                         action
                             .getNextContactHistoryEntitiesWithPiiBatch(
@@ -217,8 +211,7 @@ class WipeOutContactHistoryPiiActionTest {
 
     // The query should return a subset of all persisted data.
     assertThat(
-            jpaTm()
-                .transact(
+            tm().transact(
                     () ->
                         action
                             .getNextContactHistoryEntitiesWithPiiBatch(
@@ -233,8 +226,7 @@ class WipeOutContactHistoryPiiActionTest {
 
     // The query should return an empty stream after the wipe out action.
     assertThat(
-            jpaTm()
-                .transact(
+            tm().transact(
                     () ->
                         action
                             .getNextContactHistoryEntitiesWithPiiBatch(
@@ -254,8 +246,7 @@ class WipeOutContactHistoryPiiActionTest {
 
     // The query should return a subset of all persisted data.
     assertThat(
-            jpaTm()
-                .transact(
+            tm().transact(
                     () ->
                         action
                             .getNextContactHistoryEntitiesWithPiiBatch(
@@ -270,8 +261,7 @@ class WipeOutContactHistoryPiiActionTest {
 
     // The query should return an empty stream after the wipe out action.
     assertThat(
-            jpaTm()
-                .transact(
+            tm().transact(
                     () ->
                         action
                             .getNextContactHistoryEntitiesWithPiiBatch(
@@ -284,8 +274,7 @@ class WipeOutContactHistoryPiiActionTest {
 
   @Test
   void wipeOutContactHistoryData_wipesOutNoEntity() {
-    jpaTm()
-        .transact(
+    tm().transact(
             () ->
                 assertThat(
                         action.wipeOutContactHistoryData(
@@ -302,8 +291,7 @@ class WipeOutContactHistoryPiiActionTest {
 
     assertAllEntitiesContainPii(DatabaseHelper.loadByEntitiesIfPresent(expectedToBeWipedOut));
 
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
               action.wipeOutContactHistoryData(
                   action.getNextContactHistoryEntitiesWithPiiBatch(

--- a/core/src/test/java/google/registry/beam/common/RegistryJpaWriteTest.java
+++ b/core/src/test/java/google/registry/beam/common/RegistryJpaWriteTest.java
@@ -16,7 +16,7 @@ package google.registry.beam.common;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.immutableObjectCorrespondence;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.loadAllOf;
 import static google.registry.testing.DatabaseHelper.newContact;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -51,7 +51,7 @@ class RegistryJpaWriteTest implements Serializable {
 
   @Test
   void writeToSql_twoWriters() {
-    jpaTm().transact(() -> jpaTm().put(AppEngineExtension.makeRegistrar2()));
+    tm().transact(() -> tm().put(AppEngineExtension.makeRegistrar2()));
     ImmutableList.Builder<Contact> contactsBuilder = new ImmutableList.Builder<>();
     for (int i = 0; i < 3; i++) {
       contactsBuilder.add(newContact("contact_" + i));
@@ -72,11 +72,10 @@ class RegistryJpaWriteTest implements Serializable {
     // RegistryJpaIO.Write actions should not write existing objects to the database because the
     // object could have been mutated in between creation and when the Write actually occurs,
     // causing a race condition
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
-              jpaTm().put(AppEngineExtension.makeRegistrar2());
-              jpaTm().put(newContact("contact"));
+              tm().put(AppEngineExtension.makeRegistrar2());
+              tm().put(newContact("contact"));
             });
     Contact contact = Iterables.getOnlyElement(loadAllOf(Contact.class));
     testPipeline

--- a/core/src/test/java/google/registry/beam/resave/ResaveAllEppResourcesPipelineTest.java
+++ b/core/src/test/java/google/registry/beam/resave/ResaveAllEppResourcesPipelineTest.java
@@ -16,7 +16,7 @@ package google.registry.beam.resave;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.loadAllOf;
 import static google.registry.testing.DatabaseHelper.loadByEntity;
@@ -151,7 +151,7 @@ public class ResaveAllEppResourcesPipelineTest {
     persistDomainWithDependentResources("renewed", "tld", contact, now, now, now.plusYears(1));
     persistActiveDomain("nonrenewed.tld", now, now.plusYears(20));
     // Spy the transaction manager so we can be sure we're only saving the renewed domain
-    JpaTransactionManager spy = spy(jpaTm());
+    JpaTransactionManager spy = spy(tm());
     TransactionManagerFactory.setJpaTm(() -> spy);
     ArgumentCaptor<Domain> domainPutCaptor = ArgumentCaptor.forClass(Domain.class);
     runPipeline();
@@ -171,7 +171,7 @@ public class ResaveAllEppResourcesPipelineTest {
         persistDomainWithDependentResources(
             "nonrenewed", "tld", contact, now, now, now.plusYears(20));
     // Spy the transaction manager so we can be sure we're attempting to save everything
-    JpaTransactionManager spy = spy(jpaTm());
+    JpaTransactionManager spy = spy(tm());
     TransactionManagerFactory.setJpaTm(() -> spy);
     ArgumentCaptor<EppResource> eppResourcePutCaptor = ArgumentCaptor.forClass(EppResource.class);
     runPipeline();

--- a/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
+++ b/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
@@ -17,7 +17,7 @@ package google.registry.beam.spec11;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.immutableObjectCorrespondence;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.AppEngineExtension.makeRegistrar1;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistActiveContact;
@@ -278,11 +278,10 @@ class Spec11PipelineTest {
   }
 
   private void verifySaveToCloudSql() {
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
               ImmutableList<Spec11ThreatMatch> sqlThreatMatches =
-                  Spec11ThreatMatchDao.loadEntriesByDate(jpaTm(), new LocalDate(2020, 1, 27));
+                  Spec11ThreatMatchDao.loadEntriesByDate(tm(), new LocalDate(2020, 1, 27));
               assertThat(sqlThreatMatches)
                   .comparingElementsUsing(immutableObjectCorrespondence("id"))
                   .containsExactlyElementsIn(sqlThreatMatches);

--- a/core/src/test/java/google/registry/model/common/DatabaseMigrationStateScheduleTest.java
+++ b/core/src/test/java/google/registry/model/common/DatabaseMigrationStateScheduleTest.java
@@ -22,7 +22,7 @@ import static google.registry.model.common.DatabaseMigrationStateSchedule.Migrat
 import static google.registry.model.common.DatabaseMigrationStateSchedule.MigrationState.SQL_ONLY;
 import static google.registry.model.common.DatabaseMigrationStateSchedule.MigrationState.SQL_PRIMARY;
 import static google.registry.model.common.DatabaseMigrationStateSchedule.MigrationState.SQL_PRIMARY_READ_ONLY;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.junit.Assert.assertThrows;
 
@@ -128,7 +128,7 @@ public class DatabaseMigrationStateScheduleTest extends EntityTestCase {
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> jpaTm().transact(() -> DatabaseMigrationStateSchedule.set(nowInvalidMap)));
+            () -> tm().transact(() -> DatabaseMigrationStateSchedule.set(nowInvalidMap)));
     assertThat(thrown)
         .hasMessageThat()
         .isEqualTo(
@@ -150,7 +150,7 @@ public class DatabaseMigrationStateScheduleTest extends EntityTestCase {
   private void runValidTransition(MigrationState from, MigrationState to) {
     ImmutableSortedMap<DateTime, MigrationState> transitions =
         createMapEndingWithTransition(from, to);
-    jpaTm().transact(() -> DatabaseMigrationStateSchedule.set(transitions));
+    tm().transact(() -> DatabaseMigrationStateSchedule.set(transitions));
     assertThat(DatabaseMigrationStateSchedule.getUncached().toValueMap())
         .containsExactlyEntriesIn(transitions);
   }
@@ -161,7 +161,7 @@ public class DatabaseMigrationStateScheduleTest extends EntityTestCase {
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> jpaTm().transact(() -> DatabaseMigrationStateSchedule.set(transitions)));
+            () -> tm().transact(() -> DatabaseMigrationStateSchedule.set(transitions)));
     assertThat(thrown)
         .hasMessageThat()
         .isEqualTo(

--- a/core/src/test/java/google/registry/model/console/UserDaoTest.java
+++ b/core/src/test/java/google/registry/model/console/UserDaoTest.java
@@ -15,7 +15,7 @@
 package google.registry.model.console;
 
 import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.truth.Truth8;
@@ -62,7 +62,7 @@ public class UserDaoTest extends EntityTestCase {
     // nonexistent one should never exist
     Truth8.assertThat(UserDao.loadUser("nonexistent@email.com")).isEmpty();
     // now try deleting the one that does exist
-    jpaTm().transact(() -> jpaTm().delete(fromDb));
+    tm().transact(() -> tm().delete(fromDb));
     Truth8.assertThat(UserDao.loadUser("email@email.com")).isEmpty();
   }
 

--- a/core/src/test/java/google/registry/model/console/UserTest.java
+++ b/core/src/test/java/google/registry/model/console/UserTest.java
@@ -16,7 +16,7 @@ package google.registry.model.console;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.model.EntityTestCase;
@@ -38,19 +38,15 @@ public class UserTest extends EntityTestCase {
             .setUserRoles(
                 new UserRoles.Builder().setGlobalRole(GlobalRole.FTE).setIsAdmin(true).build())
             .build();
-    jpaTm().transact(() -> jpaTm().put(user));
-    jpaTm()
-        .transact(
+    tm().transact(() -> tm().put(user));
+    tm().transact(
             () -> {
               assertAboutImmutableObjects()
                   .that(
-                      jpaTm()
-                          .query("FROM User WHERE gaiaId = 'gaiaId'", User.class)
-                          .getSingleResult())
+                      tm().query("FROM User WHERE gaiaId = 'gaiaId'", User.class).getSingleResult())
                   .isEqualExceptFields(user, "id", "updateTimestamp");
               assertThat(
-                      jpaTm()
-                          .query("FROM User WHERE gaiaId = 'badGaiaId'", User.class)
+                      tm().query("FROM User WHERE gaiaId = 'badGaiaId'", User.class)
                           .getResultList())
                   .isEmpty();
             });

--- a/core/src/test/java/google/registry/model/domain/token/PackagePromotionTest.java
+++ b/core/src/test/java/google/registry/model/domain/token/PackagePromotionTest.java
@@ -16,7 +16,7 @@ package google.registry.model.domain.token;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -66,9 +66,9 @@ public class PackagePromotionTest extends EntityTestCase {
             .setNextBillingDate(DateTime.parse("2011-11-12T05:00:00Z"))
             .build();
 
-    jpaTm().transact(() -> jpaTm().put(packagePromotion));
+    tm().transact(() -> tm().put(packagePromotion));
     assertAboutImmutableObjects()
-        .that(jpaTm().transact(() -> PackagePromotion.loadByTokenString("abc123")).get())
+        .that(tm().transact(() -> PackagePromotion.loadByTokenString("abc123")).get())
         .isEqualExceptFields(packagePromotion, "packagePromotionId");
   }
 

--- a/core/src/test/java/google/registry/model/eppcommon/AddressTest.java
+++ b/core/src/test/java/google/registry/model/eppcommon/AddressTest.java
@@ -15,7 +15,7 @@
 package google.registry.model.eppcommon;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.loadByEntity;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -83,7 +83,7 @@ class AddressTest {
   /** Test the merge behavior. */
   @Test
   void testSuccess_putAndLoadStreetLines() {
-    jpaTm().transact(() -> jpaTm().put(entity));
+    tm().transact(() -> tm().put(entity));
     assertAddress(loadByEntity(entity).address, "123 W 14th St", "8th Fl", "Rm 8");
   }
 

--- a/core/src/test/java/google/registry/model/history/ContactHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/ContactHistoryTest.java
@@ -16,7 +16,7 @@ package google.registry.model.history;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.loadByEntity;
 import static google.registry.testing.DatabaseHelper.newContactWithRoid;
@@ -49,10 +49,9 @@ public class ContactHistoryTest extends EntityTestCase {
     Contact contactFromDb = loadByEntity(contact);
     ContactHistory contactHistory = createContactHistory(contactFromDb);
     insertInDb(contactHistory);
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
-              ContactHistory fromDatabase = jpaTm().loadByKey(contactHistory.createVKey());
+              ContactHistory fromDatabase = tm().loadByKey(contactHistory.createVKey());
               assertContactHistoriesEqual(fromDatabase, contactHistory);
               assertThat(fromDatabase.getRepoId()).isEqualTo(contactHistory.getRepoId());
             });
@@ -65,8 +64,7 @@ public class ContactHistoryTest extends EntityTestCase {
     Contact contactFromDb = loadByEntity(contact);
     ContactHistory contactHistory = createContactHistory(contactFromDb);
     insertInDb(contactHistory);
-    ContactHistory fromDatabase =
-        jpaTm().transact(() -> jpaTm().loadByKey(contactHistory.createVKey()));
+    ContactHistory fromDatabase = tm().transact(() -> tm().loadByKey(contactHistory.createVKey()));
     assertThat(SerializeUtils.serializeDeserialize(fromDatabase)).isEqualTo(fromDatabase);
   }
 

--- a/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
@@ -16,7 +16,7 @@ package google.registry.model.history;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.newContactWithRoid;
@@ -64,10 +64,9 @@ public class DomainHistoryTest extends EntityTestCase {
     DomainHistory domainHistory = createDomainHistory(domain);
     insertInDb(domainHistory);
 
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
-              DomainHistory fromDatabase = jpaTm().loadByKey(domainHistory.createVKey());
+              DomainHistory fromDatabase = tm().loadByKey(domainHistory.createVKey());
               assertDomainHistoriesEqual(fromDatabase, domainHistory);
               assertThat(fromDatabase.getRepoId()).isEqualTo(domainHistory.getRepoId());
             });
@@ -78,8 +77,7 @@ public class DomainHistoryTest extends EntityTestCase {
     Domain domain = addGracePeriodForSql(createDomainWithContactsAndHosts());
     DomainHistory domainHistory = createDomainHistory(domain);
     insertInDb(domainHistory);
-    DomainHistory fromDatabase =
-        jpaTm().transact(() -> jpaTm().loadByKey(domainHistory.createVKey()));
+    DomainHistory fromDatabase = tm().transact(() -> tm().loadByKey(domainHistory.createVKey()));
     assertThat(SerializeUtils.serializeDeserialize(fromDatabase)).isEqualTo(fromDatabase);
   }
 
@@ -88,11 +86,10 @@ public class DomainHistoryTest extends EntityTestCase {
     Host host = newHostWithRoid("ns1.example.com", "host1");
     Contact contact = newContactWithRoid("contactId", "contact1");
 
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
-              jpaTm().insert(host);
-              jpaTm().insert(contact);
+              tm().insert(host);
+              tm().insert(contact);
             });
 
     Domain domain =

--- a/core/src/test/java/google/registry/model/history/HostHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/HostHistoryTest.java
@@ -16,7 +16,7 @@ package google.registry.model.history;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.loadByEntity;
 import static google.registry.testing.DatabaseHelper.newHostWithRoid;
@@ -45,10 +45,9 @@ public class HostHistoryTest extends EntityTestCase {
     Host hostFromDb = loadByEntity(host);
     HostHistory hostHistory = createHostHistory(hostFromDb);
     insertInDb(hostHistory);
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
-              HostHistory fromDatabase = jpaTm().loadByKey(hostHistory.createVKey());
+              HostHistory fromDatabase = tm().loadByKey(hostHistory.createVKey());
               assertHostHistoriesEqual(fromDatabase, hostHistory);
               assertThat(fromDatabase.getRepoId()).isEqualTo(hostHistory.getRepoId());
             });
@@ -61,7 +60,7 @@ public class HostHistoryTest extends EntityTestCase {
     Host hostFromDb = loadByEntity(host);
     HostHistory hostHistory = createHostHistory(hostFromDb);
     insertInDb(hostHistory);
-    HostHistory fromDatabase = jpaTm().transact(() -> jpaTm().loadByKey(hostHistory.createVKey()));
+    HostHistory fromDatabase = tm().transact(() -> tm().loadByKey(hostHistory.createVKey()));
     assertThat(SerializeUtils.serializeDeserialize(fromDatabase)).isEqualTo(fromDatabase);
   }
 

--- a/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchDaoTest.java
+++ b/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchDaoTest.java
@@ -16,7 +16,7 @@ package google.registry.model.reporting;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.immutableObjectCorrespondence;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.createTlds;
 import static google.registry.testing.DatabaseHelper.persistActiveContact;
 import static google.registry.testing.DatabaseHelper.persistResource;
@@ -51,32 +51,29 @@ class Spec11ThreatMatchDaoTest extends EntityTestCase {
     todayOrgDomain = persistResource(DatabaseHelper.newDomain("today.org", contact));
     yesterdayComDomain = persistResource(DatabaseHelper.newDomain("yesterday.com", contact));
     yesterdayOrgDomain = persistResource(DatabaseHelper.newDomain("yesterday.org", contact));
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
-              jpaTm().insertAll(getThreatMatchesToday());
-              jpaTm().insertAll(getThreatMatchesYesterday());
+              tm().insertAll(getThreatMatchesToday());
+              tm().insertAll(getThreatMatchesYesterday());
             });
   }
 
   @Test
   void testDeleteEntriesByDate() {
     // Verify that all entries with the date TODAY were removed
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
-              Spec11ThreatMatchDao.deleteEntriesByDate(jpaTm(), TODAY);
+              Spec11ThreatMatchDao.deleteEntriesByDate(tm(), TODAY);
               ImmutableList<Spec11ThreatMatch> persistedToday =
-                  Spec11ThreatMatchDao.loadEntriesByDate(jpaTm(), TODAY);
+                  Spec11ThreatMatchDao.loadEntriesByDate(tm(), TODAY);
               assertThat(persistedToday).isEmpty();
             });
 
     // Verify that all other entries were not removed
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
               ImmutableList<Spec11ThreatMatch> persistedYesterday =
-                  Spec11ThreatMatchDao.loadEntriesByDate(jpaTm(), YESTERDAY);
+                  Spec11ThreatMatchDao.loadEntriesByDate(tm(), YESTERDAY);
               assertThat(persistedYesterday)
                   .comparingElementsUsing(immutableObjectCorrespondence("id"))
                   .containsExactlyElementsIn(getThreatMatchesYesterday());
@@ -85,11 +82,10 @@ class Spec11ThreatMatchDaoTest extends EntityTestCase {
 
   @Test
   void testLoadEntriesByDate() {
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
               ImmutableList<Spec11ThreatMatch> persisted =
-                  Spec11ThreatMatchDao.loadEntriesByDate(jpaTm(), TODAY);
+                  Spec11ThreatMatchDao.loadEntriesByDate(tm(), TODAY);
 
               assertThat(persisted)
                   .comparingElementsUsing(immutableObjectCorrespondence("id"))

--- a/core/src/test/java/google/registry/model/tld/RegistryLockDaoTest.java
+++ b/core/src/test/java/google/registry/model/tld/RegistryLockDaoTest.java
@@ -17,7 +17,7 @@ package google.registry.model.tld;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.SqlHelper.getMostRecentRegistryLockByRepoId;
 import static google.registry.testing.SqlHelper.getMostRecentUnlockedRegistryLockByRepoId;
 import static google.registry.testing.SqlHelper.getMostRecentVerifiedRegistryLockByRepoId;
@@ -55,16 +55,14 @@ public final class RegistryLockDaoTest extends EntityTestCase {
     RegistryLock lock = createLock();
     saveRegistryLock(lock);
     fakeClock.advanceOneMilli();
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
               RegistryLock updatedLock =
                   RegistryLockDao.getByVerificationCode(lock.getVerificationCode()).get();
               RegistryLockDao.save(
                   updatedLock.asBuilder().setLockCompletionTime(fakeClock.nowUtc()).build());
             });
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
               RegistryLock fromDatabase =
                   RegistryLockDao.getByVerificationCode(lock.getVerificationCode()).get();
@@ -97,8 +95,7 @@ public final class RegistryLockDaoTest extends EntityTestCase {
     fakeClock.advanceOneMilli();
     RegistryLock updatedLock = lock.asBuilder().setLockCompletionTime(fakeClock.nowUtc()).build();
     saveRegistryLock(updatedLock);
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
               RegistryLock fromDatabase =
                   RegistryLockDao.getByVerificationCode(lock.getVerificationCode()).get();

--- a/core/src/test/java/google/registry/model/tld/label/PremiumListDaoTest.java
+++ b/core/src/test/java/google/registry/model/tld/label/PremiumListDaoTest.java
@@ -17,7 +17,7 @@ package google.registry.model.tld.label;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.newRegistry;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.joda.money.CurrencyUnit.JPY;
@@ -88,8 +88,7 @@ public class PremiumListDaoTest {
   @Test
   void saveNew_worksSuccessfully() {
     PremiumListDao.save(testList);
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
               Optional<PremiumList> persistedListOpt = PremiumListDao.getLatestRevision("testname");
               assertThat(persistedListOpt).isPresent();
@@ -119,8 +118,7 @@ public class PremiumListDaoTest {
                     BigDecimal.valueOf(30.03)))
             .setCreationTimestamp(fakeClock.nowUtc())
             .build());
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
               Optional<PremiumList> savedListOpt = PremiumListDao.getLatestRevision("testname");
               assertThat(savedListOpt).isPresent();
@@ -167,8 +165,7 @@ public class PremiumListDaoTest {
             .setLabelsToPrices(TEST_PRICES)
             .setCreationTimestamp(fakeClock.nowUtc())
             .build());
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
               Optional<PremiumList> persistedList = PremiumListDao.getLatestRevision("list1");
               assertThat(persistedList).isPresent();
@@ -188,8 +185,7 @@ public class PremiumListDaoTest {
             .setLabelsToPrices(TEST_PRICES)
             .setCreationTimestamp(fakeClock.nowUtc())
             .build());
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
               PremiumList premiumList = PremiumListDao.getLatestRevision("list1").get();
               assertThat(premiumList.getLabelsToPrices())

--- a/core/src/test/java/google/registry/model/tld/label/ReservedListDaoTest.java
+++ b/core/src/test/java/google/registry/model/tld/label/ReservedListDaoTest.java
@@ -15,7 +15,7 @@
 package google.registry.model.tld.label;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.tld.label.ReservedList.ReservedListEntry;
@@ -60,12 +60,10 @@ public class ReservedListDaoTest {
   @Test
   void save_worksSuccessfully() {
     ReservedListDao.save(testReservedList);
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
               ReservedList persistedList =
-                  jpaTm()
-                      .query("FROM ReservedList WHERE name = :name", ReservedList.class)
+                  tm().query("FROM ReservedList WHERE name = :name", ReservedList.class)
                       .setParameter("name", "testlist")
                       .getSingleResult();
               assertThat(persistedList.getReservedListEntries())

--- a/core/src/test/java/google/registry/model/tmch/ClaimsListDaoTest.java
+++ b/core/src/test/java/google/registry/model/tmch/ClaimsListDaoTest.java
@@ -15,7 +15,7 @@
 package google.registry.model.tmch;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
@@ -110,7 +110,7 @@ public class ClaimsListDaoTest {
     ClaimsList claimsList =
         ClaimsList.create(fakeClock.nowUtc(), ImmutableMap.of("label1", "key1", "label2", "key2"));
     // Bypass the DAO to avoid the cache
-    jpaTm().transact(() -> jpaTm().insert(claimsList));
+    tm().transact(() -> tm().insert(claimsList));
     ClaimsList fromDatabase = ClaimsListDao.get();
     // At first, we haven't loaded any entries
     assertThat(fromDatabase.claimKeyCache.getIfPresent("label1")).isNull();

--- a/core/src/test/java/google/registry/persistence/converter/AllocationTokenListConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/AllocationTokenListConverterTest.java
@@ -17,7 +17,7 @@ package google.registry.persistence.converter;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.domain.token.AllocationToken.TokenType.SINGLE_USE;
 import static google.registry.model.domain.token.AllocationToken.TokenType.UNLIMITED_USE;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import com.google.common.collect.ImmutableList;
@@ -52,9 +52,7 @@ public class AllocationTokenListConverterTest {
         new TestAllocationTokenVKeyList(tokens);
     insertInDb(testAllocationTokenVKeyList);
     TestAllocationTokenVKeyList persisted =
-        jpaTm()
-            .transact(
-                () -> jpaTm().getEntityManager().find(TestAllocationTokenVKeyList.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestAllocationTokenVKeyList.class, "id"));
     assertThat(persisted.tokenList).isEqualTo(tokens);
   }
 

--- a/core/src/test/java/google/registry/persistence/converter/AllocationTokenStatusTransitionConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/AllocationTokenStatusTransitionConverterTest.java
@@ -18,7 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.ENDED;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.NOT_STARTED;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.VALID;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
@@ -60,11 +60,9 @@ public class AllocationTokenStatusTransitionConverterTest {
         new AllocationTokenStatusTransitionConverterTestEntity(timedTransitionProperty);
     insertInDb(testEntity);
     AllocationTokenStatusTransitionConverterTestEntity persisted =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () ->
-                    jpaTm()
-                        .getEntityManager()
+                    tm().getEntityManager()
                         .find(AllocationTokenStatusTransitionConverterTestEntity.class, "id"));
     assertThat(persisted.timedTransitionProperty).containsExactlyEntriesIn(timedTransitionProperty);
   }

--- a/core/src/test/java/google/registry/persistence/converter/BillingCostTransitionConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/BillingCostTransitionConverterTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.joda.money.CurrencyUnit.USD;
@@ -53,7 +53,7 @@ public class BillingCostTransitionConverterTest {
     TestEntity testEntity = new TestEntity(timedTransitionProperty);
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.timedTransitionProperty).containsExactlyEntriesIn(timedTransitionProperty);
   }
 

--- a/core/src/test/java/google/registry/persistence/converter/BloomFilterConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/BloomFilterConverterTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.converter;
 import static com.google.common.base.Charsets.US_ASCII;
 import static com.google.common.hash.Funnels.stringFunnel;
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import com.google.common.collect.ImmutableSet;
@@ -43,7 +43,7 @@ class BloomFilterConverterTest {
     TestEntity entity = new TestEntity(bloomFilter);
     insertInDb(entity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.bloomFilter).isEqualTo(bloomFilter);
   }
 

--- a/core/src/test/java/google/registry/persistence/converter/CidrAddressBlockListConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/CidrAddressBlockListConverterTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import com.google.common.collect.ImmutableList;
@@ -48,7 +48,7 @@ public class CidrAddressBlockListConverterTest {
     TestEntity testEntity = new TestEntity(addresses);
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.addresses).isEqualTo(addresses);
   }
 

--- a/core/src/test/java/google/registry/persistence/converter/CurrencyToBillingConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/CurrencyToBillingConverterTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import com.google.common.collect.ImmutableMap;
@@ -45,7 +45,7 @@ public class CurrencyToBillingConverterTest {
     TestEntity testEntity = new TestEntity(currencyToBilling);
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.currencyToBilling).containsExactlyEntriesIn(currencyToBilling);
   }
 

--- a/core/src/test/java/google/registry/persistence/converter/CurrencyUnitConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/CurrencyUnitConverterTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -41,27 +41,23 @@ public class CurrencyUnitConverterTest {
     TestEntity entity = new TestEntity(CurrencyUnit.EUR);
     insertInDb(entity);
     assertThat(
-            jpaTm()
-                .transact(
+            tm().transact(
                     () ->
-                        jpaTm()
-                            .getEntityManager()
+                        tm().getEntityManager()
                             .createNativeQuery(
                                 "SELECT currency FROM \"TestEntity\" WHERE name = 'id'")
                             .getResultList()))
         .containsExactly("EUR");
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.currency).isEqualTo(CurrencyUnit.EUR);
   }
 
   @Test
   void invalidCurrency() {
-    jpaTm()
-        .transact(
+    tm().transact(
             () ->
-                jpaTm()
-                    .getEntityManager()
+                tm().getEntityManager()
                     .createNativeQuery(
                         "INSERT INTO \"TestEntity\" (name, currency) VALUES('id', 'XXXX')")
                     .executeUpdate());
@@ -69,9 +65,7 @@ public class CurrencyUnitConverterTest {
         assertThrows(
             PersistenceException.class,
             () ->
-                jpaTm()
-                    .transact(
-                        () -> jpaTm().getEntityManager().find(TestEntity.class, "id").currency));
+                tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id").currency));
     assertThat(thrown).hasCauseThat().hasMessageThat().isEqualTo("Unknown currency 'XXXX'");
   }
 

--- a/core/src/test/java/google/registry/persistence/converter/DatabaseMigrationScheduleTransitionConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/DatabaseMigrationScheduleTransitionConverterTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
@@ -63,11 +63,9 @@ public class DatabaseMigrationScheduleTransitionConverterTest {
         new DatabaseMigrationScheduleTransitionConverterTestEntity(timedTransitionProperty);
     insertInDb(testEntity);
     DatabaseMigrationScheduleTransitionConverterTestEntity persisted =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () ->
-                    jpaTm()
-                        .getEntityManager()
+                    tm().getEntityManager()
                         .find(DatabaseMigrationScheduleTransitionConverterTestEntity.class, "id"));
     assertThat(persisted.timedTransitionProperty).containsExactlyEntriesIn(timedTransitionProperty);
   }

--- a/core/src/test/java/google/registry/persistence/converter/DateTimeConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/DateTimeConverterTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import google.registry.model.ImmutableObject;
@@ -72,9 +72,7 @@ public class DateTimeConverterTest {
     TestEntity entity = new TestEntity("normalized_utc_time", dt);
     insertInDb(entity);
     TestEntity retrievedEntity =
-        jpaTm()
-            .transact(
-                () -> jpaTm().getEntityManager().find(TestEntity.class, "normalized_utc_time"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "normalized_utc_time"));
     assertThat(retrievedEntity.dt.toString()).isEqualTo("2019-09-01T01:01:01.000Z");
   }
 
@@ -85,7 +83,7 @@ public class DateTimeConverterTest {
 
     insertInDb(entity);
     TestEntity retrievedEntity =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "new_york_time"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "new_york_time"));
     assertThat(retrievedEntity.dt.toString()).isEqualTo("2019-09-01T06:01:01.000Z");
   }
 

--- a/core/src/test/java/google/registry/persistence/converter/DurationConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/DurationConverterTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import google.registry.model.ImmutableObject;
@@ -82,7 +82,7 @@ public class DurationConverterTest {
     DurationTestEntity entity = new DurationTestEntity(duration);
     insertInDb(entity);
     DurationTestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(DurationTestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(DurationTestEntity.class, "id"));
     assertThat(persisted.duration.getMillis()).isEqualTo(duration.getMillis());
   }
 

--- a/core/src/test/java/google/registry/persistence/converter/InetAddressSetConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/InetAddressSetConverterTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import com.google.common.collect.ImmutableSet;
@@ -65,8 +65,7 @@ public class InetAddressSetConverterTest {
     InetAddressSetTestEntity testEntity = new InetAddressSetTestEntity(inetAddresses);
     insertInDb(testEntity);
     InetAddressSetTestEntity persisted =
-        jpaTm()
-            .transact(() -> jpaTm().loadByKey(VKey.create(InetAddressSetTestEntity.class, "id")));
+        tm().transact(() -> tm().loadByKey(VKey.create(InetAddressSetTestEntity.class, "id")));
     assertThat(persisted.addresses).isEqualTo(inetAddresses);
   }
 

--- a/core/src/test/java/google/registry/persistence/converter/JodaMoneyConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/JodaMoneyConverterTest.java
@@ -14,7 +14,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -60,11 +60,9 @@ public class JodaMoneyConverterTest {
     TestEntity entity = new TestEntity(money);
     insertInDb(entity);
     List<?> result =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () ->
-                    jpaTm()
-                        .getEntityManager()
+                    tm().getEntityManager()
                         .createNativeQuery(
                             "SELECT amount, currency FROM \"TestEntity\" WHERE name = 'id'")
                         .getResultList());
@@ -75,7 +73,7 @@ public class JodaMoneyConverterTest {
         .containsExactly(BigDecimal.valueOf(100.12).setScale(2), "USD")
         .inOrder();
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.money).isEqualTo(money);
   }
 
@@ -86,11 +84,9 @@ public class JodaMoneyConverterTest {
     TestEntity entity = new TestEntity(money);
     insertInDb(entity);
     List<?> result =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () ->
-                    jpaTm()
-                        .getEntityManager()
+                    tm().getEntityManager()
                         .createNativeQuery(
                             "SELECT amount, currency FROM \"TestEntity\" WHERE name = 'id'")
                         .getResultList());
@@ -102,11 +98,9 @@ public class JodaMoneyConverterTest {
         .inOrder();
 
     result =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () ->
-                    jpaTm()
-                        .getEntityManager()
+                    tm().getEntityManager()
                         .createQuery("SELECT money FROM TestEntity WHERE name" + " = 'id'")
                         .getResultList());
 
@@ -114,7 +108,7 @@ public class JodaMoneyConverterTest {
     assertThat(result.get(0)).isEqualTo(money);
 
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.money).isEqualTo(money);
   }
 
@@ -130,11 +124,9 @@ public class JodaMoneyConverterTest {
     ComplexTestEntity entity = new ComplexTestEntity(moneyMap, myMoney, yourMoney);
     insertInDb(entity);
     List<?> result =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () ->
-                    jpaTm()
-                        .getEntityManager()
+                    tm().getEntityManager()
                         .createNativeQuery(
                             "SELECT my_amount, my_currency, your_amount, your_currency FROM"
                                 + " \"ComplexTestEntity\" WHERE name = 'id'")
@@ -145,17 +137,15 @@ public class JodaMoneyConverterTest {
             BigDecimal.valueOf(100).setScale(2), "USD", BigDecimal.valueOf(80).setScale(2), "GBP")
         .inOrder();
     result =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () ->
-                    jpaTm()
-                        .getEntityManager()
+                    tm().getEntityManager()
                         .createNativeQuery(
                             "SELECT map_amount, map_currency FROM \"MoneyMap\""
                                 + " WHERE entity_name = 'id' AND map_key = 'dos'")
                         .getResultList());
     ComplexTestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(ComplexTestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(ComplexTestEntity.class, "id"));
     assertThat(result).hasSize(1);
 
     assertThat(Arrays.asList((Object[]) result.get(0)))
@@ -173,32 +163,26 @@ public class JodaMoneyConverterTest {
    */
   @Test
   void testNullSafeGet_nullAmountNullCurrency_returnsNull() throws SQLException {
-    jpaTm()
-        .transact(
+    tm().transact(
             () ->
-                jpaTm()
-                    .getEntityManager()
+                tm().getEntityManager()
                     .createNativeQuery(
                         "INSERT INTO \"TestEntity\" (name, amount, currency) VALUES('id', null,"
                             + " null)")
                     .executeUpdate());
     List<?> result =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () ->
-                    jpaTm()
-                        .getEntityManager()
+                    tm().getEntityManager()
                         .createNativeQuery(
                             "SELECT amount, currency FROM \"TestEntity\" WHERE name = 'id'")
                         .getResultList());
     assertThat(result).hasSize(1);
     assertThat(Arrays.asList((Object[]) result.get(0))).containsExactly(null, null).inOrder();
     assertThat(
-            jpaTm()
-                .transact(
+            tm().transact(
                     () ->
-                        jpaTm()
-                            .getEntityManager()
+                        tm().getEntityManager()
                             .createQuery("SELECT money FROM TestEntity WHERE name = 'id'")
                             .getResultList())
                 .get(0))
@@ -207,21 +191,17 @@ public class JodaMoneyConverterTest {
 
   @Test
   void testNullSafeGet_nullAMountValidCurrency_throwsHibernateException() throws SQLException {
-    jpaTm()
-        .transact(
+    tm().transact(
             () ->
-                jpaTm()
-                    .getEntityManager()
+                tm().getEntityManager()
                     .createNativeQuery(
                         "INSERT INTO \"TestEntity\" (name, amount, currency) VALUES('id', null,"
                             + " 'USD')")
                     .executeUpdate());
     List<?> result =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () ->
-                    jpaTm()
-                        .getEntityManager()
+                    tm().getEntityManager()
                         .createNativeQuery(
                             "SELECT amount, currency FROM \"TestEntity\" WHERE name = 'id'")
                         .getResultList());
@@ -232,11 +212,9 @@ public class JodaMoneyConverterTest {
         assertThrows(
             PersistenceException.class,
             () ->
-                jpaTm()
-                    .transact(
+                tm().transact(
                         () ->
-                            jpaTm()
-                                .getEntityManager()
+                            tm().getEntityManager()
                                 .createQuery("SELECT money FROM TestEntity WHERE name = 'id'")
                                 .getResultList()));
     assertThat(thrown)
@@ -249,21 +227,17 @@ public class JodaMoneyConverterTest {
   @Test
   void testNullSafeGet_nullAMountInValidCurrency_throwsIllegalCurrencyException()
       throws SQLException {
-    jpaTm()
-        .transact(
+    tm().transact(
             () ->
-                jpaTm()
-                    .getEntityManager()
+                tm().getEntityManager()
                     .createNativeQuery(
                         "INSERT INTO \"TestEntity\" (name, amount, currency) VALUES('id', 100,"
                             + " 'INVALIDCURRENCY')")
                     .executeUpdate());
     List<?> result =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () ->
-                    jpaTm()
-                        .getEntityManager()
+                    tm().getEntityManager()
                         .createNativeQuery(
                             "SELECT amount, currency FROM \"TestEntity\" WHERE name = 'id'")
                         .getResultList());
@@ -275,11 +249,9 @@ public class JodaMoneyConverterTest {
         assertThrows(
             IllegalCurrencyException.class,
             () ->
-                jpaTm()
-                    .transact(
+                tm().transact(
                         () ->
-                            jpaTm()
-                                .getEntityManager()
+                            tm().getEntityManager()
                                 .createQuery("SELECT money FROM TestEntity WHERE name = 'id'")
                                 .getResultList()));
     assertThat(thrown).hasMessageThat().isEqualTo("Unknown currency 'INVALIDCURRENCY'");

--- a/core/src/test/java/google/registry/persistence/converter/LocalDateConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/LocalDateConverterTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import google.registry.model.ImmutableObject;
@@ -55,8 +55,8 @@ public class LocalDateConverterTest {
   private LocalDateConverterTestEntity persistAndLoadTestEntity(LocalDate date) {
     LocalDateConverterTestEntity entity = new LocalDateConverterTestEntity(date);
     insertInDb(entity);
-    return jpaTm()
-        .transact(() -> jpaTm().loadByKey(VKey.create(LocalDateConverterTestEntity.class, "id")));
+    return tm().transact(
+            () -> tm().loadByKey(VKey.create(LocalDateConverterTestEntity.class, "id")));
   }
 
   /** Override entity name to avoid the nested class reference. */

--- a/core/src/test/java/google/registry/persistence/converter/StatusValueSetConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StatusValueSetConverterTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import com.google.common.collect.ImmutableSet;
@@ -43,7 +43,7 @@ public class StatusValueSetConverterTest {
 
     insertInDb(obj);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "foo"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "foo"));
     assertThat(persisted.data).isEqualTo(enums);
   }
 

--- a/core/src/test/java/google/registry/persistence/converter/StringListConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringListConverterTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -43,7 +43,7 @@ public class StringListConverterTest {
     TestEntity testEntity = new TestEntity(tlds);
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).containsExactly("app", "dev", "how");
   }
 
@@ -53,11 +53,10 @@ public class StringListConverterTest {
     TestEntity testEntity = new TestEntity(tlds);
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     persisted.tlds = ImmutableList.of("com", "gov");
-    jpaTm().transact(() -> jpaTm().getEntityManager().merge(persisted));
-    TestEntity updated =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+    tm().transact(() -> tm().getEntityManager().merge(persisted));
+    TestEntity updated = tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(updated.tlds).containsExactly("com", "gov");
   }
 
@@ -66,7 +65,7 @@ public class StringListConverterTest {
     TestEntity testEntity = new TestEntity(null);
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).isNull();
   }
 
@@ -75,7 +74,7 @@ public class StringListConverterTest {
     TestEntity testEntity = new TestEntity(ImmutableList.of());
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).isEmpty();
   }
 
@@ -107,13 +106,11 @@ public class StringListConverterTest {
   }
 
   private static Object getSingleResultFromNativeQuery(String sql) {
-    return jpaTm()
-        .transact(() -> jpaTm().getEntityManager().createNativeQuery(sql).getSingleResult());
+    return tm().transact(() -> tm().getEntityManager().createNativeQuery(sql).getSingleResult());
   }
 
   private static Object executeNativeQuery(String sql) {
-    return jpaTm()
-        .transact(() -> jpaTm().getEntityManager().createNativeQuery(sql).executeUpdate());
+    return tm().transact(() -> tm().getEntityManager().createNativeQuery(sql).executeUpdate());
   }
 
   @Entity(name = "TestEntity") // Override entity name to avoid the nested class reference.

--- a/core/src/test/java/google/registry/persistence/converter/StringMapConverterBaseTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringMapConverterBaseTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -51,7 +51,7 @@ public class StringMapConverterBaseTest {
     TestEntity testEntity = new TestEntity(MAP);
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.map).containsExactlyEntriesIn(MAP);
   }
 
@@ -60,12 +60,11 @@ public class StringMapConverterBaseTest {
     TestEntity testEntity = new TestEntity(MAP);
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.map).containsExactlyEntriesIn(MAP);
     persisted.map = ImmutableMap.of(new Key("key4"), new Value("value4"));
-    jpaTm().transact(() -> jpaTm().getEntityManager().merge(persisted));
-    TestEntity updated =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+    tm().transact(() -> tm().getEntityManager().merge(persisted));
+    TestEntity updated = tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(updated.map).containsExactly(new Key("key4"), new Value("value4"));
   }
 
@@ -74,7 +73,7 @@ public class StringMapConverterBaseTest {
     TestEntity testEntity = new TestEntity(null);
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.map).isNull();
   }
 
@@ -83,7 +82,7 @@ public class StringMapConverterBaseTest {
     TestEntity testEntity = new TestEntity(ImmutableMap.of());
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.map).isEmpty();
   }
 
@@ -117,13 +116,11 @@ public class StringMapConverterBaseTest {
   }
 
   private static Object getSingleResultFromNativeQuery(String sql) {
-    return jpaTm()
-        .transact(() -> jpaTm().getEntityManager().createNativeQuery(sql).getSingleResult());
+    return tm().transact(() -> tm().getEntityManager().createNativeQuery(sql).getSingleResult());
   }
 
   private static Object executeNativeQuery(String sql) {
-    return jpaTm()
-        .transact(() -> jpaTm().getEntityManager().createNativeQuery(sql).executeUpdate());
+    return tm().transact(() -> tm().getEntityManager().createNativeQuery(sql).executeUpdate());
   }
 
   private static class Key extends ImmutableObject {

--- a/core/src/test/java/google/registry/persistence/converter/StringSetConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringSetConverterTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import com.google.common.collect.ImmutableSet;
@@ -41,7 +41,7 @@ public class StringSetConverterTest {
     TestEntity testEntity = new TestEntity(tlds);
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).containsExactly("app", "dev", "how");
   }
 
@@ -50,7 +50,7 @@ public class StringSetConverterTest {
     TestEntity testEntity = new TestEntity(null);
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).isNull();
   }
 
@@ -59,7 +59,7 @@ public class StringSetConverterTest {
     TestEntity testEntity = new TestEntity(ImmutableSet.of());
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).isEmpty();
   }
 

--- a/core/src/test/java/google/registry/persistence/converter/StringValueEnumeratedTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringValueEnumeratedTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import google.registry.model.ImmutableObject;
@@ -41,7 +41,7 @@ public class StringValueEnumeratedTest {
     TestEntity testEntity = new TestEntity(State.ACTIVE);
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.state).isEqualTo(State.ACTIVE);
   }
 
@@ -51,11 +51,9 @@ public class StringValueEnumeratedTest {
     insertInDb(testEntity);
 
     assertThat(
-            jpaTm()
-                .transact(
+            tm().transact(
                     () ->
-                        jpaTm()
-                            .getEntityManager()
+                        tm().getEntityManager()
                             .createNativeQuery("SELECT state FROM \"TestEntity\" WHERE name = 'id'")
                             .getSingleResult()))
         .isEqualTo("DISABLED");

--- a/core/src/test/java/google/registry/persistence/converter/TimedTransitionPropertyConverterBaseTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/TimedTransitionPropertyConverterBaseTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -59,7 +59,7 @@ class TimedTransitionPropertyConverterBaseTest {
     TestEntity testEntity = new TestEntity(TIMED_TRANSITION_PROPERTY);
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.property).containsExactlyEntriesIn(TIMED_TRANSITION_PROPERTY);
   }
 
@@ -68,13 +68,12 @@ class TimedTransitionPropertyConverterBaseTest {
     TestEntity testEntity = new TestEntity(TIMED_TRANSITION_PROPERTY);
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.property).containsExactlyEntriesIn(TIMED_TRANSITION_PROPERTY);
     ImmutableSortedMap<DateTime, String> newValues = ImmutableSortedMap.of(START_OF_TIME, "val4");
     persisted.property = TimedTransitionProperty.fromValueMap(newValues);
-    jpaTm().transact(() -> jpaTm().getEntityManager().merge(persisted));
-    TestEntity updated =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+    tm().transact(() -> tm().getEntityManager().merge(persisted));
+    TestEntity updated = tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(updated.property).isEqualTo(newValues);
   }
 
@@ -83,7 +82,7 @@ class TimedTransitionPropertyConverterBaseTest {
     TestEntity testEntity = new TestEntity(null);
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.property).isNull();
   }
 
@@ -120,12 +119,11 @@ class TimedTransitionPropertyConverterBaseTest {
   }
 
   private static Object getSingleResultFromNativeQuery(String sql) {
-    return jpaTm()
-        .transact(() -> jpaTm().getEntityManager().createNativeQuery(sql).getSingleResult());
+    return tm().transact(() -> tm().getEntityManager().createNativeQuery(sql).getSingleResult());
   }
 
   private static void executeNativeQuery(String sql) {
-    jpaTm().transact(() -> jpaTm().getEntityManager().createNativeQuery(sql).executeUpdate());
+    tm().transact(() -> tm().getEntityManager().createNativeQuery(sql).executeUpdate());
   }
 
   @Converter(autoApply = true)

--- a/core/src/test/java/google/registry/persistence/converter/TldStateTransitionConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/TldStateTransitionConverterTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
@@ -56,7 +56,7 @@ class TldStateTransitionConverterTest {
     TestEntity testEntity = new TestEntity(timedTransitionProperty);
     insertInDb(testEntity);
     TestEntity persisted =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "id"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.timedTransitionProperty).containsExactlyEntriesIn(timedTransitionProperty);
   }
 

--- a/core/src/test/java/google/registry/persistence/converter/VKeyConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/VKeyConverterTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import google.registry.model.ImmutableObject;
@@ -53,7 +53,7 @@ public class VKeyConverterTest {
     insertInDb(stringEntity, longEntity, original);
 
     TestEntity retrieved =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, 1984L));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, 1984L));
     assertThat(retrieved.stringKey).isEqualTo(stringKey);
     assertThat(retrieved.longKey).isEqualTo(longKey);
   }

--- a/core/src/test/java/google/registry/persistence/transaction/CriteriaQueryBuilderTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/CriteriaQueryBuilderTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.transaction;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 
 import com.google.common.collect.ImmutableList;
@@ -56,11 +56,9 @@ class CriteriaQueryBuilderTest {
   @Test
   void testSuccess_noWhereClause() {
     assertThat(
-            jpaTm()
-                .transact(
+            tm().transact(
                     () ->
-                        jpaTm()
-                            .criteriaQuery(
+                        tm().criteriaQuery(
                                 CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
                                     .build())
                             .getResultList()))
@@ -71,17 +69,14 @@ class CriteriaQueryBuilderTest {
   @Test
   void testSuccess_where_exactlyOne() {
     List<CriteriaQueryBuilderTestEntity> result =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () -> {
                   CriteriaQuery<CriteriaQueryBuilderTestEntity> query =
                       CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
                           .where(
-                              "data",
-                              jpaTm().getEntityManager().getCriteriaBuilder()::equal,
-                              "zztz")
+                              "data", tm().getEntityManager().getCriteriaBuilder()::equal, "zztz")
                           .build();
-                  return jpaTm().criteriaQuery(query).getResultList();
+                  return tm().criteriaQuery(query).getResultList();
                 });
     assertThat(result).containsExactly(entity2);
   }
@@ -89,15 +84,13 @@ class CriteriaQueryBuilderTest {
   @Test
   void testSuccess_where_like_oneResult() {
     List<CriteriaQueryBuilderTestEntity> result =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () -> {
                   CriteriaQuery<CriteriaQueryBuilderTestEntity> query =
                       CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
-                          .where(
-                              "data", jpaTm().getEntityManager().getCriteriaBuilder()::like, "a%")
+                          .where("data", tm().getEntityManager().getCriteriaBuilder()::like, "a%")
                           .build();
-                  return jpaTm().criteriaQuery(query).getResultList();
+                  return tm().criteriaQuery(query).getResultList();
                 });
     assertThat(result).containsExactly(entity3);
   }
@@ -105,15 +98,13 @@ class CriteriaQueryBuilderTest {
   @Test
   void testSuccess_where_like_twoResults() {
     List<CriteriaQueryBuilderTestEntity> result =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () -> {
                   CriteriaQuery<CriteriaQueryBuilderTestEntity> query =
                       CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
-                          .where(
-                              "data", jpaTm().getEntityManager().getCriteriaBuilder()::like, "%a%")
+                          .where("data", tm().getEntityManager().getCriteriaBuilder()::like, "%a%")
                           .build();
-                  return jpaTm().criteriaQuery(query).getResultList();
+                  return tm().criteriaQuery(query).getResultList();
                 });
     assertThat(result).containsExactly(entity1, entity3).inOrder();
   }
@@ -121,19 +112,16 @@ class CriteriaQueryBuilderTest {
   @Test
   void testSuccess_multipleWheres() {
     List<CriteriaQueryBuilderTestEntity> result =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () -> {
                   CriteriaQuery<CriteriaQueryBuilderTestEntity> query =
                       CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
                           // first "where" matches 1 and 3
-                          .where(
-                              "data", jpaTm().getEntityManager().getCriteriaBuilder()::like, "%a%")
+                          .where("data", tm().getEntityManager().getCriteriaBuilder()::like, "%a%")
                           // second "where" matches 1 and 2
-                          .where(
-                              "data", jpaTm().getEntityManager().getCriteriaBuilder()::like, "%t%")
+                          .where("data", tm().getEntityManager().getCriteriaBuilder()::like, "%t%")
                           .build();
-                  return jpaTm().criteriaQuery(query).getResultList();
+                  return tm().criteriaQuery(query).getResultList();
                 });
     assertThat(result).containsExactly(entity1);
   }
@@ -141,14 +129,13 @@ class CriteriaQueryBuilderTest {
   @Test
   void testSuccess_where_in_oneResult() {
     List<CriteriaQueryBuilderTestEntity> result =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () -> {
                   CriteriaQuery<CriteriaQueryBuilderTestEntity> query =
                       CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
                           .whereFieldIsIn("data", ImmutableList.of("aaa", "bbb"))
                           .build();
-                  return jpaTm().criteriaQuery(query).getResultList();
+                  return tm().criteriaQuery(query).getResultList();
                 });
     assertThat(result).containsExactly(entity3).inOrder();
   }
@@ -156,14 +143,13 @@ class CriteriaQueryBuilderTest {
   @Test
   void testSuccess_where_not_in_twoResults() {
     List<CriteriaQueryBuilderTestEntity> result =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () -> {
                   CriteriaQuery<CriteriaQueryBuilderTestEntity> query =
                       CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
                           .whereFieldIsNotIn("data", ImmutableList.of("aaa", "bbb"))
                           .build();
-                  return jpaTm().criteriaQuery(query).getResultList();
+                  return tm().criteriaQuery(query).getResultList();
                 });
     assertThat(result).containsExactly(entity1, entity2).inOrder();
   }
@@ -171,14 +157,13 @@ class CriteriaQueryBuilderTest {
   @Test
   void testSuccess_where_in_twoResults() {
     List<CriteriaQueryBuilderTestEntity> result =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () -> {
                   CriteriaQuery<CriteriaQueryBuilderTestEntity> query =
                       CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
                           .whereFieldIsIn("data", ImmutableList.of("aaa", "bbb", "data"))
                           .build();
-                  return jpaTm().criteriaQuery(query).getResultList();
+                  return tm().criteriaQuery(query).getResultList();
                 });
     assertThat(result).containsExactly(entity1, entity3).inOrder();
   }
@@ -186,16 +171,14 @@ class CriteriaQueryBuilderTest {
   @Test
   void testSuccess_orderByAsc() {
     List<CriteriaQueryBuilderTestEntity> result =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () -> {
                   CriteriaQuery<CriteriaQueryBuilderTestEntity> query =
                       CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
                           .orderByAsc("data")
-                          .where(
-                              "data", jpaTm().getEntityManager().getCriteriaBuilder()::like, "%a%")
+                          .where("data", tm().getEntityManager().getCriteriaBuilder()::like, "%a%")
                           .build();
-                  return jpaTm().criteriaQuery(query).getResultList();
+                  return tm().criteriaQuery(query).getResultList();
                 });
     assertThat(result).containsExactly(entity3, entity1).inOrder();
   }
@@ -203,14 +186,13 @@ class CriteriaQueryBuilderTest {
   @Test
   void testSuccess_orderByDesc() {
     List<CriteriaQueryBuilderTestEntity> result =
-        jpaTm()
-            .transact(
+        tm().transact(
                 () -> {
                   CriteriaQuery<CriteriaQueryBuilderTestEntity> query =
                       CriteriaQueryBuilder.create(CriteriaQueryBuilderTestEntity.class)
                           .orderByDesc("data")
                           .build();
-                  return jpaTm().criteriaQuery(query).getResultList();
+                  return tm().criteriaQuery(query).getResultList();
                 });
     assertThat(result).containsExactly(entity2, entity1, entity3).inOrder();
   }

--- a/core/src/test/java/google/registry/persistence/transaction/DummyJpaTransactionManagerTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/DummyJpaTransactionManagerTest.java
@@ -14,7 +14,7 @@
 
 package google.registry.persistence.transaction;
 
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.testing.AppEngineExtension;
@@ -28,7 +28,7 @@ class DummyJpaTransactionManagerTest {
 
   @Test
   void throwsExceptionWhenAnyMethodIsInvoked() {
-    assertThrows(UnsupportedOperationException.class, () -> jpaTm().transact(() -> null));
-    assertThrows(UnsupportedOperationException.class, () -> jpaTm().getTransactionTime());
+    assertThrows(UnsupportedOperationException.class, () -> tm().transact(() -> null));
+    assertThrows(UnsupportedOperationException.class, () -> tm().getTransactionTime());
   }
 }

--- a/core/src/test/java/google/registry/persistence/transaction/JpaEntityCoverageExtension.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaEntityCoverageExtension.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.transaction;
 
 import static com.google.common.base.Preconditions.checkState;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -99,11 +99,9 @@ public class JpaEntityCoverageExtension implements BeforeEachCallback, AfterEach
   private static boolean isPersisted(Class<?> entityType) {
     try {
       List<?> result =
-          jpaTm()
-              .transact(
+          tm().transact(
                   () ->
-                      jpaTm()
-                          .query(
+                      tm().query(
                               String.format("SELECT e FROM %s e", getJpaEntityName(entityType)),
                               entityType)
                           .setMaxResults(1)

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTestExtensionsSqlLoggingTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTestExtensionsSqlLoggingTest.java
@@ -15,7 +15,7 @@
 package google.registry.persistence.transaction;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import google.registry.persistence.transaction.JpaTestExtensions.JpaUnitTestExtension;
@@ -51,8 +51,7 @@ class JpaTestExtensionsSqlLoggingTest {
 
   @Test
   void sqlLog_displayed() throws UnsupportedEncodingException {
-    jpaTm()
-        .transact(() -> jpaTm().getEntityManager().createNativeQuery("select 1").getSingleResult());
+    tm().transact(() -> tm().getEntityManager().createNativeQuery("select 1").getSingleResult());
     assertThat(stdoutBuffer.toString(UTF_8.name())).contains("select 1");
   }
 }

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerExtension.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerExtension.java
@@ -213,7 +213,7 @@ abstract class JpaTransactionManagerExtension implements BeforeEachCallback, Aft
       recreateSchema();
     }
     JpaTransactionManagerImpl txnManager = new JpaTransactionManagerImpl(emf, clock);
-    cachedTm = TransactionManagerFactory.jpaTm();
+    cachedTm = TransactionManagerFactory.tm();
     TransactionManagerFactory.setJpaTm(Suppliers.ofInstance(txnManager));
     TransactionManagerFactory.setReplicaJpaTm(
         Suppliers.ofInstance(new ReplicaSimulatingJpaTransactionManager(txnManager)));

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerExtensionTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerExtensionTest.java
@@ -15,8 +15,8 @@
 package google.registry.persistence.transaction;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.replicaJpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -44,19 +44,15 @@ public class JpaTransactionManagerExtensionTest {
     assertThrows(
         PersistenceException.class,
         () ->
-            jpaTm()
-                .transact(
+            tm().transact(
                     () ->
-                        jpaTm()
-                            .getEntityManager()
+                        tm().getEntityManager()
                             .createNativeQuery("SELECT * FROM NoneExistentTable")
                             .getResultList()));
-    jpaTm()
-        .transact(
+    tm().transact(
             () -> {
               List<?> results =
-                  jpaTm()
-                      .getEntityManager()
+                  tm().getEntityManager()
                       .createNativeQuery("SELECT * FROM \"TestEntity\"")
                       .getResultList();
               assertThat(results).isEmpty();
@@ -81,7 +77,7 @@ public class JpaTransactionManagerExtensionTest {
     TestEntity original = new TestEntity("key", "value");
     insertInDb(original);
     TestEntity retrieved =
-        jpaTm().transact(() -> jpaTm().getEntityManager().find(TestEntity.class, "key"));
+        tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "key"));
     assertThat(retrieved).isEqualTo(original);
   }
 

--- a/core/src/test/java/google/registry/schema/registrar/RegistrarPocTest.java
+++ b/core/src/test/java/google/registry/schema/registrar/RegistrarPocTest.java
@@ -16,7 +16,7 @@ package google.registry.schema.registrar;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.registrar.RegistrarPoc.Type.WHOIS;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.loadByEntity;
 import static google.registry.testing.SqlHelper.saveRegistrar;
@@ -69,7 +69,7 @@ class RegistrarPocTest {
   @Test
   void testSerializable_succeeds() {
     insertInDb(testRegistrarPoc);
-    RegistrarPoc persisted = jpaTm().transact(() -> jpaTm().loadByEntity(testRegistrarPoc));
+    RegistrarPoc persisted = tm().transact(() -> tm().loadByEntity(testRegistrarPoc));
     assertThat(SerializeUtils.serializeDeserialize(persisted)).isEqualTo(persisted);
   }
 }

--- a/core/src/test/java/google/registry/testing/AppEngineExtension.java
+++ b/core/src/test/java/google/registry/testing/AppEngineExtension.java
@@ -17,7 +17,7 @@ package google.registry.testing;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.io.Files.asCharSink;
 import static com.google.common.truth.Truth.assertWithMessage;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.insertSimpleResources;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 import static google.registry.util.ResourceUtils.readResourceUtf8;
@@ -352,11 +352,9 @@ public final class AppEngineExtension implements BeforeEachCallback, AfterEachCa
       }
 
       // Reset SQL Sequence based id allocation so that ids are deterministic in tests.
-      jpaTm()
-          .transact(
+      tm().transact(
               () ->
-                  jpaTm()
-                      .getEntityManager()
+                  tm().getEntityManager()
                       .createNativeQuery(
                           "alter sequence if exists project_wide_unique_id_seq start 1 minvalue 1"
                               + " restart with 1")

--- a/core/src/test/java/google/registry/testing/AppEngineExtensionTest.java
+++ b/core/src/test/java/google/registry/testing/AppEngineExtensionTest.java
@@ -16,7 +16,7 @@ package google.registry.testing;
 
 import static com.google.common.io.Files.asCharSink;
 import static com.google.common.truth.Truth.assertWithMessage;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -66,7 +66,7 @@ class AppEngineExtensionTest {
 
   @BeforeEach
   void beforeEach() throws Exception {
-    originalJpa = jpaTm();
+    originalJpa = tm();
     appEngine.beforeEach(context.getContext());
   }
 
@@ -75,7 +75,7 @@ class AppEngineExtensionTest {
     // Note: cannot use isSameInstanceAs() because DummyTransactionManager would throw on any
     // access.
     assertWithMessage("Original state not restore. Is appEngine.afterEach not called by this test?")
-        .that(originalJpa == jpaTm())
+        .that(originalJpa == tm())
         .isTrue();
   }
 

--- a/core/src/test/java/google/registry/testing/SqlHelper.java
+++ b/core/src/test/java/google/registry/testing/SqlHelper.java
@@ -15,7 +15,7 @@
 package google.registry.testing;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.AppEngineExtension.makeRegistrar1;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -33,37 +33,37 @@ import org.junit.jupiter.api.function.Executable;
 public class SqlHelper {
 
   public static RegistryLock saveRegistryLock(RegistryLock lock) {
-    return jpaTm().transact(() -> RegistryLockDao.save(lock));
+    return tm().transact(() -> RegistryLockDao.save(lock));
   }
 
   public static Optional<RegistryLock> getRegistryLockByVerificationCode(String verificationCode) {
-    return jpaTm().transact(() -> RegistryLockDao.getByVerificationCode(verificationCode));
+    return tm().transact(() -> RegistryLockDao.getByVerificationCode(verificationCode));
   }
 
   public static Optional<RegistryLock> getMostRecentRegistryLockByRepoId(String repoId) {
-    return jpaTm().transact(() -> RegistryLockDao.getMostRecentByRepoId(repoId));
+    return tm().transact(() -> RegistryLockDao.getMostRecentByRepoId(repoId));
   }
 
   public static Optional<RegistryLock> getMostRecentVerifiedRegistryLockByRepoId(String repoId) {
-    return jpaTm().transact(() -> RegistryLockDao.getMostRecentVerifiedLockByRepoId(repoId));
+    return tm().transact(() -> RegistryLockDao.getMostRecentVerifiedLockByRepoId(repoId));
   }
 
   public static Optional<RegistryLock> getMostRecentUnlockedRegistryLockByRepoId(String repoId) {
-    return jpaTm().transact(() -> RegistryLockDao.getMostRecentVerifiedUnlockByRepoId(repoId));
+    return tm().transact(() -> RegistryLockDao.getMostRecentVerifiedUnlockByRepoId(repoId));
   }
 
   public static ImmutableList<RegistryLock> getRegistryLocksByRegistrarId(String registrarId) {
-    return jpaTm().transact(() -> RegistryLockDao.getLocksByRegistrarId(registrarId));
+    return tm().transact(() -> RegistryLockDao.getLocksByRegistrarId(registrarId));
   }
 
   public static Optional<RegistryLock> getRegistryLockByRevisionId(long revisionId) {
-    return jpaTm().transact(() -> RegistryLockDao.getByRevisionId(revisionId));
+    return tm().transact(() -> RegistryLockDao.getByRevisionId(revisionId));
   }
 
   public static Registrar saveRegistrar(String registrarId) {
     Registrar registrar = makeRegistrar1().asBuilder().setRegistrarId(registrarId).build();
-    jpaTm().transact(() -> jpaTm().insert(registrar));
-    return jpaTm().transact(() -> jpaTm().loadByKey(registrar.createVKey()));
+    tm().transact(() -> tm().insert(registrar));
+    return tm().transact(() -> tm().loadByKey(registrar.createVKey()));
   }
 
   public static void assertThrowForeignKeyViolation(Executable executable) {

--- a/core/src/test/java/google/registry/tools/CreateOrUpdateReservedListCommandTestCase.java
+++ b/core/src/test/java/google/registry/tools/CreateOrUpdateReservedListCommandTestCase.java
@@ -16,7 +16,7 @@ package google.registry.tools;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.tld.label.ReservationType.FULLY_BLOCKED;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.TestDataHelper.loadFile;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -111,18 +111,16 @@ abstract class CreateOrUpdateReservedListCommandTestCase<
   }
 
   ReservedList getCloudSqlReservedList(String name) {
-    return jpaTm()
-        .transact(
+    return tm().transact(
             () -> {
               long revisionId =
-                  jpaTm()
-                      .query(
+                  tm().query(
                           "SELECT MAX(rl.revisionId) FROM ReservedList rl WHERE name = :name",
                           Long.class)
                       .setParameter("name", name)
                       .getSingleResult();
-              return jpaTm()
-                  .query("FROM ReservedList WHERE revisionId = :revisionId", ReservedList.class)
+              return tm().query(
+                      "FROM ReservedList WHERE revisionId = :revisionId", ReservedList.class)
                   .setParameter("revisionId", revisionId)
                   .getSingleResult();
             });

--- a/core/src/test/java/google/registry/tools/CreatePackagePromotionCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreatePackagePromotionCommandTest.java
@@ -16,7 +16,7 @@ package google.registry.tools;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -56,7 +56,7 @@ public class CreatePackagePromotionCommandTest
         "abc123");
 
     Optional<PackagePromotion> packagePromotionOptional =
-        jpaTm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
+        tm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
     assertThat(packagePromotionOptional).isPresent();
     PackagePromotion packagePromotion = packagePromotionOptional.get();
     assertThat(packagePromotion.getMaxDomains()).isEqualTo(100);
@@ -130,7 +130,7 @@ public class CreatePackagePromotionCommandTest
         "--next_billing_date=2012-03-17T05:00:00Z",
         "abc123");
     Optional<PackagePromotion> packagePromotionOptional =
-        jpaTm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
+        tm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
     assertThat(packagePromotionOptional).isPresent();
     IllegalArgumentException thrown =
         assertThrows(
@@ -159,7 +159,7 @@ public class CreatePackagePromotionCommandTest
             .build());
     runCommandForced("--price=USD 1000.00", "--next_billing_date=2012-03-17", "abc123");
     Optional<PackagePromotion> packagePromotionOptional =
-        jpaTm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
+        tm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
     assertThat(packagePromotionOptional).isPresent();
     PackagePromotion packagePromotion = packagePromotionOptional.get();
     assertThat(packagePromotion.getMaxDomains()).isEqualTo(0);
@@ -185,7 +185,7 @@ public class CreatePackagePromotionCommandTest
     runCommandForced("--max_domains=100", "--max_creates=500", "--price=USD 1000.00", "abc123");
 
     Optional<PackagePromotion> packagePromotionOptional =
-        jpaTm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
+        tm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
     assertThat(packagePromotionOptional).isPresent();
     PackagePromotion packagePromotion = packagePromotionOptional.get();
     assertThat(packagePromotion.getMaxDomains()).isEqualTo(100);

--- a/core/src/test/java/google/registry/tools/GetDatabaseMigrationStateCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetDatabaseMigrationStateCommandTest.java
@@ -15,7 +15,7 @@
 package google.registry.tools;
 
 import static google.registry.model.common.DatabaseMigrationStateSchedule.DEFAULT_TRANSITION_MAP;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
 import com.google.common.collect.ImmutableSortedMap;
@@ -59,7 +59,7 @@ public class GetDatabaseMigrationStateCommandTest
             MigrationState.SQL_PRIMARY,
             now.plusHours(5),
             MigrationState.SQL_ONLY);
-    jpaTm().transact(() -> DatabaseMigrationStateSchedule.set(transitions));
+    tm().transact(() -> DatabaseMigrationStateSchedule.set(transitions));
     runCommand();
     assertStdoutIs(String.format("Current migration schedule: %s\n", transitions));
   }

--- a/core/src/test/java/google/registry/tools/GetPackagePromotionCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetPackagePromotionCommandTest.java
@@ -15,7 +15,7 @@
 package google.registry.tools;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -61,7 +61,7 @@ public class GetPackagePromotionCommandTest extends CommandTestCase<GetPackagePr
             .setNextBillingDate(DateTime.parse("2012-11-12T05:00:00Z"))
             .setLastNotificationSent(DateTime.parse("2010-11-12T05:00:00Z"))
             .build();
-    jpaTm().transact(() -> jpaTm().put(packagePromotion));
+    tm().transact(() -> tm().put(packagePromotion));
     runCommand("abc123");
   }
 
@@ -78,11 +78,9 @@ public class GetPackagePromotionCommandTest extends CommandTestCase<GetPackagePr
                 .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
                 .setDiscountFraction(1)
                 .build());
-    jpaTm()
-        .transact(
+    tm().transact(
             () ->
-                jpaTm()
-                    .put(
+                tm().put(
                         new PackagePromotion.Builder()
                             .setToken(token)
                             .setMaxDomains(100)
@@ -102,11 +100,9 @@ public class GetPackagePromotionCommandTest extends CommandTestCase<GetPackagePr
                 .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
                 .setDiscountFraction(1)
                 .build());
-    jpaTm()
-        .transact(
+    tm().transact(
             () ->
-                jpaTm()
-                    .put(
+                tm().put(
                         new PackagePromotion.Builder()
                             .setToken(token2)
                             .setMaxDomains(1000)

--- a/core/src/test/java/google/registry/tools/SetDatabaseMigrationStateCommandTest.java
+++ b/core/src/test/java/google/registry/tools/SetDatabaseMigrationStateCommandTest.java
@@ -17,7 +17,7 @@ package google.registry.tools;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static google.registry.model.common.DatabaseMigrationStateSchedule.DEFAULT_TRANSITION_MAP;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -42,15 +42,13 @@ public class SetDatabaseMigrationStateCommandTest
   @Test
   void testSuccess_setsBasicSchedule() throws Exception {
     assertThat(DatabaseMigrationStateSchedule.get()).isEqualTo(DEFAULT_TRANSITION_MAP);
-    assertThat(jpaTm().transact(() -> jpaTm().loadSingleton(DatabaseMigrationStateSchedule.class)))
+    assertThat(tm().transact(() -> tm().loadSingleton(DatabaseMigrationStateSchedule.class)))
         .isEmpty();
     runCommandForced("--migration_schedule=1970-01-01T00:00:00.000Z=DATASTORE_ONLY");
-    jpaTm()
-        .transact(
+    tm().transact(
             () ->
                 assertThat(
-                        jpaTm()
-                            .loadSingleton(DatabaseMigrationStateSchedule.class)
+                        tm().loadSingleton(DatabaseMigrationStateSchedule.class)
                             .get()
                             .migrationTransitions)
                     .isEqualTo(DEFAULT_TRANSITION_MAP));

--- a/core/src/test/java/google/registry/tools/UpdatePackagePromotionCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdatePackagePromotionCommandTest.java
@@ -15,7 +15,7 @@
 package google.registry.tools;
 
 import static com.google.common.truth.Truth8.assertThat;
-import static google.registry.persistence.transaction.TransactionManagerFactory.jpaTm;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -58,7 +58,7 @@ public class UpdatePackagePromotionCommandTest
             .setNextBillingDate(DateTime.parse("2012-11-12T05:00:00Z"))
             .setLastNotificationSent(DateTime.parse("2010-11-12T05:00:00Z"))
             .build();
-    jpaTm().transact(() -> jpaTm().put(packagePromotion));
+    tm().transact(() -> tm().put(packagePromotion));
   }
 
   @Test
@@ -72,7 +72,7 @@ public class UpdatePackagePromotionCommandTest
         "abc123");
 
     Optional<PackagePromotion> packagePromotionOptional =
-        jpaTm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
+        tm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
     assertThat(packagePromotionOptional).isPresent();
     PackagePromotion packagePromotion = packagePromotionOptional.get();
     Truth.assertThat(packagePromotion.getMaxDomains()).isEqualTo(200);
@@ -120,7 +120,7 @@ public class UpdatePackagePromotionCommandTest
         "abc123");
 
     Optional<PackagePromotion> packagePromotionOptional =
-        jpaTm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
+        tm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
     assertThat(packagePromotionOptional).isPresent();
     PackagePromotion packagePromotion = packagePromotionOptional.get();
     Truth.assertThat(packagePromotion.getMaxDomains()).isEqualTo(100);
@@ -142,7 +142,7 @@ public class UpdatePackagePromotionCommandTest
         "abc123");
 
     Optional<PackagePromotion> packagePromotionOptional =
-        jpaTm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
+        tm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
     assertThat(packagePromotionOptional).isPresent();
     PackagePromotion packagePromotion = packagePromotionOptional.get();
     Truth.assertThat(packagePromotion.getMaxDomains()).isEqualTo(200);
@@ -164,7 +164,7 @@ public class UpdatePackagePromotionCommandTest
         "abc123");
 
     Optional<PackagePromotion> packagePromotionOptional =
-        jpaTm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
+        tm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
     assertThat(packagePromotionOptional).isPresent();
     PackagePromotion packagePromotion = packagePromotionOptional.get();
     Truth.assertThat(packagePromotion.getMaxDomains()).isEqualTo(200);
@@ -181,7 +181,7 @@ public class UpdatePackagePromotionCommandTest
     runCommandForced("--max_domains=200", "--max_creates=1000", "--price=USD 2000.00", "abc123");
 
     Optional<PackagePromotion> packagePromotionOptional =
-        jpaTm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
+        tm().transact(() -> PackagePromotion.loadByTokenString("abc123"));
     assertThat(packagePromotionOptional).isPresent();
     PackagePromotion packagePromotion = packagePromotionOptional.get();
     Truth.assertThat(packagePromotion.getMaxDomains()).isEqualTo(200);


### PR DESCRIPTION
Since JPA is the only TM now, there's no point distinguishing tm() from
jpaTm().
