### PR TITLE
Clean up issues with RDAP redaction

### DIFF
--- a/core/src/main/java/google/registry/rdap/RdapIcannStandardInformation.java
+++ b/core/src/main/java/google/registry/rdap/RdapIcannStandardInformation.java
@@ -150,14 +150,6 @@ public class RdapIcannStandardInformation {
           .build();
 
   /**
-   * String that replaces GDPR redacted values.
-   *
-   * <p>GTLD Registration Data Temp Spec 17may18, Appendix A, 2.2: Fields required to be "redacted"
-   * MUST privide in the value section text similar to "REDACTED FOR PRIVACY"
-   */
-  static final String CONTACT_REDACTED_VALUE = "REDACTED FOR PRIVACY";
-
-  /**
    * Included in ALL contact responses, even if the user is authorized.
    *
    * <p>Format required by ICANN RDAP Response Profile 15feb19 section 2.7.5.3.

--- a/core/src/test/resources/google/registry/rdap/rdap_associated_contact_no_personal_data.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_associated_contact_no_personal_data.json
@@ -5,7 +5,7 @@
     "icann_rdap_technical_implementation_guide_0"
   ],
   "objectClassName" : "entity",
-  "handle" : "REDACTED FOR PRIVACY",
+  "handle" : "",
   "events": [
     {
       "eventAction": "last update of RDAP database",
@@ -15,25 +15,8 @@
   "vcardArray": [
     "vcard",
     [
-      ["version",{},"text","4.0"],
-      ["fn",{},"text","REDACTED FOR PRIVACY"],
-      ["org",{},"text","REDACTED FOR PRIVACY"],
-      [
-        "adr",
-        {},
-        "text",
-        [
-          "",
-          "",
-          "REDACTED FOR PRIVACY",
-          "REDACTED FOR PRIVACY",
-          "REDACTED FOR PRIVACY",
-          "REDACTED FOR PRIVACY",
-          "XX"
-        ]
-      ],
-      ["tel",{"type":["voice"]},"uri","tel:REDACTED FOR PRIVACY"],
-      ["tel",{"type":["fax"]},"uri","tel:REDACTED FOR PRIVACY"]
+      ["version", {}, "text", "4.0"],
+      ["fn", {}, "text", ""]
     ]
   ],
   "remarks": [

--- a/core/src/test/resources/google/registry/rdap/rdap_contact_no_personal_data_with_remark.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_contact_no_personal_data_with_remark.json
@@ -5,7 +5,7 @@
     "icann_rdap_technical_implementation_guide_0"
   ],
   "objectClassName" : "entity",
-  "handle" : "REDACTED FOR PRIVACY",
+  "handle" : "",
   "events": [
     {
       "eventAction": "last update of RDAP database",
@@ -15,25 +15,8 @@
   "vcardArray": [
     "vcard",
     [
-      ["version",{},"text","4.0"],
-      ["fn",{},"text","REDACTED FOR PRIVACY"],
-      ["org",{},"text","REDACTED FOR PRIVACY"],
-      [
-        "adr",
-        {},
-        "text",
-        [
-          "",
-          "",
-          "REDACTED FOR PRIVACY",
-          "REDACTED FOR PRIVACY",
-          "REDACTED FOR PRIVACY",
-          "REDACTED FOR PRIVACY",
-          "XX"
-        ]
-      ],
-      ["tel",{"type":["voice"]},"uri","tel:REDACTED FOR PRIVACY"],
-      ["tel",{"type":["fax"]},"uri","tel:REDACTED FOR PRIVACY"]
+      ["version", {}, "text", "4.0"],
+      ["fn", {}, "text", ""]
     ]
   ],
   "remarks": [

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_no_contacts_with_remark.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_no_contacts_with_remark.json
@@ -150,7 +150,7 @@
     },
     {
       "objectClassName": "entity",
-      "handle": "REDACTED FOR PRIVACY",
+      "handle": "",
       "roles":["administrative"],
       "remarks": [
         {
@@ -180,18 +180,14 @@
         "vcard",
         [
           ["version", {}, "text", "4.0"],
-          ["fn", {}, "text", "REDACTED FOR PRIVACY"],
-          ["org", {}, "text", "REDACTED FOR PRIVACY"],
-          ["adr", {}, "text", ["", "", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "XX"]],
-          ["tel", {"type":["voice"]}, "uri", "tel:REDACTED FOR PRIVACY"],
-          ["tel", {"type":["fax"]}, "uri", "tel:REDACTED FOR PRIVACY"]
+          ["fn", {}, "text", ""]
         ]
       ]
     },
 
     {
       "objectClassName":"entity",
-      "handle":"REDACTED FOR PRIVACY",
+      "handle":"",
       "remarks":[
         {
           "title":"REDACTED FOR PRIVACY",
@@ -221,18 +217,14 @@
         "vcard",
         [
           ["version", {}, "text", "4.0"],
-          ["fn", {}, "text", "REDACTED FOR PRIVACY"],
-          ["org", {}, "text", "REDACTED FOR PRIVACY"],
-          ["adr", {}, "text", ["", "", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "XX"]],
-          ["tel", {"type":["voice"]}, "uri", "tel:REDACTED FOR PRIVACY"],
-          ["tel", {"type":["fax"]}, "uri", "tel:REDACTED FOR PRIVACY"]
+          ["fn", {}, "text", ""]
         ]
       ]
     },
 
     {
       "objectClassName":"entity",
-      "handle":"REDACTED FOR PRIVACY",
+      "handle":"",
       "remarks":[
         {
           "title":"REDACTED FOR PRIVACY",
@@ -262,11 +254,7 @@
         "vcard",
         [
           ["version", {}, "text", "4.0"],
-          ["fn", {}, "text", "REDACTED FOR PRIVACY"],
-          ["org", {}, "text", "REDACTED FOR PRIVACY"],
-          ["adr", {}, "text", ["", "", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "XX"]],
-          ["tel", {"type":["voice"]}, "uri", "tel:REDACTED FOR PRIVACY"],
-          ["tel", {"type":["fax"]}, "uri", "tel:REDACTED FOR PRIVACY"]
+          ["fn", {}, "text", ""]
         ]
       ]
     }

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_unicode_no_contacts_with_remark.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_unicode_no_contacts_with_remark.json
@@ -153,7 +153,7 @@
     },
     {
       "objectClassName": "entity",
-      "handle": "REDACTED FOR PRIVACY",
+      "handle": "",
       "roles":["administrative"],
       "remarks": [
         {
@@ -183,18 +183,14 @@
         "vcard",
         [
           ["version", {}, "text", "4.0"],
-          ["fn", {}, "text", "REDACTED FOR PRIVACY"],
-          ["org", {}, "text", "REDACTED FOR PRIVACY"],
-          ["adr", {}, "text", ["", "", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "XX"]],
-          ["tel", {"type":["voice"]}, "uri", "tel:REDACTED FOR PRIVACY"],
-          ["tel", {"type":["fax"]}, "uri", "tel:REDACTED FOR PRIVACY"]
+          ["fn", {}, "text", ""]
         ]
       ]
     },
 
     {
       "objectClassName":"entity",
-      "handle":"REDACTED FOR PRIVACY",
+      "handle":"",
       "remarks":[
         {
           "title":"REDACTED FOR PRIVACY",
@@ -224,18 +220,13 @@
         "vcard",
         [
           ["version", {}, "text", "4.0"],
-          ["fn", {}, "text", "REDACTED FOR PRIVACY"],
-          ["org", {}, "text", "REDACTED FOR PRIVACY"],
-          ["adr", {}, "text", ["", "", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "XX"]],
-          ["tel", {"type":["voice"]}, "uri", "tel:REDACTED FOR PRIVACY"],
-          ["tel", {"type":["fax"]}, "uri", "tel:REDACTED FOR PRIVACY"]
-        ]
+          ["fn", {}, "text", ""]        ]
       ]
     },
 
     {
       "objectClassName":"entity",
-      "handle":"REDACTED FOR PRIVACY",
+      "handle":"",
       "remarks":[
         {
           "title":"REDACTED FOR PRIVACY",
@@ -265,11 +256,7 @@
         "vcard",
         [
           ["version", {}, "text", "4.0"],
-          ["fn", {}, "text", "REDACTED FOR PRIVACY"],
-          ["org", {}, "text", "REDACTED FOR PRIVACY"],
-          ["adr", {}, "text", ["", "", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "REDACTED FOR PRIVACY", "XX"]],
-          ["tel", {"type":["voice"]}, "uri", "tel:REDACTED FOR PRIVACY"],
-          ["tel", {"type":["fax"]}, "uri", "tel:REDACTED FOR PRIVACY"]
+          ["fn", {}, "text", ""]
         ]
       ]
     }

--- a/core/src/test/resources/google/registry/rdap/rdapjson_domain_logged_out.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_domain_logged_out.json
@@ -137,7 +137,7 @@
     },
     {
       "objectClassName": "entity",
-      "handle": "REDACTED FOR PRIVACY",
+      "handle": "",
       "roles": ["administrative"],
       "remarks": [
         {
@@ -166,31 +166,14 @@
       "vcardArray": [
         "vcard",
         [
-          ["version",{},"text","4.0"],
-          ["fn",{},"text","REDACTED FOR PRIVACY"],
-          ["org",{},"text","REDACTED FOR PRIVACY"],
-          [
-            "adr",
-            {},
-            "text",
-            [
-              "",
-              "",
-              "REDACTED FOR PRIVACY",
-              "REDACTED FOR PRIVACY",
-              "REDACTED FOR PRIVACY",
-              "REDACTED FOR PRIVACY",
-              "XX"
-            ]
-          ],
-          ["tel",{"type":["voice"]},"uri","tel:REDACTED FOR PRIVACY"],
-          ["tel",{"type":["fax"]},"uri","tel:REDACTED FOR PRIVACY"]
+          ["version", {}, "text", "4.0"],
+          ["fn", {}, "text", ""]
         ]
       ]
     },
     {
       "objectClassName": "entity",
-      "handle": "REDACTED FOR PRIVACY",
+      "handle": "",
       "roles": ["technical"],
       "remarks": [
         {
@@ -219,31 +202,14 @@
       "vcardArray": [
         "vcard",
         [
-          ["version",{},"text","4.0"],
-          ["fn",{},"text","REDACTED FOR PRIVACY"],
-          ["org",{},"text","REDACTED FOR PRIVACY"],
-          [
-            "adr",
-            {},
-            "text",
-            [
-              "",
-              "",
-              "REDACTED FOR PRIVACY",
-              "REDACTED FOR PRIVACY",
-              "REDACTED FOR PRIVACY",
-              "REDACTED FOR PRIVACY",
-              "XX"
-            ]
-          ],
-          ["tel",{"type":["voice"]},"uri","tel:REDACTED FOR PRIVACY"],
-          ["tel",{"type":["fax"]},"uri","tel:REDACTED FOR PRIVACY"]
+          ["version", {}, "text", "4.0"],
+          ["fn", {}, "text", ""]
         ]
       ]
     },
     {
       "objectClassName": "entity",
-      "handle": "REDACTED FOR PRIVACY",
+      "handle": "",
       "roles": ["registrant"],
       "remarks": [
         {
@@ -272,25 +238,8 @@
       "vcardArray": [
         "vcard",
         [
-          ["version",{},"text","4.0"],
-          ["fn",{},"text","REDACTED FOR PRIVACY"],
-          ["org",{},"text","REDACTED FOR PRIVACY"],
-          [
-            "adr",
-            {},
-            "text",
-            [
-              "",
-              "",
-              "REDACTED FOR PRIVACY",
-              "REDACTED FOR PRIVACY",
-              "REDACTED FOR PRIVACY",
-              "REDACTED FOR PRIVACY",
-              "XX"
-            ]
-          ],
-          ["tel",{"type":["voice"]},"uri","tel:REDACTED FOR PRIVACY"],
-          ["tel",{"type":["fax"]},"uri","tel:REDACTED FOR PRIVACY"]
+          ["version", {}, "text", "4.0"],
+          ["fn", {}, "text", ""]
         ]
       ]
     }

--- a/core/src/test/resources/google/registry/rdap/rdapjson_registrant_logged_out.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_registrant_logged_out.json
@@ -1,6 +1,6 @@
 {
   "objectClassName" : "entity",
-  "handle" : "REDACTED FOR PRIVACY",
+  "handle" : "",
   "roles" : ["registrant"],
   "events": [
     {
@@ -11,25 +11,8 @@
   "vcardArray": [
     "vcard",
     [
-      ["version",{},"text","4.0"],
-      ["fn",{},"text","REDACTED FOR PRIVACY"],
-      ["org",{},"text","REDACTED FOR PRIVACY"],
-      [
-        "adr",
-        {},
-        "text",
-        [
-          "",
-          "",
-          "REDACTED FOR PRIVACY",
-          "REDACTED FOR PRIVACY",
-          "REDACTED FOR PRIVACY",
-          "REDACTED FOR PRIVACY",
-          "XX"
-        ]
-      ],
-      ["tel",{"type":["voice"]},"uri","tel:REDACTED FOR PRIVACY"],
-      ["tel",{"type":["fax"]},"uri","tel:REDACTED FOR PRIVACY"]
+      ["version", {}, "text", "4.0"],
+      ["fn", {}, "text", ""]
     ]
   ],
   "remarks": [


### PR DESCRIPTION
Instead of using REDACTED FOR PRIVACY everywhere we should just include the empty string (this is what the spec says, what other gTLD registrars do, and what the RDAP conformance tool at
https://github.com/icann/rdap-conformance-tool says to do.

In the contact VCards, we omit redacted fields entirely unless the spec requires that they exist (the version number and an empty 'fn' field). This also applies to the "handle" field.

Eventually we will probably want to add the redaction extension but that's not RFCed yet and isn't required for the August RDAP conformance deadline.

Tested on alpha and the conformance tool passes with the exception of one alpha-specific error

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2067)
<!-- Reviewable:end -->
