### PR TITLE
Allow nested transactions when per-transaction isolation level is on

### DIFF
--- a/core/src/main/java/google/registry/config/files/nomulus-config-unittest.yaml
+++ b/core/src/main/java/google/registry/config/files/nomulus-config-unittest.yaml
@@ -28,4 +28,4 @@ misc:
   transientFailureRetries: 3
 
 hibernate:
-  perTransactionIsolation: false
+  perTransactionIsolation: true


### PR DESCRIPTION
It turns out that disallowing all nested transaction is impractical. So
in this PR we make it possible to run nested transactions (which are not
really nested as far as SQL is concerned, but rather lexically nested
calls to tm().transact() which will NOT open new transactions when
called within a transaction) as long as there is no conflict between the
specified isolation levels between the enclosing and the enclosed
transactions.

Note that this will change the behavior of calling tm().transact() with
no isolation level override, or a null override INSIDE a transaction.
The lack of the override will allow the nested transaction to run at
whatever level the enclosing transaction runs at, instead of at the
default level specified in the config file.
