### PR TITLE
Remove CloudSql wipeout cron job in crash

### DIFF
--- a/core/src/main/java/google/registry/env/crash/default/WEB-INF/cloud-scheduler-tasks.xml
+++ b/core/src/main/java/google/registry/env/crash/default/WEB-INF/cloud-scheduler-tasks.xml
@@ -158,16 +158,4 @@
     </description>
     <schedule>7 3 * * *</schedule>
   </task>
-
-  <!--
-    The next two wipeout jobs are required when crash has production data.
-   -->
-  <task>
-    <url><![CDATA[/_dr/task/wipeOutCloudSql]]></url>
-    <name>wipeOutCloudSql</name>
-    <description>
-      This job runs an action that deletes all data in Cloud SQL.
-    </description>
-    <schedule>7 3 * * 6</schedule>
-  </task>
 </taskentries>


### PR DESCRIPTION
No more production data in crash. This allows us to repopulate crash with test data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2017)
<!-- Reviewable:end -->
