### PR TITLE
Ignore invalid old CRL when performing update.

### DIFF
--- a/util/src/main/java/google/registry/util/X509Utils.java
+++ b/util/src/main/java/google/registry/util/X509Utils.java
@@ -44,6 +44,7 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import javax.annotation.Tainted;
 
 /** X.509 Public Key Infrastructure (PKI) helper functions. */
@@ -163,12 +164,12 @@ public final class X509Utils {
    * are correct with respect to {@code now}.
    *
    * @throws GeneralSecurityException for unsupported protocols, certs not signed by the TMCH,
-   *         incorrect keys, and for invalid, old, not-yet-valid or revoked certificates.
+   *     incorrect keys, and for invalid, old, not-yet-valid or revoked certificates.
    */
   public static void verifyCrl(
-      X509Certificate rootCert, X509CRL oldCrl, @Tainted X509CRL newCrl, Date now)
+      X509Certificate rootCert, @Nullable X509CRL oldCrl, @Tainted X509CRL newCrl, Date now)
       throws GeneralSecurityException {
-    if (newCrl.getThisUpdate().before(oldCrl.getThisUpdate())) {
+    if (oldCrl != null && newCrl.getThisUpdate().before(oldCrl.getThisUpdate())) {
       throw new CRLException(String.format(
           "New CRL is more out of date than our current CRL. %s < %s\n%s",
           newCrl.getThisUpdate(), oldCrl.getThisUpdate(), newCrl));


### PR DESCRIPTION
There is no point comparing the old CRL to the new ones when the old one
is invalid. This could happen when the CA cert rotates, after which the
old CRL stop being valid as it fails signature verification against the
new cert.

This change will allow us to keep updating the CRL after a CA rotation without
having to manually delete the old CRL from the database.

See b/270983553.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1946)
<!-- Reviewable:end -->
