### PR TITLE
Add Java code for storing and using IDN tables per-TLD

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -176,8 +176,7 @@ public class DomainFlowUtils {
       CharMatcher.inRange('a', 'z').or(CharMatcher.inRange('0', '9').or(CharMatcher.anyOf("-.")));
 
   /** Default validator used to determine if an IDN name can be provisioned on a TLD. */
-  private static final IdnLabelValidator IDN_LABEL_VALIDATOR =
-      IdnLabelValidator.createDefaultIdnLabelValidator();
+  private static final IdnLabelValidator IDN_LABEL_VALIDATOR = new IdnLabelValidator();
 
   /** The maximum number of DS records allowed on a domain. */
   private static final int MAX_DS_RECORDS_PER_DOMAIN = 8;

--- a/core/src/main/java/google/registry/model/tld/Registry.java
+++ b/core/src/main/java/google/registry/model/tld/Registry.java
@@ -52,6 +52,7 @@ import google.registry.model.tld.label.PremiumList;
 import google.registry.model.tld.label.ReservedList;
 import google.registry.persistence.VKey;
 import google.registry.persistence.converter.JodaMoneyType;
+import google.registry.tldconfig.idn.IdnTableEnum;
 import google.registry.util.Idn;
 import java.util.List;
 import java.util.Map;
@@ -487,6 +488,9 @@ public class Registry extends ImmutableObject implements Buildable, UnsafeSerial
    */
   List<VKey<AllocationToken>> defaultPromoTokens;
 
+  /** A set of allowed {@link IdnTableEnum}s for this TLD, or empty if we should use the default. */
+  Set<IdnTableEnum> idnTables;
+
   public String getTldStr() {
     return tldStr;
   }
@@ -692,6 +696,10 @@ public class Registry extends ImmutableObject implements Buildable, UnsafeSerial
 
   public ImmutableList<VKey<AllocationToken>> getDefaultPromoTokens() {
     return nullToEmptyImmutableCopy(defaultPromoTokens);
+  }
+
+  public ImmutableSet<IdnTableEnum> getIdnTables() {
+    return nullToEmptyImmutableCopy(idnTables);
   }
 
   @Override
@@ -989,6 +997,11 @@ public class Registry extends ImmutableObject implements Buildable, UnsafeSerial
                 }
                 getInstance().defaultPromoTokens = promoTokens;
               });
+      return this;
+    }
+
+    public Builder setIdnTables(ImmutableSet<IdnTableEnum> idnTables) {
+      getInstance().idnTables = idnTables;
       return this;
     }
 

--- a/core/src/main/java/google/registry/persistence/converter/IdnTableEnumSetConverter.java
+++ b/core/src/main/java/google/registry/persistence/converter/IdnTableEnumSetConverter.java
@@ -1,0 +1,34 @@
+// Copyright 2023 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.persistence.converter;
+
+import google.registry.tldconfig.idn.IdnTableEnum;
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+/** JPA {@link AttributeConverter} for storing/retrieving {@link IdnTableEnum}s. */
+@Converter(autoApply = true)
+public class IdnTableEnumSetConverter extends StringSetConverterBase<IdnTableEnum> {
+
+  @Override
+  String toString(IdnTableEnum element) {
+    return element.name();
+  }
+
+  @Override
+  IdnTableEnum fromString(String value) {
+    return IdnTableEnum.valueOf(value);
+  }
+}

--- a/core/src/main/resources/META-INF/persistence.xml
+++ b/core/src/main/resources/META-INF/persistence.xml
@@ -91,6 +91,7 @@
     <class>google.registry.persistence.converter.DatabaseMigrationScheduleTransitionConverter</class>
     <class>google.registry.persistence.converter.DateTimeConverter</class>
     <class>google.registry.persistence.converter.DurationConverter</class>
+    <class>google.registry.persistence.converter.IdnTableEnumSetConverter</class>
     <class>google.registry.persistence.converter.InetAddressSetConverter</class>
     <class>google.registry.persistence.converter.LocalDateConverter</class>
     <class>google.registry.persistence.converter.PostalInfoChoiceListConverter</class>

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -724,6 +724,7 @@
         drive_folder_id text,
         eap_fee_schedule hstore not null,
         escrow_enabled boolean not null,
+        idn_tables text[],
         invoicing_enabled boolean not null,
         lordn_username text,
         num_dns_publish_locks int4 not null,


### PR DESCRIPTION
This includes changes to make sure that we use the proper per-TLD IDN tables as well as setting/updating/removing them via the Create/Update TLD commands.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1977)
<!-- Reviewable:end -->
