### PR TITLE
Generate and use an IAP-enabled ID token in the proxy

### DIFF
--- a/proxy/src/main/java/google/registry/proxy/EppProtocolModule.java
+++ b/proxy/src/main/java/google/registry/proxy/EppProtocolModule.java
@@ -16,6 +16,7 @@ package google.registry.proxy;
 
 import static google.registry.util.ResourceUtils.readResourceBytes;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.collect.ImmutableList;
 import dagger.Module;
 import dagger.Provides;
@@ -43,6 +44,7 @@ import io.netty.handler.timeout.ReadTimeoutHandler;
 import java.io.IOException;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
@@ -147,12 +149,18 @@ public final class EppProtocolModule {
 
   @Provides
   static EppServiceHandler provideEppServiceHandler(
-      @Named("accessToken") Supplier<String> accessTokenSupplier,
+      Supplier<GoogleCredentials> refreshedCredentialsSupplier,
+      @Named("iapClientId") Optional<String> iapClientId,
       @Named("hello") byte[] helloBytes,
       FrontendMetrics metrics,
       ProxyConfig config) {
     return new EppServiceHandler(
-        config.epp.relayHost, config.epp.relayPath, accessTokenSupplier, helloBytes, metrics);
+        config.epp.relayHost,
+        config.epp.relayPath,
+        refreshedCredentialsSupplier,
+        iapClientId,
+        helloBytes,
+        metrics);
   }
 
   @Singleton

--- a/proxy/src/main/java/google/registry/proxy/ProxyConfig.java
+++ b/proxy/src/main/java/google/registry/proxy/ProxyConfig.java
@@ -40,6 +40,7 @@ public class ProxyConfig {
   private static final String CUSTOM_CONFIG_FORMATTER = "config/proxy-config-%s.yaml";
 
   public String projectId;
+  public String iapClientId;
   public List<String> gcpScopes;
   public int serverCertificateCacheSeconds;
   public Gcs gcs;

--- a/proxy/src/main/java/google/registry/proxy/WhoisProtocolModule.java
+++ b/proxy/src/main/java/google/registry/proxy/WhoisProtocolModule.java
@@ -14,6 +14,7 @@
 
 package google.registry.proxy;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.collect.ImmutableList;
 import dagger.Module;
 import dagger.Provides;
@@ -34,6 +35,7 @@ import google.registry.util.Clock;
 import io.netty.channel.ChannelHandler;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.timeout.ReadTimeoutHandler;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
@@ -91,10 +93,15 @@ public class WhoisProtocolModule {
   @Provides
   static WhoisServiceHandler provideWhoisServiceHandler(
       ProxyConfig config,
-      @Named("accessToken") Supplier<String> accessTokenSupplier,
+      Supplier<GoogleCredentials> refreshedCredentialsSupplier,
+      @Named("iapClientId") Optional<String> iapClientId,
       FrontendMetrics metrics) {
     return new WhoisServiceHandler(
-        config.whois.relayHost, config.whois.relayPath, accessTokenSupplier, metrics);
+        config.whois.relayHost,
+        config.whois.relayPath,
+        refreshedCredentialsSupplier,
+        iapClientId,
+        metrics);
   }
 
   @Provides

--- a/proxy/src/main/java/google/registry/proxy/config/default-config.yaml
+++ b/proxy/src/main/java/google/registry/proxy/config/default-config.yaml
@@ -8,6 +8,9 @@
 # GCP project ID
 projectId: your-gcp-project-id
 
+# IAP client ID, if IAP is enabled for this project
+iapClientId: null
+
 # OAuth scope that the GoogleCredential will be constructed with. This list
 # should include all service scopes that the proxy depends on.
 gcpScopes:

--- a/proxy/src/main/java/google/registry/proxy/handler/EppServiceHandler.java
+++ b/proxy/src/main/java/google/registry/proxy/handler/EppServiceHandler.java
@@ -20,6 +20,7 @@ import static google.registry.networking.handler.SslServerInitializer.CLIENT_CER
 import static google.registry.proxy.handler.ProxyProtocolHandler.REMOTE_ADDRESS_KEY;
 import static google.registry.util.X509Utils.getCertificateHash;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.flogger.FluentLogger;
 import google.registry.proxy.metric.FrontendMetrics;
 import google.registry.util.ProxyHttpHeaders;
@@ -36,6 +37,7 @@ import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.Promise;
 import java.security.cert.X509Certificate;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 /** Handler that processes EPP protocol logic. */
@@ -60,10 +62,11 @@ public class EppServiceHandler extends HttpsRelayServiceHandler {
   public EppServiceHandler(
       String relayHost,
       String relayPath,
-      Supplier<String> accessTokenSupplier,
+      Supplier<GoogleCredentials> refreshedCredentialsSupplier,
+      Optional<String> iapClientId,
       byte[] helloBytes,
       FrontendMetrics metrics) {
-    super(relayHost, relayPath, accessTokenSupplier, metrics);
+    super(relayHost, relayPath, refreshedCredentialsSupplier, iapClientId, metrics);
     this.helloBytes = helloBytes;
   }
 

--- a/proxy/src/main/java/google/registry/proxy/handler/WhoisServiceHandler.java
+++ b/proxy/src/main/java/google/registry/proxy/handler/WhoisServiceHandler.java
@@ -16,6 +16,7 @@ package google.registry.proxy.handler;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import com.google.auth.oauth2.GoogleCredentials;
 import google.registry.proxy.metric.FrontendMetrics;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFutureListener;
@@ -25,6 +26,7 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpResponse;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 /** Handler that processes WHOIS protocol logic. */
@@ -33,9 +35,10 @@ public final class WhoisServiceHandler extends HttpsRelayServiceHandler {
   public WhoisServiceHandler(
       String relayHost,
       String relayPath,
-      Supplier<String> accessTokenSupplier,
+      Supplier<GoogleCredentials> refreshedCredentialsSupplier,
+      Optional<String> iapClientId,
       FrontendMetrics metrics) {
-    super(relayHost, relayPath, accessTokenSupplier, metrics);
+    super(relayHost, relayPath, refreshedCredentialsSupplier, iapClientId, metrics);
   }
 
   @Override

--- a/proxy/src/test/java/google/registry/proxy/EppProtocolModuleTest.java
+++ b/proxy/src/test/java/google/registry/proxy/EppProtocolModuleTest.java
@@ -36,6 +36,7 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.cookie.Cookie;
 import io.netty.handler.codec.http.cookie.DefaultCookie;
 import io.netty.util.concurrent.Promise;
+import java.io.IOException;
 import java.security.cert.X509Certificate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -96,14 +97,15 @@ class EppProtocolModuleTest extends ProtocolModuleTest {
     return buffer;
   }
 
-  private FullHttpRequest makeEppHttpRequest(byte[] content, Cookie... cookies) {
+  private FullHttpRequest makeEppHttpRequest(byte[] content, Cookie... cookies) throws IOException {
     return TestUtils.makeEppHttpRequest(
         new String(content, UTF_8),
         PROXY_CONFIG.epp.relayHost,
         PROXY_CONFIG.epp.relayPath,
-        TestModule.provideFakeAccessToken().get(),
+        TestModule.provideFakeCredentials().get(),
         getCertificateHash(certificate),
         CLIENT_ADDRESS,
+        TestModule.provideIapClientId(),
         cookies);
   }
 

--- a/proxy/src/test/java/google/registry/proxy/WhoisProtocolModuleTest.java
+++ b/proxy/src/test/java/google/registry/proxy/WhoisProtocolModuleTest.java
@@ -41,7 +41,7 @@ class WhoisProtocolModuleTest extends ProtocolModuleTest {
   }
 
   @Test
-  void testSuccess_singleFrameInboundMessage() {
+  void testSuccess_singleFrameInboundMessage() throws Exception {
     String inputString = "test.tld\r\n";
     // Inbound message processed and passed along.
     assertThat(channel.writeInbound(Unpooled.wrappedBuffer(inputString.getBytes(US_ASCII))))
@@ -53,7 +53,8 @@ class WhoisProtocolModuleTest extends ProtocolModuleTest {
             "test.tld",
             PROXY_CONFIG.whois.relayHost,
             PROXY_CONFIG.whois.relayPath,
-            TestModule.provideFakeAccessToken().get());
+            TestModule.provideFakeCredentials().get(),
+            TestModule.provideIapClientId());
     assertThat(actualRequest).isEqualTo(expectedRequest);
     assertThat(channel.isActive()).isTrue();
     // Nothing more to read.
@@ -70,7 +71,7 @@ class WhoisProtocolModuleTest extends ProtocolModuleTest {
   }
 
   @Test
-  void testSuccess_multiFrameInboundMessage() {
+  void testSuccess_multiFrameInboundMessage() throws Exception {
     String frame1 = "test";
     String frame2 = "1.tld";
     String frame3 = "\r\nte";
@@ -88,7 +89,8 @@ class WhoisProtocolModuleTest extends ProtocolModuleTest {
             "test1.tld",
             PROXY_CONFIG.whois.relayHost,
             PROXY_CONFIG.whois.relayPath,
-            TestModule.provideFakeAccessToken().get());
+            TestModule.provideFakeCredentials().get(),
+            TestModule.provideIapClientId());
     assertThat(actualRequest1).isEqualTo(expectedRequest1);
     // No more message at this point.
     assertThat((Object) channel.readInbound()).isNull();
@@ -102,7 +104,8 @@ class WhoisProtocolModuleTest extends ProtocolModuleTest {
             "test2.tld",
             PROXY_CONFIG.whois.relayHost,
             PROXY_CONFIG.whois.relayPath,
-            TestModule.provideFakeAccessToken().get());
+            TestModule.provideFakeCredentials().get(),
+            TestModule.provideIapClientId());
     assertThat(actualRequest2).isEqualTo(expectedRequest2);
     // The third message is not complete yet.
     assertThat(channel.isActive()).isTrue();

--- a/proxy/src/test/java/google/registry/proxy/handler/WhoisServiceHandlerTest.java
+++ b/proxy/src/test/java/google/registry/proxy/handler/WhoisServiceHandlerTest.java
@@ -22,8 +22,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.ComputeEngineCredentials;
+import com.google.auth.oauth2.IdToken;
+import com.google.auth.oauth2.IdTokenProvider.Option;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import google.registry.proxy.handler.HttpsRelayServiceHandler.NonOkHttpResponseException;
 import google.registry.proxy.metric.FrontendMetrics;
 import io.netty.buffer.ByteBuf;
@@ -34,6 +40,7 @@ import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,18 +50,26 @@ class WhoisServiceHandlerTest {
   private static final String RELAY_HOST = "www.example.tld";
   private static final String RELAY_PATH = "/test";
   private static final String QUERY_CONTENT = "test.tld";
-  private static final String ACCESS_TOKEN = "this.access.token";
   private static final String PROTOCOL = "whois";
   private static final String CLIENT_HASH = "none";
+  private static final String IAP_CLIENT_ID = "iapClientId";
 
+  private static final ComputeEngineCredentials mockCredentials =
+      mock(ComputeEngineCredentials.class);
   private final FrontendMetrics metrics = mock(FrontendMetrics.class);
 
   private final WhoisServiceHandler whoisServiceHandler =
-      new WhoisServiceHandler(RELAY_HOST, RELAY_PATH, () -> ACCESS_TOKEN, metrics);
+      new WhoisServiceHandler(
+          RELAY_HOST, RELAY_PATH, () -> mockCredentials, Optional.of(IAP_CLIENT_ID), metrics);
   private EmbeddedChannel channel;
 
   @BeforeEach
-  void beforeEach() {
+  void beforeEach() throws Exception {
+    when(mockCredentials.getAccessToken()).thenReturn(new AccessToken("this.access.token", null));
+    IdToken mockIdToken = mock(IdToken.class);
+    when(mockIdToken.getTokenValue()).thenReturn("fake.test.id.token");
+    when(mockCredentials.idTokenWithAudience(IAP_CLIENT_ID, ImmutableList.of(Option.FORMAT_FULL)))
+        .thenReturn(mockIdToken);
     // Need to reset metrics for each test method, since they are static fields on the class and
     // shared between each run.
     channel = new EmbeddedChannel(whoisServiceHandler);
@@ -74,7 +89,8 @@ class WhoisServiceHandlerTest {
 
     // Setup second channel.
     WhoisServiceHandler whoisServiceHandler2 =
-        new WhoisServiceHandler(RELAY_HOST, RELAY_PATH, () -> ACCESS_TOKEN, metrics);
+        new WhoisServiceHandler(
+            RELAY_HOST, RELAY_PATH, () -> mockCredentials, Optional.empty(), metrics);
     EmbeddedChannel channel2 =
         // We need a new channel id so that it has a different hash code.
         // This only is needed for EmbeddedChannel because it has a dummy hash code implementation.
@@ -85,10 +101,11 @@ class WhoisServiceHandlerTest {
   }
 
   @Test
-  void testSuccess_fireInboundHttpRequest() {
+  void testSuccess_fireInboundHttpRequest() throws Exception {
     ByteBuf inputBuffer = Unpooled.wrappedBuffer(QUERY_CONTENT.getBytes(US_ASCII));
     FullHttpRequest expectedRequest =
-        makeWhoisHttpRequest(QUERY_CONTENT, RELAY_HOST, RELAY_PATH, ACCESS_TOKEN);
+        makeWhoisHttpRequest(
+            QUERY_CONTENT, RELAY_HOST, RELAY_PATH, mockCredentials, Optional.of(IAP_CLIENT_ID));
     // Input data passed to next handler
     assertThat(channel.writeInbound(inputBuffer)).isTrue();
     FullHttpRequest inputRequest = channel.readInbound();
@@ -109,6 +126,27 @@ class WhoisServiceHandlerTest {
     // The channel is still open, and nothing else is to be written to it.
     assertThat((Object) channel.readOutbound()).isNull();
     assertThat(channel.isActive()).isFalse();
+  }
+
+  @Test
+  void testSuccess_withoutIapClientId() throws Exception {
+    // Without an IAP client ID configured, we shouldn't include the proxy-authorization header
+    WhoisServiceHandler nonIapHandler =
+        new WhoisServiceHandler(
+            RELAY_HOST, RELAY_PATH, () -> mockCredentials, Optional.empty(), metrics);
+    channel = new EmbeddedChannel(nonIapHandler);
+
+    ByteBuf inputBuffer = Unpooled.wrappedBuffer(QUERY_CONTENT.getBytes(US_ASCII));
+    FullHttpRequest expectedRequest =
+        makeWhoisHttpRequest(
+            QUERY_CONTENT, RELAY_HOST, RELAY_PATH, mockCredentials, Optional.empty());
+    // Input data passed to next handler
+    assertThat(channel.writeInbound(inputBuffer)).isTrue();
+    FullHttpRequest inputRequest = channel.readInbound();
+    assertThat(inputRequest).isEqualTo(expectedRequest);
+    // The channel is still open, and nothing else is to be read from it.
+    assertThat((Object) channel.readInbound()).isNull();
+    assertThat(channel.isActive()).isTrue();
   }
 
   @Test


### PR DESCRIPTION
This is only generated and used if "iapClientId" is set in the proxy config. If so, we use code similar to
https://cloud.google.com/iap/docs/authentication-howto#obtaining_an_oidc_token_for_the_default_service_account to generate an ID token that is valid for IAP. We set the token on the Proxy-Authorization header so that we can keep using the pre-existing access token as well -- IAP allows for us to use either the Authorization header or the Proxy-Authorization header.

Tested:
- Turned on IAP in QA and removed the standard OAuth authentication mechanism (to make sure we hit the IAP mechanism)
- Added the QA IAP client ID in the proxy's QA config, deployed this code, and ran some tests. We successfully parsed the token but failed because we haven't set up an account in the QA database for the proxy service account yet (this is expected)
- Turned off IAP in QA and re-added the OAuth authentication mechanism, keeping the IAP client ID in the proxy
- Ran more tests and these successfully authed using the old auth mechanism (this is expected) 



<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1926)
<!-- Reviewable:end -->
