### PR TITLE
Add a new MutatingFlow interface and make most flows use Transactiona…

### DIFF
--- a/core/src/main/java/google/registry/flows/FlowRunner.java
+++ b/core/src/main/java/google/registry/flows/FlowRunner.java
@@ -78,6 +78,8 @@ public class FlowRunner {
       return EppOutput.create(flowProvider.get().run());
     }
     try {
+      // TODO(mcilwain/weiminyu): Use transactReadOnly() here for TransactionalFlow and transact()
+      //                          for MutatingFlow.
       return tm().transact(
               () -> {
                 try {

--- a/core/src/main/java/google/registry/flows/MutatingFlow.java
+++ b/core/src/main/java/google/registry/flows/MutatingFlow.java
@@ -1,0 +1,23 @@
+// Copyright 2023 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.flows;
+
+/**
+ * Interface for a {@link TransactionalFlow} that mutates the database (i.e. is not read-only).
+ *
+ * <p>Any flow that mutates the DB should implement this so that {@link FlowRunner} will know how to
+ * run it.
+ */
+public interface MutatingFlow extends TransactionalFlow {}

--- a/core/src/main/java/google/registry/flows/contact/ContactCheckFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactCheckFlow.java
@@ -23,8 +23,8 @@ import com.google.common.collect.ImmutableSet;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.flows.EppException;
 import google.registry.flows.ExtensionManager;
-import google.registry.flows.Flow;
 import google.registry.flows.FlowModule.RegistrarId;
+import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactCommand.Check;
@@ -45,7 +45,7 @@ import javax.inject.Inject;
  * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  */
 @ReportingSpec(ActivityReportField.CONTACT_CHECK)
-public final class ContactCheckFlow implements Flow {
+public final class ContactCheckFlow implements TransactionalFlow {
 
   @Inject ResourceCommand resourceCommand;
   @Inject @RegistrarId String registrarId;

--- a/core/src/main/java/google/registry/flows/contact/ContactCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactCreateFlow.java
@@ -28,7 +28,7 @@ import google.registry.flows.EppException;
 import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.exceptions.ResourceAlreadyExistsForThisClientException;
 import google.registry.flows.exceptions.ResourceCreateContentionException;
@@ -54,7 +54,7 @@ import org.joda.time.DateTime;
  * @error {@link ContactFlowUtils.DeclineContactDisclosureFieldDisallowedPolicyException}
  */
 @ReportingSpec(ActivityReportField.CONTACT_CREATE)
-public final class ContactCreateFlow implements TransactionalFlow {
+public final class ContactCreateFlow implements MutatingFlow {
 
   @Inject ResourceCommand resourceCommand;
   @Inject ExtensionManager extensionManager;

--- a/core/src/main/java/google/registry/flows/contact/ContactDeleteFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactDeleteFlow.java
@@ -32,7 +32,7 @@ import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactHistory;
@@ -63,7 +63,7 @@ import org.joda.time.DateTime;
  * @error {@link google.registry.flows.exceptions.ResourceToDeleteIsReferencedException}
  */
 @ReportingSpec(ActivityReportField.CONTACT_DELETE)
-public final class ContactDeleteFlow implements TransactionalFlow {
+public final class ContactDeleteFlow implements MutatingFlow {
 
   private static final ImmutableSet<StatusValue> DISALLOWED_STATUSES =
       ImmutableSet.of(

--- a/core/src/main/java/google/registry/flows/contact/ContactInfoFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactInfoFlow.java
@@ -22,10 +22,10 @@ import static google.registry.model.EppResourceUtils.isLinked;
 import com.google.common.collect.ImmutableSet;
 import google.registry.flows.EppException;
 import google.registry.flows.ExtensionManager;
-import google.registry.flows.Flow;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
+import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactInfoData;
@@ -51,7 +51,7 @@ import org.joda.time.DateTime;
  * @error {@link google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException}
  */
 @ReportingSpec(ActivityReportField.CONTACT_INFO)
-public final class ContactInfoFlow implements Flow {
+public final class ContactInfoFlow implements TransactionalFlow {
 
   @Inject ExtensionManager extensionManager;
   @Inject Clock clock;

--- a/core/src/main/java/google/registry/flows/contact/ContactTransferApproveFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactTransferApproveFlow.java
@@ -30,7 +30,7 @@ import google.registry.flows.EppException;
 import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactHistory;
@@ -60,7 +60,7 @@ import org.joda.time.DateTime;
  * @error {@link google.registry.flows.exceptions.NotPendingTransferException}
  */
 @ReportingSpec(ActivityReportField.CONTACT_TRANSFER_APPROVE)
-public final class ContactTransferApproveFlow implements TransactionalFlow {
+public final class ContactTransferApproveFlow implements MutatingFlow {
 
   @Inject ResourceCommand resourceCommand;
   @Inject ExtensionManager extensionManager;

--- a/core/src/main/java/google/registry/flows/contact/ContactTransferCancelFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactTransferCancelFlow.java
@@ -30,7 +30,7 @@ import google.registry.flows.EppException;
 import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactHistory;
@@ -60,7 +60,7 @@ import org.joda.time.DateTime;
  * @error {@link google.registry.flows.exceptions.NotTransferInitiatorException}
  */
 @ReportingSpec(ActivityReportField.CONTACT_TRANSFER_CANCEL)
-public final class ContactTransferCancelFlow implements TransactionalFlow {
+public final class ContactTransferCancelFlow implements MutatingFlow {
 
   @Inject ResourceCommand resourceCommand;
   @Inject ExtensionManager extensionManager;

--- a/core/src/main/java/google/registry/flows/contact/ContactTransferQueryFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactTransferQueryFlow.java
@@ -21,9 +21,9 @@ import static google.registry.flows.contact.ContactFlowUtils.createTransferRespo
 
 import google.registry.flows.EppException;
 import google.registry.flows.ExtensionManager;
-import google.registry.flows.Flow;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.TargetId;
+import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.exceptions.NoTransferHistoryToQueryException;
 import google.registry.flows.exceptions.NotAuthorizedToViewTransferException;
@@ -52,7 +52,7 @@ import javax.inject.Inject;
  * @error {@link google.registry.flows.exceptions.NotAuthorizedToViewTransferException}
  */
 @ReportingSpec(ActivityReportField.CONTACT_TRANSFER_QUERY)
-public final class ContactTransferQueryFlow implements Flow {
+public final class ContactTransferQueryFlow implements TransactionalFlow {
 
   @Inject ExtensionManager extensionManager;
   @Inject Optional<AuthInfo> authInfo;

--- a/core/src/main/java/google/registry/flows/contact/ContactTransferRejectFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactTransferRejectFlow.java
@@ -30,7 +30,7 @@ import google.registry.flows.EppException;
 import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.model.contact.Contact;
 import google.registry.model.contact.ContactHistory;
@@ -59,7 +59,7 @@ import org.joda.time.DateTime;
  * @error {@link google.registry.flows.exceptions.NotPendingTransferException}
  */
 @ReportingSpec(ActivityReportField.CONTACT_TRANSFER_REJECT)
-public final class ContactTransferRejectFlow implements TransactionalFlow {
+public final class ContactTransferRejectFlow implements MutatingFlow {
 
   @Inject ExtensionManager extensionManager;
   @Inject Optional<AuthInfo> authInfo;

--- a/core/src/main/java/google/registry/flows/contact/ContactTransferRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactTransferRequestFlow.java
@@ -33,7 +33,7 @@ import google.registry.flows.EppException;
 import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.exceptions.AlreadyPendingTransferException;
 import google.registry.flows.exceptions.ObjectAlreadySponsoredException;
@@ -72,7 +72,7 @@ import org.joda.time.Duration;
  * @error {@link google.registry.flows.exceptions.ResourceStatusProhibitsOperationException}
  */
 @ReportingSpec(ActivityReportField.CONTACT_TRANSFER_REQUEST)
-public final class ContactTransferRequestFlow implements TransactionalFlow {
+public final class ContactTransferRequestFlow implements MutatingFlow {
 
   private static final ImmutableSet<StatusValue> DISALLOWED_STATUSES =
       ImmutableSet.of(

--- a/core/src/main/java/google/registry/flows/contact/ContactUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/contact/ContactUpdateFlow.java
@@ -33,7 +33,7 @@ import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.exceptions.ResourceHasClientUpdateProhibitedException;
 import google.registry.model.contact.Contact;
@@ -66,7 +66,7 @@ import org.joda.time.DateTime;
  * @error {@link ContactFlowUtils.DeclineContactDisclosureFieldDisallowedPolicyException}
  */
 @ReportingSpec(ActivityReportField.CONTACT_UPDATE)
-public final class ContactUpdateFlow implements TransactionalFlow {
+public final class ContactUpdateFlow implements MutatingFlow {
 
   /**
    * Note that CLIENT_UPDATE_PROHIBITED is intentionally not in this list. This is because it

--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -67,7 +67,7 @@ import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.custom.DomainCreateFlowCustomLogic;
 import google.registry.flows.custom.DomainCreateFlowCustomLogic.BeforeResponseParameters;
@@ -210,7 +210,7 @@ import org.joda.time.Duration;
  * @error {@link DomainPricingLogic.AllocationTokenInvalidForPremiumNameException}
  */
 @ReportingSpec(ActivityReportField.DOMAIN_CREATE)
-public final class DomainCreateFlow implements TransactionalFlow {
+public final class DomainCreateFlow implements MutatingFlow {
 
   /** Anchor tenant creates should always be for 2 years, since they get 2 years free. */
   private static final int ANCHOR_TENANT_CREATE_VALID_YEARS = 2;

--- a/core/src/main/java/google/registry/flows/domain/DomainDeleteFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainDeleteFlow.java
@@ -51,8 +51,8 @@ import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.SessionMetadata;
-import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.custom.DomainDeleteFlowCustomLogic;
 import google.registry.flows.custom.DomainDeleteFlowCustomLogic.AfterValidationParameters;
@@ -115,7 +115,7 @@ import org.joda.time.Duration;
  * @error {@link DomainFlowUtils.NotAuthorizedForTldException}
  */
 @ReportingSpec(ActivityReportField.DOMAIN_DELETE)
-public final class DomainDeleteFlow implements TransactionalFlow {
+public final class DomainDeleteFlow implements MutatingFlow {
 
   private static final ImmutableSet<StatusValue> DISALLOWED_STATUSES = ImmutableSet.of(
       StatusValue.CLIENT_DELETE_PROHIBITED,

--- a/core/src/main/java/google/registry/flows/domain/DomainRenewFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRenewFlow.java
@@ -44,7 +44,7 @@ import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.custom.DomainRenewFlowCustomLogic;
 import google.registry.flows.custom.DomainRenewFlowCustomLogic.AfterValidationParameters;
@@ -137,7 +137,7 @@ import org.joda.time.Duration;
  *     google.registry.flows.domain.token.AllocationTokenFlowUtils.AlreadyRedeemedAllocationTokenException}
  */
 @ReportingSpec(ActivityReportField.DOMAIN_RENEW)
-public final class DomainRenewFlow implements TransactionalFlow {
+public final class DomainRenewFlow implements MutatingFlow {
 
   private static final ImmutableSet<StatusValue> RENEW_DISALLOWED_STATUSES = ImmutableSet.of(
       StatusValue.CLIENT_RENEW_PROHIBITED,

--- a/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
@@ -42,7 +42,7 @@ import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.model.ImmutableObject;
 import google.registry.model.billing.BillingBase.Reason;
@@ -112,7 +112,7 @@ import org.joda.time.DateTime;
  * @error {@link DomainRestoreRequestFlow.RestoreCommandIncludesChangesException}
  */
 @ReportingSpec(ActivityReportField.DOMAIN_RGP_RESTORE_REQUEST)
-public final class DomainRestoreRequestFlow implements TransactionalFlow {
+public final class DomainRestoreRequestFlow implements MutatingFlow {
 
   @Inject ResourceCommand resourceCommand;
   @Inject ExtensionManager extensionManager;

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferApproveFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferApproveFlow.java
@@ -41,7 +41,7 @@ import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.domain.token.AllocationTokenFlowUtils;
 import google.registry.model.ImmutableObject;
@@ -106,7 +106,7 @@ import org.joda.time.DateTime;
  *     google.registry.flows.domain.token.AllocationTokenFlowUtils.AlreadyRedeemedAllocationTokenException}
  */
 @ReportingSpec(ActivityReportField.DOMAIN_TRANSFER_APPROVE)
-public final class DomainTransferApproveFlow implements TransactionalFlow {
+public final class DomainTransferApproveFlow implements MutatingFlow {
 
   @Inject ExtensionManager extensionManager;
   @Inject Optional<AuthInfo> authInfo;

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferCancelFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferCancelFlow.java
@@ -37,7 +37,7 @@ import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.model.billing.BillingRecurrence;
 import google.registry.model.domain.Domain;
@@ -74,7 +74,7 @@ import org.joda.time.DateTime;
  * @error {@link DomainFlowUtils.NotAuthorizedForTldException}
  */
 @ReportingSpec(ActivityReportField.DOMAIN_TRANSFER_CANCEL)
-public final class DomainTransferCancelFlow implements TransactionalFlow {
+public final class DomainTransferCancelFlow implements MutatingFlow {
 
   @Inject ExtensionManager extensionManager;
   @Inject Optional<AuthInfo> authInfo;

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferQueryFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferQueryFlow.java
@@ -21,10 +21,10 @@ import static google.registry.flows.domain.DomainTransferUtils.createTransferRes
 
 import google.registry.flows.EppException;
 import google.registry.flows.ExtensionManager;
-import google.registry.flows.Flow;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.TargetId;
 import google.registry.flows.ResourceFlowUtils;
+import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.exceptions.NoTransferHistoryToQueryException;
 import google.registry.flows.exceptions.NotAuthorizedToViewTransferException;
@@ -56,7 +56,7 @@ import org.joda.time.DateTime;
  * @error {@link google.registry.flows.exceptions.NotAuthorizedToViewTransferException}
  */
 @ReportingSpec(ActivityReportField.DOMAIN_TRANSFER_QUERY)
-public final class DomainTransferQueryFlow implements Flow {
+public final class DomainTransferQueryFlow implements TransactionalFlow {
 
   @Inject ExtensionManager extensionManager;
   @Inject Optional<AuthInfo> authInfo;

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferRejectFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferRejectFlow.java
@@ -39,7 +39,7 @@ import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.model.billing.BillingRecurrence;
 import google.registry.model.domain.Domain;
@@ -76,7 +76,7 @@ import org.joda.time.DateTime;
  * @error {@link DomainFlowUtils.NotAuthorizedForTldException}
  */
 @ReportingSpec(ActivityReportField.DOMAIN_TRANSFER_REJECT)
-public final class DomainTransferRejectFlow implements TransactionalFlow {
+public final class DomainTransferRejectFlow implements MutatingFlow {
 
   @Inject ExtensionManager extensionManager;
   @Inject Optional<AuthInfo> authInfo;

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
@@ -45,7 +45,7 @@ import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.domain.token.AllocationTokenFlowUtils;
 import google.registry.flows.exceptions.AlreadyPendingTransferException;
@@ -135,7 +135,7 @@ import org.joda.time.DateTime;
  *     google.registry.flows.domain.token.AllocationTokenFlowUtils.AlreadyRedeemedAllocationTokenException}
  */
 @ReportingSpec(ActivityReportField.DOMAIN_TRANSFER_REQUEST)
-public final class DomainTransferRequestFlow implements TransactionalFlow {
+public final class DomainTransferRequestFlow implements MutatingFlow {
 
   private static final ImmutableSet<StatusValue> DISALLOWED_STATUSES = ImmutableSet.of(
       StatusValue.CLIENT_TRANSFER_PROHIBITED,

--- a/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
@@ -55,7 +55,7 @@ import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.custom.DomainUpdateFlowCustomLogic;
 import google.registry.flows.custom.DomainUpdateFlowCustomLogic.AfterValidationParameters;
@@ -133,7 +133,7 @@ import org.joda.time.DateTime;
  * @error {@link DomainFlowUtils.UrgentAttributeNotSupportedException}
  */
 @ReportingSpec(ActivityReportField.DOMAIN_UPDATE)
-public final class DomainUpdateFlow implements TransactionalFlow {
+public final class DomainUpdateFlow implements MutatingFlow {
 
   /**
    * A list of {@link StatusValue}s that prohibit updates.

--- a/core/src/main/java/google/registry/flows/host/HostCheckFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostCheckFlow.java
@@ -23,8 +23,8 @@ import com.google.common.collect.ImmutableSet;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.flows.EppException;
 import google.registry.flows.ExtensionManager;
-import google.registry.flows.Flow;
 import google.registry.flows.FlowModule.RegistrarId;
+import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.model.eppinput.ResourceCommand;
 import google.registry.model.eppoutput.CheckData.HostCheck;
@@ -45,7 +45,7 @@ import javax.inject.Inject;
  * @error {@link google.registry.flows.FlowUtils.NotLoggedInException}
  */
 @ReportingSpec(ActivityReportField.HOST_CHECK)
-public final class HostCheckFlow implements Flow {
+public final class HostCheckFlow implements TransactionalFlow {
 
   @Inject ResourceCommand resourceCommand;
   @Inject @RegistrarId String registrarId;

--- a/core/src/main/java/google/registry/flows/host/HostCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostCreateFlow.java
@@ -35,7 +35,7 @@ import google.registry.flows.EppException.RequiredParameterMissingException;
 import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.exceptions.ResourceAlreadyExistsForThisClientException;
 import google.registry.flows.exceptions.ResourceCreateContentionException;
@@ -78,7 +78,7 @@ import org.joda.time.DateTime;
  * @error {@link UnexpectedExternalHostIpException}
  */
 @ReportingSpec(ActivityReportField.HOST_CREATE)
-public final class HostCreateFlow implements TransactionalFlow {
+public final class HostCreateFlow implements MutatingFlow {
 
   @Inject ResourceCommand resourceCommand;
   @Inject ExtensionManager extensionManager;

--- a/core/src/main/java/google/registry/flows/host/HostDeleteFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostDeleteFlow.java
@@ -30,7 +30,7 @@ import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.model.EppResource;
 import google.registry.model.domain.metadata.MetadataExtension;
@@ -63,7 +63,7 @@ import org.joda.time.DateTime;
  * @error {@link HostFlowUtils.HostNameNotPunyCodedException}
  */
 @ReportingSpec(ActivityReportField.HOST_DELETE)
-public final class HostDeleteFlow implements TransactionalFlow {
+public final class HostDeleteFlow implements MutatingFlow {
 
   private static final ImmutableSet<StatusValue> DISALLOWED_STATUSES =
       ImmutableSet.of(

--- a/core/src/main/java/google/registry/flows/host/HostInfoFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostInfoFlow.java
@@ -23,9 +23,9 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import com.google.common.collect.ImmutableSet;
 import google.registry.flows.EppException;
 import google.registry.flows.ExtensionManager;
-import google.registry.flows.Flow;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.TargetId;
+import google.registry.flows.TransactionalFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.model.domain.Domain;
 import google.registry.model.eppcommon.StatusValue;
@@ -50,7 +50,7 @@ import org.joda.time.DateTime;
  * @error {@link HostFlowUtils.HostNameNotPunyCodedException}
  */
 @ReportingSpec(ActivityReportField.HOST_INFO)
-public final class HostInfoFlow implements Flow {
+public final class HostInfoFlow implements TransactionalFlow {
 
   @Inject ExtensionManager extensionManager;
   @Inject @RegistrarId String registrarId;
@@ -77,8 +77,7 @@ public final class HostInfoFlow implements Flow {
     // there is no superordinate domain, the host's own values for these fields will be correct.
     if (host.isSubordinate()) {
       Domain superordinateDomain =
-          tm().transact(
-                  () -> tm().loadByKey(host.getSuperordinateDomain()).cloneProjectedAtTime(now));
+          tm().loadByKey(host.getSuperordinateDomain()).cloneProjectedAtTime(now);
       hostInfoDataBuilder
           .setCurrentSponsorRegistrarId(superordinateDomain.getCurrentSponsorRegistrarId())
           .setLastTransferTime(host.computeLastTransferTime(superordinateDomain));

--- a/core/src/main/java/google/registry/flows/host/HostUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostUpdateFlow.java
@@ -47,7 +47,7 @@ import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
 import google.registry.flows.FlowModule.Superuser;
 import google.registry.flows.FlowModule.TargetId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.annotations.ReportingSpec;
 import google.registry.flows.exceptions.ResourceHasClientUpdateProhibitedException;
 import google.registry.model.EppResource;
@@ -107,7 +107,7 @@ import org.joda.time.DateTime;
  * @error {@link RenameHostToExternalRemoveIpException}
  */
 @ReportingSpec(ActivityReportField.HOST_UPDATE)
-public final class HostUpdateFlow implements TransactionalFlow {
+public final class HostUpdateFlow implements MutatingFlow {
 
   /**
    * Note that CLIENT_UPDATE_PROHIBITED is intentionally not in this list. This is because it

--- a/core/src/main/java/google/registry/flows/poll/PollAckFlow.java
+++ b/core/src/main/java/google/registry/flows/poll/PollAckFlow.java
@@ -31,7 +31,7 @@ import google.registry.flows.EppException.RequiredParameterMissingException;
 import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.PollMessageId;
 import google.registry.flows.FlowModule.RegistrarId;
-import google.registry.flows.TransactionalFlow;
+import google.registry.flows.MutatingFlow;
 import google.registry.model.eppoutput.EppResponse;
 import google.registry.model.poll.MessageQueueInfo;
 import google.registry.model.poll.PollMessage;
@@ -55,7 +55,7 @@ import org.joda.time.DateTime;
  * @error {@link PollAckFlow.MissingMessageIdException}
  * @error {@link PollAckFlow.NotAuthorizedToAckMessageException}
  */
-public final class PollAckFlow implements TransactionalFlow {
+public final class PollAckFlow implements MutatingFlow {
 
   @Inject ExtensionManager extensionManager;
   @Inject @RegistrarId String registrarId;

--- a/core/src/main/java/google/registry/flows/session/LoginFlow.java
+++ b/core/src/main/java/google/registry/flows/session/LoginFlow.java
@@ -30,8 +30,8 @@ import google.registry.flows.EppException.UnimplementedExtensionException;
 import google.registry.flows.EppException.UnimplementedObjectServiceException;
 import google.registry.flows.ExtensionManager;
 import google.registry.flows.FlowModule.RegistrarId;
+import google.registry.flows.MutatingFlow;
 import google.registry.flows.SessionMetadata;
-import google.registry.flows.TransactionalFlow;
 import google.registry.flows.TransportCredentials;
 import google.registry.model.eppcommon.ProtocolDefinition;
 import google.registry.model.eppcommon.ProtocolDefinition.ServiceExtension;
@@ -62,7 +62,7 @@ import javax.inject.Inject;
  * @error {@link LoginFlow.RegistrarAccountNotActiveException}
  * @error {@link LoginFlow.UnsupportedLanguageException}
  */
-public class LoginFlow implements TransactionalFlow {
+public class LoginFlow implements MutatingFlow {
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 

--- a/core/src/main/java/google/registry/model/EppResource.java
+++ b/core/src/main/java/google/registry/model/EppResource.java
@@ -20,7 +20,6 @@ import static com.google.common.collect.Sets.difference;
 import static com.google.common.collect.Sets.union;
 import static google.registry.config.RegistryConfig.getEppResourceCachingDuration;
 import static google.registry.config.RegistryConfig.getEppResourceMaxCachedEntries;
-import static google.registry.persistence.transaction.TransactionManagerFactory.replicaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.CollectionUtils.nullToEmpty;
 import static google.registry.util.CollectionUtils.nullToEmptyImmutableCopy;
@@ -358,13 +357,13 @@ public abstract class EppResource extends UpdateAutoTimestampEntity implements B
 
         @Override
         public EppResource load(VKey<? extends EppResource> key) {
-          return replicaTm().transact(() -> replicaTm().loadByKey(key));
+          return tm().reTransact(() -> tm().loadByKey(key));
         }
 
         @Override
         public Map<VKey<? extends EppResource>, EppResource> loadAll(
             Iterable<? extends VKey<? extends EppResource>> keys) {
-          return replicaTm().transact(() -> replicaTm().loadByKeys(keys));
+          return tm().reTransact(() -> tm().loadByKeys(keys));
         }
       };
 
@@ -403,7 +402,7 @@ public abstract class EppResource extends UpdateAutoTimestampEntity implements B
   public static ImmutableMap<VKey<? extends EppResource>, EppResource> loadCached(
       Iterable<VKey<? extends EppResource>> keys) {
     if (!RegistryConfig.isEppResourceCachingEnabled()) {
-      return tm().transact(() -> tm().loadByKeys(keys));
+      return tm().reTransact(() -> tm().loadByKeys(keys));
     }
     return ImmutableMap.copyOf(cacheEppResources.getAll(keys));
   }
@@ -416,7 +415,7 @@ public abstract class EppResource extends UpdateAutoTimestampEntity implements B
    */
   public static <T extends EppResource> T loadCached(VKey<T> key) {
     if (!RegistryConfig.isEppResourceCachingEnabled()) {
-      return tm().transact(() -> tm().loadByKey(key));
+      return tm().reTransact(() -> tm().loadByKey(key));
     }
     // Safe to cast because loading a Key<T> returns an entity of type T.
     @SuppressWarnings("unchecked")

--- a/core/src/main/java/google/registry/model/ForeignKeyUtils.java
+++ b/core/src/main/java/google/registry/model/ForeignKeyUtils.java
@@ -109,7 +109,7 @@ public final class ForeignKeyUtils {
       Class<E> clazz, Collection<String> foreignKeys, boolean useReplicaTm) {
     String fkProperty = RESOURCE_TYPE_TO_FK_PROPERTY.get(clazz);
     JpaTransactionManager tmToUse = useReplicaTm ? replicaTm() : tm();
-    return tmToUse.transact(
+    return tmToUse.reTransact(
         () ->
             tmToUse
                 .query(

--- a/core/src/test/java/google/registry/flows/FlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/FlowTestCase.java
@@ -145,14 +145,14 @@ public abstract class FlowTestCase<F extends Flow> {
     sessionMetadata.setRegistrarId(registrarId);
   }
 
-  public void assertTransactionalFlow(boolean isTransactional) throws Exception {
+  public void assertMutatingFlow(boolean isMutating) throws Exception {
     Class<? extends Flow> flowClass = FlowPicker.getFlowClass(eppLoader.getEpp());
-    if (isTransactional) {
-      assertThat(flowClass).isAssignableTo(TransactionalFlow.class);
+    if (isMutating) {
+      assertThat(flowClass).isAssignableTo(MutatingFlow.class);
     } else {
       // There's no "isNotAssignableTo" in Truth.
-      assertWithMessage(flowClass.getSimpleName() + " implements TransactionalFlow")
-          .that(TransactionalFlow.class.isAssignableFrom(flowClass))
+      assertWithMessage(flowClass.getSimpleName() + " implements MutatingFlow")
+          .that(MutatingFlow.class.isAssignableFrom(flowClass))
           .isFalse();
     }
   }

--- a/core/src/test/java/google/registry/flows/ResourceCheckFlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/ResourceCheckFlowTestCase.java
@@ -30,7 +30,7 @@ public abstract class ResourceCheckFlowTestCase<F extends Flow, R extends EppRes
     extends ResourceFlowTestCase<F, R> {
 
   protected void doCheckTest(CheckData.Check... expected) throws Exception {
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     assertThat(((CheckData) runFlow().getResponse().getResponseData().get(0)).getChecks())
         .containsExactlyElementsIn(expected);
     assertNoHistory();  // Checks don't create a history event.

--- a/core/src/test/java/google/registry/flows/contact/ContactCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactCreateFlowTest.java
@@ -44,7 +44,7 @@ class ContactCreateFlowTest extends ResourceFlowTestCase<ContactCreateFlow, Cont
   }
 
   private void doSuccessfulTest() throws Exception {
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile("contact_create_response.xml"));
     // Check that the contact was created and persisted with a history entry.
     Contact contact = reloadResourceByForeignKey();

--- a/core/src/test/java/google/registry/flows/contact/ContactDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactDeleteFlowTest.java
@@ -78,7 +78,7 @@ class ContactDeleteFlowTest extends ResourceFlowTestCase<ContactDeleteFlow, Cont
   void testSuccess() throws Exception {
     persistActiveContact(getUniqueIdFromCommand());
     clock.advanceOneMilli();
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile("contact_delete_response.xml"));
     assertSqlDeleteSuccess();
   }
@@ -94,7 +94,7 @@ class ContactDeleteFlowTest extends ResourceFlowTestCase<ContactDeleteFlow, Cont
                 clock.nowUtc())
             .getTransferData();
     clock.advanceOneMilli();
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile("contact_delete_response.xml"));
     assertSqlDeleteSuccess(Type.CONTACT_DELETE, Type.CONTACT_TRANSFER_REQUEST);
     Contact softDeletedContact = reloadResourceByForeignKey(clock.nowUtc().minusMillis(1));
@@ -130,7 +130,7 @@ class ContactDeleteFlowTest extends ResourceFlowTestCase<ContactDeleteFlow, Cont
     setEppInput("contact_delete_no_cltrid.xml");
     persistActiveContact(getUniqueIdFromCommand());
     clock.advanceOneMilli();
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile("contact_delete_response_no_cltrid.xml"));
     assertSqlDeleteSuccess();
   }

--- a/core/src/test/java/google/registry/flows/contact/ContactInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactInfoFlowTest.java
@@ -109,7 +109,7 @@ class ContactInfoFlowTest extends ResourceFlowTestCase<ContactInfoFlow, Contact>
   void testSuccess() throws Exception {
     persistContact(true);
     // Check that the persisted contact info was returned.
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(
         loadFile("contact_info_response.xml"),
         // We use a different roid scheme than the samples so ignore it.
@@ -123,7 +123,7 @@ class ContactInfoFlowTest extends ResourceFlowTestCase<ContactInfoFlow, Contact>
     createTld("foobar");
     persistResource(DatabaseHelper.newDomain("example.foobar", persistContact(true)));
     // Check that the persisted contact info was returned.
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(
         loadFile("contact_info_response_linked.xml"),
         // We use a different roid scheme than the samples so ignore it.
@@ -137,7 +137,7 @@ class ContactInfoFlowTest extends ResourceFlowTestCase<ContactInfoFlow, Contact>
     setEppInput("contact_info_no_authinfo.xml");
     persistContact(true);
     // Check that the persisted contact info was returned.
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(
         loadFile("contact_info_response.xml"),
         // We use a different roid scheme than the samples so ignore it.
@@ -151,7 +151,7 @@ class ContactInfoFlowTest extends ResourceFlowTestCase<ContactInfoFlow, Contact>
     setRegistrarIdForFlow("NewRegistrar");
     persistContact(true);
     // Check that the persisted contact info was returned.
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     ResourceNotOwnedException thrown = assertThrows(ResourceNotOwnedException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
@@ -162,7 +162,7 @@ class ContactInfoFlowTest extends ResourceFlowTestCase<ContactInfoFlow, Contact>
     setEppInput("contact_info_no_authinfo.xml");
     persistContact(true);
     // Check that the persisted contact info was returned.
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(
         CommitMode.LIVE,
         UserPrivileges.SUPERUSER,
@@ -178,7 +178,7 @@ class ContactInfoFlowTest extends ResourceFlowTestCase<ContactInfoFlow, Contact>
     setRegistrarIdForFlow("NewRegistrar");
     persistContact(true);
     // Check that the persisted contact info was returned.
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(
         CommitMode.LIVE,
         UserPrivileges.SUPERUSER,

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferApproveFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferApproveFlowTest.java
@@ -69,7 +69,7 @@ class ContactTransferApproveFlowTest
     // Setup done; run the test.
     contact = reloadResourceByForeignKey();
     TransferData originalTransferData = contact.getTransferData();
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile(expectedXmlFilename));
 
     // Transfer should have succeeded. Verify correct fields were set.
@@ -120,7 +120,7 @@ class ContactTransferApproveFlowTest
   private void doFailingTest(String commandFilename) throws Exception {
     setEppInput(commandFilename);
     // Setup done; run the test.
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlow();
   }
 

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferCancelFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferCancelFlowTest.java
@@ -63,7 +63,7 @@ class ContactTransferCancelFlowTest
     // Setup done; run the test.
     contact = reloadResourceByForeignKey();
     TransferData originalTransferData = contact.getTransferData();
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile(expectedXmlFilename));
 
     // Transfer should have been cancelled. Verify correct fields were set.
@@ -104,7 +104,7 @@ class ContactTransferCancelFlowTest
   private void doFailingTest(String commandFilename) throws Exception {
     this.setEppInput(commandFilename);
     // Setup done; run the test.
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlow();
   }
 

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferQueryFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferQueryFlowTest.java
@@ -53,7 +53,7 @@ class ContactTransferQueryFlowTest
     setEppInput(commandFilename);
     eppLoader.replaceAll("JD1234-REP", contact.getRepoId());
     // Setup done; run the test.
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(loadFile(expectedXmlFilename));
     assertAboutContacts().that(reloadResourceByForeignKey(clock.nowUtc().minusDays(1)))
         .hasOneHistoryEntryEachOfTypes(HistoryEntry.Type.CONTACT_TRANSFER_REQUEST);
@@ -64,7 +64,7 @@ class ContactTransferQueryFlowTest
     setEppInput(commandFilename);
     eppLoader.replaceAll("JD1234-REP", contact.getRepoId());
     // Setup done; run the test.
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlow();
   }
 

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferRejectFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferRejectFlowTest.java
@@ -67,7 +67,7 @@ class ContactTransferRejectFlowTest
     // Setup done; run the test.
     contact = reloadResourceByForeignKey();
     TransferData originalTransferData = contact.getTransferData();
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile(expectedXmlFilename));
 
     // Transfer should have failed. Verify correct fields were set.
@@ -119,7 +119,7 @@ class ContactTransferRejectFlowTest
   private void doFailingTest(String commandFilename) throws Exception {
     setEppInput(commandFilename);
     // Setup done; run the test.
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlow();
   }
 

--- a/core/src/test/java/google/registry/flows/contact/ContactTransferRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactTransferRequestFlowTest.java
@@ -78,7 +78,7 @@ class ContactTransferRequestFlowTest
     DateTime afterTransfer = clock.nowUtc().plus(getContactAutomaticTransferLength());
 
     // Setup done; run the test.
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile(expectedXmlFilename));
 
     // Transfer should have been requested. Verify correct fields were set.
@@ -140,7 +140,7 @@ class ContactTransferRequestFlowTest
   private void doFailingTest(String commandFilename) throws Exception {
     setEppInput(commandFilename);
     // Setup done; run the test.
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlow();
   }
 

--- a/core/src/test/java/google/registry/flows/contact/ContactUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/contact/ContactUpdateFlowTest.java
@@ -53,7 +53,7 @@ class ContactUpdateFlowTest extends ResourceFlowTestCase<ContactUpdateFlow, Cont
 
   private void doSuccessfulTest() throws Exception {
     clock.advanceOneMilli();
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile("generic_success_response.xml"));
     Contact contact = reloadResourceByForeignKey();
     // Check that the contact was updated. This value came from the xml.

--- a/core/src/test/java/google/registry/flows/domain/DomainClaimsCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainClaimsCheckFlowTest.java
@@ -58,7 +58,7 @@ public class DomainClaimsCheckFlowTest extends ResourceFlowTestCase<DomainClaims
   }
 
   protected void doSuccessfulTest(String expectedXmlFilename) throws Exception {
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     assertNoHistory(); // Checks don't create a history event.
     assertNoBillingEvents(); // Checks are always free.
     runFlowAssertResponse(loadFile(expectedXmlFilename));
@@ -152,7 +152,7 @@ public class DomainClaimsCheckFlowTest extends ResourceFlowTestCase<DomainClaims
         ImmutableMap.of("example2", "2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001"));
     persistResource(
         loadRegistrar("TheRegistrar").asBuilder().setAllowedTlds(ImmutableSet.of()).build());
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     assertNoHistory(); // Checks don't create a history event.
     assertNoBillingEvents(); // Checks are always free.
     runFlowAssertResponse(

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -428,7 +428,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
       UserPrivileges userPrivileges,
       Map<String, String> substitutions)
       throws Exception {
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(
         CommitMode.LIVE, userPrivileges, loadFile(responseXmlFile, substitutions));
     assertSuccessfulCreate(domainTld, ImmutableSet.of());
@@ -613,7 +613,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     createTld("foo.tld");
     setEppInput("domain_create_with_tld.xml", ImmutableMap.of("TLD", "foo.tld"));
     persistContactsAndHosts("foo.tld");
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     String expectedResponseXml =
         loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "example.foo.tld"));
     runFlowAssertResponse(CommitMode.LIVE, UserPrivileges.NORMAL, expectedResponseXml);

--- a/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
@@ -152,7 +152,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
                 .setAutorenewPollMessage(autorenewPollMessage.createVKey())
                 .build());
 
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
   }
 
   private void createReferencedEntities(DateTime expirationTime) throws Exception {
@@ -217,7 +217,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
                 .setAutorenewBillingEvent(autorenewBillingEvent.createVKey())
                 .setAutorenewPollMessage(autorenewPollMessage.createVKey())
                 .build());
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
   }
 
   private void assertAutorenewClosedAndCancellationCreatedFor(

--- a/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
@@ -177,7 +177,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
       ImmutableMap<String, String> substitutions,
       boolean expectHistoryAndBilling)
       throws Exception {
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     String expected =
         loadFile(expectedXmlFilename, updateSubstitutions(substitutions, "ROID", "2FF-TLD"));
     if (inactive) {

--- a/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
@@ -250,7 +250,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
       RenewalPriceBehavior renewalPriceBehavior,
       @Nullable Money renewalPrice)
       throws Exception {
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     DateTime currentExpiration = reloadResourceByForeignKey().getRegistrationExpirationTime();
     DateTime newExpiration = currentExpiration.plusYears(renewalYears);
     runFlowAssertResponse(

--- a/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
@@ -163,7 +163,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
     setEppInput("domain_update_restore_request.xml", ImmutableMap.of("DOMAIN", "example.tld"));
     DateTime expirationTime = clock.nowUtc().plusYears(5).plusDays(45);
     persistPendingDeleteDomain(expirationTime);
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     // Double check that we see a poll message in the future for when the delete happens.
     assertThat(getPollMessages("TheRegistrar", clock.nowUtc().plusMonths(1))).hasSize(1);
     runFlowAssertResponse(loadFile("generic_success_response.xml"));
@@ -231,7 +231,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
     DateTime expirationTime = clock.nowUtc().minusDays(20);
     DateTime newExpirationTime = expirationTime.plusYears(1);
     persistPendingDeleteDomain(expirationTime);
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     // Double check that we see a poll message in the future for when the delete happens.
     assertThat(getPollMessages("TheRegistrar", clock.nowUtc().plusMonths(1))).hasSize(1);
     runFlowAssertResponse(loadFile("generic_success_response.xml"));

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
@@ -200,7 +200,7 @@ class DomainTransferApproveFlowTest
     assertThat(getPollMessages(domain, "TheRegistrar", clock.nowUtc().plusMonths(1))).hasSize(1);
     // Setup done; run the test.
     DomainTransferData originalTransferData = domain.getTransferData();
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile(expectedXmlFilename));
     // Transfer should have succeeded. Verify correct fields were set.
     domain = reloadResourceByForeignKey();
@@ -364,7 +364,7 @@ class DomainTransferApproveFlowTest
   private void doFailingTest(String commandFilename) throws Exception {
     setEppLoader(commandFilename);
     // Setup done; run the test.
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlow();
   }
 

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferCancelFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferCancelFlowTest.java
@@ -116,7 +116,7 @@ class DomainTransferCancelFlowTest
     clock.advanceOneMilli();
 
     // Setup done; run the test.
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     DateTime originalExpirationTime = domain.getRegistrationExpirationTime();
     ImmutableSet<GracePeriod> originalGracePeriods = domain.getGracePeriods();
     DomainTransferData originalTransferData = domain.getTransferData();
@@ -190,7 +190,7 @@ class DomainTransferCancelFlowTest
     // Replace the ROID in the xml file with the one generated in our test.
     eppLoader.replaceAll("JD1234-REP", contact.getRepoId());
     // Setup done; run the test.
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlow();
   }
 

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferQueryFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferQueryFlowTest.java
@@ -55,7 +55,7 @@ class DomainTransferQueryFlowTest
     // Replace the ROID in the xml file with the one generated in our test.
     eppLoader.replaceAll("JD1234-REP", contact.getRepoId());
     // Setup done; run the test.
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(loadFile(expectedXmlFilename));
     assertAboutDomains()
         .that(domain)
@@ -76,7 +76,7 @@ class DomainTransferQueryFlowTest
     // Replace the ROID in the xml file with the one generated in our test.
     eppLoader.replaceAll("JD1234-REP", contact.getRepoId());
     // Setup done; run the test.
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlow();
   }
 

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRejectFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRejectFlowTest.java
@@ -89,7 +89,7 @@ class DomainTransferRejectFlowTest
     assertThat(getPollMessages("NewRegistrar", clock.nowUtc().plusMonths(1))).hasSize(1);
     assertThat(getPollMessages("TheRegistrar", clock.nowUtc().plusMonths(1))).hasSize(1);
     // Setup done; run the test.
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     DateTime originalExpirationTime = domain.getRegistrationExpirationTime();
     ImmutableSet<GracePeriod> originalGracePeriods = domain.getGracePeriods();
     TransferData originalTransferData = domain.getTransferData();
@@ -152,7 +152,7 @@ class DomainTransferRejectFlowTest
     // Replace the ROID in the xml file with the one generated in our test.
     eppLoader.replaceAll("JD1234-REP", contact.getRepoId());
     // Setup done; run the test.
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlow();
   }
 

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
@@ -483,7 +483,7 @@ class DomainTransferRequestFlowTest
     Tld registry = Tld.get(domain.getTld());
     DateTime implicitTransferTime = clock.nowUtc().plus(registry.getAutomaticTransferLength());
     // Setup done; run the test.
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile(expectedXmlFilename, substitutions));
     // Transfer should have been requested.
     domain = reloadResourceByForeignKey();
@@ -583,7 +583,7 @@ class DomainTransferRequestFlowTest
     // the transfer timeline 3 days later by adjusting the implicit transfer time here.
     DateTime implicitTransferTime = clock.nowUtc().plus(expectedAutomaticTransferLength);
     // Setup done; run the test.
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(
         CommitMode.LIVE, UserPrivileges.SUPERUSER, loadFile(expectedXmlFilename, substitutions));
 
@@ -634,7 +634,7 @@ class DomainTransferRequestFlowTest
     // Replace the ROID in the xml file with the one generated in our test.
     eppLoader.replaceAll("JD1234-REP", contact.getRepoId());
     // Setup done; run the test.
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlow(CommitMode.LIVE, userPrivileges);
   }
 
@@ -1741,7 +1741,7 @@ class DomainTransferRequestFlowTest
         "domain_transfer_request_wildcard.xml",
         ImmutableMap.of("YEARS", "1", "DOMAIN", "--invalid", "EXDATE", "2002-09-08T22:00:00.0Z"));
     eppLoader.replaceAll("JD1234-REP", contact.getRepoId());
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     ResourceDoesNotExistException thrown =
         assertThrows(
             ResourceDoesNotExistException.class,

--- a/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
@@ -203,7 +203,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
   }
 
   private void doSuccessfulTest(String expectedXmlFilename) throws Exception {
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile(expectedXmlFilename));
     Domain domain = reloadResourceByForeignKey();
     // Check that the domain was updated. These values came from the xml.
@@ -341,7 +341,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .setRegistrant(contacts.get(3).getContactKey())
             .build());
     clock.advanceOneMilli();
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile("generic_success_response.xml"));
     Domain domain = reloadResourceByForeignKey();
     assertAboutDomains().that(domain).hasOneHistoryEntryEachOfTypes(DOMAIN_CREATE, DOMAIN_UPDATE);
@@ -407,7 +407,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
                         .createVKey()))
             .build());
     clock.advanceOneMilli();
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile("generic_success_response.xml"));
     domain = reloadResourceByForeignKey();
     assertThat(domain.getNameservers()).containsExactly(addedHost.createVKey());
@@ -490,7 +490,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .asBuilder()
             .setDsData(originalDsData)
             .build());
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     clock.advanceOneMilli();
     runFlowAssertResponse(loadFile("generic_success_response.xml"));
     Domain resource = reloadResourceByForeignKey();

--- a/core/src/test/java/google/registry/flows/host/HostCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostCreateFlowTest.java
@@ -81,7 +81,7 @@ class HostCreateFlowTest extends ResourceFlowTestCase<HostCreateFlow, Host> {
 
   private void doSuccessfulTest() throws Exception {
     clock.advanceOneMilli();
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile("host_create_response.xml"));
     Host host = reloadResourceByForeignKey();
     // Check that the host was created and persisted with a history entry.

--- a/core/src/test/java/google/registry/flows/host/HostDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostDeleteFlowTest.java
@@ -77,7 +77,7 @@ class HostDeleteFlowTest extends ResourceFlowTestCase<HostDeleteFlow, Host> {
   void testSuccess() throws Exception {
     persistActiveHost("ns1.example.tld");
     clock.advanceOneMilli();
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile("host_delete_response.xml"));
     assertSqlDeleteSuccess();
   }
@@ -87,7 +87,7 @@ class HostDeleteFlowTest extends ResourceFlowTestCase<HostDeleteFlow, Host> {
     setEppInput("host_delete_no_cltrid.xml", ImmutableMap.of("HOSTNAME", "ns1.example.tld"));
     persistActiveHost("ns1.example.tld");
     clock.advanceOneMilli();
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile("host_delete_response_no_cltrid.xml"));
     assertSqlDeleteSuccess();
   }

--- a/core/src/test/java/google/registry/flows/host/HostInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostInfoFlowTest.java
@@ -82,7 +82,7 @@ class HostInfoFlowTest extends ResourceFlowTestCase<HostInfoFlow, Host> {
   @Test
   void testSuccess() throws Exception {
     persistHost();
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     // Check that the persisted host info was returned.
     runFlowAssertResponse(
         loadFile("host_info_response.xml"),
@@ -100,7 +100,7 @@ class HostInfoFlowTest extends ResourceFlowTestCase<HostInfoFlow, Host> {
             .asBuilder()
             .addNameserver(persistHost().createVKey())
             .build());
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     // Check that the persisted host info was returned.
     runFlowAssertResponse(
         loadFile("host_info_response_linked.xml"),
@@ -131,7 +131,7 @@ class HostInfoFlowTest extends ResourceFlowTestCase<HostInfoFlow, Host> {
             .build());
     // we shouldn't have two active hosts with the same hostname
     deleteResource(firstHost);
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(
         loadFile("host_info_response_superordinate_clientid.xml"),
         // We use a different roid scheme than the samples so ignore it.

--- a/core/src/test/java/google/registry/flows/host/HostUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostUpdateFlowTest.java
@@ -160,7 +160,7 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
 
   private Host doSuccessfulTest(boolean isSuperuser) throws Exception {
     clock.advanceOneMilli();
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(
         CommitMode.LIVE,
         isSuperuser ? UserPrivileges.SUPERUSER : UserPrivileges.NORMAL,

--- a/core/src/test/java/google/registry/flows/poll/PollAckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/poll/PollAckFlowTest.java
@@ -96,7 +96,7 @@ class PollAckFlowTest extends FlowTestCase<PollAckFlow> {
             .setMsg("Some poll message.")
             .setHistoryEntry(createHistoryEntryForEppResource(contact))
             .build());
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile("poll_ack_response_empty.xml"));
   }
 
@@ -111,14 +111,14 @@ class PollAckFlowTest extends FlowTestCase<PollAckFlow> {
             .setMsg("Some poll message.")
             .setHistoryEntry(createHistoryEntryForEppResource(contact))
             .build());
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     assertThrows(MessageDoesNotExistException.class, this::runFlow);
   }
 
   @Test
   void testSuccess_messageOnContact() throws Exception {
     persistOneTimePollMessage(MESSAGE_ID);
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile("poll_ack_response_empty.xml"));
   }
 
@@ -126,7 +126,7 @@ class PollAckFlowTest extends FlowTestCase<PollAckFlow> {
   void testSuccess_recentActiveAutorenew() throws Exception {
     setEppInput("poll_ack.xml", ImmutableMap.of("MSGID", "3-2010"));
     persistAutorenewPollMessage(clock.nowUtc().minusMonths(6), END_OF_TIME);
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile("poll_ack_response_empty.xml"));
   }
 
@@ -139,7 +139,7 @@ class PollAckFlowTest extends FlowTestCase<PollAckFlow> {
     for (int i = 1; i < 4; i++) {
       persistOneTimePollMessage(MESSAGE_ID + i);
     }
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(
         loadFile("poll_ack_response.xml", ImmutableMap.of("MSGID", "3-2009", "COUNT", "4")));
   }
@@ -148,7 +148,7 @@ class PollAckFlowTest extends FlowTestCase<PollAckFlow> {
   void testSuccess_oldInactiveAutorenew() throws Exception {
     setEppInput("poll_ack.xml", ImmutableMap.of("MSGID", "3-2010"));
     persistAutorenewPollMessage(clock.nowUtc().minusMonths(6), clock.nowUtc());
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile("poll_ack_response_empty.xml"));
   }
 
@@ -158,14 +158,14 @@ class PollAckFlowTest extends FlowTestCase<PollAckFlow> {
     for (int i = 0; i < 5; i++) {
       persistOneTimePollMessage(MESSAGE_ID + i);
     }
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(
         loadFile("poll_ack_response.xml", ImmutableMap.of("MSGID", "3-2011", "COUNT", "4")));
   }
 
   @Test
   void testFailure_noSuchMessage() throws Exception {
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     Exception e = assertThrows(MessageDoesNotExistException.class, this::runFlow);
     assertThat(e).hasMessageThat().contains(String.format("(%d-2011)", MESSAGE_ID));
   }
@@ -173,14 +173,14 @@ class PollAckFlowTest extends FlowTestCase<PollAckFlow> {
   @Test
   void testFailure_invalidId_tooFewComponents() throws Exception {
     setEppInput("poll_ack.xml", ImmutableMap.of("MSGID", "1"));
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     assertThrows(InvalidMessageIdException.class, this::runFlow);
   }
 
   @Test
   void testFailure_invalidId_tooManyComponents() throws Exception {
     setEppInput("poll_ack.xml", ImmutableMap.of("MSGID", "2-2-1999-2007"));
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     assertThrows(InvalidMessageIdException.class, this::runFlow);
   }
 
@@ -195,21 +195,21 @@ class PollAckFlowTest extends FlowTestCase<PollAckFlow> {
             .setMsg("Some poll message.")
             .setHistoryEntry(createHistoryEntryForEppResource(contact))
             .build());
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     assertThrows(InvalidMessageIdException.class, this::runFlow);
   }
 
   @Test
   void testFailure_invalidId_stringInsteadOfNumeric() throws Exception {
     setEppInput("poll_ack.xml", ImmutableMap.of("MSGID", "ABC-12345"));
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     assertThrows(InvalidMessageIdException.class, this::runFlow);
   }
 
   @Test
   void testFailure_missingId() throws Exception {
     setEppInput("poll_ack_missing_id.xml");
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     assertThrows(MissingMessageIdException.class, this::runFlow);
   }
 
@@ -223,7 +223,7 @@ class PollAckFlowTest extends FlowTestCase<PollAckFlow> {
             .setMsg("Some poll message.")
             .setHistoryEntry(createHistoryEntryForEppResource(domain))
             .build());
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     assertThrows(NotAuthorizedToAckMessageException.class, this::runFlow);
   }
 
@@ -237,7 +237,7 @@ class PollAckFlowTest extends FlowTestCase<PollAckFlow> {
             .setMsg("Some poll message.")
             .setHistoryEntry(createHistoryEntryForEppResource(domain))
             .build());
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     Exception e = assertThrows(MessageDoesNotExistException.class, this::runFlow);
     assertThat(e).hasMessageThat().contains(String.format("(%d-2011)", MESSAGE_ID));
   }

--- a/core/src/test/java/google/registry/flows/poll/PollRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/poll/PollRequestFlowTest.java
@@ -87,7 +87,7 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
   @Test
   void testSuccess_domainTransferApproved() throws Exception {
     persistPendingTransferPollMessage();
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(loadFile("poll_response_domain_transfer.xml"));
   }
 
@@ -95,7 +95,7 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
   void testSuccess_clTridNotSpecified() throws Exception {
     setEppInput("poll_no_cltrid.xml");
     persistPendingTransferPollMessage();
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(loadFile("poll_response_domain_transfer_no_cltrid.xml"));
   }
 
@@ -120,7 +120,7 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
                         .build()))
             .setHistoryEntry(createHistoryEntryForEppResource(contact))
             .build());
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(loadFile("poll_response_contact_transfer.xml"));
   }
 
@@ -140,7 +140,7 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
                         clock.nowUtc())))
             .setHistoryEntry(createHistoryEntryForEppResource(domain))
             .build());
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(loadFile("poll_response_domain_pending_notification.xml"));
   }
 
@@ -164,7 +164,7 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
                         clock.nowUtc())))
             .setHistoryEntry(createHistoryEntryForEppResource(domain))
             .build());
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(loadFile("poll_message_domain_pending_action_immediate_delete.xml"));
   }
 
@@ -178,7 +178,7 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
             .setTargetId("test.example")
             .setHistoryEntry(createHistoryEntryForEppResource(domain))
             .build());
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(loadFile("poll_response_autorenew.xml"));
   }
 
@@ -221,7 +221,7 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
             .setTargetId("target.example")
             .setHistoryEntry(createHistoryEntryForEppResource(domain))
             .build());
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(loadFile("poll_response_empty.xml"));
   }
 
@@ -244,7 +244,7 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
             .setHistoryEntry(historyEntry)
             .setEventTime(clock.nowUtc().minusDays(1))
             .build());
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(loadFile("poll_response_contact_delete.xml"));
   }
 
@@ -268,14 +268,14 @@ class PollRequestFlowTest extends FlowTestCase<PollRequestFlow> {
             .setEventTime(clock.nowUtc().minusDays(1))
             .build());
     clock.advanceOneMilli();
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(loadFile("poll_response_host_delete.xml"));
   }
 
   @Test
   void testFailure_messageIdProvided() throws Exception {
     setEppInput("poll_with_id.xml");
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     EppException thrown = assertThrows(UnexpectedMessageIdException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }

--- a/core/src/test/java/google/registry/flows/session/HelloFlowTest.java
+++ b/core/src/test/java/google/registry/flows/session/HelloFlowTest.java
@@ -30,7 +30,7 @@ class HelloFlowTest extends FlowTestCase<HelloFlow> {
   @Test
   void testHello() throws Exception {
     setEppInput("hello.xml");
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     runFlowAssertResponse(
         loadFile(
             "greeting.xml", ImmutableMap.of("DATE", clock.nowUtc().toString(dateTimeNoMillis()))));

--- a/core/src/test/java/google/registry/flows/session/LoginFlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/session/LoginFlowTestCase.java
@@ -62,7 +62,7 @@ public abstract class LoginFlowTestCase extends FlowTestCase<LoginFlow> {
   // Also called in subclasses.
   void doSuccessfulTest(String xmlFilename) throws Exception {
     setEppInput(xmlFilename);
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile("generic_success_response.xml"));
   }
 
@@ -81,7 +81,7 @@ public abstract class LoginFlowTestCase extends FlowTestCase<LoginFlow> {
   @Test
   void testSuccess_setsIsLoginResponse() throws Exception {
     setEppInput("login_valid.xml");
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     EppOutput output = runFlow();
     assertThat(output.getResponse().isLoginResponse()).isTrue();
   }
@@ -125,7 +125,7 @@ public abstract class LoginFlowTestCase extends FlowTestCase<LoginFlow> {
     assertThat(registrar.verifyPassword("randomstring")).isFalse();
 
     setEppInput("login_set_new_password.xml", ImmutableMap.of("NEWPW", "ANewPassword"));
-    assertTransactionalFlow(true);
+    assertMutatingFlow(true);
     runFlowAssertResponse(loadFile("generic_success_response.xml"));
 
     Registrar newRegistrar = loadRegistrar("NewRegistrar");

--- a/core/src/test/java/google/registry/flows/session/LogoutFlowTest.java
+++ b/core/src/test/java/google/registry/flows/session/LogoutFlowTest.java
@@ -38,7 +38,7 @@ class LogoutFlowTest extends FlowTestCase<LogoutFlow> {
 
   @Test
   void testSuccess() throws Exception {
-    assertTransactionalFlow(false);
+    assertMutatingFlow(false);
     // All flow tests are implicitly logged in, so logout should work.
     runFlowAssertResponse(loadFile("logout_response.xml"));
   }


### PR DESCRIPTION
…lFlow

The old semantics for TransactionalFlow meant "anything that needs to mutate the database", but then FlowRunner was not creating transactions for non-transactional flows even though nearly every flow needs a transaction (as nearly every flow needs to hit the database for some purpose).  So now TransactionalFlow simply means "any flow that needs the database", and MutatingFlow means "a flow that mutates the database". In the future we will have FlowRunner use a read-only transaction for TransactionalFlow and then a normal writes-allowed transaction for MutatingFlow. That is a TODO.

This also fixes up some transact() calls inside caches to be reTransact(), as we rightly can't move the transaction outside them as from some callsites we legitimately do not know whether a transaction will be needed at all (depending on whether said data is already in memory). And it removes the replicaTm() calls which weren't actually doing anything as they were always nested inside of normal tm()s, thus causing confusion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2129)
<!-- Reviewable:end -->
