### PR TITLE
Use gmail to send invoices

### DIFF
--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -724,6 +724,18 @@ public final class RegistryConfig {
     }
 
     /**
+     * Returns an optional return email address that overrides the default {@code reply-to} address
+     * in outgoing invoicing email messages.
+     */
+    @Provides
+    @Config("invoiceReplyToEmailAddress")
+    public static Optional<InternetAddress> provideInvoiceReplyToEmailAddress(
+        RegistryConfigSettings config) {
+      return Optional.ofNullable(config.billing.invoiceReplyToEmailAddress)
+          .map(RegistryConfig::parseEmailAddress);
+    }
+
+    /**
      * Returns the file prefix for the invoice CSV file.
      *
      * @see google.registry.beam.billing.InvoicingPipeline

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -170,6 +170,7 @@ public class RegistryConfigSettings {
   /** Configuration for monthly invoices. */
   public static class Billing {
     public List<String> invoiceEmailRecipients;
+    public String invoiceReplyToEmailAddress;
     public String invoiceFilePrefix;
   }
 

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -382,6 +382,8 @@ icannReporting:
 
 billing:
   invoiceEmailRecipients: []
+  # Optional return address that overrides the default.
+  invoiceReplyToEmailAddress: null
   invoiceFilePrefix: REG-INV
 
 rde:

--- a/core/src/main/java/google/registry/groups/GmailClient.java
+++ b/core/src/main/java/google/registry/groups/GmailClient.java
@@ -120,7 +120,8 @@ public final class GmailClient {
       MimeMessage msg =
           new MimeMessage(Session.getDefaultInstance(new Properties(), /* authenticator= */ null));
       msg.setFrom(this.outgoingEmailAddressWithUsername);
-      msg.setReplyTo(new InternetAddress[] {replyToEmailAddress});
+      msg.setReplyTo(
+          new InternetAddress[] {emailMessage.replyToEmailAddress().orElse(replyToEmailAddress)});
       msg.addRecipients(
           RecipientType.TO, toArray(emailMessage.recipients(), InternetAddress.class));
       msg.setSubject(emailMessage.subject());

--- a/core/src/test/java/google/registry/groups/GmailClientTest.java
+++ b/core/src/test/java/google/registry/groups/GmailClientTest.java
@@ -125,6 +125,9 @@ public class GmailClientTest {
     assertThat(mimeMessage.getRecipients(RecipientType.TO)).asList().containsExactly(toAddr);
     assertThat(mimeMessage.getRecipients(RecipientType.CC)).asList().containsExactly(ccAddr);
     assertThat(mimeMessage.getRecipients(RecipientType.BCC)).asList().containsExactly(bccAddr);
+    assertThat(mimeMessage.getReplyTo())
+        .asList()
+        .containsExactly(new InternetAddress("replyTo@example.com"));
     assertThat(mimeMessage.getSubject()).isEqualTo("My subject");
     assertThat(mimeMessage.getContent()).isInstanceOf(MimeMultipart.class);
     MimeMultipart parts = (MimeMultipart) mimeMessage.getContent();
@@ -135,6 +138,23 @@ public class GmailClientTest {
     assertThat(attachment.getContentType()).startsWith(CSV_UTF_8.toString());
     assertThat(attachment.getContentType()).endsWith("name=filename");
     assertThat(attachment.getContent()).isEqualTo("foo,bar\nbaz,qux");
+  }
+
+  @Test
+  public void toMimeMessage_overrideReplyToAddr() throws Exception {
+    InternetAddress fromAddr = new InternetAddress("from@example.com", "My sender");
+    InternetAddress toAddr = new InternetAddress("to@example.com");
+    InternetAddress replyToAddr = new InternetAddress("some-addr@another.com");
+    EmailMessage emailMessage =
+        EmailMessage.newBuilder()
+            .setFrom(fromAddr)
+            .setRecipients(ImmutableList.of(toAddr))
+            .setReplyToEmailAddress(replyToAddr)
+            .setSubject("My subject")
+            .setBody("My body")
+            .build();
+    MimeMessage mimeMessage = getGmailClient(true).toMimeMessage(emailMessage);
+    assertThat(mimeMessage.getReplyTo()).asList().containsExactly(replyToAddr);
   }
 
   @Test

--- a/util/src/main/java/google/registry/util/EmailMessage.java
+++ b/util/src/main/java/google/registry/util/EmailMessage.java
@@ -49,6 +49,9 @@ public abstract class EmailMessage {
   // TODO(b/279671974): remove `from` after migration.
   public abstract InternetAddress from();
 
+  /** Optional return email address that overrides the default. */
+  public abstract Optional<InternetAddress> replyToEmailAddress();
+
   public abstract ImmutableSet<InternetAddress> ccs();
 
   public abstract ImmutableSet<InternetAddress> bccs();
@@ -68,6 +71,10 @@ public abstract class EmailMessage {
     public abstract Builder setRecipients(Collection<InternetAddress> recipients);
 
     public abstract Builder setFrom(InternetAddress from);
+
+    public abstract Builder setReplyToEmailAddress(InternetAddress replyToEmailAddress);
+
+    public abstract Builder setReplyToEmailAddress(Optional<InternetAddress> replyToEmailAddress);
 
     public abstract Builder setBccs(Collection<InternetAddress> bccs);
 


### PR DESCRIPTION
Added support for an optional `reply-to` address for invoicing messages, since these messages are confidential and may not be appropriate for the default address.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2130)
<!-- Reviewable:end -->
