### PR TITLE
Fix minor RDAP typos

### DIFF
--- a/core/src/main/java/google/registry/rdap/RdapDataStructures.java
+++ b/core/src/main/java/google/registry/rdap/RdapDataStructures.java
@@ -367,7 +367,7 @@ final class RdapDataStructures {
     PENDING_RESTORE("pending restore"),
     REDEMPTION_PERIOD("redemption period"),
     RENEW_PERIOD("renew period"),
-    SERVER_DELETE_PROHIBITED("server deleted prohibited"),
+    SERVER_DELETE_PROHIBITED("server delete prohibited"),
     SERVER_RENEW_PROHIBITED("server renew prohibited"),
     SERVER_TRANSFER_PROHIBITED("server transfer prohibited"),
     SERVER_UPDATE_PROHIBITED("server update prohibited"),

--- a/core/src/main/java/google/registry/rdap/RdapIcannStandardInformation.java
+++ b/core/src/main/java/google/registry/rdap/RdapIcannStandardInformation.java
@@ -54,12 +54,11 @@ public class RdapIcannStandardInformation {
   private static final Notice INACCURACY_COMPLAINT_FORM_NOTICE =
       Notice.builder()
           .setTitle("RDDS Inaccuracy Complaint Form")
-          .setDescription(
-              "URL of the ICANN RDDS Inaccuracy Complaint Form: https://www.icann.org/wicf")
+          .setDescription("URL of the ICANN RDDS Inaccuracy Complaint Form: https://icann.org/wicf")
           .addLink(
               Link.builder()
                   .setRel("alternate")
-                  .setHref("https://www.icann.org/wicf")
+                  .setHref("https://icann.org/wicf")
                   .setType("text/html")
                   .build())
           .build();

--- a/core/src/main/java/google/registry/rdap/RdapJsonFormatter.java
+++ b/core/src/main/java/google/registry/rdap/RdapJsonFormatter.java
@@ -1000,7 +1000,7 @@ public class RdapJsonFormatter {
     // Gustavo Lozano of ICANN, the one we should use is an embedded array of street address lines
     // if there is more than one line:
     //
-    //   RFC7095 provides two examples of structured addresses, and one of the examples shows a
+    //   RFC 7095 provides two examples of structured addresses, and one of the examples shows a
     //   street JSON element that contains several data elements. The example showing (see below)
     //   several data elements is the expected output when two or more <contact:street> elements
     //   exists in the contact object.

--- a/core/src/test/java/google/registry/rdap/RdapTestHelper.java
+++ b/core/src/test/java/google/registry/rdap/RdapTestHelper.java
@@ -139,13 +139,12 @@ class RdapTestHelper {
                 "RDDS Inaccuracy Complaint Form",
                 "description",
                 ImmutableList.of(
-                    "URL of the ICANN RDDS Inaccuracy Complaint Form:"
-                        + " https://www.icann.org/wicf"),
+                    "URL of the ICANN RDDS Inaccuracy Complaint Form: https://icann.org/wicf"),
                 "links",
                 ImmutableList.of(
                     ImmutableMap.of(
                         "rel", "alternate",
-                        "href", "https://www.icann.org/wicf",
+                        "href", "https://icann.org/wicf",
                         "type", "text/html")))));
   }
 

--- a/core/src/test/resources/google/registry/rdap/rdap_domains_four_truncated.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domains_four_truncated.json
@@ -156,12 +156,12 @@
     },
     {
       "title": "RDDS Inaccuracy Complaint Form",
-      "description" : ["URL of the ICANN RDDS Inaccuracy Complaint Form: https://www.icann.org/wicf"],
+      "description" : ["URL of the ICANN RDDS Inaccuracy Complaint Form: https://icann.org/wicf"],
       "links" :
       [
         {
           "rel" : "alternate",
-          "href" : "https://www.icann.org/wicf",
+          "href" : "https://icann.org/wicf",
           "type" : "text/html"
         }
       ]

--- a/core/src/test/resources/google/registry/rdap/rdap_domains_four_with_one_unicode.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domains_four_with_one_unicode.json
@@ -137,12 +137,12 @@
     },
     {
       "title": "RDDS Inaccuracy Complaint Form",
-      "description" : ["URL of the ICANN RDDS Inaccuracy Complaint Form: https://www.icann.org/wicf"],
+      "description" : ["URL of the ICANN RDDS Inaccuracy Complaint Form: https://icann.org/wicf"],
       "links" :
       [
         {
           "rel" : "alternate",
-          "href" : "https://www.icann.org/wicf",
+          "href" : "https://icann.org/wicf",
           "type" : "text/html"
         }
       ]

--- a/core/src/test/resources/google/registry/rdap/rdap_domains_four_with_one_unicode_truncated.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domains_four_with_one_unicode_truncated.json
@@ -157,12 +157,12 @@
     },
     {
       "title": "RDDS Inaccuracy Complaint Form",
-      "description" : ["URL of the ICANN RDDS Inaccuracy Complaint Form: https://www.icann.org/wicf"],
+      "description" : ["URL of the ICANN RDDS Inaccuracy Complaint Form: https://icann.org/wicf"],
       "links" :
       [
         {
           "rel" : "alternate",
-          "href" : "https://www.icann.org/wicf",
+          "href" : "https://icann.org/wicf",
           "type" : "text/html"
         }
       ]

--- a/core/src/test/resources/google/registry/rdap/rdap_domains_two.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domains_two.json
@@ -95,12 +95,12 @@
     },
     {
       "title": "RDDS Inaccuracy Complaint Form",
-      "description": ["URL of the ICANN RDDS Inaccuracy Complaint Form: https://www.icann.org/wicf"],
+      "description": ["URL of the ICANN RDDS Inaccuracy Complaint Form: https://icann.org/wicf"],
       "links":
       [
         {
           "rel": "alternate",
-          "href": "https://www.icann.org/wicf",
+          "href": "https://icann.org/wicf",
           "type": "text/html"
         }
       ]

--- a/core/src/test/resources/google/registry/rdap/rdap_incomplete_domain_result_set.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_incomplete_domain_result_set.json
@@ -130,12 +130,12 @@
     },
     {
       "title": "RDDS Inaccuracy Complaint Form",
-      "description": ["URL of the ICANN RDDS Inaccuracy Complaint Form: https://www.icann.org/wicf"],
+      "description": ["URL of the ICANN RDDS Inaccuracy Complaint Form: https://icann.org/wicf"],
       "links":
       [
         {
           "rel":"alternate",
-          "href":"https://www.icann.org/wicf",
+          "href":"https://icann.org/wicf",
           "type":"text/html"
         }
       ]

--- a/core/src/test/resources/google/registry/rdap/rdap_incomplete_domains.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_incomplete_domains.json
@@ -98,12 +98,12 @@
     },
     {
       "title": "RDDS Inaccuracy Complaint Form",
-      "description":["URL of the ICANN RDDS Inaccuracy Complaint Form: https://www.icann.org/wicf"],
+      "description":["URL of the ICANN RDDS Inaccuracy Complaint Form: https://icann.org/wicf"],
       "links":[
         {
           "type":"text/html",
           "rel":"alternate",
-          "href":"https://www.icann.org/wicf"
+          "href":"https://icann.org/wicf"
         }
       ]
     }

--- a/core/src/test/resources/google/registry/rdap/rdap_nontruncated_domains.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_nontruncated_domains.json
@@ -144,12 +144,12 @@
     },
     {
       "title": "RDDS Inaccuracy Complaint Form",
-      "description" : ["URL of the ICANN RDDS Inaccuracy Complaint Form: https://www.icann.org/wicf"],
+      "description" : ["URL of the ICANN RDDS Inaccuracy Complaint Form: https://icann.org/wicf"],
       "links" :
       [
         {
           "rel" : "alternate",
-          "href" : "https://www.icann.org/wicf",
+          "href" : "https://icann.org/wicf",
           "type" : "text/html"
         }
       ]

--- a/core/src/test/resources/google/registry/rdap/rdapjson_toplevel_domain.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_toplevel_domain.json
@@ -59,12 +59,12 @@
     },
     {
       "title": "RDDS Inaccuracy Complaint Form",
-      "description": ["URL of the ICANN RDDS Inaccuracy Complaint Form: https://www.icann.org/wicf"],
+      "description": ["URL of the ICANN RDDS Inaccuracy Complaint Form: https://icann.org/wicf"],
       "links":
       [
         {
           "rel": "alternate",
-          "href": "https://www.icann.org/wicf",
+          "href": "https://icann.org/wicf",
           "type": "text/html"
         }
       ]


### PR DESCRIPTION
These wording changes are necessary for compliance with the latest
(2019) RDAP profile found at https://www.icann.org/en/system/files/files/rdap-response-profile-15feb19-en.pdf

The old version (2016), at https://www.icann.org/resources/pages/rdap-operational-profile-2016-07-26-en
included the "www" in the URL for ICANN complaints.

These (among others) were found using the RDAP conformance tool 
https://github.com/icann/rdap-conformance-tool

See https://buganizer.corp.google.com/issues/252317192 for more info,
these are just the low-hanging fruit (removing a www and fixing a typo
in a status)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2062)
<!-- Reviewable:end -->
