### PR TITLE
Add allowed license for json

### DIFF
--- a/config/dependency-license/allowed_licenses.json
+++ b/config/dependency-license/allowed_licenses.json
@@ -271,6 +271,10 @@
       "moduleName": "org.tukaani:xz"
     },
     {
+      "moduleLicense": "Public Domain",
+      "moduleName": "org.json:json"
+    },
+    {
       // "Apache License, Version 2.0".
       "moduleLicense": null,
       "moduleVersion": "2.10.0",


### PR DESCRIPTION
For some reason `./gradlew clean build` on master is failing for me on
multiple machines due to a new org.json:json version triggering license
violations, even though the lock files are not changing.

Note that the old versions are still present because if I remove
"The JSON license", which the old versions use, the check also fails...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1942)
<!-- Reviewable:end -->
