### PR TITLE
Add placeholder configs for Gmail

### DIFF
--- a/core/src/main/java/google/registry/batch/CannedScriptExecutionAction.java
+++ b/core/src/main/java/google/registry/batch/CannedScriptExecutionAction.java
@@ -71,7 +71,7 @@ public class CannedScriptExecutionAction implements Runnable {
       GmailClient gmailClient,
       @Config("projectId") String projectId,
       @Config("gSuiteDomainName") String gSuiteDomainName,
-      @Config("alertRecipientEmailAddress") InternetAddress recipientAddress) {
+      @Config("newAlertRecipientEmailAddress") InternetAddress recipientAddress) {
     this.groupsConnection = groupsConnection;
     this.gmailClient = gmailClient;
     this.gSuiteDomainName = gSuiteDomainName;
@@ -116,6 +116,8 @@ public class CannedScriptExecutionAction implements Runnable {
         try {
           Set<String> currentMembers = groupsConnection.getMembersOfGroup(groupKey);
           logger.atInfo().log("%s has %s members.", groupKey, currentMembers.size());
+          // One success is enough for validation.
+          return;
         } catch (IOException e) {
           logger.atWarning().withCause(e).log("Failed to check %s", groupKey);
         }

--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -538,6 +538,13 @@ public final class RegistryConfig {
       return parseEmailAddress(config.gSuite.outgoingEmailAddress);
     }
 
+    // TODO(b/279671974): reuse the 'gSuiteOutgoingEmailAddress' annotation after migration
+    @Provides
+    @Config("gSuiteNewOutgoingEmailAddress")
+    public static String provideGSuiteNewOutgoingEmailAddress(RegistryConfigSettings config) {
+      return config.gSuite.newOutgoingEmailAddress;
+    }
+
     /**
      * The display name that is used on outgoing emails sent by Nomulus.
      *
@@ -547,6 +554,16 @@ public final class RegistryConfig {
     @Config("gSuiteOutgoingEmailDisplayName")
     public static String provideGSuiteOutgoingEmailDisplayName(RegistryConfigSettings config) {
       return config.gSuite.outgoingEmailDisplayName;
+    }
+
+    /**
+     * Provides the `reply-to` address for outgoing email messages. This address may be outside the
+     * GSuite domain.
+     */
+    @Provides
+    @Config("replyToEmailAddress")
+    public static InternetAddress provideReplyToEmailAddress(RegistryConfigSettings config) {
+      return parseEmailAddress(config.gSuite.replyToEmailAddress);
     }
 
     /**
@@ -857,6 +874,14 @@ public final class RegistryConfig {
     @Config("alertRecipientEmailAddress")
     public static InternetAddress provideAlertRecipientEmailAddress(RegistryConfigSettings config) {
       return parseEmailAddress(config.misc.alertRecipientEmailAddress);
+    }
+
+    // TODO(b/279671974): remove below method after migration
+    @Provides
+    @Config("newAlertRecipientEmailAddress")
+    public static InternetAddress provideNewAlertRecipientEmailAddress(
+        RegistryConfigSettings config) {
+      return parseEmailAddress(config.misc.newAlertRecipientEmailAddress);
     }
 
     /**

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -77,6 +77,9 @@ public class RegistryConfigSettings {
   public static class GSuite {
     public String domainName;
     public String outgoingEmailAddress;
+    // TODO(b/279671974): remove below field after migration
+    public String newOutgoingEmailAddress;
+    public String replyToEmailAddress;
     public String outgoingEmailDisplayName;
     public String adminAccountEmailAddress;
     public String supportGroupEmailAddress;
@@ -203,6 +206,8 @@ public class RegistryConfigSettings {
   public static class Misc {
     public String sheetExportId;
     public String alertRecipientEmailAddress;
+    // TODO(b/279671974): remove below field after migration
+    public String newAlertRecipientEmailAddress;
     public String spec11OutgoingEmailAddress;
     public List<String> spec11BccEmailAddresses;
     public int transientFailureRetries;

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -33,6 +33,9 @@ gSuite:
   # https://cloud.google.com/appengine/docs/standard/java/mail/#who_can_send_mail
   outgoingEmailDisplayName: Example Registry
   outgoingEmailAddress: noreply@project-id.appspotmail.com
+  # TODO(b/279671974): reuse `outgoingEmailAddress` after migration
+  newOutgoingEmailAddress: noreply@example.com
+  replyToEmailAddress: reply-to@example.com
 
   # Email address of the admin account on the G Suite app. This is used for
   # logging in to perform administrative actions, not sending emails.
@@ -431,6 +434,9 @@ misc:
 
   # Address we send alert summary emails to.
   alertRecipientEmailAddress: email@example.com
+
+  # TODO(b/279671974): reuse `alertRecipientEmailAddress` after migration
+  newAlertRecipientEmailAddress: email@example.com
 
   # Address from which Spec 11 emails to registrars are sent. This needs
   # to be a deliverable email address to handle replies from registrars as well.

--- a/core/src/main/java/google/registry/groups/GmailModule.java
+++ b/core/src/main/java/google/registry/groups/GmailModule.java
@@ -17,7 +17,7 @@ package google.registry.groups;
 import com.google.api.services.gmail.Gmail;
 import dagger.Module;
 import dagger.Provides;
-import google.registry.config.CredentialModule.AdcDelegatedCredential;
+import google.registry.config.CredentialModule.GmailDelegatedCredential;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.util.GoogleCredentialsBundle;
 import javax.inject.Singleton;
@@ -29,7 +29,7 @@ public class GmailModule {
   @Provides
   @Singleton
   Gmail provideGmail(
-      @AdcDelegatedCredential GoogleCredentialsBundle credentialsBundle,
+      @GmailDelegatedCredential GoogleCredentialsBundle credentialsBundle,
       @Config("projectId") String projectId) {
     return new Gmail.Builder(
             credentialsBundle.getHttpTransport(),

--- a/util/src/main/java/google/registry/util/EmailMessage.java
+++ b/util/src/main/java/google/registry/util/EmailMessage.java
@@ -46,6 +46,7 @@ public abstract class EmailMessage {
 
   public abstract ImmutableSet<InternetAddress> recipients();
 
+  // TODO(b/279671974): remove `from` after migration.
   public abstract InternetAddress from();
 
   public abstract ImmutableSet<InternetAddress> ccs();


### PR DESCRIPTION
Add placeholder configs for sending emails using Gmail in GSuite.

The names of the new configs are temporary. After migration they will revert to the names currently in use by the AppEngine email API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2089)
<!-- Reviewable:end -->
