### PR TITLE
Use registrar ID, not name, in selector

### DIFF
--- a/console-webapp/src/app/registrar/registrar-selector.component.html
+++ b/console-webapp/src/app/registrar/registrar-selector.component.html
@@ -8,9 +8,9 @@
       >
         <mat-option
           *ngFor="let registrar of registrarService.registrars"
-          [value]="registrar.registrarName"
+          [value]="registrar.registrarId"
         >
-          {{ registrar.registrarName }}
+          {{ registrar.registrarId }}
         </mat-option>
       </mat-select>
     </mat-form-field>


### PR DESCRIPTION
We set the active registrar ID based on this choice so it needs to be the ID, not the name

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2138)
<!-- Reviewable:end -->
