### PR TITLE
Remove @IdAllocation annotation from repoId

### DIFF
--- a/core/src/main/java/google/registry/model/EppResource.java
+++ b/core/src/main/java/google/registry/model/EppResource.java
@@ -33,7 +33,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import google.registry.config.RegistryConfig;
 import google.registry.dns.RefreshDnsAction;
-import google.registry.model.annotations.IdAllocation;
 import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.transfer.TransferData;
 import google.registry.persistence.VKey;
@@ -68,7 +67,7 @@ public abstract class EppResource extends UpdateAutoTimestampEntity implements B
    *
    * @see <a href="https://tools.ietf.org/html/rfc5730">RFC 5730</a>
    */
-  @IdAllocation @Transient String repoId;
+  @Transient String repoId;
 
   /**
    * The ID of the registrar that is currently sponsoring this resource.


### PR DESCRIPTION
This annotation only works for Long or long field.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1923)
<!-- Reviewable:end -->
