### PR TITLE
Install procps

### DIFF
--- a/release/schema-verifier/Dockerfile
+++ b/release/schema-verifier/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update -y \
            'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
            > /etc/apt/sources.list.d/pgdg.list' \
     && apt-get update -y \
-    && apt install postgresql-client-11 -y
+    && apt install postgresql-client-11 procps -y
 
 # Use unzip to extract files from jars.
 RUN apt-get install zip -y


### PR DESCRIPTION
The schema verifier script needs pgrep and pkill, which do not come with
Debian.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1932)
<!-- Reviewable:end -->
