### PR TITLE
Remove "letter G with stroke" from Extended Latin IDN table

### DIFF
--- a/core/src/main/java/google/registry/idn/Latin-IDN.txt
+++ b/core/src/main/java/google/registry/idn/Latin-IDN.txt
@@ -68,7 +68,6 @@ U+011F                         # LATIN SMALL LETTER G WITH BREVE
 U+01E7                         # LATIN SMALL LETTER G WITH CARON
 U+0121                         # LATIN SMALL LETTER G WITH DOT ABOVE
 U+0123                         # LATIN SMALL LETTER G WITH CEDILLA
-U+01E5                         # LATIN SMALL LETTER G WITH STROKE
 U+0068                         # LATIN SMALL LETTER H
 U+0127                         # LATIN SMALL LETTER H WITH STROKE
 U+0069                         # LATIN SMALL LETTER I

--- a/core/src/main/java/google/registry/tldconfig/idn/extended_latin.txt
+++ b/core/src/main/java/google/registry/tldconfig/idn/extended_latin.txt
@@ -49,7 +49,6 @@ U+011F                         # LATIN SMALL LETTER G WITH BREVE
 U+01E7                         # LATIN SMALL LETTER G WITH CARON
 U+0121                         # LATIN SMALL LETTER G WITH DOT ABOVE
 U+0123                         # LATIN SMALL LETTER G WITH CEDILLA
-U+01E5                         # LATIN SMALL LETTER G WITH STROKE
 U+0068                         # LATIN SMALL LETTER H
 U+0127                         # LATIN SMALL LETTER H WITH STROKE
 U+0069                         # LATIN SMALL LETTER I


### PR DESCRIPTION
ICANN doesn't like this character because it's confusable with a normal G (the stroke tends to get lost in the visual clutter of the descender), and .com's Extended Latin table doesn't use it either. Best to get rid of it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1938)
<!-- Reviewable:end -->
