### PR TITLE
Fix unicode issue in GetTldCommand

### DIFF
--- a/core/src/main/java/google/registry/tools/GetTldCommand.java
+++ b/core/src/main/java/google/registry/tools/GetTldCommand.java
@@ -16,12 +16,15 @@ package google.registry.tools;
 
 import static google.registry.model.tld.TldYamlUtils.getObjectMapper;
 import static google.registry.model.tld.Tlds.assertTldsExist;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import google.registry.model.tld.Tld;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.List;
 
 /** Command to show a TLD record. */
@@ -34,10 +37,12 @@ final class GetTldCommand implements Command {
   private List<String> mainParameters;
 
   @Override
-  public void run() throws JsonProcessingException {
+  public void run() throws JsonProcessingException, UnsupportedEncodingException {
     ObjectMapper mapper = getObjectMapper();
-    for (String tld : assertTldsExist(mainParameters)) {
-      System.out.println(mapper.writeValueAsString(Tld.get(tld)));
+    try (PrintStream printStream = new PrintStream(System.out, false, UTF_8.name())) {
+      for (String tld : assertTldsExist(mainParameters)) {
+        printStream.println(mapper.writeValueAsString(Tld.get(tld)));
+      }
     }
   }
 }

--- a/core/src/test/java/google/registry/tools/CommandTestCase.java
+++ b/core/src/test/java/google/registry/tools/CommandTestCase.java
@@ -80,11 +80,12 @@ public abstract class CommandTestCase<C extends Command> {
     RegistryToolEnvironment.UNITTEST.setup(systemPropertyExtension);
     command = newCommandInstance();
 
-    // Capture standard output/error.
+    // Capture standard output/error. Use a single-byte encoding to emulate platforms where default
+    // charset is not UTF_8.
     oldStdout = System.out;
-    System.setOut(new PrintStream(new OutputSplitter(System.out, stdout)));
+    System.setOut(new PrintStream(new OutputSplitter(System.out, stdout), false, "US-ASCII"));
     oldStderr = System.err;
-    System.setErr(new PrintStream(new OutputSplitter(System.err, stderr)));
+    System.setErr(new PrintStream(new OutputSplitter(System.err, stderr), false, "US-ASCII"));
   }
 
   @AfterEach

--- a/core/src/test/java/google/registry/tools/GetTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetTldCommandTest.java
@@ -20,14 +20,11 @@ import static google.registry.testing.TestDataHelper.loadFile;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.beust.jcommander.ParameterException;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link GetTldCommand}. */
 class GetTldCommandTest extends CommandTestCase<GetTldCommand> {
 
-  // TODO (sarahbot): re-enable this test after we figure out why it fails during RC build.
-  @Disabled
   @Test
   void testSuccess() throws Exception {
     createTld("xn--q9jyb4c");


### PR DESCRIPTION
`System.out` uses the default charset on the platform. Not a big issue since it is only used in tools, but test may break, say on Cloud Build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2108)
<!-- Reviewable:end -->
