### PR TITLE
Double the number of frontend instances on production from 12 to 24

### DIFF
--- a/core/src/main/java/google/registry/env/production/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/default/WEB-INF/appengine-web.xml
@@ -7,7 +7,7 @@
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <manual-scaling>
-    <instances>12</instances>
+    <instances>24</instances>
   </manual-scaling>
 
   <system-properties>


### PR DESCRIPTION
It seems like we're hitting App Engine capacity issues resulting in actual pages now (for whatever reason, but likely one customer), and we obviously don't want that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1954)
<!-- Reviewable:end -->
