### PR TITLE
Remove a couple unnecessary inner transact() calls

### DIFF
--- a/core/src/main/java/google/registry/beam/rde/RdeIO.java
+++ b/core/src/main/java/google/registry/beam/rde/RdeIO.java
@@ -274,10 +274,7 @@ public class RdeIO {
                 PendingDeposit key = input.getKey();
                 Tld tld = Tld.get(key.tld());
                 Optional<Cursor> cursor =
-                    tm().transact(
-                            () ->
-                                tm().loadByKeyIfPresent(
-                                        Cursor.createScopedVKey(key.cursor(), tld)));
+                    tm().loadByKeyIfPresent(Cursor.createScopedVKey(key.cursor(), tld));
                 DateTime position = getCursorTimeOrStartOfTime(cursor);
                 checkState(key.interval() != null, "Interval must be present");
                 DateTime newPosition = key.watermark().plus(key.interval());

--- a/core/src/test/java/google/registry/model/registrar/RegistrarTest.java
+++ b/core/src/test/java/google/registry/model/registrar/RegistrarTest.java
@@ -507,11 +507,14 @@ class RegistrarTest extends EntityTestCase {
   @Test
   void testSuccess_setAllowedTldsUncached() {
     assertThat(
-            registrar
-                .asBuilder()
-                .setAllowedTldsUncached(ImmutableSet.of("xn--q9jyb4c"))
-                .build()
-                .getAllowedTlds())
+            tm().transact(
+                    () -> {
+                      return registrar
+                          .asBuilder()
+                          .setAllowedTldsUncached(ImmutableSet.of("xn--q9jyb4c"))
+                          .build()
+                          .getAllowedTlds();
+                    }))
         .containsExactly("xn--q9jyb4c");
   }
 
@@ -524,9 +527,12 @@ class RegistrarTest extends EntityTestCase {
 
   @Test
   void testFailure_setAllowedTldsUncached_nonexistentTld() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> registrar.asBuilder().setAllowedTldsUncached(ImmutableSet.of("bad")));
+    tm().transact(
+            () -> {
+              assertThrows(
+                  IllegalArgumentException.class,
+                  () -> registrar.asBuilder().setAllowedTldsUncached(ImmutableSet.of("bad")));
+            });
   }
 
   @Test
@@ -614,11 +620,14 @@ class RegistrarTest extends EntityTestCase {
 
       // Test that the uncached version works
       assertThat(
-              registrar
-                  .asBuilder()
-                  .setAllowedTldsUncached(ImmutableSet.of("newtld"))
-                  .build()
-                  .getAllowedTlds())
+              tm().transact(
+                      () -> {
+                        return registrar
+                            .asBuilder()
+                            .setAllowedTldsUncached(ImmutableSet.of("newtld"))
+                            .build()
+                            .getAllowedTlds();
+                      }))
           .containsExactly("newtld");
 
       // Test that the "regular" cached version fails. If this doesn't throw - then we changed how


### PR DESCRIPTION
Also refactors a function to no longer unnecessarily return a low level Iterable type.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2124)
<!-- Reviewable:end -->
