### PR TITLE
Change base image for schema-verifier and schema-deployer

### DIFF
--- a/release/schema-deployer/Dockerfile
+++ b/release/schema-deployer/Dockerfile
@@ -23,7 +23,7 @@
 
 # Although any Linux-based Java image with bash would work (e.g., openjdk:11),
 # as a GCP application we prefer to start with a GCP-approved base image.
-FROM marketplace.gcr.io/google/ubuntu1804
+FROM marketplace.gcr.io/google/debian10
 ENV DEBIAN_FRONTEND=noninteractive LANG=en_US.UTF-8
 # Install openjdk-11
 RUN apt-get update -y \

--- a/release/schema-verifier/Dockerfile
+++ b/release/schema-verifier/Dockerfile
@@ -22,7 +22,7 @@
 # Please refer to verify_deployed_sql_schema.sh for expected volumes and
 # arguments.
 
-FROM marketplace.gcr.io/google/ubuntu1804
+FROM marketplace.gcr.io/google/debian10
 ENV DEBIAN_FRONTEND=noninteractive LANG=en_US.UTF-8
 # Install pg_dump v11 (same as current server version). This needs to be
 # downloaded from postgresql's own repo, because ubuntu1804 is too old. With a


### PR DESCRIPTION
Ubuntu 18.04 is entering EOL and the Cloud Build jobs are failing,
seemingly due to connection error to 18.04 repos:

https://pantheon.corp.google.com/cloud-build/builds;region=global/126a7c90-4322-41f1-ba1c-a10e38a32dab;step=5?project=domain-registry-dev

We use Debian 10 for the main builder, so it's better to keep everything
on the same schedule:

https://cs.opensource.google/nomulus/nomulus/+/master:release/builder/Dockerfile

Debian 10 is supported till June 2024:

https://wiki.debian.org/LTS

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1930)
<!-- Reviewable:end -->
