### PR TITLE
Remove dnsRefreshRequestTime from EppResources

### DIFF
--- a/core/src/main/java/google/registry/model/EppResource.java
+++ b/core/src/main/java/google/registry/model/EppResource.java
@@ -33,7 +33,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.annotations.Expose;
 import google.registry.config.RegistryConfig;
-import google.registry.dns.RefreshDnsAction;
 import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.transfer.TransferData;
 import google.registry.persistence.VKey;
@@ -42,7 +41,6 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import javax.annotation.Nullable;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
 import javax.persistence.AttributeOverride;
@@ -137,23 +135,6 @@ public abstract class EppResource extends UpdateAutoTimestampEntity implements B
   /** Status values associated with this resource. */
   @Expose Set<StatusValue> statuses;
 
-  /**
-   * When this domain/host's DNS was requested to be refreshed, or null if its DNS is up-to-date.
-   *
-   * <p>This will almost always be null except in the couple of minutes' interval between when a
-   * DNS-affecting create or update operation takes place and when the {@link RefreshDnsAction}
-   * runs, which resets this back to null upon completion of the DNS refresh task. This is a {@link
-   * DateTime} rather than a simple dirty boolean so that the DNS refresh action can order by the
-   * DNS refresh request time and take action on the oldest ones first.
-   *
-   * <p>Note that in the {@code DomainHistory}/{@code HostHistory} table this value means something
-   * slightly different: It means that the given domain/host action requested a DNS update. Unlike
-   * on the {@code Domain}/{code Host} table, this value is not then subsequently nulled out once
-   * the DNS refresh is complete; rather, it remains as a permanent record of which actions were
-   * DNS-affecting and which were not.
-   */
-  @Transient @Nullable protected DateTime dnsRefreshRequestTime;
-
   public String getRepoId() {
     return repoId;
   }
@@ -203,19 +184,6 @@ public abstract class EppResource extends UpdateAutoTimestampEntity implements B
 
   public DateTime getDeletionTime() {
     return deletionTime;
-  }
-
-  /**
-   * Returns the DNS refresh request time iff this domain/host's DNS needs refreshing, otherwise
-   * absent.
-   */
-  public Optional<DateTime> getDnsRefreshRequestTime() {
-    return Optional.ofNullable(dnsRefreshRequestTime);
-  }
-
-  @SuppressWarnings("unused")
-  private void setInternalDnsRefreshRequestTime(DateTime time) {
-    dnsRefreshRequestTime = time;
   }
 
   /** Return a clone of the resource with timed status values modified using the given time. */
@@ -368,11 +336,6 @@ public abstract class EppResource extends UpdateAutoTimestampEntity implements B
      */
     public B setUpdateTimestamp(UpdateAutoTimestamp updateTimestamp) {
       getInstance().setUpdateTimestamp(updateTimestamp);
-      return thisCastToDerived();
-    }
-
-    public B setDnsRefreshRequestTime(Optional<DateTime> dnsRefreshRequestTime) {
-      getInstance().dnsRefreshRequestTime = dnsRefreshRequestTime.orElse(null);
       return thisCastToDerived();
     }
 

--- a/core/src/main/java/google/registry/model/domain/Domain.java
+++ b/core/src/main/java/google/registry/model/domain/Domain.java
@@ -58,7 +58,6 @@ import org.joda.time.DateTime;
       @Index(columnList = "techContact"),
       @Index(columnList = "tld"),
       @Index(columnList = "registrantContact"),
-      @Index(columnList = "dnsRefreshRequestTime"),
       @Index(columnList = "lordnPhase"),
       @Index(columnList = "billing_recurrence_id"),
       @Index(columnList = "transfer_billing_event_id"),
@@ -200,7 +199,6 @@ public class Domain extends DomainBase implements ForeignKeyedEppResource {
           .setSubordinateHosts(domainBase.getSubordinateHosts())
           .setStatusValues(domainBase.getStatusValues())
           .setTransferData(domainBase.getTransferData())
-          .setDnsRefreshRequestTime(domainBase.getDnsRefreshRequestTime())
           .setLordnPhase(domainBase.getLordnPhase())
           .setCurrentPackageToken(domainBase.getCurrentPackageToken().orElse(null));
     }

--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -274,13 +274,6 @@ public class DomainBase extends EppResource
     return lordnPhase;
   }
 
-  @Access(AccessType.PROPERTY)
-  @SuppressWarnings("unused")
-  @Column(name = "dnsRefreshRequestTime")
-  private DateTime getInternalDnsRefreshRequestTime() {
-    return getDnsRefreshRequestTime().orElse(null);
-  }
-
   public ImmutableSet<String> getSubordinateHosts() {
     return nullToEmptyImmutableCopy(subordinateHosts);
   }

--- a/core/src/main/java/google/registry/model/host/Host.java
+++ b/core/src/main/java/google/registry/model/host/Host.java
@@ -49,7 +49,6 @@ import javax.persistence.Table;
       @Index(columnList = "creationTime"),
       @Index(columnList = "deletionTime"),
       @Index(columnList = "currentSponsorRegistrarId"),
-      @Index(columnList = "dnsRefreshRequestTime")
     })
 @ExternalMessagingName("host")
 @WithVKey(String.class)
@@ -94,7 +93,6 @@ public class Host extends HostBase implements ForeignKeyedEppResource {
           .setPersistedCurrentSponsorRegistrarId(hostBase.getPersistedCurrentSponsorRegistrarId())
           .setRepoId(hostBase.getRepoId())
           .setSuperordinateDomain(hostBase.getSuperordinateDomain())
-          .setDnsRefreshRequestTime(hostBase.getDnsRefreshRequestTime())
           .setStatusValues(hostBase.getStatusValues());
     }
   }

--- a/core/src/main/java/google/registry/model/host/HostBase.java
+++ b/core/src/main/java/google/registry/model/host/HostBase.java
@@ -32,7 +32,6 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import javax.persistence.Access;
 import javax.persistence.AccessType;
-import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import javax.persistence.MappedSuperclass;
 import org.joda.time.DateTime;
@@ -85,13 +84,6 @@ public class HostBase extends EppResource {
    * superordinate domain.
    */
   DateTime lastSuperordinateChange;
-
-  @Access(AccessType.PROPERTY)
-  @SuppressWarnings("unused")
-  @Column(name = "dnsRefreshRequestTime")
-  private DateTime getInternalDnsRefreshRequestTime() {
-    return getDnsRefreshRequestTime().orElse(null);
-  }
 
   public String getHostName() {
     return hostName;

--- a/core/src/test/java/google/registry/model/domain/DomainTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainTest.java
@@ -221,7 +221,6 @@ public class DomainTest {
                             "TheRegistrar",
                             oneTimeBillKey))
                     .setAutorenewEndTime(Optional.of(fakeClock.nowUtc().plusYears(2)))
-                    .setDnsRefreshRequestTime(Optional.of(fakeClock.nowUtc()))
                     .build()));
   }
 

--- a/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
@@ -41,8 +41,6 @@ import google.registry.model.reporting.DomainTransactionRecord;
 import google.registry.model.reporting.DomainTransactionRecord.TransactionReportField;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.util.SerializeUtils;
-import java.util.Optional;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -97,7 +95,6 @@ public class DomainHistoryTest extends EntityTestCase {
             .asBuilder()
             .setNameservers(host.createVKey())
             .setDsData(ImmutableSet.of(DomainDsData.create(1, 2, 3, new byte[] {0, 1, 2})))
-            .setDnsRefreshRequestTime(Optional.of(DateTime.parse("2020-03-09T16:40:00Z")))
             .build();
     insertInDb(domain);
     return domain;

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -276,7 +276,6 @@
         deletion_poll_message_id int8,
         domain_name text,
         idn_table_name text,
-        dns_refresh_request_time timestamptz,
         last_transfer_time timestamptz,
         launch_notice_accepted_time timestamptz,
         launch_notice_expiration_time timestamptz,
@@ -349,7 +348,6 @@
         deletion_poll_message_id int8,
         domain_name text,
         idn_table_name text,
-        dns_refresh_request_time timestamptz,
         last_transfer_time timestamptz,
         launch_notice_accepted_time timestamptz,
         launch_notice_expiration_time timestamptz,
@@ -451,7 +449,6 @@
         statuses text[],
         host_name text,
         inet_addresses text[],
-        dns_refresh_request_time timestamptz,
         last_superordinate_change timestamptz,
         last_transfer_time timestamptz,
         superordinate_domain text,
@@ -472,7 +469,6 @@
         history_xml_bytes bytea,
         host_name text,
         inet_addresses text[],
-        dns_refresh_request_time timestamptz,
         last_superordinate_change timestamptz,
         last_transfer_time timestamptz,
         superordinate_domain text,
@@ -801,7 +797,6 @@ create index IDXc5aw4pk1vkd6ymhvkpanmoadv on "Domain" (domain_name);
 create index IDXr22ciyccwi9rrqmt1ro0s59qf on "Domain" (tech_contact);
 create index IDXrwl38wwkli1j7gkvtywi9jokq on "Domain" (tld);
 create index IDXa7fu0bqynfb79rr80528b4jqt on "Domain" (registrant_contact);
-create index IDXcws5mvmpl8o10wrhde780ors2 on "Domain" (dns_refresh_request_time);
 create index IDXnjhib7v6fj7dhj5qydkefkl2u on "Domain" (lordn_phase);
 create index IDXsfci08jgsymxy6ovh4k7r358c on "Domain" (billing_recurrence_id);
 create index IDX3y3k7m2bkgahm9sixiohgyrga on "Domain" (transfer_billing_event_id);
@@ -825,7 +820,6 @@ create index IDXkpkh68n6dy5v51047yr6b0e9l on "Host" (host_name);
 create index IDXy98mebut8ix1v07fjxxdkqcx on "Host" (creation_time);
 create index IDXovmntef6l45tw2bsfl56tcugx on "Host" (deletion_time);
 create index IDXl49vydnq0h5j1piefwjy4i8er on "Host" (current_sponsor_registrar_id);
-create index IDX7wg0yn3wdux3xsc4pfaljqf08 on "Host" (dns_refresh_request_time);
 create index IDXfg2nnjlujxo6cb9fha971bq2n on "HostHistory" (creation_time);
 create index IDX1iy7njgb7wjmj9piml4l2g0qi on "HostHistory" (history_registrar_id);
 create index IDXkkwbwcwvrdkkqothkiye4jiff on "HostHistory" (host_name);


### PR DESCRIPTION
We have decided to use a separate table (#1940) to track DNS refresh requests
due to performance reasons.

See: go/registry-pull-queue-redesign

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1943)
<!-- Reviewable:end -->
