### PR TITLE
Change default beam job region

### DIFF
--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -427,7 +427,7 @@ misc:
 
 beam:
   # The default region to run Apache Beam (Cloud Dataflow) jobs in.
-  defaultJobRegion: us-east1
+  defaultJobRegion: us-central1
   # The GCE machine type to use when a job is CPU-intensive (e. g. RDE). Be sure
   # to check the VM CPU quota for the job region. In a massively parallel
   # pipeline this quota can be easily reached and needs to be raised, otherwise

--- a/core/src/main/resources/google/registry/beam/expand_recurring_billing_events_pipeline_metadata.json
+++ b/core/src/main/resources/google/registry/beam/expand_recurring_billing_events_pipeline_metadata.json
@@ -24,12 +24,6 @@
       "is_optional": false
     },
     {
-      "name": "shard",
-      "label": "The exclusive upper bound of the operation window.",
-      "helpText": "The exclusive upper bound of the operation window, in ISO 8601 format.",
-      "is_optional": true
-    },
-    {
       "name": "isDryRun",
       "label": "Whether this job is a dry run.",
       "helpText": "If true, no changes will be saved to the database.",


### PR DESCRIPTION
For reasons that I cannot explain, the same expand recurring billing
event pipeline would fail in us-east1 but succeed in us-central1.

See:

https://pantheon.corp.google.com/dataflow/jobs/us-central1/2023-02-09_14_52_24-162498476138221714;graphView=0?project=domain-registry

https://pantheon.corp.google.com/dataflow/jobs/us-east1/2023-02-09_14_26_07-4564782062878841960;graphView=1?project=domain-registry

Also improved how the accuracy of the metrics:

It is observed that both counters are consistently higher for the same
start and end times when running in dry run mode. There is no way to
test for consistency when not running in dry run, for obviously reasons.

I can make the recurrings in scope counter consistent by not updating it
in a side-effect-causing transaction, but there is no way around the
other counter. It can only be trusted when running in dry run mode,
unfortunately.
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1937)
<!-- Reviewable:end -->
