### PR TITLE
Change usage grouping key in the invoice CSV

### DIFF
--- a/core/src/main/java/google/registry/beam/billing/BillingEvent.java
+++ b/core/src/main/java/google/registry/beam/billing/BillingEvent.java
@@ -189,7 +189,7 @@ public abstract class BillingEvent implements Serializable {
                 .minusDays(1)
                 .toString(),
         billingId(),
-        String.format("%s - %s", registrarId(), tld()),
+        registrarId(),
         String.format("%s | TLD: %s | TERM: %d-year", action(), tld(), years()),
         amount(),
         currency(),
@@ -233,7 +233,7 @@ public abstract class BillingEvent implements Serializable {
     /** Returns the billing account id, which is the {@code BillingEvent.billingId}. */
     abstract String productAccountKey();
 
-    /** Returns the invoice grouping key, which is in the format "registrarId - tld". */
+    /** Returns the invoice grouping key, which is the registrar ID. */
     abstract String usageGroupingKey();
 
     /** Returns a description of the item, formatted as "action | TLD: tld | TERM: n-year." */

--- a/core/src/test/java/google/registry/beam/billing/BillingEventTest.java
+++ b/core/src/test/java/google/registry/beam/billing/BillingEventTest.java
@@ -83,7 +83,7 @@ class BillingEventTest {
     assertThat(invoiceKey.startDate()).isEqualTo("2017-10-01");
     assertThat(invoiceKey.endDate()).isEqualTo("2022-09-30");
     assertThat(invoiceKey.productAccountKey()).isEqualTo("12345-CRRHELLO");
-    assertThat(invoiceKey.usageGroupingKey()).isEqualTo("myRegistrar - test");
+    assertThat(invoiceKey.usageGroupingKey()).isEqualTo("myRegistrar");
     assertThat(invoiceKey.description()).isEqualTo("RENEW | TLD: test | TERM: 5-year");
     assertThat(invoiceKey.unitPrice()).isEqualTo(20.5);
     assertThat(invoiceKey.unitPriceCurrency()).isEqualTo("USD");
@@ -104,7 +104,7 @@ class BillingEventTest {
     assertThat(invoiceKey.toCsv(3L))
         .isEqualTo(
             "2017-10-01,2022-09-30,12345-CRRHELLO,61.50,USD,10125,1,PURCHASE,"
-                + "myRegistrar - test,3,RENEW | TLD: test | TERM: 5-year,20.50,USD,");
+                + "myRegistrar,3,RENEW | TLD: test | TERM: 5-year,20.50,USD,");
   }
 
   @Test
@@ -114,7 +114,7 @@ class BillingEventTest {
     assertThat(invoiceKey.toCsv(3L))
         .isEqualTo(
             "2017-10-01,,12345-CRRHELLO,61.50,USD,10125,1,PURCHASE,"
-                + "myRegistrar - test,3,RENEW | TLD: test | TERM: 0-year,20.50,USD,");
+                + "myRegistrar,3,RENEW | TLD: test | TERM: 0-year,20.50,USD,");
   }
 
   @Test

--- a/core/src/test/java/google/registry/beam/billing/InvoicingPipelineTest.java
+++ b/core/src/test/java/google/registry/beam/billing/InvoicingPipelineTest.java
@@ -224,13 +224,13 @@ class InvoicingPipelineTest {
 
   private static final ImmutableList<String> EXPECTED_INVOICE_OUTPUT =
       ImmutableList.of(
-          "2017-10-01,2020-09-30,234,41.00,USD,10125,1,PURCHASE,theRegistrar - test,2,"
+          "2017-10-01,2020-09-30,234,41.00,USD,10125,1,PURCHASE,theRegistrar,2,"
               + "RENEW | TLD: test | TERM: 3-year,20.50,USD,",
-          "2017-10-01,2022-09-30,234,70.00,JPY,10125,1,PURCHASE,theRegistrar - hello,1,"
+          "2017-10-01,2022-09-30,234,70.00,JPY,10125,1,PURCHASE,theRegistrar,1,"
               + "CREATE | TLD: hello | TERM: 5-year,70.00,JPY,",
-          "2017-10-01,,234,20.00,USD,10125,1,PURCHASE,theRegistrar - test,1,"
+          "2017-10-01,,234,20.00,USD,10125,1,PURCHASE,theRegistrar,1,"
               + "SERVER_STATUS | TLD: test | TERM: 0-year,20.00,USD,",
-          "2017-10-01,2018-09-30,456,20.50,USD,10125,1,PURCHASE,bestdomains - test,1,"
+          "2017-10-01,2018-09-30,456,20.50,USD,10125,1,PURCHASE,bestdomains,1,"
               + "RENEW | TLD: test | TERM: 1-year,20.50,USD,116688");
 
   private final InvoicingPipelineOptions options =


### PR DESCRIPTION
This column is used by the billing team to create invoices. Registrars
have asked that a single invoice be created for a given registrar,
instead of one per registrar-tld pair. This should have no other effect
on the billing pipeline as the invoice grouping key has a description
field that also contains the TLD, so the granularity as a whole does not
change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2024)
<!-- Reviewable:end -->
