### PR TITLE
Allow for multiple service accounts in authentication

### DIFF
--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -107,9 +107,9 @@ public final class RegistryConfig {
     }
 
     @Provides
-    @Config("cloudSchedulerServiceAccountEmail")
-    public static String provideCloudSchedulerServiceAccountEmail(RegistryConfigSettings config) {
-      return config.gcpProject.cloudSchedulerServiceAccountEmail;
+    @Config("serviceAccountEmails")
+    public static ImmutableList<String> provideServiceAccountEmails(RegistryConfigSettings config) {
+      return ImmutableList.copyOf(config.gcpProject.serviceAccountEmails);
     }
 
     @Provides

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -54,7 +54,7 @@ public class RegistryConfigSettings {
     public String backendServiceUrl;
     public String toolsServiceUrl;
     public String pubapiServiceUrl;
-    public String cloudSchedulerServiceAccountEmail;
+    public List<String> serviceAccountEmails;
   }
 
   /** Configuration options for OAuth settings for authenticating users. */

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -22,8 +22,11 @@ gcpProject:
   backendServiceUrl: https://localhost
   toolsServiceUrl: https://localhost
   pubapiServiceUrl: https://localhost
-  # Service account used by Cloud Scheduler to send authenticated requests.
-  cloudSchedulerServiceAccountEmail: cloud-scheduler-email@email.com
+  # Service accounts eligible for authorization (e.g. default service account,
+  # account used by Cloud Scheduler) to send authenticated requests.
+  serviceAccountEmails:
+  - default-service-account-email@email.com
+  - cloud-scheduler-email@email.com
 
 gSuite:
   # Publicly accessible domain name of the running G Suite instance.

--- a/core/src/main/java/google/registry/request/auth/ServiceAccountAuthenticationMechanism.java
+++ b/core/src/main/java/google/registry/request/auth/ServiceAccountAuthenticationMechanism.java
@@ -18,6 +18,7 @@ import static com.google.common.net.HttpHeaders.AUTHORIZATION;
 import static google.registry.request.auth.AuthLevel.APP;
 
 import com.google.auth.oauth2.TokenVerifier;
+import com.google.common.collect.ImmutableList;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.request.auth.AuthModule.ServiceAccount;
 import javax.inject.Inject;
@@ -30,16 +31,16 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class ServiceAccountAuthenticationMechanism extends IdTokenAuthenticationBase {
 
-  private final String cloudSchedulerEmailPrefix;
   private static final String BEARER_PREFIX = "Bearer ";
+
+  private final ImmutableList<String> serviceAccountEmails;
 
   @Inject
   public ServiceAccountAuthenticationMechanism(
       @ServiceAccount TokenVerifier tokenVerifier,
-      @Config("cloudSchedulerServiceAccountEmail") String cloudSchedulerEmailPrefix) {
-
+      @Config("serviceAccountEmails") ImmutableList<String> serviceAccountEmails) {
     super(tokenVerifier);
-    this.cloudSchedulerEmailPrefix = cloudSchedulerEmailPrefix;
+    this.serviceAccountEmails = serviceAccountEmails;
   }
 
   @Override
@@ -53,7 +54,7 @@ public class ServiceAccountAuthenticationMechanism extends IdTokenAuthentication
 
   @Override
   AuthResult authResultFromEmail(String emailAddress) {
-    if (emailAddress.equals(cloudSchedulerEmailPrefix)) {
+    if (serviceAccountEmails.stream().anyMatch(e -> e.equals(emailAddress))) {
       return AuthResult.create(APP);
     } else {
       return AuthResult.NOT_AUTHENTICATED;


### PR DESCRIPTION
When submitting tasks to Cloud Tasks, we will use the built-in OIDC authentication which runs under the default service account (not the cloud scheduler service account). We want either to work for app-level auth.