### PR TITLE
Separate DEFAULT_TOKEN type into CREATE and RENEW types

### DIFF
--- a/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
+++ b/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
@@ -118,8 +118,17 @@ public class AllocationToken extends UpdateAutoTimestampEntity implements Builda
 
   /** Type of the token that indicates how and where it should be used. */
   public enum TokenType {
+    /**
+     * Token soved on a TLD to use on a create request if no other token is passed from the client
+     */
+    DEFAULT_CREATE_PROMO,
     /** Token saved on a TLD to use if no other token is passed from the client */
+    @Deprecated
     DEFAULT_PROMO,
+    /**
+     * Token soved on a TLD to use on a renew request if no other token is passed from the client
+     */
+    DEFAULT_RENEW_PROMO,
     /** Token used for package pricing */
     PACKAGE,
     /** Invalid after use */

--- a/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
+++ b/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
@@ -123,6 +123,7 @@ public class AllocationToken extends UpdateAutoTimestampEntity implements Builda
      */
     DEFAULT_CREATE_PROMO,
     /** Token saved on a TLD to use if no other token is passed from the client */
+    // TODO(sarahbot@): Remove this type once we are sure it is safe
     @Deprecated
     DEFAULT_PROMO,
     /**

--- a/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
+++ b/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
@@ -119,14 +119,14 @@ public class AllocationToken extends UpdateAutoTimestampEntity implements Builda
   /** Type of the token that indicates how and where it should be used. */
   public enum TokenType {
     /**
-     * Token soved on a TLD to use on a create request if no other token is passed from the client
+     * Token saved on a TLD to use on a create request if no other token is passed from the client
      */
     DEFAULT_CREATE_PROMO,
     /** Token saved on a TLD to use if no other token is passed from the client */
     @Deprecated
     DEFAULT_PROMO,
     /**
-     * Token soved on a TLD to use on a renew request if no other token is passed from the client
+     * Token saved on a TLD to use on a renew request if no other token is passed from the client
      */
     DEFAULT_RENEW_PROMO,
     /** Token used for package pricing */

--- a/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
+++ b/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
@@ -22,6 +22,7 @@ import static google.registry.model.domain.token.AllocationToken.TokenStatus.CAN
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.ENDED;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.NOT_STARTED;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.VALID;
+import static google.registry.model.domain.token.AllocationToken.TokenType.DEFAULT_PROMO;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.CollectionUtils.forceEmptyToNull;
 import static google.registry.util.CollectionUtils.nullToEmptyImmutableCopy;
@@ -370,6 +371,11 @@ public class AllocationToken extends UpdateAutoTimestampEntity implements Builda
       checkArgument(
           getInstance().discountFraction > 0 || getInstance().discountYears == 1,
           "Discount years can only be specified along with a discount fraction");
+      // Don't allow DEFAULT_TOKEN token type on new tokens so the deprecated type is safe to remove
+      // in the future
+      checkArgument(
+          !getInstance().getTokenType().equals(DEFAULT_PROMO),
+          "DEFAULT_PROMO is a deprecated token type and should not be used");
       if (getInstance().registrationBehavior.equals(RegistrationBehavior.ANCHOR_TENANT)) {
         checkArgumentNotNull(
             getInstance().domainName, "ANCHOR_TENANT tokens must be tied to a domain");

--- a/core/src/main/java/google/registry/model/tld/Registry.java
+++ b/core/src/main/java/google/registry/model/tld/Registry.java
@@ -926,10 +926,11 @@ public class Registry extends ImmutableObject implements Buildable, UnsafeSerial
                 for (VKey<AllocationToken> tokenKey : promoTokens) {
                   AllocationToken token = tm().loadByKey(tokenKey);
                   checkArgument(
-                      token.getTokenType().equals(TokenType.DEFAULT_PROMO),
+                      token.getTokenType().equals(TokenType.DEFAULT_CREATE_PROMO)
+                          || token.getTokenType().equals(TokenType.DEFAULT_RENEW_PROMO),
                       String.format(
                           "Token %s has an invalid token type of %s. DefaultPromoTokens must be of"
-                              + " the type DEFAULT_PROMO",
+                              + " the type DEFAULT_CREATE_PROMO or DEFAULT_RENEW_PROMO",
                           token.getToken(), token.getTokenType()));
                   checkArgument(
                       token.getAllowedTlds().contains(getInstance().tldStr),

--- a/core/src/main/java/google/registry/tools/GenerateAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateAllocationTokensCommand.java
@@ -18,7 +18,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Sets.difference;
 import static google.registry.model.billing.BillingEvent.RenewalPriceBehavior.DEFAULT;
-import static google.registry.model.domain.token.AllocationToken.TokenType.DEFAULT_PROMO;
 import static google.registry.model.domain.token.AllocationToken.TokenType.PACKAGE;
 import static google.registry.model.domain.token.AllocationToken.TokenType.SINGLE_USE;
 import static google.registry.model.domain.token.AllocationToken.TokenType.UNLIMITED_USE;
@@ -277,12 +276,6 @@ class GenerateAllocationTokensCommand implements Command {
     if (tokenStrings != null) {
       verifyTokenStringsDoNotExist();
     }
-
-    // Don't allow DEFAULT_TOKEN token type on new tokens so the deprecated type is safe to remove
-    // in the future
-    checkArgument(
-        !DEFAULT_PROMO.equals(tokenType),
-        "DEFAULT_PROMO is a deprecated token type and should not be used");
   }
 
   private void verifyTokenStringsDoNotExist() {

--- a/core/src/main/java/google/registry/tools/GenerateAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateAllocationTokensCommand.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Sets.difference;
 import static google.registry.model.billing.BillingEvent.RenewalPriceBehavior.DEFAULT;
+import static google.registry.model.domain.token.AllocationToken.TokenType.DEFAULT_PROMO;
 import static google.registry.model.domain.token.AllocationToken.TokenType.PACKAGE;
 import static google.registry.model.domain.token.AllocationToken.TokenType.SINGLE_USE;
 import static google.registry.model.domain.token.AllocationToken.TokenType.UNLIMITED_USE;
@@ -101,7 +102,9 @@ class GenerateAllocationTokensCommand implements Command {
 
   @Parameter(
       names = {"-t", "--type"},
-      description = "Type of type token, either SINGLE_USE (default) or UNLIMITED_USE")
+      description =
+          "Type of token, either DEFAULT_CREATE_PROMO, DEFAULT_RENEW_PROMO, PACKAGE, SINGLE_USE"
+              + " (default) or UNLIMITED_USE")
   private TokenType tokenType;
 
   @Parameter(
@@ -274,6 +277,12 @@ class GenerateAllocationTokensCommand implements Command {
     if (tokenStrings != null) {
       verifyTokenStringsDoNotExist();
     }
+
+    // Don't allow DEFAULT_TOKEN token type on new tokens so the deprecated type is safe to remove
+    // in the future
+    checkArgument(
+        !DEFAULT_PROMO.equals(tokenType),
+        "DEFAULT_PROMO is a deprecated token type and should not be used");
   }
 
   private void verifyTokenStringsDoNotExist() {

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -26,7 +26,7 @@ import static google.registry.model.billing.BillingEvent.RenewalPriceBehavior.DE
 import static google.registry.model.billing.BillingEvent.RenewalPriceBehavior.NONPREMIUM;
 import static google.registry.model.billing.BillingEvent.RenewalPriceBehavior.SPECIFIED;
 import static google.registry.model.domain.fee.Fee.FEE_EXTENSION_URIS;
-import static google.registry.model.domain.token.AllocationToken.TokenType.DEFAULT_PROMO;
+import static google.registry.model.domain.token.AllocationToken.TokenType.DEFAULT_CREATE_PROMO;
 import static google.registry.model.domain.token.AllocationToken.TokenType.PACKAGE;
 import static google.registry.model.domain.token.AllocationToken.TokenType.SINGLE_USE;
 import static google.registry.model.domain.token.AllocationToken.TokenType.UNLIMITED_USE;
@@ -1129,7 +1129,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("bbbbb")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("TheRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .setDiscountFraction(0.5)
@@ -1156,7 +1156,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("bbbbb")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("TheRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .setDiscountFraction(0.5)
@@ -1190,7 +1190,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("bbbbb")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("TheRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .setDiscountFraction(0.5)
@@ -1217,7 +1217,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("bbbbb")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("TheRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .setDiscountFraction(0.5)
@@ -1251,7 +1251,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("bbbbb")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("TheRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .setDiscountFraction(0.5)
@@ -1278,7 +1278,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("bbbbb")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("TheRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .setDiscountFraction(0.5)
@@ -1862,7 +1862,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("aaaaa")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("NewRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .build());
@@ -1870,7 +1870,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("bbbbb")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("TheRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .build());
@@ -1896,7 +1896,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("aaaaa")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("NewRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .build());
@@ -1904,7 +1904,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("bbbbb")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("TheRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .build());
@@ -1934,7 +1934,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("aaaaa")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("NewRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .build());
@@ -1942,7 +1942,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("bbbbb")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("OtherRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .build());
@@ -1961,7 +1961,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("aaaaa")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("NewRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .build());
@@ -1969,7 +1969,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("bbbbb")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("NewRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .build());
@@ -1988,7 +1988,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("aaaaa")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("NewRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .build());
@@ -1996,7 +1996,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("bbbbb")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("TheRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .build());
@@ -2017,7 +2017,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("aaaaa")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("NewRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .build());
@@ -2025,7 +2025,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("bbbbb")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setDiscountFraction(0.5)
                 .setAllowedRegistrarIds(ImmutableSet.of("TheRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
@@ -2047,7 +2047,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("aaaaa")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedRegistrarIds(ImmutableSet.of("NewRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .build());
@@ -2055,7 +2055,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("bbbbb")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setDiscountFraction(0.5)
                 .setAllowedRegistrarIds(ImmutableSet.of("TheRegistrar"))
                 .setAllowedTlds(ImmutableSet.of("tld"))

--- a/core/src/test/java/google/registry/model/tld/RegistryTest.java
+++ b/core/src/test/java/google/registry/model/tld/RegistryTest.java
@@ -17,7 +17,7 @@ package google.registry.model.tld;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static com.google.common.truth.Truth8.assertThat;
-import static google.registry.model.domain.token.AllocationToken.TokenType.DEFAULT_PROMO;
+import static google.registry.model.domain.token.AllocationToken.TokenType.DEFAULT_CREATE_PROMO;
 import static google.registry.model.domain.token.AllocationToken.TokenType.SINGLE_USE;
 import static google.registry.model.tld.Registry.TldState.GENERAL_AVAILABILITY;
 import static google.registry.model.tld.Registry.TldState.PREDELEGATION;
@@ -643,7 +643,7 @@ public final class RegistryTest extends EntityTestCase {
             new AllocationToken()
                 .asBuilder()
                 .setToken("abc123")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .build());
     AllocationToken token2 =
@@ -651,7 +651,7 @@ public final class RegistryTest extends EntityTestCase {
             new AllocationToken()
                 .asBuilder()
                 .setToken("token")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedTlds(ImmutableSet.of("tld"))
                 .build());
     ImmutableList<VKey<AllocationToken>> tokens =
@@ -683,7 +683,7 @@ public final class RegistryTest extends EntityTestCase {
     assertThat(thrown.getMessage())
         .isEqualTo(
             "Token abc123 has an invalid token type of SINGLE_USE. DefaultPromoTokens must be of"
-                + " the type DEFAULT_PROMO");
+                + " the type DEFAULT_CREATE_PROMO or DEFAULT_RENEW_PROMO");
   }
 
   @Test
@@ -695,7 +695,7 @@ public final class RegistryTest extends EntityTestCase {
             new AllocationToken()
                 .asBuilder()
                 .setToken("abc123")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedTlds(ImmutableSet.of("example"))
                 .build());
     IllegalArgumentException thrown =

--- a/core/src/test/java/google/registry/tools/CreateTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateTldCommandTest.java
@@ -16,7 +16,7 @@ package google.registry.tools;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
-import static google.registry.model.domain.token.AllocationToken.TokenType.DEFAULT_PROMO;
+import static google.registry.model.domain.token.AllocationToken.TokenType.DEFAULT_CREATE_PROMO;
 import static google.registry.model.tld.Registry.TldState.GENERAL_AVAILABILITY;
 import static google.registry.model.tld.Registry.TldState.PREDELEGATION;
 import static google.registry.testing.DatabaseHelper.createTld;
@@ -578,7 +578,7 @@ class CreateTldCommandTest extends CommandTestCase<CreateTldCommand> {
             new AllocationToken()
                 .asBuilder()
                 .setToken("abc123")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedTlds(ImmutableSet.of("xn--q9jyb4c"))
                 .build());
     runCommandForced(
@@ -597,7 +597,7 @@ class CreateTldCommandTest extends CommandTestCase<CreateTldCommand> {
             new AllocationToken()
                 .asBuilder()
                 .setToken("abc123")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedTlds(ImmutableSet.of("xn--q9jyb4c"))
                 .build());
     AllocationToken token2 =
@@ -605,7 +605,7 @@ class CreateTldCommandTest extends CommandTestCase<CreateTldCommand> {
             new AllocationToken()
                 .asBuilder()
                 .setToken("token")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedTlds(ImmutableSet.of("xn--q9jyb4c"))
                 .build());
     runCommandForced(

--- a/core/src/test/java/google/registry/tools/GenerateAllocationTokensCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateAllocationTokensCommandTest.java
@@ -376,8 +376,8 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
     assertThat(thrown)
         .hasMessageThat()
         .isEqualTo(
-            "Invalid value for -t parameter. Allowed values:[DEFAULT_PROMO, PACKAGE, SINGLE_USE,"
-                + " UNLIMITED_USE]");
+            "Invalid value for -t parameter. Allowed values:[DEFAULT_CREATE_PROMO, DEFAULT_PROMO,"
+                + " DEFAULT_RENEW_PROMO, PACKAGE, SINGLE_USE, UNLIMITED_USE]");
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/UpdateTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateTldCommandTest.java
@@ -16,7 +16,8 @@ package google.registry.tools;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
-import static google.registry.model.domain.token.AllocationToken.TokenType.DEFAULT_PROMO;
+import static google.registry.model.domain.token.AllocationToken.TokenType.DEFAULT_CREATE_PROMO;
+import static google.registry.model.domain.token.AllocationToken.TokenType.DEFAULT_RENEW_PROMO;
 import static google.registry.model.tld.Registry.TldState.GENERAL_AVAILABILITY;
 import static google.registry.model.tld.Registry.TldState.PREDELEGATION;
 import static google.registry.model.tld.Registry.TldState.QUIET_PERIOD;
@@ -184,7 +185,7 @@ class UpdateTldCommandTest extends CommandTestCase<UpdateTldCommand> {
             new AllocationToken()
                 .asBuilder()
                 .setToken("abc123")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedTlds(ImmutableSet.of("xn--q9jyb4c"))
                 .build());
     assertThat(Registry.get("xn--q9jyb4c").getDefaultPromoTokens()).isEmpty();
@@ -200,7 +201,7 @@ class UpdateTldCommandTest extends CommandTestCase<UpdateTldCommand> {
             new AllocationToken()
                 .asBuilder()
                 .setToken("abc123")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedTlds(ImmutableSet.of("xn--q9jyb4c"))
                 .build());
     AllocationToken token2 =
@@ -208,7 +209,7 @@ class UpdateTldCommandTest extends CommandTestCase<UpdateTldCommand> {
             new AllocationToken()
                 .asBuilder()
                 .setToken("token")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_RENEW_PROMO)
                 .setAllowedTlds(ImmutableSet.of("xn--q9jyb4c"))
                 .build());
     assertThat(Registry.get("xn--q9jyb4c").getDefaultPromoTokens()).isEmpty();
@@ -224,7 +225,7 @@ class UpdateTldCommandTest extends CommandTestCase<UpdateTldCommand> {
             new AllocationToken()
                 .asBuilder()
                 .setToken("abc123")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedTlds(ImmutableSet.of("xn--q9jyb4c"))
                 .build());
     assertThat(Registry.get("xn--q9jyb4c").getDefaultPromoTokens()).isEmpty();
@@ -246,7 +247,7 @@ class UpdateTldCommandTest extends CommandTestCase<UpdateTldCommand> {
             new AllocationToken()
                 .asBuilder()
                 .setToken("abc123")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedTlds(ImmutableSet.of("xn--q9jyb4c"))
                 .build());
     AllocationToken token2 =
@@ -254,7 +255,7 @@ class UpdateTldCommandTest extends CommandTestCase<UpdateTldCommand> {
             new AllocationToken()
                 .asBuilder()
                 .setToken("token")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_CREATE_PROMO)
                 .setAllowedTlds(ImmutableSet.of("xn--q9jyb4c"))
                 .build());
     AllocationToken token3 =
@@ -262,7 +263,7 @@ class UpdateTldCommandTest extends CommandTestCase<UpdateTldCommand> {
             new AllocationToken()
                 .asBuilder()
                 .setToken("othertoken")
-                .setTokenType(DEFAULT_PROMO)
+                .setTokenType(DEFAULT_RENEW_PROMO)
                 .setAllowedTlds(ImmutableSet.of("xn--q9jyb4c"))
                 .build());
     assertThat(Registry.get("xn--q9jyb4c").getDefaultPromoTokens()).isEmpty();


### PR DESCRIPTION
This separates the DEFAULT_TOKEN type into DEFAULT_CREATE_TOKEN and DEFAULT_RENEW_TOKEN. This will allow us to store default tokens for both types of commands on the same field of the TLD but distinguish what specific command that token should be applied to. 

This marks the DEFAULT_TOKEN type as deprecated, however I do not believe there currently are any tokens in production or sandbox with that type, so it may be safe to remove it entirely.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1952)
<!-- Reviewable:end -->
