### PR TITLE
Remove unnecessary overload of AsyncTaskEnqueuer.enqueueAsyncResave()

### DIFF
--- a/core/src/main/java/google/registry/batch/AsyncTaskEnqueuer.java
+++ b/core/src/main/java/google/registry/batch/AsyncTaskEnqueuer.java
@@ -50,12 +50,6 @@ public final class AsyncTaskEnqueuer {
     this.cloudTasksUtils = cloudTasksUtils;
   }
 
-  /** Enqueues a task to asynchronously re-save an entity at some point in the future. */
-  public void enqueueAsyncResave(
-      VKey<? extends EppResource> entityToResave, DateTime now, DateTime whenToResave) {
-    enqueueAsyncResave(entityToResave, now, ImmutableSortedSet.of(whenToResave));
-  }
-
   /**
    * Enqueues a task to asynchronously re-save an entity at some point(s) in the future.
    *

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
@@ -38,6 +38,7 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 import google.registry.batch.AsyncTaskEnqueuer;
 import google.registry.flows.EppException;
 import google.registry.flows.ExtensionManager;
@@ -286,7 +287,8 @@ public final class DomainTransferRequestFlow implements TransactionalFlow {
             .build();
     DomainHistory domainHistory = buildDomainHistory(newDomain, tld, now, period);
 
-    asyncTaskEnqueuer.enqueueAsyncResave(newDomain.createVKey(), now, automaticTransferTime);
+    asyncTaskEnqueuer.enqueueAsyncResave(
+        newDomain.createVKey(), now, ImmutableSortedSet.of(automaticTransferTime));
     tm().putAll(
             new ImmutableSet.Builder<>()
                 .add(newDomain, domainHistory, requestPollMessage)

--- a/core/src/test/java/google/registry/batch/AsyncTaskEnqueuerTest.java
+++ b/core/src/test/java/google/registry/batch/AsyncTaskEnqueuerTest.java
@@ -69,7 +69,7 @@ public class AsyncTaskEnqueuerTest {
   void test_enqueueAsyncResave_success() {
     Contact contact = persistActiveContact("jd23456");
     asyncTaskEnqueuer.enqueueAsyncResave(
-        contact.createVKey(), clock.nowUtc(), clock.nowUtc().plusDays(5));
+        contact.createVKey(), clock.nowUtc(), ImmutableSortedSet.of(clock.nowUtc().plusDays(5)));
     cloudTasksHelper.assertTasksEnqueued(
         QUEUE_ASYNC_ACTIONS,
         new CloudTasksHelper.TaskMatcher()
@@ -108,7 +108,7 @@ public class AsyncTaskEnqueuerTest {
   void test_enqueueAsyncResave_ignoresTasksTooFarIntoFuture() {
     Contact contact = persistActiveContact("jd23456");
     asyncTaskEnqueuer.enqueueAsyncResave(
-        contact.createVKey(), clock.nowUtc(), clock.nowUtc().plusDays(31));
+        contact.createVKey(), clock.nowUtc(), ImmutableSortedSet.of(clock.nowUtc().plusDays(31)));
     cloudTasksHelper.assertNoTasksEnqueued(QUEUE_ASYNC_ACTIONS);
     assertLogMessage(logHandler, Level.INFO, "Ignoring async re-save");
   }


### PR DESCRIPTION
It was only called in one place (in actual production code), and it was just slightly obscuring the fact that re-saves can be scheduled for multiple points in the future in a way that wasn't amazingly helpful to understanding of the system logic at the callsite.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2083)
<!-- Reviewable:end -->
