### PR TITLE
Add the ability to specify transaction isolation level on a per-transaction basis

### DIFF
--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -1547,6 +1547,11 @@ public final class RegistryConfig {
     return CONFIG_SETTINGS.get().hibernate.connectionIsolation;
   }
 
+  /** Returns true if per-transaction isolation level is enabled. */
+  public static boolean getHibernatePerTransactionIsolationEnabled() {
+    return CONFIG_SETTINGS.get().hibernate.perTransactionIsolation;
+  }
+
   /** Returns true if hibernate.show_sql is enabled. */
   public static String getHibernateLogSqlQueries() {
     return CONFIG_SETTINGS.get().hibernate.logSqlQueries;

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -115,6 +115,7 @@ public class RegistryConfigSettings {
 
   /** Configuration for Hibernate. */
   public static class Hibernate {
+    public boolean perTransactionIsolation;
     public String connectionIsolation;
     public String logSqlQueries;
     public String hikariConnectionTimeout;

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -189,6 +189,12 @@ registryPolicy:
   sunriseDomainCreateDiscount: 0.15
 
 hibernate:
+  # Make it possible to specify the isolation level for each transaction. If set
+  # to true, nested transactions will throw an exception. If set to false, a
+  # transaction with the isolation override specified will still execute at the
+  # default level (specified below).
+  perTransactionIsolation: false
+
   # Make 'SERIALIZABLE' the default isolation level to ensure correctness.
   #
   # Entities that are never involved in multi-table transactions may use optimistic
@@ -479,7 +485,7 @@ keyring:
 
 # Configuration options relevant to the "nomulus" registry tool.
 registryTool:
-  # OAuth client Id used by the tool.
+  # OAuth client ID used by the tool.
   clientId: YOUR_CLIENT_ID
   # OAuth client secret used by the tool.
   clientSecret: YOUR_CLIENT_SECRET

--- a/core/src/main/java/google/registry/config/files/nomulus-config-unittest.yaml
+++ b/core/src/main/java/google/registry/config/files/nomulus-config-unittest.yaml
@@ -26,3 +26,6 @@ gSuite:
 misc:
   # We would rather have failures than timeouts, so reduce the number of retries
   transientFailureRetries: 3
+
+hibernate:
+  perTransactionIsolation: false

--- a/core/src/main/java/google/registry/flows/FlowModule.java
+++ b/core/src/main/java/google/registry/flows/FlowModule.java
@@ -35,6 +35,8 @@ import google.registry.model.eppoutput.EppResponse;
 import google.registry.model.eppoutput.Result;
 import google.registry.model.host.HostHistory;
 import google.registry.model.reporting.HistoryEntry;
+import google.registry.persistence.IsolationLevel;
+import google.registry.persistence.PersistenceModule.TransactionIsolationLevel;
 import java.lang.annotation.Documented;
 import java.util.Optional;
 import javax.inject.Qualifier;
@@ -137,6 +139,14 @@ public class FlowModule {
 
   @Provides
   @FlowScope
+  Optional<TransactionIsolationLevel> provideIsolationLevelOverride(
+      Class<? extends Flow> flowClass) {
+    return Optional.ofNullable(flowClass.getAnnotation(IsolationLevel.class))
+        .map(IsolationLevel::value);
+  }
+
+  @Provides
+  @FlowScope
   @Superuser
   boolean provideIsSuperuser() {
     return isSuperuser;
@@ -166,7 +176,7 @@ public class FlowModule {
   @FlowScope
   @RegistrarId
   static String provideRegistrarId(SessionMetadata sessionMetadata) {
-    // Treat a missing registrarId as null so we can always inject a non-null value. All we do with
+    // Treat a missing registrarId as null, so we can always inject a non-null value. All we do with
     // the registrarId is log it (as "") or detect its absence, both of which work fine with empty.
     return Strings.nullToEmpty(sessionMetadata.getRegistrarId());
   }

--- a/core/src/main/java/google/registry/flows/FlowRunner.java
+++ b/core/src/main/java/google/registry/flows/FlowRunner.java
@@ -28,6 +28,8 @@ import google.registry.flows.session.LoginFlow;
 import google.registry.model.eppcommon.Trid;
 import google.registry.model.eppoutput.EppOutput;
 import google.registry.monitoring.whitebox.EppMetric;
+import google.registry.persistence.PersistenceModule.TransactionIsolationLevel;
+import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Provider;
 
@@ -42,6 +44,7 @@ public class FlowRunner {
   @Inject TransportCredentials credentials;
   @Inject EppRequestSource eppRequestSource;
   @Inject Provider<Flow> flowProvider;
+  @Inject Optional<TransactionIsolationLevel> isolationLevelOverride;
   @Inject Class<? extends Flow> flowClass;
   @Inject @InputXml byte[] inputXmlBytes;
   @Inject @DryRun boolean isDryRun;
@@ -91,7 +94,8 @@ public class FlowRunner {
                 } catch (EppException e) {
                   throw new EppRuntimeException(e);
                 }
-              });
+              },
+              isolationLevelOverride.orElse(null));
     } catch (DryRunException e) {
       return e.output;
     } catch (EppRuntimeException e) {

--- a/core/src/main/java/google/registry/persistence/IsolationLevel.java
+++ b/core/src/main/java/google/registry/persistence/IsolationLevel.java
@@ -1,0 +1,33 @@
+// Copyright 2023 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.persistence;
+
+import google.registry.persistence.PersistenceModule.TransactionIsolationLevel;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates which {@link TransactionIsolationLevel} that a {@link
+ * google.registry.flows.TransactionalFlow} show run at.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface IsolationLevel {
+  TransactionIsolationLevel value();
+}

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManager.java
@@ -14,6 +14,7 @@
 
 package google.registry.persistence.transaction;
 
+import google.registry.persistence.PersistenceModule.TransactionIsolationLevel;
 import google.registry.persistence.VKey;
 import java.util.function.Supplier;
 import javax.persistence.EntityManager;
@@ -64,8 +65,20 @@ public interface JpaTransactionManager extends TransactionManager {
   /** Executes the work in a transaction with no retries and returns the result. */
   <T> T transactNoRetry(Supplier<T> work);
 
+  /**
+   * Executes the work in a transaction at the given {@link TransactionIsolationLevel} with no
+   * retries and returns the result.
+   */
+  <T> T transactNoRetry(Supplier<T> work, TransactionIsolationLevel isolationLevel);
+
   /** Executes the work in a transaction with no retries. */
   void transactNoRetry(Runnable work);
+
+  /**
+   * Executes the work in a transaction at the given {@link TransactionIsolationLevel} with no
+   * retries.
+   */
+  void transactNoRetry(Runnable work, TransactionIsolationLevel isolationLevel);
 
   /** Deletes the entity by its id, throws exception if the entity is not deleted. */
   <T> void assertDelete(VKey<T> key);
@@ -84,4 +97,13 @@ public interface JpaTransactionManager extends TransactionManager {
   static Query setQueryFetchSize(Query query, int fetchSize) {
     return query.setHint("org.hibernate.fetchSize", fetchSize);
   }
+
+  /** Return the default {@link TransactionIsolationLevel} specified via the config file. */
+  TransactionIsolationLevel getDefaultTransactionIsolationLevel();
+
+  /** Return the {@link TransactionIsolationLevel} used in the current transaction. */
+  TransactionIsolationLevel getCurrentTransactionIsolationLevel();
+
+  /** Asserts that the current transaction runs at the given level. */
+  void assertTransactionIsolationLevel(TransactionIsolationLevel expectedLevel);
 }

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static google.registry.config.RegistryConfig.getHibernatePerTransactionIsolationEnabled;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 import static java.util.AbstractMap.SimpleEntry;
 import static java.util.stream.Collectors.joining;
@@ -31,6 +32,7 @@ import com.google.common.collect.Streams;
 import com.google.common.flogger.FluentLogger;
 import google.registry.model.ImmutableObject;
 import google.registry.persistence.JpaRetries;
+import google.registry.persistence.PersistenceModule.TransactionIsolationLevel;
 import google.registry.persistence.VKey;
 import google.registry.util.Clock;
 import google.registry.util.Retrier;
@@ -65,6 +67,7 @@ import javax.persistence.TemporalType;
 import javax.persistence.TypedQuery;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.metamodel.EntityType;
+import org.hibernate.cfg.Environment;
 import org.joda.time.DateTime;
 
 /** Implementation of {@link JpaTransactionManager} for JPA compatible database. */
@@ -77,9 +80,6 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   private final EntityManagerFactory emf;
   private final Clock clock;
 
-  // TODO(b/177588434): Investigate alternatives for managing transaction information. ThreadLocal
-  // adds an unnecessary restriction that each request has to be processed by one thread
-  // synchronously.
   private static final ThreadLocal<TransactionInfo> transactionInfo =
       ThreadLocal.withInitial(TransactionInfo::new);
 
@@ -137,18 +137,42 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   }
 
   @Override
-  public <T> T transact(Supplier<T> work) {
-    // This prevents inner transaction from retrying, thus avoiding a cascade retry effect.
-    if (inTransaction()) {
-      return transactNoRetry(work);
+  public void assertTransactionIsolationLevel(TransactionIsolationLevel expectedLevel) {
+    assertInTransaction();
+    TransactionIsolationLevel currentLevel = getCurrentTransactionIsolationLevel();
+    if (currentLevel != expectedLevel) {
+      throw new IllegalStateException(
+          String.format(
+              "Current transaction isolation level (%s) is not as expected (%s)",
+              currentLevel, expectedLevel));
     }
-    return retrier.callWithRetry(() -> transactNoRetry(work), JpaRetries::isFailedTxnRetriable);
   }
 
   @Override
-  public <T> T transactNoRetry(Supplier<T> work) {
+  public <T> T transact(Supplier<T> work, TransactionIsolationLevel isolationLevel) {
+    // This prevents inner transaction from retrying, thus avoiding a cascade retry effect.
     if (inTransaction()) {
-      return work.get();
+      return transactNoRetry(work, isolationLevel);
+    }
+    return retrier.callWithRetry(
+        () -> transactNoRetry(work, isolationLevel), JpaRetries::isFailedTxnRetriable);
+  }
+
+  @Override
+  public <T> T transact(Supplier<T> work) {
+    return transact(work, null);
+  }
+
+  @Override
+  public <T> T transactNoRetry(
+      Supplier<T> work, @Nullable TransactionIsolationLevel isolationLevel) {
+    if (inTransaction()) {
+      if (getHibernatePerTransactionIsolationEnabled()) {
+        throw new IllegalStateException("Nested transaction detected");
+      } else {
+        logger.atWarning().log("Nested transaction detected");
+        return work.get();
+      }
     }
     TransactionInfo txnInfo = transactionInfo.get();
     txnInfo.entityManager = emf.createEntityManager();
@@ -156,6 +180,18 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
     try {
       txn.begin();
       txnInfo.start(clock);
+      if (isolationLevel != null) {
+        if (getHibernatePerTransactionIsolationEnabled()) {
+          getEntityManager()
+              .createNativeQuery(
+                  String.format("SET TRANSACTION ISOLATION LEVEL %s", isolationLevel.getMode()))
+              .executeUpdate();
+          logger.atInfo().log("Running transaction at %s", isolationLevel);
+        } else {
+          logger.atWarning().log(
+              "Per-transaction isolation level disabled, but %s was requested", isolationLevel);
+        }
+      }
       T result = work.get();
       txn.commit();
       return result;
@@ -174,21 +210,55 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   }
 
   @Override
-  public void transact(Runnable work) {
+  public <T> T transactNoRetry(Supplier<T> work) {
+    return transactNoRetry(work, null);
+  }
+
+  @Override
+  public void transact(Runnable work, TransactionIsolationLevel isolationLevel) {
     transact(
         () -> {
           work.run();
           return null;
-        });
+        },
+        isolationLevel);
   }
 
   @Override
-  public void transactNoRetry(Runnable work) {
+  public void transact(Runnable work) {
+    transact(work, null);
+  }
+
+  @Override
+  public void transactNoRetry(Runnable work, TransactionIsolationLevel isolationLevel) {
     transactNoRetry(
         () -> {
           work.run();
           return null;
-        });
+        },
+        isolationLevel);
+  }
+
+  @Override
+  public void transactNoRetry(Runnable work) {
+    transactNoRetry(work, null);
+  }
+
+  @Override
+  public TransactionIsolationLevel getDefaultTransactionIsolationLevel() {
+    return TransactionIsolationLevel.valueOf(
+        (String) emf.getProperties().get(Environment.ISOLATION));
+  }
+
+  @Override
+  public TransactionIsolationLevel getCurrentTransactionIsolationLevel() {
+    assertInTransaction();
+    String mode =
+        (String)
+            getEntityManager()
+                .createNativeQuery("SHOW TRANSACTION ISOLATION LEVEL")
+                .getSingleResult();
+    return TransactionIsolationLevel.fromMode(mode);
   }
 
   @Override
@@ -287,7 +357,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
                 Integer.class)
             .setMaxResults(1);
     entityIds.forEach(entityId -> query.setParameter(entityId.name, entityId.value));
-    return query.getResultList().size() > 0;
+    return !query.getResultList().isEmpty();
   }
 
   @Override
@@ -506,7 +576,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
         .collect(toImmutableSet());
   }
 
-  private String getAndClause(ImmutableSet<EntityId> entityIds) {
+  private static String getAndClause(ImmutableSet<EntityId> entityIds) {
     return entityIds.stream()
         .map(entityId -> String.format("%s = :%s", entityId.name, entityId.name))
         .collect(joining(" AND "));
@@ -556,7 +626,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
     try {
       getEntityManager().getMetamodel().entity(object.getClass());
     } catch (IllegalArgumentException e) {
-      // The object is not an entity.  Return without detaching.
+      // The object is not an entity. Return without detaching.
       return object;
     }
 
@@ -637,7 +707,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
 
     TypedQuery<T> delegate;
 
-    public DetachingTypedQuery(TypedQuery<T> delegate) {
+    DetachingTypedQuery(TypedQuery<T> delegate) {
       this.delegate = delegate;
     }
 
@@ -866,7 +936,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
     @Override
     public Optional<T> first() {
       List<T> results = buildQuery().setMaxResults(1).getResultList();
-      return results.size() > 0 ? Optional.of(detach(results.get(0))) : Optional.empty();
+      return !results.isEmpty() ? Optional.of(detach(results.get(0))) : Optional.empty();
     }
 
     @Override
@@ -895,7 +965,7 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
     public ImmutableList<T> list() {
       return buildQuery().getResultList().stream()
           .map(JpaTransactionManagerImpl.this::detach)
-          .collect(ImmutableList.toImmutableList());
+          .collect(toImmutableList());
     }
   }
 }

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.ImmutableObject;
+import google.registry.persistence.PersistenceModule.TransactionIsolationLevel;
 import google.registry.persistence.VKey;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -49,8 +50,17 @@ public interface TransactionManager {
   /** Executes the work in a transaction and returns the result. */
   <T> T transact(Supplier<T> work);
 
+  /**
+   * Executes the work in a transaction at the given {@link TransactionIsolationLevel} and returns
+   * the result.
+   */
+  <T> T transact(Supplier<T> work, TransactionIsolationLevel isolationLevel);
+
   /** Executes the work in a transaction. */
   void transact(Runnable work);
+
+  /** Executes the work in a transaction at the given {@link TransactionIsolationLevel}. */
+  void transact(Runnable work, TransactionIsolationLevel isolationLevel);
 
   /** Returns the time associated with the start of this particular transaction attempt. */
   DateTime getTransactionTime();

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerImplTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerImplTest.java
@@ -16,6 +16,8 @@ package google.registry.persistence.transaction;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
+import static google.registry.persistence.PersistenceModule.TransactionIsolationLevel.TRANSACTION_READ_UNCOMMITTED;
+import static google.registry.persistence.PersistenceModule.TransactionIsolationLevel.TRANSACTION_REPEATABLE_READ;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.assertDetachedFromEntityManager;
 import static google.registry.testing.DatabaseHelper.existsInDb;
@@ -31,6 +33,7 @@ import static org.mockito.Mockito.verify;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import google.registry.config.RegistryConfig;
 import google.registry.model.ImmutableObject;
 import google.registry.persistence.VKey;
 import google.registry.persistence.transaction.JpaTestExtensions.JpaUnitTestExtension;
@@ -81,7 +84,7 @@ class JpaTransactionManagerImplTest {
           .buildUnitTestExtension();
 
   @Test
-  void transact_succeeds() {
+  void transact_success() {
     assertPersonEmpty();
     assertCompanyEmpty();
     tm().transact(
@@ -89,12 +92,59 @@ class JpaTransactionManagerImplTest {
               insertPerson(10);
               insertCompany("Foo");
               insertCompany("Bar");
+              tm().assertTransactionIsolationLevel(tm().getDefaultTransactionIsolationLevel());
             });
     assertPersonCount(1);
     assertPersonExist(10);
     assertCompanyCount(2);
     assertCompanyExist("Foo");
     assertCompanyExist("Bar");
+  }
+
+  @Test
+  void transact_setIsolationLevel() {
+    tm().transact(
+            () -> {
+              tm().assertTransactionIsolationLevel(
+                      RegistryConfig.getHibernatePerTransactionIsolationEnabled()
+                          ? TRANSACTION_READ_UNCOMMITTED
+                          : tm().getDefaultTransactionIsolationLevel());
+              return null;
+            },
+            TRANSACTION_READ_UNCOMMITTED);
+    // Make sure that we can start a new transaction on the same thread with a different isolation
+    // level.
+    tm().transact(
+            () -> {
+              tm().assertTransactionIsolationLevel(
+                      RegistryConfig.getHibernatePerTransactionIsolationEnabled()
+                          ? TRANSACTION_REPEATABLE_READ
+                          : tm().getDefaultTransactionIsolationLevel());
+              return null;
+            },
+            TRANSACTION_REPEATABLE_READ);
+  }
+
+  @Test
+  void transact_nestedTransactions() {
+    // Unit tests always allows for per-transaction isolation level (and therefore throws when a
+    // nested transaction is detected).
+    if (RegistryConfig.getHibernatePerTransactionIsolationEnabled()) {
+      IllegalArgumentException e =
+          assertThrows(
+              IllegalArgumentException.class,
+              () ->
+                  tm().transact(
+                          () -> {
+                            tm().transact(() -> {});
+                          }));
+      assertThat(e).hasMessageThat().isEqualTo("Nested transaction detected");
+    } else {
+      tm().transact(
+              () -> {
+                tm().transact(() -> {});
+              });
+    }
   }
 
   @Test
@@ -606,19 +656,19 @@ class JpaTransactionManagerImplTest {
     verify(spyJpaTm, times(3)).delete(theEntityKey);
   }
 
-  private void insertPerson(int age) {
+  private static void insertPerson(int age) {
     tm().getEntityManager()
         .createNativeQuery(String.format("INSERT INTO Person (age) VALUES (%d)", age))
         .executeUpdate();
   }
 
-  private void insertCompany(String name) {
+  private static void insertCompany(String name) {
     tm().getEntityManager()
         .createNativeQuery(String.format("INSERT INTO Company (name) VALUES ('%s')", name))
         .executeUpdate();
   }
 
-  private void assertPersonExist(int age) {
+  private static void assertPersonExist(int age) {
     tm().transact(
             () -> {
               EntityManager em = tm().getEntityManager();
@@ -631,7 +681,7 @@ class JpaTransactionManagerImplTest {
             });
   }
 
-  private void assertCompanyExist(String name) {
+  private static void assertCompanyExist(String name) {
     tm().transact(
             () -> {
               String maybeName =
@@ -644,23 +694,23 @@ class JpaTransactionManagerImplTest {
             });
   }
 
-  private void assertPersonCount(int count) {
+  private static void assertPersonCount(int count) {
     assertThat(countTable("Person")).isEqualTo(count);
   }
 
-  private void assertCompanyCount(int count) {
+  private static void assertCompanyCount(int count) {
     assertThat(countTable("Company")).isEqualTo(count);
   }
 
-  private void assertPersonEmpty() {
+  private static void assertPersonEmpty() {
     assertPersonCount(0);
   }
 
-  private void assertCompanyEmpty() {
+  private static void assertCompanyEmpty() {
     assertCompanyCount(0);
   }
 
-  private int countTable(String tableName) {
+  private static int countTable(String tableName) {
     return tm().transact(
             () -> {
               BigInteger colCount =


### PR DESCRIPTION
A config file field is added to control if per-transaction isolation
level is actually used. If set to true, nested transactions will throw
a runtime exception as the enclosing transaction may run at a different
isolation level.

In this PR we only add the ability to specify the isolation level,
without enabling it in any environment (including unit tests), or
actually specifying one for any query. This should allow us to set up
the system without impacting anything currently working.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2104)
<!-- Reviewable:end -->
