### PR TITLE
Add configurable discount on sunrise domain creates

### DIFF
--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -1568,6 +1568,11 @@ public final class RegistryConfig {
     return Duration.standardDays(CONFIG_SETTINGS.get().registryPolicy.contactAutomaticTransferDays);
   }
 
+  /** A discount for all sunrise domain creates, between 0.0 (no discount) and 1.0 (free). */
+  public static double getSunriseDomainCreateDiscount() {
+    return CONFIG_SETTINGS.get().registryPolicy.sunriseDomainCreateDiscount;
+  }
+
   /**
    * Memoizes loading of the {@link RegistryConfigSettings} POJO.
    *

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -108,6 +108,7 @@ public class RegistryConfigSettings {
     public String registryName;
     public List<String> spec11WebResources;
     public boolean requireSslCertificates;
+    public double sunriseDomainCreateDiscount;
   }
 
   /** Configuration for Hibernate. */

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -188,6 +188,11 @@ registryPolicy:
   # should generally be true for production environments, for added security.
   requireSslCertificates: true
 
+  # A fractional discount, if any, to be provided to all sunrise domain creates.
+  # 0 means no discount will be applied, and 1 means that all sunrise creates
+  # will be free.
+  sunriseDomainCreateDiscount: 0.15
+
 hibernate:
   # Make 'SERIALIZABLE' the default isolation level to ensure correctness.
   #

--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -337,7 +337,8 @@ public final class DomainCreateFlow implements TransactionalFlow {
     Optional<FeeCreateCommandExtension> feeCreate =
         eppInput.getSingleExtension(FeeCreateCommandExtension.class);
     FeesAndCredits feesAndCredits =
-        pricingLogic.getCreatePrice(tld, targetId, now, years, isAnchorTenant, allocationToken);
+        pricingLogic.getCreatePrice(
+            tld, targetId, now, years, isAnchorTenant, isSunriseCreate, allocationToken);
     validateFeeChallenge(feeCreate, feesAndCredits, defaultTokenUsed);
     Optional<SecDnsCreateExtension> secDnsCreate =
         validateSecDnsExtension(eppInput.getSingleExtension(SecDnsCreateExtension.class));

--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -690,6 +690,7 @@ public class DomainFlowUtils {
                       now,
                       years,
                       isAnchorTenant(domainName, allocationToken, Optional.empty()),
+                      isSunrise,
                       allocationToken)
                   .getFees();
         }

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -276,16 +276,24 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
     boolean isAnchorTenant = expectedBillingFlags.contains(ANCHOR_TENANT);
     // Set up the creation cost.
+    BigDecimal createCost =
+        isDomainPremium(getUniqueIdFromCommand(), clock.nowUtc())
+            ? BigDecimal.valueOf(200)
+            : BigDecimal.valueOf(26);
+    if (isAnchorTenant) {
+      createCost = BigDecimal.ZERO;
+    }
+    if (expectedBillingFlags.contains(SUNRISE)) {
+      createCost =
+          createCost.multiply(
+              BigDecimal.valueOf(1 - RegistryConfig.getSunriseDomainCreateDiscount()));
+    }
     FeesAndCredits feesAndCredits =
         new FeesAndCredits.Builder()
             .setCurrency(USD)
             .addFeeOrCredit(
                 Fee.create(
-                    isAnchorTenant
-                        ? BigDecimal.valueOf(0)
-                        : isDomainPremium(getUniqueIdFromCommand(), clock.nowUtc())
-                            ? BigDecimal.valueOf(200)
-                            : BigDecimal.valueOf(26),
+                    createCost,
                     FeeType.CREATE,
                     isDomainPremium(getUniqueIdFromCommand(), clock.nowUtc())))
             .build();

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_fee_reserved_sunrise_response_v06.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_fee_reserved_sunrise_response_v06.xml
@@ -55,7 +55,7 @@
           <fee:currency>USD</fee:currency>
           <fee:command>create</fee:command>
           <fee:period unit="y">1</fee:period>
-          <fee:fee description="create">13.00</fee:fee>
+          <fee:fee description="create">11.05</fee:fee>
         </fee:cd>
         <fee:cd xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
           <fee:name>allowedinsunrise.tld</fee:name>
@@ -83,7 +83,7 @@
           <fee:currency>USD</fee:currency>
           <fee:command>create</fee:command>
           <fee:period unit="y">1</fee:period>
-          <fee:fee description="create">13.00</fee:fee>
+          <fee:fee description="create">11.05</fee:fee>
           <fee:class>collision</fee:class>
         </fee:cd>
         <fee:cd xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
@@ -115,7 +115,7 @@
           <fee:currency>USD</fee:currency>
           <fee:command>create</fee:command>
           <fee:period unit="y">1</fee:period>
-          <fee:fee description="create">70.00</fee:fee>
+          <fee:fee description="create">59.50</fee:fee>
           <fee:class>premium-collision</fee:class>
         </fee:cd>
         <fee:cd xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_fee_reserved_sunrise_response_v06_with_renewals.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_fee_reserved_sunrise_response_v06_with_renewals.xml
@@ -59,7 +59,7 @@
           <fee:currency>USD</fee:currency>
           <fee:command>create</fee:command>
           <fee:period unit="y">1</fee:period>
-          <fee:fee description="create">13.00</fee:fee>
+          <fee:fee description="create">11.05</fee:fee>
         </fee:cd>
         <fee:cd xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
           <fee:name>allowedinsunrise.tld</fee:name>
@@ -88,7 +88,7 @@
           <fee:currency>USD</fee:currency>
           <fee:command>create</fee:command>
           <fee:period unit="y">1</fee:period>
-          <fee:fee description="create">13.00</fee:fee>
+          <fee:fee description="create">11.05</fee:fee>
           <fee:class>collision</fee:class>
         </fee:cd>
         <fee:cd xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
@@ -121,7 +121,7 @@
           <fee:currency>USD</fee:currency>
           <fee:command>create</fee:command>
           <fee:period unit="y">1</fee:period>
-          <fee:fee description="create">70.00</fee:fee>
+          <fee:fee description="create">59.50</fee:fee>
           <fee:class>premium-collision</fee:class>
         </fee:cd>
         <fee:cd xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_fee_reserved_sunrise_response_v11_create.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_fee_reserved_sunrise_response_v11_create.xml
@@ -40,7 +40,7 @@
           <fee:command>create</fee:command>
           <fee:currency>USD</fee:currency>
           <fee:period unit="y">1</fee:period>
-          <fee:fee description="create">13.00</fee:fee>
+          <fee:fee description="create">11.05</fee:fee>
         </fee:cd>
         <fee:cd avail="1">
           <fee:object>
@@ -49,7 +49,7 @@
           <fee:command>create</fee:command>
           <fee:currency>USD</fee:currency>
           <fee:period unit="y">1</fee:period>
-          <fee:fee description="create">13.00</fee:fee>
+          <fee:fee description="create">11.05</fee:fee>
           <fee:class>collision</fee:class>
         </fee:cd>
         <fee:cd avail="1">
@@ -59,7 +59,7 @@
           <fee:command>create</fee:command>
           <fee:currency>USD</fee:currency>
           <fee:period unit="y">1</fee:period>
-          <fee:fee description="create">70.00</fee:fee>
+          <fee:fee description="create">59.50</fee:fee>
           <fee:class>premium-collision</fee:class>
         </fee:cd>
       </fee:chkData>

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_fee_reserved_sunrise_response_v12.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_fee_reserved_sunrise_response_v12.xml
@@ -66,7 +66,7 @@
           </fee:object>
           <fee:command name="create">
             <fee:period unit="y">1</fee:period>
-            <fee:fee description="create">13.00</fee:fee>
+            <fee:fee description="create">11.05</fee:fee>
           </fee:command>
         </fee:cd>
         <fee:cd>
@@ -102,7 +102,7 @@
           </fee:object>
           <fee:command name="create">
             <fee:period unit="y">1</fee:period>
-            <fee:fee description="create">13.00</fee:fee>
+            <fee:fee description="create">11.05</fee:fee>
             <fee:class>collision</fee:class>
           </fee:command>
         </fee:cd>
@@ -142,7 +142,7 @@
           </fee:object>
           <fee:command name="create">
             <fee:period unit="y">1</fee:period>
-            <fee:fee description="create">70.00</fee:fee>
+            <fee:fee description="create">59.50</fee:fee>
             <fee:class>premium-collision</fee:class>
           </fee:command>
         </fee:cd>


### PR DESCRIPTION
Previously we had a 15% discount applied at invoicing time. We got rid of
that inadvertently in 2022 and we want to add it back, but instead of
being applied at invoicing time we'll just apply it directly to the
creation cost when creating the billing events.

Note: previous behavior didn't care about standard vs premium pricing so
we don't either

https://buganizer.corp.google.com/issues/287070313 is a bug for the
issue, and
https://github.com/google/nomulus/pull/1710/files#diff-5097b0ef57578718444ea6b9d4c6cb32f655686a37e2ca3dd96ad2db86a77f06L151-L170
is the section of the pull request that inadvertently removed it


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2056)
<!-- Reviewable:end -->
