### PR TITLE
Add minor refactoring follow-up for RefreshDnsForAllDomainsAction

### DIFF
--- a/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
+++ b/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
@@ -75,8 +75,8 @@ public class RefreshDnsForAllDomainsActionTest {
     action =
         new RefreshDnsForAllDomainsAction(
             response, ImmutableSet.of("bar"), Optional.of(1), new Random());
-    tm().transact(() -> action.refreshBatch("", 1000));
-    tm().transact(() -> action.refreshBatch("", 1000));
+    tm().transact(() -> action.refreshBatch(Optional.empty(), 1000));
+    tm().transact(() -> action.refreshBatch(Optional.empty(), 1000));
     ImmutableList<DnsRefreshRequest> refreshRequests =
         tm().transact(
                 () ->


### PR DESCRIPTION
This is a follow-on to comments in PR #2037. It makes the main loop cleaner and also removes ambiguities around database handling when the first query is run with the cursor still empty because no results have been found yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2063)
<!-- Reviewable:end -->
