### PR TITLE
Transaction manager to not retry inner transactions

### DIFF
--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -154,6 +154,10 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
 
   @Override
   public <T> T transact(Supplier<T> work) {
+    // This prevents inner transaction from retrying, thus avoiding a cascade retry effect.
+    if (inTransaction()) {
+      return transactNoRetry(work);
+    }
     return retrier.callWithRetry(() -> transactNoRetry(work), JpaRetries::isFailedTxnRetriable);
   }
 


### PR DESCRIPTION
This resolves b/256151008 
The test added shows that without the change outer transaction retries 3 times and inner transaction retries 9 times, with the change inner transaction retries 3 times as well as outer transaction.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1974)
<!-- Reviewable:end -->
