### PR TITLE
Add disable_runner_v2 to pipeline options

### DIFF
--- a/release/stage_beam_pipeline.sh
+++ b/release/stage_beam_pipeline.sh
@@ -75,5 +75,6 @@ while (( "$#" > 0 )); do
     --metadata-file "./core/src/main/resources/${metadata_pathname}" \
     --jar "./core/build/libs/${uberjar_name}.jar" \
     --env FLEX_TEMPLATE_JAVA_MAIN_CLASS="${main_class}" \
+    --additional-experiments=disable_runner_v2 \
     --project "${dev_project}"
 done


### PR DESCRIPTION
Fix turned out to be pretty easy, however discovering it and verifying on alpha was a bit complex. 
Anyhow the fix verified on alpha on `expand-billing-2023-03-26t03-00-00z-2023-03-30t17-14-33z` pipeline. It confirmed to be successful with runner v2 disabled.

TODO: b/276340570 to track the status of runner_v2 + autosharding in the future. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1976)
<!-- Reviewable:end -->
