### PR TITLE
Find the most recent prefix for RdeReportAction

### DIFF
--- a/core/src/main/java/google/registry/beam/rde/RdeIO.java
+++ b/core/src/main/java/google/registry/beam/rde/RdeIO.java
@@ -43,7 +43,7 @@ import google.registry.rde.RdeMarshaller;
 import google.registry.rde.RdeModule;
 import google.registry.rde.RdeResourceType;
 import google.registry.rde.RdeUploadAction;
-import google.registry.rde.RdeUtil;
+import google.registry.rde.RdeUtils;
 import google.registry.request.Action.Service;
 import google.registry.request.RequestParameters;
 import google.registry.tldconfig.idn.IdnTableEnum;
@@ -166,7 +166,7 @@ public class RdeIO {
       final int revision =
           Optional.ofNullable(key.revision())
               .orElseGet(() -> RdeRevision.getNextRevision(tld, watermark, mode));
-      String id = RdeUtil.timestampToId(watermark);
+      String id = RdeUtils.timestampToId(watermark);
       String prefix =
           options.getJobName()
               + '/'

--- a/core/src/main/java/google/registry/rde/ContactToXjcConverter.java
+++ b/core/src/main/java/google/registry/rde/ContactToXjcConverter.java
@@ -112,8 +112,8 @@ final class ContactToXjcConverter {
   private static XjcRdeContactTransferDataType convertTransferData(TransferData model) {
     XjcRdeContactTransferDataType bean = new XjcRdeContactTransferDataType();
     bean.setTrStatus(XjcEppcomTrStatusType.fromValue(model.getTransferStatus().getXmlName()));
-    bean.setReRr(RdeUtil.makeXjcRdeRrType(model.getGainingRegistrarId()));
-    bean.setAcRr(RdeUtil.makeXjcRdeRrType(model.getLosingRegistrarId()));
+    bean.setReRr(RdeUtils.makeXjcRdeRrType(model.getGainingRegistrarId()));
+    bean.setAcRr(RdeUtils.makeXjcRdeRrType(model.getLosingRegistrarId()));
     bean.setReDate(model.getTransferRequestTime());
     bean.setAcDate(model.getPendingTransferExpirationTime());
     return bean;

--- a/core/src/main/java/google/registry/rde/DomainToXjcConverter.java
+++ b/core/src/main/java/google/registry/rde/DomainToXjcConverter.java
@@ -262,8 +262,8 @@ final class DomainToXjcConverter {
     XjcRdeDomainTransferDataType bean = new XjcRdeDomainTransferDataType();
     bean.setTrStatus(
         XjcEppcomTrStatusType.fromValue(model.getTransferStatus().getXmlName()));
-    bean.setReRr(RdeUtil.makeXjcRdeRrType(model.getGainingRegistrarId()));
-    bean.setAcRr(RdeUtil.makeXjcRdeRrType(model.getLosingRegistrarId()));
+    bean.setReRr(RdeUtils.makeXjcRdeRrType(model.getGainingRegistrarId()));
+    bean.setAcRr(RdeUtils.makeXjcRdeRrType(model.getLosingRegistrarId()));
     bean.setReDate(model.getTransferRequestTime());
     bean.setAcDate(model.getPendingTransferExpirationTime());
     bean.setExDate(model.getTransferredRegistrationExpirationTime());

--- a/core/src/main/java/google/registry/tools/EscrowDepositEncryptor.java
+++ b/core/src/main/java/google/registry/tools/EscrowDepositEncryptor.java
@@ -20,7 +20,7 @@ import com.google.common.io.ByteStreams;
 import google.registry.keyring.api.KeyModule.Key;
 import google.registry.model.rde.RdeMode;
 import google.registry.model.rde.RdeNamingUtils;
-import google.registry.rde.RdeUtil;
+import google.registry.rde.RdeUtils;
 import google.registry.rde.RydeEncoder;
 import google.registry.xml.XmlException;
 import java.io.BufferedInputStream;
@@ -59,7 +59,7 @@ final class EscrowDepositEncryptor {
       throws IOException, XmlException {
     try (InputStream xmlFileInput = Files.newInputStream(xmlFile);
         BufferedInputStream xmlInput = new BufferedInputStream(xmlFileInput, PEEK_BUFFER_SIZE)) {
-      DateTime watermark = RdeUtil.peekWatermark(xmlInput);
+      DateTime watermark = RdeUtils.peekWatermark(xmlInput);
       String name = RdeNamingUtils.makeRydeFilename(tld, watermark, mode, 1, revision);
       Path rydePath = outdir.resolve(name + ".ryde");
       Path sigPath = outdir.resolve(name + ".sig");

--- a/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
+++ b/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
@@ -343,7 +343,7 @@ public class RdeUploadActionTest {
     gcsUtils.delete(GHOSTRYDE_FILE);
     gcsUtils.delete(LENGTH_FILE);
     gcsUtils.delete(REPORT_FILE);
-    // Add a folder that is alphabetically before the desired folder and fill it will nonsense data.
+    // Add a folder that is alphabetically before the desired folder and fill it with nonsense data.
     // It should NOT be picked up.
     BlobId ghostrydeFileWithPrefixBefore =
         BlobId.of("bucket", JOB_PREFIX + "-job-nama/tld_2010-10-17_full_S1_R0.xml.ghostryde");
@@ -464,7 +464,7 @@ public class RdeUploadActionTest {
     action.sftpCooldown = standardHours(2);
     DateTime stagingCursor = DateTime.parse("2010-10-18TZ");
     DateTime uploadCursor = DateTime.parse("2010-10-17TZ");
-    DateTime sftpCursor = uploadCursor.minusMinutes(97); // Within the 2 hour cooldown period.
+    DateTime sftpCursor = uploadCursor.minusMinutes(97); // Within the 2-hour cooldown period.
     persistResource(Cursor.createScoped(RDE_STAGING, stagingCursor, Tld.get("tld")));
     persistResource(Cursor.createScoped(RDE_UPLOAD_SFTP, sftpCursor, Tld.get("tld")));
     NoContentException thrown =
@@ -477,7 +477,7 @@ public class RdeUploadActionTest {
                 + " ago)");
   }
 
-  private String slurp(InputStream is) throws IOException {
+  private static String slurp(InputStream is) throws IOException {
     return CharStreams.toString(new InputStreamReader(is, UTF_8));
   }
 }


### PR DESCRIPTION
When RdeReportAction is invoked without a prefix parameter (as in the
case when it is kicked off by cron jobs for potential catch ups), we
need to used the same heuristics that's employed in RdeUploadAction to
find the most recent prefix for the given watermark, otherwise the job
will not find any deposits to upload.

Also renamed RdeUtil to RdeUtils, to be consistent with our naming
conventions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2043)
<!-- Reviewable:end -->
