### PR TITLE
Add batching to the RefreshDnsForAllDomainsAction

### DIFF
--- a/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
+++ b/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
@@ -21,10 +21,10 @@ import static google.registry.model.tld.Tlds.assertTldsExist;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.RequestParameters.PARAM_TLDS;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
+import static com.google.common.collect.Iterables.getLast;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.google.common.flogger.FluentLogger;
 import google.registry.request.Action;
 import google.registry.request.Parameter;
@@ -115,11 +115,11 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
                       } catch (Throwable t) {
                         logger.atSevere().withCause(t).log(
                             "Error while enqueuing DNS refresh for domain '%s'.", domainName);
-                        response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+                        response.setStatus(HttpStatus.SC_OK);
                       }
                     });
               });
-      lastInPreviousBatch = Iterables.getLast(domainBatch);
+      lastInPreviousBatch = getLast(domainBatch);
     } while (lastBatchSize == batchSize);
   }
 }

--- a/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
+++ b/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
@@ -20,9 +20,11 @@ import static google.registry.dns.DnsUtils.requestDomainDnsRefresh;
 import static google.registry.model.tld.Tlds.assertTldsExist;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.RequestParameters.PARAM_TLDS;
+import static google.registry.util.DateTimeUtils.END_OF_TIME;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterables;
 import com.google.common.flogger.FluentLogger;
 import google.registry.request.Action;
 import google.registry.request.Parameter;
@@ -58,7 +60,7 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
-  static final int BATCH_SIZE = 10;
+  static final int BATCH_SIZE = 250;
 
   @Inject Response response;
 
@@ -81,38 +83,40 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
     assertTldsExist(tlds);
     checkArgument(smearMinutes > 0, "Must specify a positive number of smear minutes");
     String lastInPreviousBatch = "";
-    while (true) {
+    int lastBatchSize;
+    do {
       String previousLastName = lastInPreviousBatch;
       ImmutableList<String> domainBatch =
-          ImmutableList.copyOf(
-              tm().transact(
-                      () ->
-                          tm().query(
-                                  "SELECT domainName FROM Domain WHERE tld IN (:tlds) AND"
-                                      + " deletionTime > :now  AND domainName >"
-                                      + " :lastInPreviousBatch ORDER BY domainName ASC",
-                                  String.class)
-                              .setParameter("tlds", tlds)
-                              .setParameter("now", clock.nowUtc())
-                              .setParameter("lastInPreviousBatch", previousLastName)
-                              .setMaxResults(BATCH_SIZE)
-                              .getResultStream()
-                              .collect(toImmutableList())));
-
-      if (domainBatch.isEmpty()) break;
-      domainBatch.forEach(
-          domainName -> {
-            try {
-              // Smear the task execution time over the next N minutes.
-              requestDomainDnsRefresh(
-                  domainName, Duration.standardMinutes(random.nextInt(smearMinutes)));
-            } catch (Throwable t) {
-              logger.atSevere().withCause(t).log(
-                  "Error while enqueuing DNS refresh for domain '%s'.", domainName);
-              response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-            }
-          });
-      lastInPreviousBatch = domainBatch.get(domainBatch.size() - 1);
-    }
+          tm().transact(
+                  () ->
+                      tm().query(
+                              "SELECT domainName FROM Domain WHERE tld IN (:tlds) AND"
+                                  + " deletionTime = :endOfTime  AND domainName >"
+                                  + " :lastInPreviousBatch ORDER BY domainName ASC",
+                              String.class)
+                          .setParameter("tlds", tlds)
+                          .setParameter("endOfTime", END_OF_TIME)
+                          .setParameter("lastInPreviousBatch", previousLastName)
+                          .setMaxResults(BATCH_SIZE)
+                          .getResultStream()
+                          .collect(toImmutableList()));
+      lastBatchSize = domainBatch.size();
+      tm().transact(
+              () -> {
+                domainBatch.forEach(
+                    domainName -> {
+                      try {
+                        // Smear the task execution time over the next N minutes.
+                        requestDomainDnsRefresh(
+                            domainName, Duration.standardMinutes(random.nextInt(smearMinutes)));
+                      } catch (Throwable t) {
+                        logger.atSevere().withCause(t).log(
+                            "Error while enqueuing DNS refresh for domain '%s'.", domainName);
+                        response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+                      }
+                    });
+              });
+      lastInPreviousBatch = Iterables.getLast(domainBatch);
+    } while (lastBatchSize == BATCH_SIZE);
   }
 }

--- a/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
+++ b/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
@@ -15,11 +15,13 @@
 package google.registry.tools.server;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static google.registry.dns.DnsUtils.requestDomainDnsRefresh;
 import static google.registry.model.tld.Tlds.assertTldsExist;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.RequestParameters.PARAM_TLDS;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.FluentLogger;
 import google.registry.request.Action;
@@ -29,7 +31,6 @@ import google.registry.request.auth.Auth;
 import google.registry.util.Clock;
 import java.util.Random;
 import javax.inject.Inject;
-import javax.persistence.TypedQuery;
 import org.apache.http.HttpStatus;
 import org.joda.time.Duration;
 
@@ -57,6 +58,8 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
+  static final int BATCH_SIZE = 10;
+
   @Inject Response response;
 
   @Inject
@@ -66,11 +69,6 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
   @Inject
   @Parameter("smearMinutes")
   int smearMinutes;
-
-  /** Include deleted domain names. */
-  @Inject
-  @Parameter("includeDeleted")
-  boolean includeDeleted;
 
   @Inject Clock clock;
   @Inject Random random;
@@ -82,31 +80,39 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
   public void run() {
     assertTldsExist(tlds);
     checkArgument(smearMinutes > 0, "Must specify a positive number of smear minutes");
-    StringBuilder query = new StringBuilder("SELECT domainName FROM Domain WHERE tld IN (:tlds)");
-    if (!includeDeleted) {
-      query.append(" AND deletionTime > :now");
+    String lastInPreviousBatch = "";
+    while (true) {
+      String previousLastName = lastInPreviousBatch;
+      ImmutableList<String> domainBatch =
+          ImmutableList.copyOf(
+              tm().transact(
+                      () ->
+                          tm().query(
+                                  "SELECT domainName FROM Domain WHERE tld IN (:tlds) AND"
+                                      + " deletionTime > :now  AND domainName >"
+                                      + " :lastInPreviousBatch ORDER BY domainName ASC",
+                                  String.class)
+                              .setParameter("tlds", tlds)
+                              .setParameter("now", clock.nowUtc())
+                              .setParameter("lastInPreviousBatch", previousLastName)
+                              .setMaxResults(BATCH_SIZE)
+                              .getResultStream()
+                              .collect(toImmutableList())));
+
+      if (domainBatch.isEmpty()) break;
+      domainBatch.forEach(
+          domainName -> {
+            try {
+              // Smear the task execution time over the next N minutes.
+              requestDomainDnsRefresh(
+                  domainName, Duration.standardMinutes(random.nextInt(smearMinutes)));
+            } catch (Throwable t) {
+              logger.atSevere().withCause(t).log(
+                  "Error while enqueuing DNS refresh for domain '%s'.", domainName);
+              response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            }
+          });
+      lastInPreviousBatch = domainBatch.get(domainBatch.size() - 1);
     }
-    tm().transact(
-            () -> {
-              TypedQuery<String> typedQuery =
-                  tm().query(query.toString(), String.class).setParameter("tlds", tlds);
-              if (!includeDeleted) {
-                typedQuery.setParameter("now", clock.nowUtc());
-              }
-              typedQuery
-                  .getResultStream()
-                  .forEach(
-                      domainName -> {
-                        try {
-                          // Smear the task execution time over the next N minutes.
-                          requestDomainDnsRefresh(
-                              domainName, Duration.standardMinutes(random.nextInt(smearMinutes)));
-                        } catch (Throwable t) {
-                          logger.atSevere().withCause(t).log(
-                              "Error while enqueuing DNS refresh for domain '%s'.", domainName);
-                          response.setStatus(HttpStatus.SC_INTERNAL_SERVER_ERROR);
-                        }
-                      });
-            });
   }
 }

--- a/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
+++ b/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
@@ -78,7 +78,7 @@ public class ToolsServerModule {
 
   @Provides
   @Parameter("batchSize")
-  static int provideBatchSize(HttpServletRequest req) {
-    return extractOptionalIntParameter(req, "batchSize").orElse(250);
+  static Optional<Integer> provideBatchSize(HttpServletRequest req) {
+    return extractOptionalIntParameter(req, "batchSize");
   }
 }

--- a/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
+++ b/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
@@ -16,6 +16,7 @@ package google.registry.tools.server;
 
 import static com.google.common.base.Strings.emptyToNull;
 import static google.registry.request.RequestParameters.extractIntParameter;
+import static google.registry.request.RequestParameters.extractOptionalIntParameter;
 import static google.registry.request.RequestParameters.extractOptionalParameter;
 import static google.registry.request.RequestParameters.extractRequiredParameter;
 
@@ -84,6 +85,6 @@ public class ToolsServerModule {
   @Provides
   @Parameter("batchSize")
   static int provideBatchSize(HttpServletRequest req) {
-    return extractIntParameter(req, "batchSize");
+    return extractOptionalIntParameter(req, "batchSize").orElse(250);
   }
 }

--- a/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
+++ b/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
@@ -80,4 +80,10 @@ public class ToolsServerModule {
   static int provideSmearMinutes(HttpServletRequest req) {
     return extractIntParameter(req, "smearMinutes");
   }
+
+  @Provides
+  @Parameter("batchSize")
+  static int provideBatchSize(HttpServletRequest req) {
+    return extractIntParameter(req, "batchSize");
+  }
 }

--- a/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
+++ b/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
@@ -77,12 +77,6 @@ public class ToolsServerModule {
   }
 
   @Provides
-  @Parameter("smearMinutes")
-  static int provideSmearMinutes(HttpServletRequest req) {
-    return extractIntParameter(req, "smearMinutes");
-  }
-
-  @Provides
   @Parameter("batchSize")
   static int provideBatchSize(HttpServletRequest req) {
     return extractOptionalIntParameter(req, "batchSize").orElse(250);

--- a/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
+++ b/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
@@ -15,7 +15,6 @@
 package google.registry.tools.server;
 
 import static com.google.common.base.Strings.emptyToNull;
-import static google.registry.request.RequestParameters.extractBooleanParameter;
 import static google.registry.request.RequestParameters.extractIntParameter;
 import static google.registry.request.RequestParameters.extractOptionalParameter;
 import static google.registry.request.RequestParameters.extractRequiredParameter;
@@ -80,11 +79,5 @@ public class ToolsServerModule {
   @Parameter("smearMinutes")
   static int provideSmearMinutes(HttpServletRequest req) {
     return extractIntParameter(req, "smearMinutes");
-  }
-
-  @Provides
-  @Parameter("includeDeleted")
-  static boolean provideIncludeDeleted(HttpServletRequest req) {
-    return extractBooleanParameter(req, "includeDeleted");
   }
 }

--- a/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
+++ b/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
@@ -15,6 +15,7 @@
 package google.registry.tools.server;
 
 import static com.google.common.base.Strings.emptyToNull;
+import static google.registry.request.RequestParameters.extractBooleanParameter;
 import static google.registry.request.RequestParameters.extractIntParameter;
 import static google.registry.request.RequestParameters.extractOptionalParameter;
 import static google.registry.request.RequestParameters.extractRequiredParameter;
@@ -79,5 +80,11 @@ public class ToolsServerModule {
   @Parameter("smearMinutes")
   static int provideSmearMinutes(HttpServletRequest req) {
     return extractIntParameter(req, "smearMinutes");
+  }
+
+  @Provides
+  @Parameter("includeDeleted")
+  static boolean provideIncludeDeleted(HttpServletRequest req) {
+    return extractBooleanParameter(req, "includeDeleted");
   }
 }

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -1357,5 +1357,16 @@ public final class DatabaseHelper {
         .isEqualTo(1);
   }
 
+  public static void assertDnsRequestsWithRequestTime(DateTime requestTime, int numOfDomains) {
+    assertThat(
+            tm().transact(
+                    () ->
+                        tm().createQueryComposer(DnsRefreshRequest.class)
+                            .where("type", EQ, DnsUtils.TargetType.DOMAIN)
+                            .where("requestTime", EQ, requestTime)
+                            .count()))
+        .isEqualTo(numOfDomains);
+  }
+
   private DatabaseHelper() {}
 }

--- a/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
+++ b/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
@@ -53,6 +53,7 @@ public class RefreshDnsForAllDomainsActionTest {
     action.random.setSeed(123L);
     action.clock = clock;
     action.response = response;
+    action.batchSize = 10;
     createTld("bar");
   }
 
@@ -113,11 +114,13 @@ public class RefreshDnsForAllDomainsActionTest {
 
   @Test
   void test_successfullyBatchesNames() {
-    for (int i = 0; i <= RefreshDnsForAllDomainsAction.BATCH_SIZE; i++) {
+    int batchSize = 3;
+    action.batchSize = batchSize;
+    for (int i = 0; i <= batchSize; i++) {
       persistActiveDomain(String.format("test%s.bar", i));
     }
     action.tlds = ImmutableSet.of("bar");
     action.run();
-    assertDnsRequestsWithRequestTime(clock.nowUtc(), RefreshDnsForAllDomainsAction.BATCH_SIZE + 1);
+    assertDnsRequestsWithRequestTime(clock.nowUtc(), batchSize + 1);
   }
 }

--- a/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
+++ b/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
@@ -15,6 +15,8 @@
 package google.registry.tools.server;
 
 import static com.google.common.truth.Truth.assertThat;
+import static google.registry.persistence.transaction.QueryComposer.Comparator.EQ;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.assertDnsRequestsWithRequestTime;
 import static google.registry.testing.DatabaseHelper.assertDomainDnsRequestWithRequestTime;
 import static google.registry.testing.DatabaseHelper.assertNoDnsRequestsExcept;
@@ -23,7 +25,10 @@ import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistDeletedDomain;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import google.registry.dns.DnsUtils;
+import google.registry.model.common.DnsRefreshRequest;
 import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationTestExtension;
 import google.registry.testing.FakeClock;
@@ -47,21 +52,15 @@ public class RefreshDnsForAllDomainsActionTest {
 
   @BeforeEach
   void beforeEach() {
-    action = new RefreshDnsForAllDomainsAction();
-    action.smearMinutes = 1;
-    action.random = new Random();
-    action.random.setSeed(123L);
-    action.clock = clock;
-    action.response = response;
-    action.batchSize = 10;
     createTld("bar");
+    action =
+        new RefreshDnsForAllDomainsAction(response, ImmutableSet.of("bar"), 10, 1, new Random());
   }
 
   @Test
   void test_runAction_successfullyEnqueuesDnsRefreshes() throws Exception {
     persistActiveDomain("foo.bar");
     persistActiveDomain("low.bar");
-    action.tlds = ImmutableSet.of("bar");
     action.run();
     assertDomainDnsRequestWithRequestTime("foo.bar", clock.nowUtc());
     assertDomainDnsRequestWithRequestTime("low.bar", clock.nowUtc());
@@ -71,18 +70,25 @@ public class RefreshDnsForAllDomainsActionTest {
   void test_runAction_smearsOutDnsRefreshes() throws Exception {
     persistActiveDomain("foo.bar");
     persistActiveDomain("low.bar");
-    action.tlds = ImmutableSet.of("bar");
-    action.smearMinutes = 1000;
+    // Set batch size to 1 since each batch will be enqueud at the same time
+    action =
+        new RefreshDnsForAllDomainsAction(response, ImmutableSet.of("bar"), 1, 1000, new Random());
     action.run();
-    assertDomainDnsRequestWithRequestTime("foo.bar", clock.nowUtc().plusMinutes(782));
-    assertDomainDnsRequestWithRequestTime("low.bar", clock.nowUtc().plusMinutes(450));
+    ImmutableList<DnsRefreshRequest> refreshRequests =
+        tm().transact(
+                () ->
+                    tm().createQueryComposer(DnsRefreshRequest.class)
+                        .where("type", EQ, DnsUtils.TargetType.DOMAIN)
+                        .list());
+    assertThat(refreshRequests.size()).isEqualTo(2);
+    assertThat(refreshRequests.get(0).getRequestTime())
+        .isNotEqualTo(refreshRequests.get(1).getRequestTime());
   }
 
   @Test
   void test_runAction_doesntRefreshDeletedDomain() throws Exception {
     persistActiveDomain("foo.bar");
     persistDeletedDomain("deleted.bar", clock.nowUtc().minusYears(1));
-    action.tlds = ImmutableSet.of("bar");
     action.run();
     assertDomainDnsRequestWithRequestTime("foo.bar", clock.nowUtc());
     assertNoDnsRequestsExcept("foo.bar");
@@ -94,7 +100,6 @@ public class RefreshDnsForAllDomainsActionTest {
     persistActiveDomain("foo.bar");
     persistActiveDomain("low.bar");
     persistActiveDomain("ignore.baz");
-    action.tlds = ImmutableSet.of("bar");
     action.run();
     assertDomainDnsRequestWithRequestTime("foo.bar", clock.nowUtc());
     assertDomainDnsRequestWithRequestTime("low.bar", clock.nowUtc());
@@ -103,8 +108,8 @@ public class RefreshDnsForAllDomainsActionTest {
 
   @Test
   void test_smearMinutesMustBeSpecified() {
-    action.tlds = ImmutableSet.of("bar");
-    action.smearMinutes = 0;
+    action =
+        new RefreshDnsForAllDomainsAction(response, ImmutableSet.of("bar"), 10, 0, new Random());
     IllegalArgumentException thrown =
         assertThrows(IllegalArgumentException.class, () -> action.run());
     assertThat(thrown)
@@ -114,13 +119,10 @@ public class RefreshDnsForAllDomainsActionTest {
 
   @Test
   void test_successfullyBatchesNames() {
-    int batchSize = 3;
-    action.batchSize = batchSize;
-    for (int i = 0; i <= batchSize; i++) {
+    for (int i = 0; i <= 10; i++) {
       persistActiveDomain(String.format("test%s.bar", i));
     }
-    action.tlds = ImmutableSet.of("bar");
     action.run();
-    assertDnsRequestsWithRequestTime(clock.nowUtc(), batchSize + 1);
+    assertDnsRequestsWithRequestTime(clock.nowUtc(), 11);
   }
 }

--- a/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
+++ b/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
@@ -87,6 +87,17 @@ public class RefreshDnsForAllDomainsActionTest {
   }
 
   @Test
+  void test_runAction_refreshesDeletedDomainWithIncludeDeleted() throws Exception {
+    persistActiveDomain("foo.bar");
+    persistDeletedDomain("deleted.bar", clock.nowUtc().minusYears(1));
+    action.tlds = ImmutableSet.of("bar");
+    action.includeDeleted = true;
+    action.run();
+    assertDomainDnsRequestWithRequestTime("foo.bar", clock.nowUtc());
+    assertDomainDnsRequestWithRequestTime("deleted.bar", clock.nowUtc());
+  }
+
+  @Test
   void test_runAction_ignoresDomainsOnOtherTlds() throws Exception {
     createTld("baz");
     persistActiveDomain("foo.bar");

--- a/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
+++ b/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
@@ -32,6 +32,7 @@ import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationTestExtension;
 import google.registry.testing.FakeClock;
 import google.registry.testing.FakeResponse;
+import java.util.Optional;
 import java.util.Random;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,7 +53,9 @@ public class RefreshDnsForAllDomainsActionTest {
   @BeforeEach
   void beforeEach() {
     createTld("bar");
-    action = new RefreshDnsForAllDomainsAction(response, ImmutableSet.of("bar"), 10, new Random());
+    action =
+        new RefreshDnsForAllDomainsAction(
+            response, ImmutableSet.of("bar"), Optional.of(10), new Random());
   }
 
   @Test
@@ -69,9 +72,11 @@ public class RefreshDnsForAllDomainsActionTest {
     persistActiveDomain("foo.bar");
     persistActiveDomain("low.bar");
     // Set batch size to 1 since each batch will be enqueud at the same time
-    action = new RefreshDnsForAllDomainsAction(response, ImmutableSet.of("bar"), 1, new Random());
-    tm().transact(() -> action.refreshBatch(ImmutableList.of(""), 1000));
-    tm().transact(() -> action.refreshBatch(ImmutableList.of(""), 1000));
+    action =
+        new RefreshDnsForAllDomainsAction(
+            response, ImmutableSet.of("bar"), Optional.of(1), new Random());
+    tm().transact(() -> action.refreshBatch("", 1000));
+    tm().transact(() -> action.refreshBatch("", 1000));
     ImmutableList<DnsRefreshRequest> refreshRequests =
         tm().transact(
                 () ->


### PR DESCRIPTION
This PR batches the domains read and processed in the RefreshDnsForAllDomainsAction. The batching is necessary to prevent issues with predicate locking as described in go/dr-psql-index-pitfall.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2037)
<!-- Reviewable:end -->
