### PR TITLE
Re-enable flyway deadlock check

### DIFF
--- a/db/build.gradle
+++ b/db/build.gradle
@@ -179,6 +179,14 @@ dependencies {
   testImplementation project(path: ':common', configuration: 'testing')
 }
 
+test {
+  // When set, run FlywayDeadlockTest#validNewScript.
+  def deadlock_check = 'do_flyway_deadlock_check'
+  if (findProperty(deadlock_check)) {
+    systemProperty deadlock_check, findProperty(deadlock_check)
+  }
+}
+
 task generateFlywayIndex {
   def flywayBase = "$projectDir/src/main/resources/sql/flyway"
   def filenamePattern = /V(\d+)__.*\.sql/


### PR DESCRIPTION
Use a system property to specify whether this check should be executed.

We will update the presubmit test script to run this check only during foss-pr.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2092)
<!-- Reviewable:end -->
