### PR TITLE
Allow incorrect fee extensions on domain creates with default tokens

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -337,7 +337,7 @@ public final class DomainCreateFlow implements TransactionalFlow {
     FeesAndCredits feesAndCredits =
         pricingLogic.getCreatePrice(
             registry, targetId, now, years, isAnchorTenant, allocationToken);
-    validateFeeChallenge(feeCreate, feesAndCredits);
+    validateFeeChallenge(feeCreate, feesAndCredits, false);
     Optional<SecDnsCreateExtension> secDnsCreate =
         validateSecDnsExtension(eppInput.getSingleExtension(SecDnsCreateExtension.class));
     DateTime registrationExpirationTime = leapSafeAddYears(now, years);

--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -277,8 +277,12 @@ public final class DomainCreateFlow implements TransactionalFlow {
             registrarId,
             now,
             eppInput.getSingleExtension(AllocationTokenExtension.class));
+    boolean defaultTokenUsed = false;
     if (!allocationToken.isPresent() && !registry.getDefaultPromoTokens().isEmpty()) {
       allocationToken = checkForDefaultToken(registry, command);
+      if (allocationToken.isPresent()) {
+        defaultTokenUsed = true;
+      }
     }
     boolean isAnchorTenant =
         isAnchorTenant(
@@ -337,7 +341,7 @@ public final class DomainCreateFlow implements TransactionalFlow {
     FeesAndCredits feesAndCredits =
         pricingLogic.getCreatePrice(
             registry, targetId, now, years, isAnchorTenant, allocationToken);
-    validateFeeChallenge(feeCreate, feesAndCredits, false);
+    validateFeeChallenge(feeCreate, feesAndCredits, defaultTokenUsed);
     Optional<SecDnsCreateExtension> secDnsCreate =
         validateSecDnsExtension(eppInput.getSingleExtension(SecDnsCreateExtension.class));
     DateTime registrationExpirationTime = leapSafeAddYears(now, years);

--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -778,12 +778,13 @@ public class DomainFlowUtils {
    */
   public static void validateFeeChallenge(
       final Optional<? extends FeeTransformCommandExtension> feeCommand,
-      FeesAndCredits feesAndCredits)
+      FeesAndCredits feesAndCredits,
+      boolean defaultTokenUsed)
       throws EppException {
     if (feesAndCredits.hasAnyPremiumFees() && !feeCommand.isPresent()) {
       throw new FeesRequiredForPremiumNameException();
     }
-    validateFeesAckedIfPresent(feeCommand, feesAndCredits);
+    validateFeesAckedIfPresent(feeCommand, feesAndCredits, defaultTokenUsed);
   }
 
   /**
@@ -795,7 +796,8 @@ public class DomainFlowUtils {
    */
   public static void validateFeesAckedIfPresent(
       final Optional<? extends FeeTransformCommandExtension> feeCommand,
-      FeesAndCredits feesAndCredits)
+      FeesAndCredits feesAndCredits,
+      boolean defaultTokenUsed)
       throws EppException {
     // Check for the case where a fee command extension was required but not provided.
     // This only happens when the total fees are non-zero and include custom fees requiring the
@@ -856,7 +858,9 @@ public class DomainFlowUtils {
     // Checking if total amount is expected. Extra fees that we are not expecting may be passed in.
     // Or if there is only a single fee type expected.
     if (!feeTotal.equals(feesAndCredits.getTotalCost())) {
-      throw new FeesMismatchException(feesAndCredits.getTotalCost());
+      if (!defaultTokenUsed || feeTotal.isLessThan(feesAndCredits.getTotalCost())) {
+        throw new FeesMismatchException(feesAndCredits.getTotalCost());
+      }
     }
   }
 

--- a/core/src/main/java/google/registry/flows/domain/DomainRenewFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRenewFlow.java
@@ -199,7 +199,7 @@ public final class DomainRenewFlow implements TransactionalFlow {
             now,
             years,
             existingRecurringBillingEvent);
-    validateFeeChallenge(feeRenew, feesAndCredits);
+    validateFeeChallenge(feeRenew, feesAndCredits, false);
     flowCustomLogic.afterValidation(
         AfterValidationParameters.newBuilder()
             .setExistingDomain(existingDomain)

--- a/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
@@ -226,7 +226,7 @@ public final class DomainRestoreRequestFlow implements TransactionalFlow {
     if (!existingDomain.getGracePeriodStatuses().contains(GracePeriodStatus.REDEMPTION)) {
       throw new DomainNotEligibleForRestoreException();
     }
-    validateFeeChallenge(feeUpdate, feesAndCredits);
+    validateFeeChallenge(feeUpdate, feesAndCredits, false);
   }
 
   private static Domain performRestore(

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
@@ -210,7 +210,7 @@ public final class DomainTransferRequestFlow implements TransactionalFlow {
     }
 
     if (feesAndCredits.isPresent()) {
-      validateFeeChallenge(feeTransfer, feesAndCredits.get());
+      validateFeeChallenge(feeTransfer, feesAndCredits.get(), false);
     }
     HistoryEntryId domainHistoryId = createHistoryEntryId(existingDomain);
     historyBuilder

--- a/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
@@ -231,7 +231,7 @@ public final class DomainUpdateFlow implements TransactionalFlow {
     Optional<FeeUpdateCommandExtension> feeUpdate =
         eppInput.getSingleExtension(FeeUpdateCommandExtension.class);
     FeesAndCredits feesAndCredits = pricingLogic.getUpdatePrice(registry, targetId, now);
-    validateFeesAckedIfPresent(feeUpdate, feesAndCredits);
+    validateFeesAckedIfPresent(feeUpdate, feesAndCredits, false);
     verifyNotInPendingDelete(
         add.getContacts(),
         command.getInnerChange().getRegistrant(),

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -1106,8 +1106,10 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDefaultPromoTokens(ImmutableList.of(defaultToken.createVKey()))
             .setCreateBillingCost(Money.of(USD, 8))
             .build());
+    // Expects fee of $26
     setEppInput("domain_create_fee.xml", ImmutableMap.of("FEE_VERSION", "0.6", "CURRENCY", "USD"));
     persistContactsAndHosts();
+    // $12 is equal to 50% off the first year registration and 0% 0ff the 2nd year
     runFlowAssertResponse(
         loadFile(
             "domain_create_response_fee.xml",
@@ -1131,6 +1133,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDefaultPromoTokens(ImmutableList.of(defaultToken.createVKey()))
             .setCreateBillingCost(Money.of(USD, 100))
             .build());
+    // Expects fee of $26
     setEppInput("domain_create_fee.xml", ImmutableMap.of("FEE_VERSION", "0.6", "CURRENCY", "USD"));
     persistContactsAndHosts();
     EppException thrown = assertThrows(FeesMismatchException.class, this::runFlow);
@@ -1164,8 +1167,10 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDefaultPromoTokens(ImmutableList.of(defaultToken.createVKey()))
             .setCreateBillingCost(Money.of(USD, 8))
             .build());
+    // Expects fee of $26
     setEppInput("domain_create_fee.xml", ImmutableMap.of("FEE_VERSION", "0.11", "CURRENCY", "USD"));
     persistContactsAndHosts();
+    // $12 is equal to 50% off the first year registration and 0% 0ff the 2nd year
     runFlowAssertResponse(
         loadFile(
             "domain_create_response_fee.xml",
@@ -1189,6 +1194,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDefaultPromoTokens(ImmutableList.of(defaultToken.createVKey()))
             .setCreateBillingCost(Money.of(USD, 100))
             .build());
+    // Expects fee of $26
     setEppInput("domain_create_fee.xml", ImmutableMap.of("FEE_VERSION", "0.11", "CURRENCY", "USD"));
     persistContactsAndHosts();
     EppException thrown = assertThrows(FeesMismatchException.class, this::runFlow);
@@ -1222,8 +1228,10 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDefaultPromoTokens(ImmutableList.of(defaultToken.createVKey()))
             .setCreateBillingCost(Money.of(USD, 8))
             .build());
+    // Expects fee of $26
     setEppInput("domain_create_fee.xml", ImmutableMap.of("FEE_VERSION", "0.12", "CURRENCY", "USD"));
     persistContactsAndHosts();
+    // $12 is equal to 50% off the first year registration and 0% 0ff the 2nd year
     runFlowAssertResponse(
         loadFile(
             "domain_create_response_fee.xml",
@@ -1247,6 +1255,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDefaultPromoTokens(ImmutableList.of(defaultToken.createVKey()))
             .setCreateBillingCost(Money.of(USD, 100))
             .build());
+    // Expects fee of $26
     setEppInput("domain_create_fee.xml", ImmutableMap.of("FEE_VERSION", "0.12", "CURRENCY", "USD"));
     persistContactsAndHosts();
     EppException thrown = assertThrows(FeesMismatchException.class, this::runFlow);

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_response_fee.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_response_fee.xml
@@ -14,7 +14,7 @@
     <extension>
       <fee:creData xmlns:fee="urn:ietf:params:xml:ns:fee-%FEE_VERSION%">
         <fee:currency>USD</fee:currency>
-        <fee:fee description="create">26.00</fee:fee>
+        <fee:fee description="create">%FEE%</fee:fee>
       </fee:creData>
     </extension>
     <trID>


### PR DESCRIPTION
Allow Domain creations to succeed if the fee in the fee extension is equal to or higher than the actual cost of the registration with the default token applied. Still require fees to match if there are no valid default tokens.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1927)
<!-- Reviewable:end -->
