### PR TITLE
Allow EPP password to be changed during login flow

### DIFF
--- a/core/src/main/java/google/registry/flows/FlowRunner.java
+++ b/core/src/main/java/google/registry/flows/FlowRunner.java
@@ -72,21 +72,20 @@ public class FlowRunner {
     }
     eppMetricBuilder.setCommandNameFromFlow(flowClass.getSimpleName());
     if (!isTransactional) {
-      EppOutput eppOutput = EppOutput.create(flowProvider.get().run());
-      if (flowClass.equals(LoginFlow.class)) {
-        // In LoginFlow, registrarId isn't known until after the flow executes, so save it then.
-        eppMetricBuilder.setRegistrarId(sessionMetadata.getRegistrarId());
-      }
-      return eppOutput;
+      return EppOutput.create(flowProvider.get().run());
     }
     try {
-      return tm()
-          .transact(
+      return tm().transact(
               () -> {
                 try {
                   EppOutput output = EppOutput.create(flowProvider.get().run());
                   if (isDryRun) {
                     throw new DryRunException(output);
+                  }
+                  if (flowClass.equals(LoginFlow.class)) {
+                    // In LoginFlow, registrarId isn't known until after the flow executes, so save
+                    // it then.
+                    eppMetricBuilder.setRegistrarId(sessionMetadata.getRegistrarId());
                   }
                   return output;
                 } catch (EppException e) {

--- a/core/src/main/java/google/registry/model/eppinput/EppInput.java
+++ b/core/src/main/java/google/registry/model/eppinput/EppInput.java
@@ -291,8 +291,8 @@ public class EppInput extends ImmutableObject {
       return password;
     }
 
-    public String getNewPassword() {
-      return newPassword;
+    public Optional<String> getNewPassword() {
+      return Optional.ofNullable(newPassword);
     }
 
     public Options getOptions() {

--- a/core/src/test/resources/google/registry/flows/session/login_set_new_password.xml
+++ b/core/src/test/resources/google/registry/flows/session/login_set_new_password.xml
@@ -3,7 +3,7 @@
     <login>
       <clID>NewRegistrar</clID>
       <pw>foo-BAR2</pw>
-      <newPW>ANewPassword</newPW>
+      <newPW>%NEWPW%</newPW>
       <options>
         <version>1.0</version>
         <lang>en</lang>

--- a/docs/flows.md
+++ b/docs/flows.md
@@ -992,12 +992,12 @@ An EPP flow for login.
 
 ### Errors
 
+*   2001
+    *   Generic XML syntax error that can be thrown by any flow.
 *   2002
     *   Registrar is already logged in.
 *   2100
     *   Specified protocol version is not implemented.
-*   2102
-    *   In-band password changes are not supported.
 *   2103
     *   Specified extension is not implemented.
 *   2200


### PR DESCRIPTION
This is part of the spec in RFC 5730 that we hadn't implemented until now. Note that this requires changing LoginFlow to be transactional, but I don't think that should cause any issues.

See https://b.corp.google.com/issues/291759824

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2080)
<!-- Reviewable:end -->
