### PR TITLE
Refactor OIDC-based auth mechanism

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -564,14 +564,18 @@ task deployCloudSchedulerAndQueue {
     def env = environment
     if (!prodOrSandboxEnv) {
       exec {
+        workingDir "${rootDir}/release/builder/"
         commandLine 'go', 'run',
-                "${rootDir}/release/builder/deployCloudSchedulerAndQueue.go",
+                "./deployCloudSchedulerAndQueue.go",
+                "${rootDir}/core/src/main/java/google/registry/config/files/nomulus-config-${env}.yaml",
                 "${rootDir}/core/src/main/java/google/registry/env/${env}/default/WEB-INF/cloud-scheduler-tasks.xml",
                 "domain-registry-${env}"
       }
       exec {
+        workingDir "${rootDir}/release/builder/"
         commandLine 'go', 'run',
-                "${rootDir}/release/builder/deployCloudSchedulerAndQueue.go",
+                "./deployCloudSchedulerAndQueue.go",
+                "${rootDir}/core/src/main/java/google/registry/config/files/nomulus-config-${env}.yaml",
                 "${rootDir}/core/src/main/java/google/registry/env/common/default/WEB-INF/cloud-tasks-queue.xml",
                 "domain-registry-${env}"
       }

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -23,7 +23,7 @@ public class RegistryConfigSettings {
 
   public GcpProject gcpProject;
   public GSuite gSuite;
-  public OAuth oAuth;
+  public Auth auth;
   public CredentialOAuth credentialOAuth;
   public RegistryPolicy registryPolicy;
   public Hibernate hibernate;
@@ -54,16 +54,15 @@ public class RegistryConfigSettings {
     public String backendServiceUrl;
     public String toolsServiceUrl;
     public String pubapiServiceUrl;
-    public List<String> serviceAccountEmails;
-    public String defaultServiceAccount;
   }
 
-  /** Configuration options for OAuth settings for authenticating users. */
-  public static class OAuth {
+  /** Configuration options for authenticating users. */
+  public static class Auth {
     public List<String> availableOauthScopes;
     public List<String> requiredOauthScopes;
     public List<String> allowedOauthClientIds;
-    public String iapClientId;
+    public List<String> allowedServiceAccountEmails;
+    public String oauthClientId;
   }
 
   /** Configuration options for accessing Google APIs. */

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -18,18 +18,10 @@ gcpProject:
   # whether to use local/test credentials when connecting to the servers
   isLocal: true
   # URLs of the services for the project.
-  defaultServiceUrl: https://localhost
-  backendServiceUrl: https://localhost
-  toolsServiceUrl: https://localhost
-  pubapiServiceUrl: https://localhost
-  # Service accounts eligible for authorization (e.g. default service account,
-  # account used by Cloud Scheduler) to send authenticated requests.
-  serviceAccountEmails:
-  - default-service-account-email@email.com
-  - cloud-scheduler-email@email.com
-  # The default service account with which the service is running. For example,
-  # on GAE this would be {project-id}@appspot.gserviceaccount.com
-  defaultServiceAccount: null
+  defaultServiceUrl: https://default.example.com
+  backendServiceUrl: https://backend.example.com
+  toolsServiceUrl: https://tools.example.com
+  pubapiServiceUrl: https://pubapi.example.com
 
 gSuite:
   # Publicly accessible domain name of the running G Suite instance.
@@ -295,24 +287,41 @@ caching:
   # long duration is acceptable because claims lists don't change frequently.
   claimsListCachingSeconds: 21600 # six hours
 
-oAuth:
+# Note: Only allowedServiceAccountEmails and oauthClientId should be configured.
+# Other fields are related to OAuth-based authentication and will be removed.
+auth:
+  # Deprecated: Use OIDC-based auth instead. This field is for OAuth-based auth.
   # OAuth scopes to detect on access tokens. Superset of requiredOauthScopes.
   availableOauthScopes:
   - https://www.googleapis.com/auth/userinfo.email
 
+  # Deprecated: Use OIDC-based auth instead. This field is for OAuth-based auth.
   # OAuth scopes required for authenticating. Subset of availableOauthScopes.
   requiredOauthScopes:
   - https://www.googleapis.com/auth/userinfo.email
 
+  # Deprecated: Use OIDC-based auth instead. This field is for OAuth-based auth.
   # OAuth client IDs that are allowed to authenticate and communicate with
-  # backend services, e. g. nomulus tool, EPP proxy, etc. The client_id value
-  # used in registryTool.clientId field for associated tooling should be included
-  # in this list. Client IDs are typically of the format
+  # backend services, e.g. nomulus tool, EPP proxy, etc. The value in
+  # registryTool.clientId field should be included in this list. Client IDs are
+  # typically of the format
   # numbers-alphanumerics.apps.googleusercontent.com
   allowedOauthClientIds: []
-  # GCP Identity-Aware Proxy client ID, if set up (note: this requires manual setup
-  # of User objects in the database for Nomulus tool users)
-  iapClientId: null
+
+  # Service accounts (e.g. default service account, account used by Cloud
+  # Scheduler) allowed to send authenticated requests.
+  allowedServiceAccountEmails:
+  - default-service-account-email@email.com
+  - cloud-scheduler-email@email.com
+
+  # OAuth 2.0 client ID that will be used as the audience in OIDC ID tokens sent
+  # from clients (e.g. proxy, nomulus tool, cloud tasks) for authentication. The
+  # same ID is the only one accepted by the regular OIDC or IAP authentication
+  # mechanisms. In most cases we should use the client ID created for IAP here,
+  # as it allows requests bearing a token with this audience to be accepted by
+  # both IAP or regular OIDC. The clientId value in proxy config file should be
+  # the same as this one.
+  oauthClientId: iap-oauth-clientid
 
 credentialOAuth:
   # OAuth scopes required for accessing Google APIs using the default

--- a/core/src/main/java/google/registry/cron/TldFanoutAction.java
+++ b/core/src/main/java/google/registry/cron/TldFanoutAction.java
@@ -140,25 +140,13 @@ public final class TldFanoutAction implements Runnable {
     for (String tld : tlds) {
       Task task = createTask(tld, flowThruParams);
       Task createdTask = cloudTasksUtils.enqueue(queue, task);
-      if (createdTask.hasAppEngineHttpRequest()) {
-        outputPayload.append(
-            String.format(
-                "- Task: '%s', tld: '%s', endpoint: '%s'\n",
-                createdTask.getName(),
-                tld,
-                createdTask.getAppEngineHttpRequest().getRelativeUri()));
-        logger.atInfo().log(
-            "Task: '%s', tld: '%s', endpoint: '%s'.",
-            createdTask.getName(), tld, createdTask.getAppEngineHttpRequest().getRelativeUri());
-      } else {
-        outputPayload.append(
-            String.format(
-                "- Task: '%s', tld: '%s', endpoint: '%s'\n",
-                createdTask.getName(), tld, createdTask.getHttpRequest().getUrl()));
-        logger.atInfo().log(
-            "Task: '%s', tld: '%s', endpoint: '%s'.",
-            createdTask.getName(), tld, createdTask.getHttpRequest().getUrl());
-      }
+      outputPayload.append(
+          String.format(
+              "- Task: '%s', tld: '%s', endpoint: '%s'\n",
+              createdTask.getName(), tld, createdTask.getHttpRequest().getUrl()));
+      logger.atInfo().log(
+          "Task: '%s', tld: '%s', endpoint: '%s'.",
+          createdTask.getName(), tld, createdTask.getHttpRequest().getUrl());
     }
     response.setContentType(PLAIN_TEXT_UTF_8);
     response.setPayload(outputPayload.toString());

--- a/core/src/main/java/google/registry/request/auth/AuthModule.java
+++ b/core/src/main/java/google/registry/request/auth/AuthModule.java
@@ -44,7 +44,7 @@ public class AuthModule {
   // See: https://cloud.google.com/iap/docs/signed-headers-howto#verifying_the_jwt_payload
   private static final String IAP_AUDIENCE_FORMAT = "/projects/%d/apps/%s";
   private static final String IAP_ISSUER_URL = "https://cloud.google.com/iap";
-  private static final String SA_ISSUER_URL = "https://accounts.google.com";
+  private static final String REGULAR_ISSUER_URL = "https://accounts.google.com";
 
   /** Provides the custom authentication mechanisms (including OAuth and OIDC). */
   @Provides
@@ -82,8 +82,8 @@ public class AuthModule {
   @Provides
   @RegularOidc
   @Singleton
-  TokenVerifier provideRegularTokenVerifier(@Config("projectId") String projectId) {
-    return TokenVerifier.newBuilder().setAudience(projectId).setIssuer(SA_ISSUER_URL).build();
+  TokenVerifier provideRegularTokenVerifier(@Config("oauthClientId") String clientId) {
+    return TokenVerifier.newBuilder().setAudience(clientId).setIssuer(REGULAR_ISSUER_URL).build();
   }
 
   @Provides

--- a/core/src/main/java/google/registry/request/auth/OAuthAuthenticationMechanism.java
+++ b/core/src/main/java/google/registry/request/auth/OAuthAuthenticationMechanism.java
@@ -32,7 +32,7 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * OAuth authentication mechanism, using the OAuthService interface.
  *
- * Only OAuth version 2 is supported.
+ * <p>Only OAuth version 2 is supported.
  */
 public class OAuthAuthenticationMechanism implements AuthenticationMechanism {
 

--- a/core/src/test/java/google/registry/batch/AsyncTaskEnqueuerTest.java
+++ b/core/src/test/java/google/registry/batch/AsyncTaskEnqueuerTest.java
@@ -73,7 +73,7 @@ public class AsyncTaskEnqueuerTest {
     cloudTasksHelper.assertTasksEnqueued(
         QUEUE_ASYNC_ACTIONS,
         new CloudTasksHelper.TaskMatcher()
-            .url(ResaveEntityAction.PATH)
+            .path(ResaveEntityAction.PATH)
             .method(HttpMethod.POST)
             .service("backend")
             .header("content-type", "application/x-www-form-urlencoded")
@@ -93,7 +93,7 @@ public class AsyncTaskEnqueuerTest {
     cloudTasksHelper.assertTasksEnqueued(
         QUEUE_ASYNC_ACTIONS,
         new TaskMatcher()
-            .url(ResaveEntityAction.PATH)
+            .path(ResaveEntityAction.PATH)
             .method(HttpMethod.POST)
             .service("backend")
             .header("content-type", "application/x-www-form-urlencoded")

--- a/core/src/test/java/google/registry/batch/RelockDomainActionTest.java
+++ b/core/src/test/java/google/registry/batch/RelockDomainActionTest.java
@@ -305,7 +305,7 @@ public class RelockDomainActionTest {
     cloudTasksHelper.assertTasksEnqueued(
         QUEUE_ASYNC_ACTIONS,
         new TaskMatcher()
-            .url(RelockDomainAction.PATH)
+            .path(RelockDomainAction.PATH)
             .method(HttpMethod.POST)
             .param(
                 RelockDomainAction.OLD_UNLOCK_REVISION_ID_PARAM,

--- a/core/src/test/java/google/registry/batch/ResaveEntityActionTest.java
+++ b/core/src/test/java/google/registry/batch/ResaveEntityActionTest.java
@@ -136,7 +136,7 @@ public class ResaveEntityActionTest {
     cloudTasksHelper.assertTasksEnqueued(
         QUEUE_ASYNC_ACTIONS,
         new TaskMatcher()
-            .url(ResaveEntityAction.PATH)
+            .path(ResaveEntityAction.PATH)
             .method(HttpMethod.POST)
             .service("backend")
             .header("content-type", "application/x-www-form-urlencoded")

--- a/core/src/test/java/google/registry/beam/rde/RdePipelineTest.java
+++ b/core/src/test/java/google/registry/beam/rde/RdePipelineTest.java
@@ -464,7 +464,7 @@ public class RdePipelineTest {
     cloudTasksHelper.assertTasksEnqueued(
         "brda",
         new TaskMatcher()
-            .url("/_dr/task/brdaCopy")
+            .path("/_dr/task/brdaCopy")
             .service("backend")
             .param("tld", "soy")
             .param("watermark", now.toString())
@@ -472,7 +472,7 @@ public class RdePipelineTest {
     cloudTasksHelper.assertTasksEnqueued(
         "rde-upload",
         new TaskMatcher()
-            .url("/_dr/task/rdeUpload")
+            .path("/_dr/task/rdeUpload")
             .service("backend")
             .param("tld", "soy")
             .param("prefix", "rde-job/"));

--- a/core/src/test/java/google/registry/cron/TldFanoutActionTest.java
+++ b/core/src/test/java/google/registry/cron/TldFanoutActionTest.java
@@ -91,14 +91,14 @@ class TldFanoutActionTest {
             .map(
                 namespace ->
                     new TaskMatcher()
-                        .url(ENDPOINT)
+                        .path(ENDPOINT)
                         .header("content-type", "application/x-www-form-urlencoded")
                         .param("tld", namespace))
             .collect(toImmutableList()));
   }
 
   private void assertTaskWithoutTld() {
-    cloudTasksHelper.assertTasksEnqueued(QUEUE, new TaskMatcher().url(ENDPOINT));
+    cloudTasksHelper.assertTasksEnqueued(QUEUE, new TaskMatcher().path(ENDPOINT));
   }
 
   @Test
@@ -211,7 +211,7 @@ class TldFanoutActionTest {
   void testSuccess_additionalArgsFlowThroughToPostParams() {
     run(getParamsMap("forEachTestTld", "", "newkey", "newval"));
     cloudTasksHelper.assertTasksEnqueued(
-        QUEUE, new TaskMatcher().url("/the/servlet").param("newkey", "newval"));
+        QUEUE, new TaskMatcher().path("/the/servlet").param("newkey", "newval"));
   }
 
   @Test
@@ -224,9 +224,9 @@ class TldFanoutActionTest {
     String expectedResponse =
         String.format(
             "OK: Launched the following 3 tasks in queue the-queue\n"
-                + "- Task: '%s', tld: 'com', endpoint: '/the/servlet'\n"
-                + "- Task: '%s', tld: 'net', endpoint: '/the/servlet'\n"
-                + "- Task: '%s', tld: 'org', endpoint: '/the/servlet'\n",
+                + "- Task: '%s', tld: 'com', endpoint: 'https://backend.example.com/the/servlet'\n"
+                + "- Task: '%s', tld: 'net', endpoint: 'https://backend.example.com/the/servlet'\n"
+                + "- Task: '%s', tld: 'org', endpoint: 'https://backend.example.com/the/servlet'\n",
             taskList.get(0).getName(), taskList.get(1).getName(), taskList.get(2).getName());
     assertThat(response.getPayload()).isEqualTo(expectedResponse);
   }
@@ -241,7 +241,7 @@ class TldFanoutActionTest {
     String expectedResponse =
         String.format(
             "OK: Launched the following 1 tasks in queue the-queue\n"
-                + "- Task: '%s', tld: '', endpoint: '/the/servlet'\n",
+                + "- Task: '%s', tld: '', endpoint: 'https://backend.example.com/the/servlet'\n",
             taskList.get(0).getName());
     assertThat(response.getPayload()).isEqualTo(expectedResponse);
   }

--- a/core/src/test/java/google/registry/dns/PublishDnsUpdatesActionTest.java
+++ b/core/src/test/java/google/registry/dns/PublishDnsUpdatesActionTest.java
@@ -294,7 +294,7 @@ public class PublishDnsUpdatesActionTest {
     cloudTasksHelper.assertTasksEnqueued(
         DNS_PUBLISH_PUSH_QUEUE_NAME,
         new TaskMatcher()
-            .url(PublishDnsUpdatesAction.PATH)
+            .path(PublishDnsUpdatesAction.PATH)
             .param(PARAM_TLD, "xn--q9jyb4c")
             .param(PARAM_DNS_WRITER, "correctWriter")
             .param(PARAM_LOCK_INDEX, "1")
@@ -305,7 +305,7 @@ public class PublishDnsUpdatesActionTest {
             .param(PARAM_HOSTS, "")
             .header("content-type", "application/x-www-form-urlencoded"),
         new TaskMatcher()
-            .url(PublishDnsUpdatesAction.PATH)
+            .path(PublishDnsUpdatesAction.PATH)
             .param(PARAM_TLD, "xn--q9jyb4c")
             .param(PARAM_DNS_WRITER, "correctWriter")
             .param(PARAM_LOCK_INDEX, "1")
@@ -333,7 +333,7 @@ public class PublishDnsUpdatesActionTest {
     cloudTasksHelper.assertTasksEnqueued(
         DNS_PUBLISH_PUSH_QUEUE_NAME,
         new TaskMatcher()
-            .url(PublishDnsUpdatesAction.PATH)
+            .path(PublishDnsUpdatesAction.PATH)
             .param(PARAM_TLD, "xn--q9jyb4c")
             .param(PARAM_DNS_WRITER, "correctWriter")
             .param(PARAM_LOCK_INDEX, "1")
@@ -344,7 +344,7 @@ public class PublishDnsUpdatesActionTest {
             .param(PARAM_HOSTS, "")
             .header("content-type", "application/x-www-form-urlencoded"),
         new TaskMatcher()
-            .url(PublishDnsUpdatesAction.PATH)
+            .path(PublishDnsUpdatesAction.PATH)
             .param(PARAM_TLD, "xn--q9jyb4c")
             .param(PARAM_DNS_WRITER, "correctWriter")
             .param(PARAM_LOCK_INDEX, "1")
@@ -370,7 +370,7 @@ public class PublishDnsUpdatesActionTest {
     cloudTasksHelper.assertTasksEnqueued(
         DNS_PUBLISH_PUSH_QUEUE_NAME,
         new TaskMatcher()
-            .url(PublishDnsUpdatesAction.PATH)
+            .path(PublishDnsUpdatesAction.PATH)
             .param(PARAM_TLD, "xn--q9jyb4c")
             .param(PARAM_DNS_WRITER, "correctWriter")
             .param(PARAM_LOCK_INDEX, "1")
@@ -381,7 +381,7 @@ public class PublishDnsUpdatesActionTest {
             .param(PARAM_HOSTS, "")
             .header("content-type", "application/x-www-form-urlencoded"),
         new TaskMatcher()
-            .url(PublishDnsUpdatesAction.PATH)
+            .path(PublishDnsUpdatesAction.PATH)
             .param(PARAM_TLD, "xn--q9jyb4c")
             .param(PARAM_DNS_WRITER, "correctWriter")
             .param(PARAM_LOCK_INDEX, "1")

--- a/core/src/test/java/google/registry/dns/ReadDnsRefreshRequestsActionTest.java
+++ b/core/src/test/java/google/registry/dns/ReadDnsRefreshRequestsActionTest.java
@@ -225,7 +225,7 @@ public class ReadDnsRefreshRequestsActionTest {
     cloudTasksHelper.assertTasksEnqueued(
         "dns-publish",
         new TaskMatcher()
-            .url("/_dr/task/publishDnsUpdates")
+            .path("/_dr/task/publishDnsUpdates")
             .service("BACKEND")
             .param("tld", "tld")
             .param("dnsWriter", "FooWriter")
@@ -236,7 +236,7 @@ public class ReadDnsRefreshRequestsActionTest {
             .param("domains", "domain.tld,future.tld")
             .param("hosts", "ns1.domain.tld"),
         new TaskMatcher()
-            .url("/_dr/task/publishDnsUpdates")
+            .path("/_dr/task/publishDnsUpdates")
             .service("BACKEND")
             .param("tld", "tld")
             .param("dnsWriter", "BarWriter")

--- a/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
@@ -304,7 +304,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     cloudTasksHelper.assertTasksEnqueued(
         QUEUE_ASYNC_ACTIONS,
         new TaskMatcher()
-            .url(ResaveEntityAction.PATH)
+            .path(ResaveEntityAction.PATH)
             .method(HttpMethod.POST)
             .service("backend")
             .header("content-type", "application/x-www-form-urlencoded")

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
@@ -520,7 +520,7 @@ class DomainTransferRequestFlowTest
     cloudTasksHelper.assertTasksEnqueued(
         QUEUE_ASYNC_ACTIONS,
         new TaskMatcher()
-            .url(ResaveEntityAction.PATH)
+            .path(ResaveEntityAction.PATH)
             .method(HttpMethod.POST)
             .service("backend")
             .header("content-type", "application/x-www-form-urlencoded")

--- a/core/src/test/java/google/registry/flows/host/HostUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostUpdateFlowTest.java
@@ -207,7 +207,7 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
     cloudTasksHelper.assertTasksEnqueued(
         QUEUE_HOST_RENAME,
         new TaskMatcher()
-            .url(RefreshDnsOnHostRenameAction.PATH)
+            .path(RefreshDnsOnHostRenameAction.PATH)
             .method(HttpMethod.POST)
             .service("backend")
             .param(PARAM_HOST_KEY, renamedHost.createVKey().stringify()));

--- a/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
+++ b/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
@@ -227,7 +227,7 @@ public class RdeUploadActionTest {
             action, Tld.get("lol"), standardSeconds(23), CursorType.RDE_UPLOAD, standardDays(1));
     cloudTasksHelper.assertTasksEnqueued(
         "rde-report",
-        new TaskMatcher().url(RdeReportAction.PATH).param(RequestParameters.PARAM_TLD, "lol"));
+        new TaskMatcher().path(RdeReportAction.PATH).param(RequestParameters.PARAM_TLD, "lol"));
     verifyNoMoreInteractions(runner);
   }
 
@@ -244,7 +244,7 @@ public class RdeUploadActionTest {
     cloudTasksHelper.assertTasksEnqueued(
         "rde-report",
         new TaskMatcher()
-            .url(RdeReportAction.PATH)
+            .path(RdeReportAction.PATH)
             .param(RequestParameters.PARAM_TLD, "lol")
             .param(RdeModule.PARAM_PREFIX, "job-name/"));
     verifyNoMoreInteractions(runner);

--- a/core/src/test/java/google/registry/reporting/billing/GenerateInvoicesActionTest.java
+++ b/core/src/test/java/google/registry/reporting/billing/GenerateInvoicesActionTest.java
@@ -74,7 +74,7 @@ class GenerateInvoicesActionTest extends BeamActionTestBase {
     cloudTasksHelper.assertTasksEnqueued(
         "beam-reporting",
         new TaskMatcher()
-            .url("/_dr/task/publishInvoices")
+            .path("/_dr/task/publishInvoices")
             .method(HttpMethod.POST)
             .param("jobId", "jobid")
             .param("yearMonth", "2017-10")

--- a/core/src/test/java/google/registry/reporting/billing/PublishInvoicesActionTest.java
+++ b/core/src/test/java/google/registry/reporting/billing/PublishInvoicesActionTest.java
@@ -83,7 +83,7 @@ class PublishInvoicesActionTest {
     verify(emailUtils).emailOverallInvoice();
     TaskMatcher matcher =
         new TaskMatcher()
-            .url("/_dr/task/copyDetailReports")
+            .path("/_dr/task/copyDetailReports")
             .method(HttpMethod.POST)
             .param("yearMonth", "2017-10");
     cloudTasksHelper.assertTasksEnqueued("retryable-cron-tasks", matcher);

--- a/core/src/test/java/google/registry/reporting/icann/IcannReportingStagingActionTest.java
+++ b/core/src/test/java/google/registry/reporting/icann/IcannReportingStagingActionTest.java
@@ -78,7 +78,7 @@ class IcannReportingStagingActionTest {
     cloudTasksHelper.assertTasksEnqueued(
         "retryable-cron-tasks",
         new TaskMatcher()
-            .url("/_dr/task/icannReportingUpload")
+            .path("/_dr/task/icannReportingUpload")
             .method(HttpMethod.POST)
             .scheduleTime(clock.nowUtc().plus(Duration.standardMinutes(2))));
   }

--- a/core/src/test/java/google/registry/reporting/spec11/GenerateSpec11ReportActionTest.java
+++ b/core/src/test/java/google/registry/reporting/spec11/GenerateSpec11ReportActionTest.java
@@ -86,7 +86,7 @@ class GenerateSpec11ReportActionTest extends BeamActionTestBase {
     cloudTasksHelper.assertTasksEnqueued(
         "beam-reporting",
         new TaskMatcher()
-            .url("/_dr/task/publishSpec11")
+            .path("/_dr/task/publishSpec11")
             .method(HttpMethod.POST)
             .param("jobId", "jobid")
             .param("date", "2018-06-11")

--- a/core/src/test/java/google/registry/request/auth/OidcTokenAuthenticationMechanismTest.java
+++ b/core/src/test/java/google/registry/request/auth/OidcTokenAuthenticationMechanismTest.java
@@ -29,7 +29,7 @@ import com.google.api.client.json.webtoken.JsonWebSignature;
 import com.google.api.client.json.webtoken.JsonWebSignature.Header;
 import com.google.auth.oauth2.TokenVerifier;
 import com.google.auth.oauth2.TokenVerifier.VerificationException;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import dagger.Component;
 import dagger.Module;
 import dagger.Provides;
@@ -54,8 +54,8 @@ public class OidcTokenAuthenticationMechanismTest {
   private static final String rawToken = "this-token";
   private static final String email = "user@email.test";
   private static final String gaiaId = "gaia-id";
-  private static final ImmutableList<String> serviceAccounts =
-      ImmutableList.of("service@email.test", "email@service.goog");
+  private static final ImmutableSet<String> serviceAccounts =
+      ImmutableSet.of("service@email.test", "email@service.goog");
 
   private final Payload payload = new Payload();
   private final User user =
@@ -222,9 +222,16 @@ public class OidcTokenAuthenticationMechanismTest {
 
     @Provides
     @Singleton
-    @Config("serviceAccountEmails")
-    ImmutableList<String> provideServiceAccountEmails() {
+    @Config("allowedServiceAccountEmails")
+    ImmutableSet<String> provideAllowedServiceAccountEmails() {
       return serviceAccounts;
+    }
+
+    @Provides
+    @Singleton
+    @Config("oauthClientId")
+    String provideOauthClientId() {
+      return "client-id";
     }
   }
 }

--- a/core/src/test/java/google/registry/tmch/NordnUploadActionTest.java
+++ b/core/src/test/java/google/registry/tmch/NordnUploadActionTest.java
@@ -252,7 +252,7 @@ class NordnUploadActionTest {
     cloudTasksHelper.assertTasksEnqueued(
         NordnVerifyAction.QUEUE,
         new TaskMatcher()
-            .url(NordnVerifyAction.PATH)
+            .path(NordnVerifyAction.PATH)
             .param(NordnVerifyAction.NORDN_URL_PARAM, LOCATION_URL)
             .param(RequestParameters.PARAM_TLD, "tld")
             .header(CONTENT_TYPE, FORM_DATA.toString()));

--- a/core/src/test/java/google/registry/tools/DomainLockUtilsTest.java
+++ b/core/src/test/java/google/registry/tools/DomainLockUtilsTest.java
@@ -259,7 +259,7 @@ public final class DomainLockUtilsTest {
     cloudTasksHelper.assertTasksEnqueued(
         QUEUE_ASYNC_ACTIONS,
         new TaskMatcher()
-            .url(RelockDomainAction.PATH)
+            .path(RelockDomainAction.PATH)
             .method(HttpMethod.POST)
             .service("backend")
             .param(
@@ -481,7 +481,7 @@ public final class DomainLockUtilsTest {
     cloudTasksHelper.assertTasksEnqueued(
         QUEUE_ASYNC_ACTIONS,
         new CloudTasksHelper.TaskMatcher()
-            .url(RelockDomainAction.PATH)
+            .path(RelockDomainAction.PATH)
             .method(HttpMethod.POST)
             .service("backend")
             .param(

--- a/core/src/test/java/google/registry/tools/GcpProjectConnectionTest.java
+++ b/core/src/test/java/google/registry/tools/GcpProjectConnectionTest.java
@@ -73,7 +73,7 @@ final class GcpProjectConnectionTest {
       ByteArrayOutputStream output = new ByteArrayOutputStream();
       getStreamingContent().writeTo(output);
       output.close();
-      return new String(output.toByteArray(), UTF_8);
+      return output.toString(UTF_8);
     }
   }
 
@@ -97,7 +97,7 @@ final class GcpProjectConnectionTest {
         .isEqualTo("MyContent");
     assertThat(httpTransport.method).isEqualTo("GET");
     assertThat(httpTransport.url)
-        .isEqualTo("https://localhost/my/path?query&key1=value1&key2=value2");
+        .isEqualTo("https://tools.example.com/my/path?query&key1=value1&key2=value2");
     assertThat(lowLevelHttpRequest.headers).containsEntry("Cache-Control", "no-cache");
     assertThat(lowLevelHttpRequest.headers).containsEntry("x-requested-with", "RegistryTool");
   }
@@ -113,7 +113,7 @@ final class GcpProjectConnectionTest {
         .isEqualTo("MyContent");
     assertThat(httpTransport.method).isEqualTo("POST");
     assertThat(httpTransport.url)
-        .isEqualTo("https://localhost/my/path?query&key1=value1&key2=value2");
+        .isEqualTo("https://tools.example.com/my/path?query&key1=value1&key2=value2");
     assertThat(lowLevelHttpRequest.getContentType()).isEqualTo("text/plain; charset=utf-8");
     assertThat(lowLevelHttpRequest.getContentString()).isEqualTo("some data");
     assertThat(lowLevelHttpRequest.headers).containsEntry("Cache-Control", "no-cache");
@@ -130,7 +130,7 @@ final class GcpProjectConnectionTest {
                 "/my/path?query", ImmutableMap.of("string", "value1", "bool", true)))
         .containsExactly("key", "value");
     assertThat(httpTransport.method).isEqualTo("POST");
-    assertThat(httpTransport.url).isEqualTo("https://localhost/my/path?query");
+    assertThat(httpTransport.url).isEqualTo("https://tools.example.com/my/path?query");
     assertThat(lowLevelHttpRequest.getContentType()).isEqualTo("application/json; charset=utf-8");
     assertThat(lowLevelHttpRequest.getContentString())
         .isEqualTo("{\"string\":\"value1\",\"bool\":true}");

--- a/core/src/test/java/google/registry/tools/GenerateEscrowDepositCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateEscrowDepositCommandTest.java
@@ -187,7 +187,7 @@ public class GenerateEscrowDepositCommandTest
     cloudTasksHelper.assertTasksEnqueued(
         "rde-report",
         new TaskMatcher()
-            .url("/_dr/task/rdeStaging")
+            .path("/_dr/task/rdeStaging")
             .param("mode", "THIN")
             .param("lenient", "true")
             .param("watermarks", "2017-01-01T00:00:00.000Z")
@@ -204,7 +204,7 @@ public class GenerateEscrowDepositCommandTest
     cloudTasksHelper.assertTasksEnqueued(
         "rde-report",
         new TaskMatcher()
-            .url("/_dr/task/rdeStaging")
+            .path("/_dr/task/rdeStaging")
             .param("mode", "THIN")
             .param("lenient", "false")
             .param("watermarks", "2017-01-01T00:00:00.000Z")
@@ -221,7 +221,7 @@ public class GenerateEscrowDepositCommandTest
     cloudTasksHelper.assertTasksEnqueued(
         "rde-report",
         new TaskMatcher()
-            .url("/_dr/task/rdeStaging")
+            .path("/_dr/task/rdeStaging")
             .param("lenient", "false")
             .param("mode", "THIN")
             .param("watermarks", "2017-01-01T00:00:00.000Z")
@@ -237,7 +237,7 @@ public class GenerateEscrowDepositCommandTest
     cloudTasksHelper.assertTasksEnqueued(
         "rde-report",
         new TaskMatcher()
-            .url("/_dr/task/rdeStaging")
+            .path("/_dr/task/rdeStaging")
             .param("mode", "FULL")
             .param("lenient", "false")
             .param("watermarks", "2017-01-01T00:00:00.000Z")
@@ -259,7 +259,7 @@ public class GenerateEscrowDepositCommandTest
     cloudTasksHelper.assertTasksEnqueued(
         "rde-report",
         new TaskMatcher()
-            .url("/_dr/task/rdeStaging")
+            .path("/_dr/task/rdeStaging")
             .param("mode", "THIN")
             .param("lenient", "false")
             .param("watermarks", "2017-01-01T00:00:00.000Z,2017-01-02T00:00:00.000Z")

--- a/core/src/test/java/google/registry/tools/ServiceConnectionTest.java
+++ b/core/src/test/java/google/registry/tools/ServiceConnectionTest.java
@@ -26,13 +26,13 @@ public class ServiceConnectionTest {
   void testServerUrl_notCanary() {
     ServiceConnection connection = new ServiceConnection().withService(DEFAULT, false);
     String serverUrl = connection.getServer().toString();
-    assertThat(serverUrl).isEqualTo("https://localhost"); // See default-config.yaml
+    assertThat(serverUrl).isEqualTo("https://default.example.com"); // See default-config.yaml
   }
 
   @Test
   void testServerUrl_canary() {
     ServiceConnection connection = new ServiceConnection().withService(DEFAULT, true);
     String serverUrl = connection.getServer().toString();
-    assertThat(serverUrl).isEqualTo("https://nomulus-dot-localhost");
+    assertThat(serverUrl).isEqualTo("https://nomulus-dot-default.example.com");
   }
 }

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistrarSettingsActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistrarSettingsActionTest.java
@@ -70,7 +70,7 @@ class RegistrarSettingsActionTest extends RegistrarSettingsActionTestCase {
     cloudTasksHelper.assertTasksEnqueued(
         "sheet",
         new TaskMatcher()
-            .url(SyncRegistrarsSheetAction.PATH)
+            .path(SyncRegistrarsSheetAction.PATH)
             .service("Backend")
             .method(HttpMethod.GET));
     assertMetric(CLIENT_ID, "update", "[OWNER]", "SUCCESS");

--- a/proxy/src/main/java/google/registry/proxy/EppProtocolModule.java
+++ b/proxy/src/main/java/google/registry/proxy/EppProtocolModule.java
@@ -16,7 +16,6 @@ package google.registry.proxy;
 
 import static google.registry.util.ResourceUtils.readResourceBytes;
 
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.collect.ImmutableList;
 import dagger.Module;
 import dagger.Provides;
@@ -44,7 +43,6 @@ import io.netty.handler.timeout.ReadTimeoutHandler;
 import java.io.IOException;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
@@ -116,7 +114,7 @@ public final class EppProtocolModule {
         config.epp.headerLengthBytes,
         // Adjustment applied to the header field value in order to obtain message length.
         -config.epp.headerLengthBytes,
-        // Initial bytes to strip (i. e. strip the length header).
+        // Initial bytes to strip (i.e. strip the length header).
         config.epp.headerLengthBytes);
   }
 
@@ -149,18 +147,12 @@ public final class EppProtocolModule {
 
   @Provides
   static EppServiceHandler provideEppServiceHandler(
-      Supplier<GoogleCredentials> refreshedCredentialsSupplier,
-      @Named("iapClientId") Optional<String> iapClientId,
+      @Named("idToken") Supplier<String> idTokenSupplier,
       @Named("hello") byte[] helloBytes,
       FrontendMetrics metrics,
       ProxyConfig config) {
     return new EppServiceHandler(
-        config.epp.relayHost,
-        config.epp.relayPath,
-        refreshedCredentialsSupplier,
-        iapClientId,
-        helloBytes,
-        metrics);
+        config.epp.relayHost, config.epp.relayPath, idTokenSupplier, helloBytes, metrics);
   }
 
   @Singleton

--- a/proxy/src/main/java/google/registry/proxy/ProxyConfig.java
+++ b/proxy/src/main/java/google/registry/proxy/ProxyConfig.java
@@ -40,7 +40,7 @@ public class ProxyConfig {
   private static final String CUSTOM_CONFIG_FORMATTER = "config/proxy-config-%s.yaml";
 
   public String projectId;
-  public String iapClientId;
+  public String oauthClientId;
   public List<String> gcpScopes;
   public int serverCertificateCacheSeconds;
   public Gcs gcs;

--- a/proxy/src/main/java/google/registry/proxy/WhoisProtocolModule.java
+++ b/proxy/src/main/java/google/registry/proxy/WhoisProtocolModule.java
@@ -14,7 +14,6 @@
 
 package google.registry.proxy;
 
-import com.google.auth.oauth2.GoogleCredentials;
 import com.google.common.collect.ImmutableList;
 import dagger.Module;
 import dagger.Provides;
@@ -35,7 +34,6 @@ import google.registry.util.Clock;
 import io.netty.channel.ChannelHandler;
 import io.netty.handler.codec.LineBasedFrameDecoder;
 import io.netty.handler.timeout.ReadTimeoutHandler;
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Supplier;
@@ -46,7 +44,9 @@ import javax.inject.Singleton;
 
 /** A module that provides the {@link FrontendProtocol} used for whois protocol. */
 @Module
-public class WhoisProtocolModule {
+public final class WhoisProtocolModule {
+
+  private WhoisProtocolModule() {}
 
   /** Dagger qualifier to provide whois protocol related handlers and other bindings. */
   @Qualifier
@@ -93,15 +93,10 @@ public class WhoisProtocolModule {
   @Provides
   static WhoisServiceHandler provideWhoisServiceHandler(
       ProxyConfig config,
-      Supplier<GoogleCredentials> refreshedCredentialsSupplier,
-      @Named("iapClientId") Optional<String> iapClientId,
+      @Named("idToken") Supplier<String> idTokenSupplier,
       FrontendMetrics metrics) {
     return new WhoisServiceHandler(
-        config.whois.relayHost,
-        config.whois.relayPath,
-        refreshedCredentialsSupplier,
-        iapClientId,
-        metrics);
+        config.whois.relayHost, config.whois.relayPath, idTokenSupplier, metrics);
   }
 
   @Provides

--- a/proxy/src/main/java/google/registry/proxy/config/default-config.yaml
+++ b/proxy/src/main/java/google/registry/proxy/config/default-config.yaml
@@ -8,14 +8,17 @@
 # GCP project ID
 projectId: your-gcp-project-id
 
-# IAP client ID, if IAP is enabled for this project
-iapClientId: null
+# OAuth client ID set as the audience of the OIDC token. This value must be the
+# same as the auth.oauthClientId value in Nomulus config file, which usually is
+# the IAP client ID, to allow the request to access IAP protected endpoints.
+# Regular OIDC authentication mechanism also checks for this audience.
+oauthClientId: iap-client-id
 
 # OAuth scope that the GoogleCredential will be constructed with. This list
 # should include all service scopes that the proxy depends on.
 gcpScopes:
   # The default OAuth scope granted to GCE instances. Local development instance
-  # needs this scope to mimic running on GCE. Currently it is used to access
+  # needs this scope to mimic running on GCE. Currently, it is used to access
   # Cloud KMS and Stackdriver Monitoring APIs.
   - https://www.googleapis.com/auth/cloud-platform
 
@@ -25,8 +28,8 @@ gcpScopes:
 
 # Server certificate is cached for 30 minutes.
 #
-# Encrypted server server certificate and private keys are stored on GCS. They
-# are cached and shared for all connections for 30 minutes. We not not cache
+# Encrypted server certificate and private keys are stored on GCS. They
+# are cached and shared for all connections for 30 minutes. We do not cache
 # the certificate indefinitely because if we upload a new one to GCS, all
 # existing instances need to be killed if they cache the old one indefinitely.
 serverCertificateCacheSeconds: 1800
@@ -59,8 +62,8 @@ epp:
   # The first 4 bytes in a message is the total length of message, in bytes.
   #
   # We accept a message up to 1 GB, which should be plentiful, if not over the
-  # top. In fact we should probably limit this to a more reasonable number, as a
-  # 1 GB message will likely cause the proxy to go out of memory.
+  # top. In fact, we should probably limit this to a more reasonable number, as
+  # a 1 GB message will likely cause the proxy to go out of memory.
   #
   # See also: RFC 5734 4 Data Unit Format
   # (https://tools.ietf.org/html/rfc5734#section-4).
@@ -76,7 +79,7 @@ epp:
   # Time after which an idle connection will be closed.
   #
   # The RFC gives registry discretionary power to set a timeout period. 1 hr
-  # should be reasonable enough for any registrar to login and submit their
+  # should be reasonable enough for any registrar to log in and submit their
   # request.
   readTimeoutSeconds: 3600
 
@@ -91,7 +94,7 @@ epp:
     # Default quota for any userId not matched in customQuota.
     defaultQuota:
 
-      # List of identifiers, e. g. IP address, certificate hash.
+      # List of identifiers, e.g. IP address, certificate hash.
       #
       # userId for defaultQuota should always be an empty list. Any value
       # in the list will be discarded.
@@ -129,7 +132,7 @@ whois:
   # (http://www.freesoft.org/CIE/RFC/1035/9.htm).
   maxMessageLengthBytes: 512
 
-  # Whois protocol is transient, the client should not establish a long lasting
+  # Whois protocol is transient, the client should not establish a long-lasting
   # idle connection.
   readTimeoutSeconds: 60
 
@@ -144,7 +147,7 @@ whois:
     # Default quota for any userId not matched in customQuota.
     defaultQuota:
 
-      # List of identifiers, e. g. IP address, certificate hash.
+      # List of identifiers, e.g. IP address, certificate hash.
       #
       # userId for defaultQuota should always be an empty list.
       userId: []

--- a/proxy/src/main/java/google/registry/proxy/handler/WhoisServiceHandler.java
+++ b/proxy/src/main/java/google/registry/proxy/handler/WhoisServiceHandler.java
@@ -16,7 +16,6 @@ package google.registry.proxy.handler;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.auth.oauth2.GoogleCredentials;
 import google.registry.proxy.metric.FrontendMetrics;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFutureListener;
@@ -26,7 +25,6 @@ import io.netty.handler.codec.http.FullHttpRequest;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import io.netty.handler.codec.http.HttpResponse;
-import java.util.Optional;
 import java.util.function.Supplier;
 
 /** Handler that processes WHOIS protocol logic. */
@@ -35,10 +33,9 @@ public final class WhoisServiceHandler extends HttpsRelayServiceHandler {
   public WhoisServiceHandler(
       String relayHost,
       String relayPath,
-      Supplier<GoogleCredentials> refreshedCredentialsSupplier,
-      Optional<String> iapClientId,
+      Supplier<String> idTokenSupplier,
       FrontendMetrics metrics) {
-    super(relayHost, relayPath, refreshedCredentialsSupplier, iapClientId, metrics);
+    super(relayHost, relayPath, idTokenSupplier, metrics);
   }
 
   @Override

--- a/proxy/src/test/java/google/registry/proxy/WhoisProtocolModuleTest.java
+++ b/proxy/src/test/java/google/registry/proxy/WhoisProtocolModuleTest.java
@@ -53,8 +53,7 @@ class WhoisProtocolModuleTest extends ProtocolModuleTest {
             "test.tld",
             PROXY_CONFIG.whois.relayHost,
             PROXY_CONFIG.whois.relayPath,
-            TestModule.provideFakeCredentials().get(),
-            TestModule.provideIapClientId());
+            TestModule.provideFakeIdToken().get());
     assertThat(actualRequest).isEqualTo(expectedRequest);
     assertThat(channel.isActive()).isTrue();
     // Nothing more to read.
@@ -89,8 +88,7 @@ class WhoisProtocolModuleTest extends ProtocolModuleTest {
             "test1.tld",
             PROXY_CONFIG.whois.relayHost,
             PROXY_CONFIG.whois.relayPath,
-            TestModule.provideFakeCredentials().get(),
-            TestModule.provideIapClientId());
+            TestModule.provideFakeIdToken().get());
     assertThat(actualRequest1).isEqualTo(expectedRequest1);
     // No more message at this point.
     assertThat((Object) channel.readInbound()).isNull();
@@ -104,8 +102,7 @@ class WhoisProtocolModuleTest extends ProtocolModuleTest {
             "test2.tld",
             PROXY_CONFIG.whois.relayHost,
             PROXY_CONFIG.whois.relayPath,
-            TestModule.provideFakeCredentials().get(),
-            TestModule.provideIapClientId());
+            TestModule.provideFakeIdToken().get());
     assertThat(actualRequest2).isEqualTo(expectedRequest2);
     // The third message is not complete yet.
     assertThat(channel.isActive()).isTrue();

--- a/release/builder/Dockerfile
+++ b/release/builder/Dockerfile
@@ -23,8 +23,9 @@
 
 FROM golang:1.19 as deployCloudSchedulerAndQueueBuilder
 WORKDIR /usr/src/deployCloudSchedulerAndQueue
-RUN go mod init deployCloudSchedulerAndQueue
-COPY *.go ./
+COPY deployCloudSchedulerAndQueue.go ./
+COPY go.sum ./
+COPY go.mod ./
 RUN go build -o /deployCloudSchedulerAndQueue
 
 FROM marketplace.gcr.io/google/debian10

--- a/release/builder/go.mod
+++ b/release/builder/go.mod
@@ -1,0 +1,5 @@
+module nomulus/release/builder
+
+go 1.21
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/release/builder/go.sum
+++ b/release/builder/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/release/cloudbuild-deploy.yaml
+++ b/release/cloudbuild-deploy.yaml
@@ -43,8 +43,9 @@ steps:
     fi
     gsutil cp gs://$PROJECT_ID-deploy/${TAG_NAME}/${_ENV}.tar .
     tar -xvf ${_ENV}.tar
-    deployCloudSchedulerAndQueue default/WEB-INF/cloud-scheduler-tasks.xml $project_id
-    deployCloudSchedulerAndQueue default/WEB-INF/cloud-tasks-queue.xml $project_id
+    unzip default/WEB-INF/lib/core.jar
+    deployCloudSchedulerAndQueue google/registry/config/files/nomulus-config-${_ENV}.yaml default/WEB-INF/cloud-scheduler-tasks.xml $project_id
+    deployCloudSchedulerAndQueue google/registry/config/files/nomulus-config-${_ENV}.yaml default/WEB-INF/cloud-tasks-queue.xml $project_id
 # Deploy the GAE config files.
 # First authorize the gcloud tool to use the credential json file, then
 # download and unzip the tarball that contains the relevant config files

--- a/util/src/main/java/google/registry/util/GoogleCredentialsBundle.java
+++ b/util/src/main/java/google/registry/util/GoogleCredentialsBundle.java
@@ -20,6 +20,7 @@ import com.google.api.client.googleapis.util.Utils;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
+import com.google.auth.ServiceAccountSigner;
 import com.google.auth.http.HttpCredentialsAdapter;
 import com.google.auth.oauth2.GoogleCredentials;
 import java.io.Serializable;
@@ -31,12 +32,13 @@ import java.io.Serializable;
  */
 public class GoogleCredentialsBundle implements Serializable {
 
+  private static final long serialVersionUID = -7184513645423688942L;
   private static final HttpTransport HTTP_TRANSPORT = Utils.getDefaultTransport();
   private static final JsonFactory JSON_FACTORY = Utils.getDefaultJsonFactory();
 
-  private GoogleCredentials googleCredentials;
+  private final GoogleCredentials googleCredentials;
 
-  private GoogleCredentialsBundle(GoogleCredentials googleCredentials) {
+  protected GoogleCredentialsBundle(GoogleCredentials googleCredentials) {
     checkNotNull(googleCredentials);
     this.googleCredentials = googleCredentials;
   }
@@ -44,6 +46,21 @@ public class GoogleCredentialsBundle implements Serializable {
   /** Creates a {@link GoogleCredentialsBundle} instance from given {@link GoogleCredentials}. */
   public static GoogleCredentialsBundle create(GoogleCredentials credentials) {
     return new GoogleCredentialsBundle(credentials);
+  }
+
+  /**
+   * Returns the service account email address of the underlying {@link} GoogleCredentials, if
+   * possible.
+   */
+  public String serviceAccount() {
+    if (googleCredentials instanceof ServiceAccountSigner) {
+      return ((ServiceAccountSigner) googleCredentials).getAccount();
+    } else {
+      throw new RuntimeException(
+          String.format(
+              "%s is a %s, not a service account.",
+              googleCredentials, googleCredentials.getClass().getSimpleName()));
+    }
   }
 
   /** Returns the same {@link GoogleCredentials} used to create this object. */

--- a/util/src/main/java/google/registry/util/OidcTokenUtils.java
+++ b/util/src/main/java/google/registry/util/OidcTokenUtils.java
@@ -1,0 +1,98 @@
+// Copyright 2023 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package google.registry.util;
+
+import static com.google.api.client.googleapis.auth.oauth2.GoogleOAuthConstants.TOKEN_SERVER_URL;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.api.client.http.UrlEncodedContent;
+import com.google.api.client.util.GenericData;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.auth.oauth2.IdToken;
+import com.google.auth.oauth2.IdTokenProvider;
+import com.google.auth.oauth2.IdTokenProvider.Option;
+import com.google.auth.oauth2.UserCredentials;
+import com.google.common.collect.ImmutableList;
+import com.google.common.flogger.FluentLogger;
+import java.io.IOException;
+import java.net.URI;
+import java.security.GeneralSecurityException;
+
+public final class OidcTokenUtils {
+
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
+  private OidcTokenUtils() {}
+
+  public static String createOidcToken(GoogleCredentialsBundle credentialsBundle, String clientId) {
+    GoogleCredentials credentials = credentialsBundle.getGoogleCredentials();
+    if (credentials instanceof UserCredentials) {
+      try {
+        return getIdTokenForUserCredential(credentialsBundle, clientId);
+      } catch (Exception e) {
+        logger.atSevere().withCause(e).log(
+            "Cannot generate OIDC token for credential %s", credentials);
+        throw new RuntimeException("Cannot create OIDC token", e);
+      }
+    } else {
+      IdTokenProvider idTokenProvider = (IdTokenProvider) credentials;
+      // Note: we use Option.FORMAT_FULL to make sure the JWT we receive contains the email
+      // address (as is required by IAP)
+      try {
+        IdToken idToken =
+            idTokenProvider.idTokenWithAudience(clientId, ImmutableList.of(Option.FORMAT_FULL));
+        return idToken.getTokenValue();
+      } catch (IOException e) {
+        logger.atSevere().withCause(e).log(
+            "Cannot generate OIDC token for credential %s", credentials);
+        throw new RuntimeException("Cannot create OIDC token", e);
+      }
+    }
+  }
+
+  /**
+   * Uses the saved desktop-app refresh token to acquire a token with the given audience.
+   *
+   * <p>This is lifted mostly from the Google Auth Library's {@link UserCredentials}
+   * "doRefreshAccessToken" method (which is private and thus inaccessible) while adding in the
+   * audience of the IAP client ID. The "idTokenWithAudience" method of that class does not support
+   * setting custom audience, paradoxically.
+   *
+   * @see <a
+   *     href="https://cloud.google.com/iap/docs/authentication-howto#authenticating_from_a_desktop_app">
+   *     Authenticating from a desktop app</a>
+   */
+  private static String getIdTokenForUserCredential(
+      GoogleCredentialsBundle credentialsBundle, String audience)
+      throws GeneralSecurityException, IOException {
+    UserCredentials credentials = (UserCredentials) credentialsBundle.getGoogleCredentials();
+    GenericData tokenRequest = new GenericData();
+    tokenRequest.set("client_id", credentials.getClientId());
+    tokenRequest.set("client_secret", credentials.getClientSecret());
+    tokenRequest.set("refresh_token", credentials.getRefreshToken());
+    tokenRequest.set("audience", audience);
+    tokenRequest.set("grant_type", "refresh_token");
+    UrlEncodedContent content = new UrlEncodedContent(tokenRequest);
+
+    HttpRequestFactory requestFactory = credentialsBundle.getHttpTransport().createRequestFactory();
+    HttpRequest request =
+        requestFactory.buildPostRequest(new GenericUrl(URI.create(TOKEN_SERVER_URL)), content);
+    request.setParser(credentialsBundle.getJsonFactory().createJsonObjectParser());
+    HttpResponse response = request.execute();
+    return response.parseAs(GenericData.class).get("id_token").toString();
+  }
+}


### PR DESCRIPTION
This PR changes the two flavors of OIDC authentication mechanisms to
verify the same audience. This allows the same token to pass both
mechanisms. Previously the regular OIDC flavor uses the project id as
its required audience, which does not work for local user credentials
(such as ones used by the nomulus tool), which requires a valid OAuth
client ID as audience when minting the token (project id is NOT a valid
OAuth client ID).

I considered allowing multiple audiences, but the result is not as clean
as just using the same everywhere, because the fall-through logic would
have generated a lot of noises for failed attempts.

This PR also changes the client side to solely use OIDC token whenever
possible, including the proxy, cloud scheduler and cloud tasks. The nomulus
tool still uses OAuth access token by default because it requires USER level
authentication, which in turn requires us to fill the User table with objects
corresponding to the email address of everyone needing access to the tool.

TESTED=verified each client is able to make authenticated calls on QA with or
without IAP.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2049)
<!-- Reviewable:end -->
