### PR TITLE
Inject getTldCommand in RegistryToolComponent

### DIFF
--- a/core/src/main/java/google/registry/tools/RegistryToolComponent.java
+++ b/core/src/main/java/google/registry/tools/RegistryToolComponent.java
@@ -114,17 +114,18 @@ interface RegistryToolComponent {
 
   void inject(GenerateEscrowDepositCommand command);
 
+  void inject(GetBulkPricingPackageCommand command);
+
   void inject(GetContactCommand command);
 
   void inject(GetDomainCommand command);
 
   void inject(GetHostCommand command);
-
-  void inject(GetBulkPricingPackageCommand command);
-
   void inject(GetKeyringSecretCommand command);
 
   void inject(GetSqlCredentialCommand command);
+
+  void inject(GetTldCommand command);
 
   void inject(GhostrydeCommand command);
 


### PR DESCRIPTION
Need to add this small fix to get the get_tld command working again

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2123)
<!-- Reviewable:end -->
