### PR TITLE
Add tm().reTransact() methods and refactor away some inner transactions

### DIFF
--- a/core/src/main/java/google/registry/dns/RefreshDnsAction.java
+++ b/core/src/main/java/google/registry/dns/RefreshDnsAction.java
@@ -60,18 +60,21 @@ public final class RefreshDnsAction implements Runnable {
     if (!domainOrHostName.contains(".")) {
       throw new BadRequestException("URL parameter 'name' must be fully qualified");
     }
-    switch (type) {
-      case DOMAIN:
-        loadAndVerifyExistence(Domain.class, domainOrHostName);
-        tm().transact(() -> requestDomainDnsRefresh(domainOrHostName));
-        break;
-      case HOST:
-        verifyHostIsSubordinate(loadAndVerifyExistence(Host.class, domainOrHostName));
-        tm().transact(() -> requestHostDnsRefresh(domainOrHostName));
-        break;
-      default:
-        throw new BadRequestException("Unsupported type: " + type);
-    }
+    tm().transact(
+            () -> {
+              switch (type) {
+                case DOMAIN:
+                  loadAndVerifyExistence(Domain.class, domainOrHostName);
+                  requestDomainDnsRefresh(domainOrHostName);
+                  break;
+                case HOST:
+                  verifyHostIsSubordinate(loadAndVerifyExistence(Host.class, domainOrHostName));
+                  requestHostDnsRefresh(domainOrHostName);
+                  break;
+                default:
+                  throw new BadRequestException("Unsupported type: " + type);
+              }
+            });
   }
 
   private <T extends EppResource & ForeignKeyedEppResource>

--- a/core/src/main/java/google/registry/flows/domain/DomainClaimsCheckFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainClaimsCheckFlow.java
@@ -23,6 +23,7 @@ import static google.registry.flows.domain.DomainFlowUtils.validateDomainNameWit
 import static google.registry.flows.domain.DomainFlowUtils.verifyClaimsPeriodNotEnded;
 import static google.registry.flows.domain.DomainFlowUtils.verifyNotInPredelegation;
 import static google.registry.model.domain.launch.LaunchPhase.CLAIMS;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -108,7 +109,8 @@ public final class DomainClaimsCheckFlow implements Flow {
           verifyClaimsPeriodNotEnded(tld, now);
         }
       }
-      Optional<String> claimKey = ClaimsListDao.get().getClaimKey(parsedDomain.parts().get(0));
+      Optional<String> claimKey =
+          tm().transact(() -> ClaimsListDao.get().getClaimKey(parsedDomain.parts().get(0)));
       launchChecksBuilder.add(
           LaunchCheck.create(
               LaunchCheckName.create(claimKey.isPresent(), domainName), claimKey.orElse(null)));

--- a/core/src/main/java/google/registry/flows/poll/PollAckFlow.java
+++ b/core/src/main/java/google/registry/flows/poll/PollAckFlow.java
@@ -108,7 +108,7 @@ public final class PollAckFlow implements TransactionalFlow {
     // acked, then we return a special status code indicating that. Note that the query will
     // include the message being acked.
 
-    int messageCount = tm().transact(() -> getPollMessageCount(registrarId, now));
+    int messageCount = getPollMessageCount(registrarId, now);
     if (messageCount <= 0) {
       return responseBuilder.setResultFromCode(SUCCESS_WITH_NO_MESSAGES).build();
     }

--- a/core/src/main/java/google/registry/flows/poll/PollFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/poll/PollFlowUtils.java
@@ -30,13 +30,12 @@ public final class PollFlowUtils {
 
   /** Returns the number of poll messages for the given registrar that are not in the future. */
   public static int getPollMessageCount(String registrarId, DateTime now) {
-    return tm().transact(() -> createPollMessageQuery(registrarId, now).count()).intValue();
+    return (int) createPollMessageQuery(registrarId, now).count();
   }
 
   /** Returns the first (by event time) poll message not in the future for this registrar. */
   public static Optional<PollMessage> getFirstPollMessage(String registrarId, DateTime now) {
-    return tm().transact(
-            () -> createPollMessageQuery(registrarId, now).orderBy("eventTime").first());
+    return createPollMessageQuery(registrarId, now).orderBy("eventTime").first();
   }
 
   /**

--- a/core/src/main/java/google/registry/model/EppResourceUtils.java
+++ b/core/src/main/java/google/registry/model/EppResourceUtils.java
@@ -156,7 +156,9 @@ public final class EppResourceUtils {
     T resource =
         useCache
             ? EppResource.loadCached(key)
-            : tm().transact(() -> tm().loadByKeyIfPresent(key).orElse(null));
+            // This transaction is buried very deeply inside many outer nested calls, hence merits
+            // the use of reTransact() for now pending a substantial refactoring.
+            : tm().reTransact(() -> tm().loadByKeyIfPresent(key).orElse(null));
     if (resource == null || isAtOrAfter(now, resource.getDeletionTime())) {
       return Optional.empty();
     }

--- a/core/src/main/java/google/registry/model/tmch/ClaimsList.java
+++ b/core/src/main/java/google/registry/model/tmch/ClaimsList.java
@@ -206,13 +206,11 @@ public class ClaimsList extends ImmutableObject {
     if (labelsToKeys != null) {
       return Optional.ofNullable(labelsToKeys.get(label));
     }
-    return tm().transact(
-            () ->
-                tm().createQueryComposer(ClaimsEntry.class)
-                    .where("revisionId", EQ, revisionId)
-                    .where("domainLabel", EQ, label)
-                    .first()
-                    .map(ClaimsEntry::getClaimKey));
+    return tm().createQueryComposer(ClaimsEntry.class)
+        .where("revisionId", EQ, revisionId)
+        .where("domainLabel", EQ, label)
+        .first()
+        .map(ClaimsEntry::getClaimKey);
   }
 
   public static ClaimsList create(

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -159,6 +159,11 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   }
 
   @Override
+  public <T> T reTransact(Supplier<T> work) {
+    return transact(work);
+  }
+
+  @Override
   public <T> T transact(Supplier<T> work) {
     return transact(work, null);
   }
@@ -227,6 +232,11 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
           return null;
         },
         isolationLevel);
+  }
+
+  @Override
+  public void reTransact(Runnable work) {
+    transact(work);
   }
 
   @Override

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
@@ -56,11 +56,43 @@ public interface TransactionManager {
    */
   <T> T transact(Supplier<T> work, TransactionIsolationLevel isolationLevel);
 
+  /**
+   * Executes the work in a (potentially wrapped) transaction and returns the result.
+   *
+   * <p>Calls to this method are typically going to be in inner functions, that are called either as
+   * top-level transactions themselves or are nested inside of larger transactions (e.g. a
+   * transactional flow). Invocations of reTransact must be vetted to occur in both situations and
+   * with such complexity that it is not trivial to refactor out the nested transaction calls. New
+   * code should be written in such a way as to avoid requiring reTransact in the first place.
+   *
+   * <p>In the future we will be enforcing that {@link #transact(Supplier)} calls be top-level only,
+   * with reTransact calls being the only ones that can potentially be an inner nested transaction
+   * (which is a noop). Note that, as this can be a nested inner exception, there is no overload
+   * provided to specify a (potentially conflicting) transaction isolation level.
+   */
+  <T> T reTransact(Supplier<T> work);
+
   /** Executes the work in a transaction. */
   void transact(Runnable work);
 
   /** Executes the work in a transaction at the given {@link TransactionIsolationLevel}. */
   void transact(Runnable work, TransactionIsolationLevel isolationLevel);
+
+  /**
+   * Executes the work in a (potentially wrapped) transaction and returns the result.
+   *
+   * <p>Calls to this method are typically going to be in inner functions, that are called either as
+   * top-level transactions themselves or are nested inside of larger transactions (e.g. a
+   * transactional flow). Invocations of reTransact must be vetted to occur in both situations and
+   * with such complexity that it is not trivial to refactor out the nested transaction calls. New
+   * code should be written in such a way as to avoid requiring reTransact in the first place.
+   *
+   * <p>In the future we will be enforcing that {@link #transact(Runnable)} calls be top-level only,
+   * with reTransact calls being the only ones that can potentially be an inner nested transaction
+   * (which is a noop). Note that, as this can be a nested inner exception, there is no overload *
+   * provided to specify a (potentially conflicting) transaction isolation level.
+   */
+  void reTransact(Runnable work);
 
   /** Returns the time associated with the start of this particular transaction attempt. */
   DateTime getTransactionTime();

--- a/core/src/test/java/google/registry/persistence/transaction/ReplicaSimulatingJpaTransactionManager.java
+++ b/core/src/test/java/google/registry/persistence/transaction/ReplicaSimulatingJpaTransactionManager.java
@@ -117,6 +117,11 @@ public class ReplicaSimulatingJpaTransactionManager implements JpaTransactionMan
   }
 
   @Override
+  public <T> T reTransact(Supplier<T> work) {
+    return transact(work);
+  }
+
+  @Override
   public <T> T transact(Supplier<T> work) {
     return transact(work, null);
   }
@@ -139,6 +144,11 @@ public class ReplicaSimulatingJpaTransactionManager implements JpaTransactionMan
           return null;
         },
         isolationLevel);
+  }
+
+  @Override
+  public void reTransact(Runnable work) {
+    transact(work);
   }
 
   @Override

--- a/core/src/test/java/google/registry/tmch/TmchDnlActionTest.java
+++ b/core/src/test/java/google/registry/tmch/TmchDnlActionTest.java
@@ -17,6 +17,7 @@ package google.registry.tmch;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -41,7 +42,8 @@ class TmchDnlActionTest extends TmchActionTestCase {
 
   @Test
   void testDnl() throws Exception {
-    assertThat(ClaimsListDao.get().getClaimKey("xn----7sbejwbn3axu3d")).isEmpty();
+    assertThat(tm().transact(() -> ClaimsListDao.get().getClaimKey("xn----7sbejwbn3axu3d")))
+        .isEmpty();
     when(httpUrlConnection.getInputStream())
         .thenReturn(new ByteArrayInputStream(TmchTestData.loadBytes("dnl/dnl-latest.csv").read()))
         .thenReturn(new ByteArrayInputStream(TmchTestData.loadBytes("dnl/dnl-latest.sig").read()));
@@ -54,8 +56,8 @@ class TmchDnlActionTest extends TmchActionTestCase {
     ClaimsList claimsList = ClaimsListDao.get();
     assertThat(claimsList.getTmdbGenerationTime())
         .isEqualTo(DateTime.parse("2013-11-24T23:15:37.4Z"));
-    assertThat(claimsList.getClaimKey("xn----7sbejwbn3axu3d"))
+    assertThat(tm().transact(() -> claimsList.getClaimKey("xn----7sbejwbn3axu3d")))
         .hasValue("2013112500/7/4/8/dIHW0DiuybvhdP8kIz");
-    assertThat(claimsList.getClaimKey("lolcat")).isEmpty();
+    assertThat(tm().transact(() -> claimsList.getClaimKey("lolcat"))).isEmpty();
   }
 }

--- a/core/src/test/java/google/registry/tools/UploadClaimsListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UploadClaimsListCommandTest.java
@@ -16,6 +16,7 @@ package google.registry.tools;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.model.tmch.ClaimsList;
@@ -46,11 +47,11 @@ class UploadClaimsListCommandTest extends CommandTestCase<UploadClaimsListComman
     ClaimsList claimsList = ClaimsListDao.get();
     assertThat(claimsList.getTmdbGenerationTime())
         .isEqualTo(DateTime.parse("2012-08-16T00:00:00.0Z"));
-    assertThat(claimsList.getClaimKey("example"))
+    assertThat(tm().transact(() -> claimsList.getClaimKey("example")))
         .hasValue("2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001");
-    assertThat(claimsList.getClaimKey("another-example"))
+    assertThat(tm().transact(() -> claimsList.getClaimKey("another-example")))
         .hasValue("2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002");
-    assertThat(claimsList.getClaimKey("anotherexample"))
+    assertThat(tm().transact(() -> claimsList.getClaimKey("anotherexample")))
         .hasValue("2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003");
   }
 


### PR DESCRIPTION
In the future, reTransact() will be the only way to initiate a transaction that doesn't fail when called inside an outer wrapping transaction (when wrapped, it's a no-op). It should be used sparingly, with a preference towards refactoring the code to move transactions outwards (which this PR also contains).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2125)
<!-- Reviewable:end -->
