### PR TITLE
Allow a credit of 0 when deleting a domain during a grace period

### DIFF
--- a/core/src/main/java/google/registry/model/domain/fee/Credit.java
+++ b/core/src/main/java/google/registry/model/domain/fee/Credit.java
@@ -34,7 +34,7 @@ public class Credit extends BaseFee {
       BigDecimal cost, FeeType type, String description) {
     Credit instance = new Credit();
     instance.cost = checkNotNull(cost);
-    checkArgument(instance.cost.signum() < 0);
+    checkArgument(instance.cost.signum() <= 0, "A credit cannot have a positive cost");
     instance.type = checkNotNull(type);
     instance.description = description;
     return instance;

--- a/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
@@ -1236,4 +1236,16 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     EppException thrown = assertThrows(UnimplementedExtensionException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
+
+  @Test
+  void testSuccess_freeCreation_deletionDuringGracePeriod() throws Exception {
+    // Deletion during the add grace period should still work even if the credit is 0
+    setUpSuccessfulTest();
+    BillingEvent.OneTime graceBillingEvent =
+        persistResource(createBillingEvent(Reason.CREATE, Money.of(USD, 0)));
+    setUpGracePeriods(
+        GracePeriod.forBillingEvent(GracePeriodStatus.ADD, domain.getRepoId(), graceBillingEvent));
+    clock.advanceOneMilli();
+    runFlowAssertResponse(loadFile("domain_delete_response_fee_free_grace.xml"));
+  }
 }

--- a/core/src/test/resources/google/registry/flows/domain/domain_delete_response_fee_free_grace.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_delete_response_fee_free_grace.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<epp xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xmlns:contact="urn:ietf:params:xml:ns:contact-1.0" xmlns:fee="urn:ietf:params:xml:ns:fee-0.6" xmlns:packageToken="urn:google:params:xml:ns:packageToken-1.0" xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0" xmlns:fee11="urn:ietf:params:xml:ns:fee-0.11" xmlns:fee12="urn:ietf:params:xml:ns:fee-0.12" xmlns:launch="urn:ietf:params:xml:ns:launch-1.0" xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1" xmlns:host="urn:ietf:params:xml:ns:host-1.0">
+  <response>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
+    </result>
+    <extension>
+      <fee12:delData>
+        <fee12:currency>USD</fee12:currency>
+        <fee12:credit description="addPeriod credit">0.00</fee12:credit>
+      </fee12:delData>
+    </extension>
+    <trID>
+      <clTRID>ABC-12345</clTRID>
+      <svTRID>server-trid</svTRID>
+    </trID>
+  </response>
+</epp>


### PR DESCRIPTION
There can be situations (anchor tenants, test tokens, other ways of getting a domain to cost $0) where we may want to delete a domain during the add grace period but the credit applied is 0. We should not fail on those cases.

See b/277115241 for an example.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1984)
<!-- Reviewable:end -->
