### PR TITLE
Trim cloud scheduler config url value before submitting

### DIFF
--- a/release/builder/cloudSchedulerDeployer.go
+++ b/release/builder/cloudSchedulerDeployer.go
@@ -93,7 +93,7 @@ func main() {
 			"http", taskRecord.Name,
 			"--location", "us-central1",
 			"--schedule", taskRecord.Schedule,
-			"--uri", fmt.Sprintf("https://backend-dot-%s.appspot.com%s", projectName, taskRecord.URL),
+			"--uri", fmt.Sprintf("https://backend-dot-%s.appspot.com%s", projectName, strings.TrimSpace(taskRecord.URL)),
 			"--description", description,
 			"--http-method", "get",
 			"--oidc-service-account-email", serviceAccountEmail,


### PR DESCRIPTION
This should resolve failing deployment because of the extra new line or empty space in xml config

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/1988)
<!-- Reviewable:end -->
