### PR TITLE
Allow usage of standard HTTP requests in CloudTasksUtils

### DIFF
--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -109,12 +109,6 @@ public final class RegistryConfig {
     }
 
     @Provides
-    @Config("serviceAccountEmails")
-    public static ImmutableList<String> provideServiceAccountEmails(RegistryConfigSettings config) {
-      return ImmutableList.copyOf(config.gcpProject.serviceAccountEmails);
-    }
-
-    @Provides
     @Config("projectIdNumber")
     public static long provideProjectIdNumber(RegistryConfigSettings config) {
       return config.gcpProject.projectIdNumber;
@@ -124,6 +118,18 @@ public final class RegistryConfig {
     @Config("locationId")
     public static String provideLocationId(RegistryConfigSettings config) {
       return config.gcpProject.locationId;
+    }
+
+    @Provides
+    @Config("serviceAccountEmails")
+    public static ImmutableList<String> provideServiceAccountEmails(RegistryConfigSettings config) {
+      return ImmutableList.copyOf(config.gcpProject.serviceAccountEmails);
+    }
+
+    @Provides
+    @Config("defaultServiceAccount")
+    public static Optional<String> provideDefaultServiceAccount(RegistryConfigSettings config) {
+      return Optional.ofNullable(config.gcpProject.defaultServiceAccount);
     }
 
     /**

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -55,6 +55,7 @@ public class RegistryConfigSettings {
     public String toolsServiceUrl;
     public String pubapiServiceUrl;
     public List<String> serviceAccountEmails;
+    public String defaultServiceAccount;
   }
 
   /** Configuration options for OAuth settings for authenticating users. */

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -27,6 +27,9 @@ gcpProject:
   serviceAccountEmails:
   - default-service-account-email@email.com
   - cloud-scheduler-email@email.com
+  # The default service account with which the service is running. For example,
+  # on GAE this would be {project-id}@appspot.gserviceaccount.com
+  defaultServiceAccount: null
 
 gSuite:
   # Publicly accessible domain name of the running G Suite instance.

--- a/core/src/main/java/google/registry/cron/TldFanoutAction.java
+++ b/core/src/main/java/google/registry/cron/TldFanoutAction.java
@@ -140,13 +140,25 @@ public final class TldFanoutAction implements Runnable {
     for (String tld : tlds) {
       Task task = createTask(tld, flowThruParams);
       Task createdTask = cloudTasksUtils.enqueue(queue, task);
-      outputPayload.append(
-          String.format(
-              "- Task: '%s', tld: '%s', endpoint: '%s'\n",
-              createdTask.getName(), tld, createdTask.getAppEngineHttpRequest().getRelativeUri()));
-      logger.atInfo().log(
-          "Task: '%s', tld: '%s', endpoint: '%s'.",
-          createdTask.getName(), tld, createdTask.getAppEngineHttpRequest().getRelativeUri());
+      if (createdTask.hasAppEngineHttpRequest()) {
+        outputPayload.append(
+            String.format(
+                "- Task: '%s', tld: '%s', endpoint: '%s'\n",
+                createdTask.getName(),
+                tld,
+                createdTask.getAppEngineHttpRequest().getRelativeUri()));
+        logger.atInfo().log(
+            "Task: '%s', tld: '%s', endpoint: '%s'.",
+            createdTask.getName(), tld, createdTask.getAppEngineHttpRequest().getRelativeUri());
+      } else {
+        outputPayload.append(
+            String.format(
+                "- Task: '%s', tld: '%s', endpoint: '%s'\n",
+                createdTask.getName(), tld, createdTask.getHttpRequest().getUrl()));
+        logger.atInfo().log(
+            "Task: '%s', tld: '%s', endpoint: '%s'.",
+            createdTask.getName(), tld, createdTask.getHttpRequest().getUrl());
+      }
     }
     response.setContentType(PLAIN_TEXT_UTF_8);
     response.setPayload(outputPayload.toString());

--- a/core/src/main/java/google/registry/tools/ServiceConnection.java
+++ b/core/src/main/java/google/registry/tools/ServiceConnection.java
@@ -85,7 +85,7 @@ public class ServiceConnection {
   private String internalSend(
       String endpoint, Map<String, ?> params, MediaType contentType, @Nullable byte[] payload)
       throws IOException {
-    GenericUrl url = new GenericUrl(String.format("%s%s", getServer(), endpoint));
+    GenericUrl url = new GenericUrl(String.format("%s%s", getServer(service), endpoint));
     url.putAll(params);
     HttpRequest request =
         (payload != null)
@@ -141,7 +141,7 @@ public class ServiceConnection {
     return (Map<String, Object>) JSONValue.parse(response.substring(JSON_SAFETY_PREFIX.length()));
   }
 
-  public URL getServer() {
+  public static URL getServer(Service service) {
     switch (service) {
       case DEFAULT:
         return RegistryConfig.getDefaultServer();

--- a/core/src/test/java/google/registry/testing/CloudTasksHelper.java
+++ b/core/src/test/java/google/registry/testing/CloudTasksHelper.java
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -107,6 +108,8 @@ public class CloudTasksHelper implements Serializable {
             clock,
             PROJECT_ID,
             LOCATION_ID,
+            Optional.empty(),
+            Optional.empty(),
             new FakeCloudTasksClient());
     testTasks.put(instanceId, Multimaps.synchronizedListMultimap(LinkedListMultimap.create()));
   }


### PR DESCRIPTION
This adds a possible configuration point "defaultServiceAccount" (which in GAE will be the standard GAE service account). If this is configured, CloudTasksUtils can create tasks with standard HTTP requests with an OIDC token corresponding to that service account, as opposed to using the AppEngine-specific request methods.

This also works with IAP, in that if IAP is on and we specify the IAP client ID in the config, CloudTasksUtils will use the IAP client ID as the token audience and the request will successfully be passed through the IAP layer. Unfortunately, unlike other areas (e.g. RequestFactoryModule), we cannot use both IAP and standard authentication; we must choose one. This means that we will need to turn on IAP at roughly the same time that we deploy with the internal configuration change that adds the IAP client ID.

Tetsted in QA.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2013)
<!-- Reviewable:end -->
