### PR TITLE
Mitigate Cloud task retry problem

### DIFF
--- a/core/src/main/java/google/registry/reporting/spec11/GenerateSpec11ReportAction.java
+++ b/core/src/main/java/google/registry/reporting/spec11/GenerateSpec11ReportAction.java
@@ -141,7 +141,8 @@ public class GenerateSpec11ReportAction implements Runnable {
                     jobId,
                     ReportingModule.PARAM_DATE,
                     date.toString()),
-                Duration.standardMinutes(ReportingModule.ENQUEUE_DELAY_MINUTES)));
+                // TODO(b/296582836): mitigating retry problem. Remove `+10` when bug is fixed.
+                Duration.standardMinutes(ReportingModule.ENQUEUE_DELAY_MINUTES + 10)));
       }
       response.setStatus(SC_OK);
       response.setPayload(String.format("Launched Spec11 pipeline: %s", jobId));

--- a/core/src/test/java/google/registry/reporting/spec11/GenerateSpec11ReportActionTest.java
+++ b/core/src/test/java/google/registry/reporting/spec11/GenerateSpec11ReportActionTest.java
@@ -93,7 +93,8 @@ class GenerateSpec11ReportActionTest extends BeamActionTestBase {
             .scheduleTime(
                 clock
                     .nowUtc()
-                    .plus(Duration.standardMinutes(ReportingModule.ENQUEUE_DELAY_MINUTES))));
+                    // TODO(b/296582836): mitigating retry problem. Remove `+10` when bug is fixed.
+                    .plus(Duration.standardMinutes(ReportingModule.ENQUEUE_DELAY_MINUTES + 10))));
   }
 
   @Test


### PR DESCRIPTION
Increase PublishSpec11Action start delay to avoid the need to retry.

The only other use case is invoice, which typically does not retry: delay is 10 minutes, pipeline finishes within 7 minutes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2116)
<!-- Reviewable:end -->
