### PR TITLE
Standardize hostname handling in URS command

### DIFF
--- a/core/src/main/java/google/registry/model/EppResourceUtils.java
+++ b/core/src/main/java/google/registry/model/EppResourceUtils.java
@@ -40,8 +40,8 @@ import google.registry.model.transfer.DomainTransferData;
 import google.registry.model.transfer.TransferData;
 import google.registry.model.transfer.TransferStatus;
 import google.registry.persistence.VKey;
+import java.util.Collection;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -183,7 +183,7 @@ public final class EppResourceUtils {
    * @param now the logical time of the check
    */
   public static <T extends EppResource> ImmutableSet<String> checkResourcesExist(
-      Class<T> clazz, List<String> uniqueIds, final DateTime now) {
+      Class<T> clazz, Collection<String> uniqueIds, final DateTime now) {
     return ForeignKeyUtils.load(clazz, uniqueIds, now).keySet();
   }
 

--- a/core/src/main/java/google/registry/tools/params/NameserversParameter.java
+++ b/core/src/main/java/google/registry/tools/params/NameserversParameter.java
@@ -25,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.re2j.Matcher;
 import com.google.re2j.Pattern;
+import google.registry.util.DomainNameUtils;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -50,12 +51,9 @@ public final class NameserversParameter extends ParameterConverterValidator<Set<
     if (Strings.isNullOrEmpty(value)) {
       return ImmutableSet.of();
     }
-    return Splitter.on(',')
-        .trimResults()
-        .omitEmptyStrings()
-        .splitToList(value)
-        .stream()
+    return Splitter.on(',').trimResults().omitEmptyStrings().splitToList(value).stream()
         .flatMap(NameserversParameter::splitNameservers)
+        .map(DomainNameUtils::canonicalizeHostname)
         .collect(toImmutableSet());
   }
 

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -1006,7 +1006,6 @@ public final class DatabaseHelper {
    *
    * <p>This was coded for testing RDE since its queries depend on the associated entries.
    *
-   *
    * @see #persistResource(ImmutableObject)
    */
   public static <R extends EppResource> R persistEppResource(final R resource) {

--- a/core/src/test/java/google/registry/tools/CreateDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateDomainCommandTest.java
@@ -58,11 +58,45 @@ class CreateDomainCommandTest extends EppToolCommandTestCase<CreateDomainCommand
   }
 
   @Test
+  void testSuccess_completeWithCanonicalization() throws Exception {
+    runCommandForced(
+        "--client=NewRegistrar",
+        "--period=1",
+        "--nameservers=NS1.zdns.google,ns2.ZDNS.google,ns3.zdns.gOOglE,ns4.zdns.google",
+        "--registrant=crr-admin",
+        "--admins=crr-admin",
+        "--techs=crr-tech",
+        "--password=2fooBAR",
+        "--ds_records=1 2 2 9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08,4 5 1"
+            + " A94A8FE5CCB19BA61C4C0873D391E987982FBBD3",
+        "--ds_records=60485 5  2  D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A",
+        "example.tld");
+    eppVerifier.verifySent("domain_create_complete.xml");
+  }
+
+  @Test
   void testSuccess_completeWithSquareBrackets() throws Exception {
     runCommandForced(
         "--client=NewRegistrar",
         "--period=1",
         "--nameservers=ns[1-4].zdns.google",
+        "--registrant=crr-admin",
+        "--admins=crr-admin",
+        "--techs=crr-tech",
+        "--password=2fooBAR",
+        "--ds_records=1 2 2 9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08,4 5 1"
+            + " A94A8FE5CCB19BA61C4C0873D391E987982FBBD3",
+        "--ds_records=60485 5  2  D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A",
+        "example.tld");
+    eppVerifier.verifySent("domain_create_complete.xml");
+  }
+
+  @Test
+  void testSuccess_completeWithSquareBracketsAndCanonicalization() throws Exception {
+    runCommandForced(
+        "--client=NewRegistrar",
+        "--period=1",
+        "--nameservers=NS[1-4].zdns.google",
         "--registrant=crr-admin",
         "--admins=crr-admin",
         "--techs=crr-tech",

--- a/core/src/test/java/google/registry/tools/UniformRapidSuspensionCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UniformRapidSuspensionCommandTest.java
@@ -164,6 +164,27 @@ class UniformRapidSuspensionCommandTest
   }
 
   @Test
+  void testCommand_bracketNameserverNotationWithCanonicalization() throws Exception {
+    persistDomainWithHosts(defaultDomain, defaultDsData, ns1, ns2);
+    runCommandForced(
+        "--domain_name=evil.tld",
+        "--hosts=URS[1-2].example.com",
+        "--dsdata=1 1 1 A94A8FE5CCB19BA61C4C0873D391E987982FBBD3",
+        "--renew_one_year=false");
+    eppVerifier
+        .expectRegistrarId("CharlestonRoad")
+        .expectSuperuser()
+        .verifySent("uniform_rapid_suspension.xml")
+        .verifyNoMoreSent();
+    assertInStdout("uniform_rapid_suspension --undo");
+    assertInStdout("--domain_name evil.tld");
+    assertInStdout("--hosts ns1.example.com,ns2.example.com");
+    assertInStdout("--dsdata 1 2 3 DEAD,4 5 6 BEEF");
+    assertNotInStdout("--locks_to_preserve");
+    assertNotInStdout("--restore_client_hold");
+  }
+
+  @Test
   void testUndo_removesLocksReplacesHostsAndDsData() throws Exception {
     persistDomainWithHosts(defaultDomain, defaultDsData, urs1, urs2);
     runCommandForced(

--- a/core/src/test/java/google/registry/tools/UpdateDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateDomainCommandTest.java
@@ -93,10 +93,10 @@ class UpdateDomainCommandTest extends EppToolCommandTestCase<UpdateDomainCommand
   }
 
   @Test
-  void testSuccess_completeWithSquareBrackets() throws Exception {
+  void testSuccess_completeWithSquareBracketsAndCanonicalization() throws Exception {
     runCommandForced(
         "--client=NewRegistrar",
-        "--add_nameservers=ns[1-2].zdns.google",
+        "--add_nameservers=NS[1-2].zdns.google",
         "--add_admins=crr-admin2",
         "--add_techs=crr-tech2",
         "--add_statuses=serverDeleteProhibited",


### PR DESCRIPTION
This allows use of the ns[1-4].foo.bar notation to specify multiple nameservers matching a common numeric pattern. It allows fixes hostname canonicalization in the existing create/update_domain command (though this is mostly a no-op as it just affects the input to the EPP flows; the EPP flows themselves perform canonicalization as well).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1886)
<!-- Reviewable:end -->
