### PR TITLE
Add CurlCommand option to connect to canary

### DIFF
--- a/core/src/main/java/google/registry/tools/CurlCommand.java
+++ b/core/src/main/java/google/registry/tools/CurlCommand.java
@@ -75,6 +75,11 @@ class CurlCommand implements CommandWithConnection {
       required = true)
   private Service service;
 
+  @Parameter(
+      names = {"--canary"},
+      description = "If set, use the canary end-point; otherwise use the regular end-point.")
+  private Boolean canary = Boolean.FALSE;
+
   @Override
   public void setConnection(ServiceConnection connection) {
     this.connection = connection;
@@ -90,7 +95,7 @@ class CurlCommand implements CommandWithConnection {
       throw new IllegalArgumentException("You may not specify a body for a get method.");
     }
 
-    ServiceConnection connectionToService = connection.withService(service);
+    ServiceConnection connectionToService = connection.withService(service, canary);
     String response =
         (method == Method.GET)
             ? connectionToService.sendGetRequest(path, ImmutableMap.<String, String>of())

--- a/core/src/test/java/google/registry/tools/ServiceConnectionTest.java
+++ b/core/src/test/java/google/registry/tools/ServiceConnectionTest.java
@@ -1,0 +1,38 @@
+// Copyright 2023 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.tools;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.request.Action.Service.DEFAULT;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link google.registry.tools.ServiceConnection}. */
+public class ServiceConnectionTest {
+
+  @Test
+  void testServerUrl_notCanary() {
+    ServiceConnection connection = new ServiceConnection().withService(DEFAULT, false);
+    String serverUrl = connection.getServer().toString();
+    assertThat(serverUrl).isEqualTo("https://localhost"); // See default-config.yaml
+  }
+
+  @Test
+  void testServerUrl_canary() {
+    ServiceConnection connection = new ServiceConnection().withService(DEFAULT, true);
+    String serverUrl = connection.getServer().toString();
+    assertThat(serverUrl).isEqualTo("https://nomulus-dot-localhost");
+  }
+}


### PR DESCRIPTION
Add a --canary option (default to false) to the CurlCommand that allows connection to the canary endpoints.

During canary analysis, only the DEFAULT-canary receives traffic. This new flag allows use to test other canary services manually using the curl command.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2060)
<!-- Reviewable:end -->
