### PR TITLE
Use the Proxy-Authorization header when using nomulus + IAP

### DIFF
--- a/core/src/test/java/google/registry/tools/RequestFactoryModuleTest.java
+++ b/core/src/test/java/google/registry/tools/RequestFactoryModuleTest.java
@@ -100,6 +100,7 @@ public class RequestFactoryModuleTest {
 
   @Test
   void test_provideHttpRequestFactory_remote_withIap() throws Exception {
+    when(credentialsBundle.getHttpRequestInitializer()).thenReturn(httpRequestInitializer);
     // Mock the request/response to/from the IAP server requesting an ID token
     UserCredentials mockUserCredentials = mock(UserCredentials.class);
     when(credentialsBundle.getGoogleCredentials()).thenReturn(mockUserCredentials);
@@ -123,9 +124,10 @@ public class RequestFactoryModuleTest {
           RequestFactoryModule.provideHttpRequestFactory(
               credentialsBundle, Optional.of("iapClientId"));
       HttpRequest request = factory.buildGetRequest(new GenericUrl("http://localhost"));
-      assertThat(request.getHeaders().getAuthorization()).isEqualTo("Bearer iapIdToken");
+      assertThat(request.getHeaders().get("Proxy-Authorization")).isEqualTo("Bearer iapIdToken");
       assertThat(request.getConnectTimeout()).isEqualTo(REQUEST_TIMEOUT_MS);
       assertThat(request.getReadTimeout()).isEqualTo(REQUEST_TIMEOUT_MS);
+      verify(httpRequestInitializer).initialize(request);
       verifyNoMoreInteractions(httpRequestInitializer);
     } finally {
       RegistryConfig.CONFIG_SETTINGS.get().gcpProject.isLocal = origIsLocal;


### PR DESCRIPTION
https://cloud.google.com/iap/docs/authentication-howto#authenticating_from_proxy-authorization_header discusses how we can use Proxy-Authorization instead of the simple Authorization header to authenticate with IAP. This is helpful because it will allow us to seamlessly transition from non-IAP to IAP. That is, we can have a period where clients (e.g. Nomulus tool, cron jobs) send both the old Authorization and the new IAP Proxy-Authorization headers and the app will use either the old mechanism or IAP to authenticate the client based on whether or not IAP is enabled in Pantheon.

tested in QA that setting Proxy-Authorization works

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1921)
<!-- Reviewable:end -->
