### PR TITLE
Only email support for package non-compliance

### DIFF
--- a/core/src/main/java/google/registry/batch/CheckPackagesComplianceAction.java
+++ b/core/src/main/java/google/registry/batch/CheckPackagesComplianceAction.java
@@ -13,10 +13,10 @@
 // limitations under the License.
 package google.registry.batch;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 
+import avro.shaded.com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.flogger.FluentLogger;
@@ -25,7 +25,6 @@ import google.registry.config.RegistryConfig.Config;
 import google.registry.model.domain.token.AllocationToken;
 import google.registry.model.domain.token.PackagePromotion;
 import google.registry.model.registrar.Registrar;
-import google.registry.model.registrar.RegistrarPoc;
 import google.registry.request.Action;
 import google.registry.request.Action.Service;
 import google.registry.request.auth.Auth;
@@ -90,8 +89,8 @@ public class CheckPackagesComplianceAction implements Runnable {
     ImmutableList<PackagePromotion> packages = tm().loadAllOf(PackagePromotion.class);
     ImmutableList.Builder<PackagePromotion> packagesOverCreateLimitBuilder =
         new ImmutableList.Builder<>();
-    ImmutableList.Builder<PackagePromotion> packagesOverActiveDomainsLimitBuilder =
-        new ImmutableList.Builder<>();
+    ImmutableMap.Builder<PackagePromotion, Integer> packagesOverActiveDomainsLimitBuilder =
+        new ImmutableMap.Builder<>();
     for (PackagePromotion packagePromo : packages) {
       Long creates =
           (Long)
@@ -125,7 +124,7 @@ public class CheckPackagesComplianceAction implements Runnable {
             "Package with package token %s has exceed their max active domains limit by"
                 + " %d name(s).",
             packagePromo.getToken().getKey(), overage);
-        packagesOverActiveDomainsLimitBuilder.add(packagePromo);
+        packagesOverActiveDomainsLimitBuilder.put(packagePromo, Ints.saturatedCast(creates));
       }
     }
     handlePackageCreationOverage(packagesOverCreateLimitBuilder.build());
@@ -147,9 +146,10 @@ public class CheckPackagesComplianceAction implements Runnable {
         String body =
             String.format(
                 packageCreateLimitEmailBody,
-                registrar.get().getRegistrarName(),
+                packagePromotion.getId(),
                 packageToken.getToken(),
-                registrySupportEmail);
+                registrar.get().getRegistrarName(),
+                packagePromotion.getMaxCreates());
         sendNotification(packageToken, packageCreateLimitEmailSubject, body, registrar.get());
       } else {
         throw new IllegalStateException(
@@ -158,13 +158,13 @@ public class CheckPackagesComplianceAction implements Runnable {
     }
   }
 
-  private void handleActiveDomainOverage(ImmutableList<PackagePromotion> overageList) {
+  private void handleActiveDomainOverage(ImmutableMap<PackagePromotion, Integer> overageList) {
     if (overageList.isEmpty()) {
       logger.atInfo().log("Found no packages over their active domains limit.");
       return;
     }
     logger.atInfo().log("Found %d packages over their active domains limit.", overageList.size());
-    for (PackagePromotion packagePromotion : overageList) {
+    for (PackagePromotion packagePromotion : overageList.keySet()) {
       int daysSinceLastNotification =
           packagePromotion
               .getLastNotificationSent()
@@ -176,15 +176,18 @@ public class CheckPackagesComplianceAction implements Runnable {
         continue;
       } else if (daysSinceLastNotification < FORTY_DAYS) {
         // Send an upgrade email if last email was between 30 and 40 days ago
-        sendActiveDomainOverageEmail(/* warning= */ false, packagePromotion);
+        sendActiveDomainOverageEmail(
+            /* warning= */ false, packagePromotion, overageList.get(packagePromotion));
       } else {
         // Send a warning email
-        sendActiveDomainOverageEmail(/* warning= */ true, packagePromotion);
+        sendActiveDomainOverageEmail(
+            /* warning= */ true, packagePromotion, overageList.get(packagePromotion));
       }
     }
   }
 
-  private void sendActiveDomainOverageEmail(boolean warning, PackagePromotion packagePromotion) {
+  private void sendActiveDomainOverageEmail(
+      boolean warning, PackagePromotion packagePromotion, int activeDomains) {
     String emailSubject =
         warning ? packageDomainLimitWarningEmailSubject : packageDomainLimitUpgradeEmailSubject;
     String emailTemplate =
@@ -197,9 +200,11 @@ public class CheckPackagesComplianceAction implements Runnable {
       String body =
           String.format(
               emailTemplate,
-              registrar.get().getRegistrarName(),
+              packagePromotion.getId(),
               packageToken.getToken(),
-              registrySupportEmail);
+              registrar.get().getRegistrarName(),
+              packagePromotion.getMaxDomains(),
+              activeDomains);
       sendNotification(packageToken, emailSubject, body, registrar.get());
       tm().put(packagePromotion.asBuilder().setLastNotificationSent(clock.nowUtc()).build());
     } else {
@@ -212,15 +217,9 @@ public class CheckPackagesComplianceAction implements Runnable {
       AllocationToken packageToken, String subject, String body, Registrar registrar) {
     logger.atInfo().log(
         String.format(
-            "Compliance email sent to the %s registrar regarding the package with token" + " %s.",
+            "Compliance email sent to support regarding the %s registrar and the package with token"
+                + " %s.",
             registrar.getRegistrarName(), packageToken.getToken()));
-    sendEmailUtils.sendEmail(
-        subject,
-        body,
-        Optional.of(registrySupportEmail),
-        registrar.getContacts().stream()
-            .filter(c -> c.getTypes().contains(RegistrarPoc.Type.ADMIN))
-            .map(RegistrarPoc::getEmailAddress)
-            .collect(toImmutableList()));
+    sendEmailUtils.sendEmail(subject, body, ImmutableList.of(registrySupportEmail));
   }
 }

--- a/core/src/main/java/google/registry/batch/CheckPackagesComplianceAction.java
+++ b/core/src/main/java/google/registry/batch/CheckPackagesComplianceAction.java
@@ -16,8 +16,8 @@ package google.registry.batch;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 
-import avro.shaded.com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.flogger.FluentLogger;
 import com.google.common.primitives.Ints;

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -538,52 +538,52 @@ sslCertificateValidation:
 
 # Configuration options for the package compliance monitoring
 packageMonitoring:
-  # Email subject text to notify partners their package has exceeded the limit for domain creates
-  packageCreateLimitEmailSubject: "NOTICE: Your package is being upgraded"
-  # Email body text template notify partners their package has exceeded the limit for domain creates
+  # Email subject text to notify tech support that a package has exceeded the limit for domain creates
+  packageCreateLimitEmailSubject: "ACTION REQUIRED: Package needs to be upgraded"
+  # Email body text template notify support that a package has exceeded the limit for domain creates
   packageCreateLimitEmailBody: >
-    Dear %1$s,
+    Dear Support,
     
-    We are contacting you to inform you that your package with the package token 
-    %2$s has exceeded its limit for annual domain creations.
-    Your package will now be upgraded to the next tier. 
+    A package has exceeded its max create limit and needs to be upgraded to the 
+    next tier.
     
-    If you have any questions or require additional support, please contact us
-    at %3$s.
-    
-    Regards,
-    Example Registry
+    Package ID: %1$s
+    Package Token: %2$s
+    Registrar: %3$s
+    Current Max Create Limit: %4$s
 
-  # Email subject text to notify partners their package has exceeded the limit for current active domains and warn them their package will be upgraded in 30 days
-  packageDomainLimitWarningEmailSubject: "WARNING: Your package has exceeded the domain limit"
-  # Email body text template to warn partners their package has exceeded the limit for active domains and will be upgraded in 30 days
+  # Email subject text to notify support that a package has exceeded the limit
+  # for current active domains and a warning needs to be sent
+  packageDomainLimitWarningEmailSubject: "ACTION REQUIRED: Package has exceeded the domain limit - send warning"
+  # Email body text template to inform support that a package has exceeded the
+  # limit for active domains and a warning needs to be sent that the package
+  # will be upgraded in 30 days
   packageDomainLimitWarningEmailBody: >
-    Dear %1$s,
-      
-    We are contacting you to inform you that your package with the package token 
-    %2$s has exceeded its limit for active domains.
-    Your package will be upgraded to the next tier in 30 days if the number of active domains does not return below the limit. 
-
-    If you have any questions or require additional support, please contact us
-    at %3$s.
-
-    Regards,
-    Example Registry
-
-  # Email subject text to notify partners their package has exceeded the limit
-  # for current active domains for more than 30 days and will be upgraded
-  packageDomainLimitUpgradeEmailSubject: "NOTICE: Your package is being upgraded"
-  # Email body text template to warn partners their package has exceeded the
-  # limit for active domains for more than 30 days and will be upgraded
-  packageDomainLimitUpgradeEmailBody: >
-    Dear %1$s,
+    Dear Support,
     
-    We are contacting you to inform you that your package with the package token 
-    %2$s has exceeded its limit for active domains.
-    Your package will now be upgraded to the next tier. 
+    A package has exceeded its max domain limit. Please send a warning to the 
+    registrar that their package will be upgraded to the next tier in 30 days if 
+    the number of active domains does not return below the limit.
+    
+    Package ID: %1$s
+    Package Token: %2$s
+    Registrar: %3$s
+    Active Domain Limit: %4$s
+    Current Active Domains: %5$s
 
-    If you have any questions or require additional support, please contact us
-    at %3$s.
-
-    Regards,
-    Example Registry
+  # Email subject text to notify support that a package has exceeded the limit
+  # for current active domains for more than 30 days and needs to be upgraded
+  packageDomainLimitUpgradeEmailSubject: "ACTION REQUIRED: Package has exceeded the domain limit - upgrade package"
+  # Email body text template to inform support that a package has exceeded the
+  # limit for active domains for more than 30 days and needs to be upgraded
+  packageDomainLimitUpgradeEmailBody: >
+    Dear Support,
+    
+    A package has exceeded its max domain limit for over 30 days and needs to be 
+    upgraded to the next tier.
+    
+    Package ID: %1$s
+    Package Token: %2$s
+    Registrar: %3$s
+    Active Domain Limit: %4$s
+    Current Active Domains: %5$s

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -551,6 +551,7 @@ packageMonitoring:
     Package Token: %2$s
     Registrar: %3$s
     Current Max Create Limit: %4$s
+    Creates Completed: %5$s
 
   # Email subject text to notify support that a package has exceeded the limit
   # for current active domains and a warning needs to be sent

--- a/core/src/main/java/google/registry/model/domain/token/PackagePromotion.java
+++ b/core/src/main/java/google/registry/model/domain/token/PackagePromotion.java
@@ -74,6 +74,10 @@ public class PackagePromotion extends ImmutableObject implements Buildable {
   /** Date the last warning email was sent that the package has exceeded the maxDomains limit. */
   @Nullable DateTime lastNotificationSent;
 
+  public long getId() {
+    return packagePromotionId;
+  }
+
   public VKey<AllocationToken> getToken() {
     return token;
   }

--- a/core/src/test/java/google/registry/batch/CheckPackagesComplianceActionTest.java
+++ b/core/src/test/java/google/registry/batch/CheckPackagesComplianceActionTest.java
@@ -60,11 +60,11 @@ public class CheckPackagesComplianceActionTest {
   private static final String CREATE_LIMIT_EMAIL_SUBJECT = "create limit subject";
   private static final String DOMAIN_LIMIT_WARNING_EMAIL_SUBJECT = "domain limit warning subject";
   private static final String DOMAIN_LIMIT_UPGRADE_EMAIL_SUBJECT = "domain limit upgrade subject";
-  private static final String CREATE_LIMIT_EMAIL_BODY = "create limit body %1$s %2$s %3$s";
+  private static final String CREATE_LIMIT_EMAIL_BODY = "create limit body %1$s %2$s %3$s %4$s";
   private static final String DOMAIN_LIMIT_WARNING_EMAIL_BODY =
-      "domain limit warning body %1$s %2$s %3$s";
+      "domain limit warning body %1$s %2$s %3$s %4$s %5$s";
   private static final String DOMAIN_LIMIT_UPGRADE_EMAIL_BODY =
-      "domain limit upgrade body %1$s %2$s %3$s";
+      "domain limit upgrade body %1$s %2$s %3$s %4$s %5$s";
   private static final String SUPPORT_EMAIL = "registry@test.com";
 
   @RegisterExtension
@@ -177,8 +177,7 @@ public class CheckPackagesComplianceActionTest {
     EmailMessage emailMessage = emailCaptor.getValue();
     assertThat(emailMessage.subject()).isEqualTo(CREATE_LIMIT_EMAIL_SUBJECT);
     assertThat(emailMessage.body())
-        .isEqualTo(
-            String.format(CREATE_LIMIT_EMAIL_BODY, "The Registrar", "abc123", SUPPORT_EMAIL));
+        .isEqualTo(String.format(CREATE_LIMIT_EMAIL_BODY, 1, "abc123", "The Registrar", 1));
   }
 
   @Test
@@ -364,8 +363,7 @@ public class CheckPackagesComplianceActionTest {
     assertThat(emailMessage.subject()).isEqualTo(DOMAIN_LIMIT_WARNING_EMAIL_SUBJECT);
     assertThat(emailMessage.body())
         .isEqualTo(
-            String.format(
-                DOMAIN_LIMIT_WARNING_EMAIL_BODY, "The Registrar", "abc123", SUPPORT_EMAIL));
+            String.format(DOMAIN_LIMIT_WARNING_EMAIL_BODY, 1, "abc123", "The Registrar", 1, 2));
     PackagePromotion packageAfterCheck =
         tm().transact(() -> PackagePromotion.loadByTokenString(token.getToken()).get());
     assertThat(packageAfterCheck.getLastNotificationSent().get()).isEqualTo(clock.nowUtc());
@@ -514,8 +512,7 @@ public class CheckPackagesComplianceActionTest {
     assertThat(emailMessage.subject()).isEqualTo(DOMAIN_LIMIT_WARNING_EMAIL_SUBJECT);
     assertThat(emailMessage.body())
         .isEqualTo(
-            String.format(
-                DOMAIN_LIMIT_WARNING_EMAIL_BODY, "The Registrar", "abc123", SUPPORT_EMAIL));
+            String.format(DOMAIN_LIMIT_WARNING_EMAIL_BODY, 1, "abc123", "The Registrar", 1, 2));
     PackagePromotion packageAfterCheck =
         tm().transact(() -> PackagePromotion.loadByTokenString(token.getToken()).get());
     assertThat(packageAfterCheck.getLastNotificationSent().get()).isEqualTo(clock.nowUtc());
@@ -558,8 +555,7 @@ public class CheckPackagesComplianceActionTest {
     assertThat(emailMessage.subject()).isEqualTo(DOMAIN_LIMIT_UPGRADE_EMAIL_SUBJECT);
     assertThat(emailMessage.body())
         .isEqualTo(
-            String.format(
-                DOMAIN_LIMIT_UPGRADE_EMAIL_BODY, "The Registrar", "abc123", SUPPORT_EMAIL));
+            String.format(DOMAIN_LIMIT_UPGRADE_EMAIL_BODY, 1, "abc123", "The Registrar", 1, 2));
     PackagePromotion packageAfterCheck =
         tm().transact(() -> PackagePromotion.loadByTokenString(token.getToken()).get());
     assertThat(packageAfterCheck.getLastNotificationSent().get()).isEqualTo(clock.nowUtc());

--- a/core/src/test/java/google/registry/batch/CheckPackagesComplianceActionTest.java
+++ b/core/src/test/java/google/registry/batch/CheckPackagesComplianceActionTest.java
@@ -60,7 +60,8 @@ public class CheckPackagesComplianceActionTest {
   private static final String CREATE_LIMIT_EMAIL_SUBJECT = "create limit subject";
   private static final String DOMAIN_LIMIT_WARNING_EMAIL_SUBJECT = "domain limit warning subject";
   private static final String DOMAIN_LIMIT_UPGRADE_EMAIL_SUBJECT = "domain limit upgrade subject";
-  private static final String CREATE_LIMIT_EMAIL_BODY = "create limit body %1$s %2$s %3$s %4$s";
+  private static final String CREATE_LIMIT_EMAIL_BODY =
+      "create limit body %1$s %2$s %3$s %4$s %5$s";
   private static final String DOMAIN_LIMIT_WARNING_EMAIL_BODY =
       "domain limit warning body %1$s %2$s %3$s %4$s %5$s";
   private static final String DOMAIN_LIMIT_UPGRADE_EMAIL_BODY =
@@ -177,7 +178,7 @@ public class CheckPackagesComplianceActionTest {
     EmailMessage emailMessage = emailCaptor.getValue();
     assertThat(emailMessage.subject()).isEqualTo(CREATE_LIMIT_EMAIL_SUBJECT);
     assertThat(emailMessage.body())
-        .isEqualTo(String.format(CREATE_LIMIT_EMAIL_BODY, 1, "abc123", "The Registrar", 1));
+        .isEqualTo(String.format(CREATE_LIMIT_EMAIL_BODY, 1, "abc123", "The Registrar", 1, 2));
   }
 
   @Test


### PR DESCRIPTION
Changing this since we decided that we will have GTech handle the communication with the partners for now. We will likely change this back in the future once we have more users of packages and decide to automate more of the tiering.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1900)
<!-- Reviewable:end -->
