### PR TITLE
Pass around the full URL in RegistrarGuard

### DIFF
--- a/console-webapp/src/app/registrar/registrar.guard.spec.ts
+++ b/console-webapp/src/app/registrar/registrar.guard.spec.ts
@@ -39,7 +39,7 @@ describe('RegistrarGuard', () => {
 
   it('should not be able to activate when activeRegistrarId is empty', () => {
     guard = TestBed.inject(RegistrarGuard);
-    const res = guard.canActivate(dummyRoute);
+    const res = guard.canActivate();
     expect(res).toBeFalsy();
   });
 
@@ -48,14 +48,14 @@ describe('RegistrarGuard', () => {
       useValue: { activeRegistrarId: 'value' },
     });
     guard = TestBed.inject(RegistrarGuard);
-    const res = guard.canActivate(dummyRoute);
+    const res = guard.canActivate();
     expect(res).toBeTrue();
   });
 
   it('should navigate to registrars when activeRegistrarId is empty', () => {
     const dummyRoute = { url: '/value' } as RouterStateSnapshot;
     guard = TestBed.inject(RegistrarGuard);
-    guard.canActivate(dummyRoute);
+    guard.canActivate();
     expect(routeSpy.navigate).toHaveBeenCalledOnceWith([
       '/registrars',
       { nextUrl: '/value' },

--- a/console-webapp/src/app/registrar/registrar.guard.ts
+++ b/console-webapp/src/app/registrar/registrar.guard.ts
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 import { Injectable } from '@angular/core';
-import { Router, RouterStateSnapshot } from '@angular/router';
+import { Router } from '@angular/router';
+
 import { RegistrarService } from './registrar.service';
 
 @Injectable({
@@ -25,10 +26,12 @@ export class RegistrarGuard {
     private registrarService: RegistrarService
   ) {}
 
-  canActivate(state: RouterStateSnapshot): Promise<boolean> | boolean {
+  canActivate(): Promise<boolean> | boolean {
     if (this.registrarService.activeRegistrarId) {
       return true;
     }
-    return this.router.navigate([`/empty-registrar`, { nextUrl: state.url }]);
+    // Get the full URL including any nested children (skip the initial '#/')
+    const nextUrl = location.hash.split('#/')[1];
+    return this.router.navigate([`/empty-registrar`, { nextUrl }]);
   }
 }


### PR DESCRIPTION
Previously this didn't properly deal with nested routings, e.g. "settings/whois". It tried to just pass "whois" as the next url which doesn't work with the router because it's nested under the settings. Using all parts of the URL allows us to handle the nesting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2139)
<!-- Reviewable:end -->
