### PR TITLE
Use PrintStream in ConfirmingCommand

### DIFF
--- a/core/src/main/java/google/registry/tools/ConfirmingCommand.java
+++ b/core/src/main/java/google/registry/tools/ConfirmingCommand.java
@@ -31,10 +31,12 @@ public abstract class ConfirmingCommand implements Command {
   boolean force;
 
   public PrintStream printStream;
+  public PrintStream errorPrintStream;
 
   protected ConfirmingCommand() {
     try {
       printStream = new PrintStream(System.out, false, UTF_8.name());
+      errorPrintStream = new PrintStream(System.err, false, UTF_8.name());
     } catch (UnsupportedEncodingException e) {
       throw new RuntimeException(e);
     }
@@ -58,6 +60,7 @@ public abstract class ConfirmingCommand implements Command {
       }
     }
     printStream.close();
+    errorPrintStream.close();
   }
 
   /** Run any pre-execute command checks and return true if they all pass. */

--- a/core/src/main/java/google/registry/tools/ConfirmingCommand.java
+++ b/core/src/main/java/google/registry/tools/ConfirmingCommand.java
@@ -15,9 +15,12 @@
 package google.registry.tools;
 
 import static google.registry.tools.CommandUtilities.promptForYes;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.beust.jcommander.Parameter;
 import com.google.common.base.Strings;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 
 /** A {@link Command} that implements a confirmation step before executing. */
 public abstract class ConfirmingCommand implements Command {
@@ -27,23 +30,34 @@ public abstract class ConfirmingCommand implements Command {
       description = "Do not prompt before executing")
   boolean force;
 
+  public PrintStream printStream;
+
+  protected ConfirmingCommand() {
+    try {
+      printStream = new PrintStream(System.out, false, UTF_8.name());
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   @Override
   public final void run() throws Exception {
     if (checkExecutionState()) {
       init();
-      printLineIfNotEmpty(prompt());
+      printLineIfNotEmpty(prompt(), printStream);
       if (dontRunCommand()) {
         // This typically happens when all of the work is accomplished inside of prompt(), so do
         // nothing further.
         return;
       } else if (force || promptForYes("Perform this command?")) {
-        System.out.println("Running ... ");
-        System.out.println(execute());
-        printLineIfNotEmpty(postExecute());
+        printStream.println("Running ... ");
+        printStream.println(execute());
+        printLineIfNotEmpty(postExecute(), printStream);
       } else {
-        System.out.println("Command aborted.");
+        printStream.println("Command aborted.");
       }
     }
+    printStream.close();
   }
 
   /** Run any pre-execute command checks and return true if they all pass. */
@@ -76,9 +90,9 @@ public abstract class ConfirmingCommand implements Command {
   }
 
   /** Prints the provided text with a trailing newline, if text is not null or empty. */
-  private static void printLineIfNotEmpty(String text) {
+  private static void printLineIfNotEmpty(String text, PrintStream printStream) {
     if (!Strings.isNullOrEmpty(text)) {
-      System.out.println(text);
+      printStream.println(text);
     }
   }
 }

--- a/core/src/main/java/google/registry/tools/CreateDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateDomainCommand.java
@@ -78,7 +78,7 @@ final class CreateDomainCommand extends CreateOrUpdateDomainCommand {
         Money createCost = prices.getCreateCost();
         currency = createCost.getCurrencyUnit().getCode();
         cost = createCost.multipliedBy(period).getAmount().toString();
-        System.out.printf(
+        printStream.printf(
             "NOTE: %s is premium at %s per year; sending total cost for %d year(s) of %s %s.\n",
             domain, createCost, period, currency, cost);
       }

--- a/core/src/main/java/google/registry/tools/CreateOrUpdateTldCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdateTldCommand.java
@@ -19,7 +19,6 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static google.registry.tools.UpdateOrDeleteAllocationTokensCommand.getTokenKeys;
 import static google.registry.util.CollectionUtils.findDuplicates;
 import static google.registry.util.DomainNameUtils.canonicalizeHostname;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.beust.jcommander.Parameter;
 import com.google.common.base.Joiner;
@@ -40,7 +39,6 @@ import google.registry.tools.params.OptionalStringParameter;
 import google.registry.tools.params.StringListParameter;
 import google.registry.tools.params.TransitionListParameter.BillingCostTransitions;
 import google.registry.tools.params.TransitionListParameter.TldStateTransitions;
-import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.List;
@@ -478,12 +476,10 @@ abstract class CreateOrUpdateTldCommand extends MutatingCommand {
       String errMsg = String.format("The reserved list(s) %s cannot be applied to the tld %s",
           Joiner.on(", ").join(invalidNames),
           tld);
-      try (PrintStream errorPrintStream = new PrintStream(System.err, false, UTF_8.name())) {
-        if (overrideReservedListRules) {
-          errorPrintStream.println("Error overridden: " + errMsg);
-        } else {
-          throw new IllegalArgumentException(errMsg);
-        }
+      if (overrideReservedListRules) {
+        errorPrintStream.println("Error overridden: " + errMsg);
+      } else {
+        throw new IllegalArgumentException(errMsg);
       }
     }
   }

--- a/core/src/main/java/google/registry/tools/CreateOrUpdateTldCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdateTldCommand.java
@@ -362,13 +362,11 @@ abstract class CreateOrUpdateTldCommand extends MutatingCommand {
       if (!renewBillingCostTransitions.isEmpty()) {
         // TODO(b/20764952): need invoicing support for multiple renew billing costs.
         if (renewBillingCostTransitions.size() > 1) {
-          try (PrintStream errorPrintStream = new PrintStream(System.err, false, UTF_8.name())) {
-            errorPrintStream.println(
-                "----------------------\n"
-                    + "WARNING: Do not set multiple renew cost transitions "
-                    + "until b/20764952 is fixed.\n"
-                    + "----------------------\n");
-          }
+          errorPrintStream.println(
+              "----------------------\n"
+                  + "WARNING: Do not set multiple renew cost transitions "
+                  + "until b/20764952 is fixed.\n"
+                  + "----------------------\n");
         }
         builder.setRenewBillingCostTransitions(renewBillingCostTransitions);
       }

--- a/core/src/main/java/google/registry/tools/DeleteAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/DeleteAllocationTokensCommand.java
@@ -85,7 +85,7 @@ final class DeleteAllocationTokensCommand extends UpdateOrDeleteAllocationTokens
     if (!dryRun) {
       tm().delete(tokensToDelete);
     }
-    System.out.printf(
+    printStream.printf(
         "%s tokens: %s\n",
         dryRun ? "Would delete" : "Deleted",
         JOINER.join(tokensToDelete.stream().map(VKey::getKey).sorted().collect(toImmutableList())));

--- a/core/src/main/java/google/registry/tools/LoadTestCommand.java
+++ b/core/src/main/java/google/registry/tools/LoadTestCommand.java
@@ -14,7 +14,6 @@
 
 package google.registry.tools;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
@@ -23,8 +22,6 @@ import com.google.common.net.MediaType;
 import google.registry.loadtest.LoadTestAction;
 import google.registry.model.registrar.Registrar;
 import google.registry.model.tld.Tlds;
-import java.io.PrintStream;
-import java.io.UnsupportedEncodingException;
 
 /** Command to initiate a load-test. */
 @Parameters(separators = " =", commandDescription = "Run a load test.")
@@ -82,16 +79,6 @@ class LoadTestCommand extends ConfirmingCommand implements CommandWithConnection
 
   private ServiceConnection connection;
 
-  PrintStream errorPrintStream;
-
-  protected LoadTestCommand() {
-    try {
-      errorPrintStream = new PrintStream(System.err, false, UTF_8.name());
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
   @Override
   public void setConnection(ServiceConnection connection) {
     this.connection = connection;
@@ -119,7 +106,6 @@ class LoadTestCommand extends ConfirmingCommand implements CommandWithConnection
 
   private void printError(String errorMessage) {
     errorPrintStream.println(errorMessage);
-    errorPrintStream.close();
   }
 
   @Override

--- a/core/src/main/java/google/registry/tools/LoadTestCommand.java
+++ b/core/src/main/java/google/registry/tools/LoadTestCommand.java
@@ -87,25 +87,21 @@ class LoadTestCommand extends ConfirmingCommand implements CommandWithConnection
   @Override
   protected boolean checkExecutionState() {
     if (RegistryToolEnvironment.get() == RegistryToolEnvironment.PRODUCTION) {
-      printError("You may not run a load test against production.");
+      errorPrintStream.println("You may not run a load test against production.");
       return false;
     }
 
     // Check validity of TLD and Client Id.
     if (!Tlds.getTlds().contains(tld)) {
-      printError(String.format("No such TLD: %s\n", tld));
+      errorPrintStream.printf("No such TLD: %s\n", tld);
       return false;
     }
     if (!Registrar.loadByRegistrarId(clientId).isPresent()) {
-      printError(String.format("No such client: %s\n", clientId));
+      errorPrintStream.printf("No such client: %s\n", clientId);
       return false;
     }
 
     return true;
-  }
-
-  private void printError(String errorMessage) {
-    errorPrintStream.println(errorMessage);
   }
 
   @Override
@@ -117,7 +113,7 @@ class LoadTestCommand extends ConfirmingCommand implements CommandWithConnection
 
   @Override
   protected String execute() throws Exception {
-    printError("Initiating load test...");
+    errorPrintStream.println("Initiating load test...");
 
     ImmutableMap<String, Object> params = new ImmutableMap.Builder<String, Object>()
         .put("tld", tld)

--- a/core/src/main/java/google/registry/tools/LockOrUnlockDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/LockOrUnlockDomainCommand.java
@@ -71,7 +71,7 @@ public abstract class LockOrUnlockDomainCommand extends ConfirmingCommand {
     }
     String duplicates = Joiner.on(", ").join(findDuplicates(mainParameters));
     checkArgument(duplicates.isEmpty(), "Duplicate domain arguments found: '%s'", duplicates);
-    System.out.println(
+    printStream.println(
         "== ENSURE THAT YOU HAVE AUTHENTICATED THE REGISTRAR BEFORE RUNNING THIS COMMAND ==");
   }
 

--- a/core/src/main/java/google/registry/tools/UnrenewDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/UnrenewDomainCommand.java
@@ -24,6 +24,7 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static google.registry.util.DateTimeUtils.isBeforeOrAt;
 import static google.registry.util.DateTimeUtils.leapSafeSubtractYears;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
@@ -42,6 +43,8 @@ import google.registry.model.poll.PollMessage;
 import google.registry.model.reporting.HistoryEntry.Type;
 import google.registry.util.Clock;
 import google.registry.util.NonFinalForTesting;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -76,7 +79,7 @@ class UnrenewDomainCommand extends ConfirmingCommand {
           StatusValue.SERVER_UPDATE_PROHIBITED);
 
   @Override
-  protected void init() {
+  protected void init() throws UnsupportedEncodingException {
     checkArgument(period >= 1 && period <= 9, "Period must be in the range 1-9");
     DateTime now = clock.nowUtc();
     ImmutableSet.Builder<String> domainsNonexistentBuilder = new ImmutableSet.Builder<>();
@@ -116,21 +119,27 @@ class UnrenewDomainCommand extends ConfirmingCommand {
             && domainsDeleting.isEmpty()
             && domainsWithDisallowedStatuses.isEmpty()
             && domainsExpiringTooSoon.isEmpty());
+
+    PrintStream errorPrintStream = new PrintStream(System.err, false, UTF_8.name());
     if (foundInvalidDomains) {
-      System.err.print("Found domains that cannot be unrenewed for the following reasons:\n\n");
+      errorPrintStream.print(
+          "Found domains that cannot be unrenewed for the following reasons:\n\n");
     }
     if (!domainsNonexistent.isEmpty()) {
-      System.err.printf("Domains that don't exist: %s\n\n", domainsNonexistent);
+      errorPrintStream.printf("Domains that don't exist: %s\n\n", domainsNonexistent);
     }
     if (!domainsDeleting.isEmpty()) {
-      System.err.printf("Domains that are deleted or pending delete: %s\n\n", domainsDeleting);
+      errorPrintStream.printf(
+          "Domains that are deleted or pending delete: %s\n\n", domainsDeleting);
     }
     if (!domainsWithDisallowedStatuses.isEmpty()) {
-      System.err.printf("Domains with disallowed statuses: %s\n\n", domainsWithDisallowedStatuses);
+      errorPrintStream.printf(
+          "Domains with disallowed statuses: %s\n\n", domainsWithDisallowedStatuses);
     }
     if (!domainsExpiringTooSoon.isEmpty()) {
-      System.err.printf("Domains expiring too soon: %s\n\n", domainsExpiringTooSoon);
+      errorPrintStream.printf("Domains expiring too soon: %s\n\n", domainsExpiringTooSoon);
     }
+    errorPrintStream.close();
     checkArgument(!foundInvalidDomains, "Aborting because some domains cannot be unrenewed");
   }
 
@@ -154,7 +163,7 @@ class UnrenewDomainCommand extends ConfirmingCommand {
   protected String execute() {
     for (String domainName : mainParameters) {
       tm().transact(() -> unrenewDomain(domainName));
-      System.out.printf("Unrenewed %s\n", domainName);
+      printStream.printf("Unrenewed %s\n", domainName);
     }
     return "Successfully unrenewed all domains.";
   }

--- a/core/src/main/java/google/registry/tools/UnrenewDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/UnrenewDomainCommand.java
@@ -24,7 +24,6 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static google.registry.util.DateTimeUtils.isBeforeOrAt;
 import static google.registry.util.DateTimeUtils.leapSafeSubtractYears;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
@@ -43,7 +42,6 @@ import google.registry.model.poll.PollMessage;
 import google.registry.model.reporting.HistoryEntry.Type;
 import google.registry.util.Clock;
 import google.registry.util.NonFinalForTesting;
-import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.Optional;
@@ -120,7 +118,6 @@ class UnrenewDomainCommand extends ConfirmingCommand {
             && domainsWithDisallowedStatuses.isEmpty()
             && domainsExpiringTooSoon.isEmpty());
 
-    PrintStream errorPrintStream = new PrintStream(System.err, false, UTF_8.name());
     if (foundInvalidDomains) {
       errorPrintStream.print(
           "Found domains that cannot be unrenewed for the following reasons:\n\n");
@@ -139,7 +136,6 @@ class UnrenewDomainCommand extends ConfirmingCommand {
     if (!domainsExpiringTooSoon.isEmpty()) {
       errorPrintStream.printf("Domains expiring too soon: %s\n\n", domainsExpiringTooSoon);
     }
-    errorPrintStream.close();
     checkArgument(!foundInvalidDomains, "Aborting because some domains cannot be unrenewed");
   }
 

--- a/core/src/main/java/google/registry/tools/UpdateAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdateAllocationTokensCommand.java
@@ -208,7 +208,7 @@ final class UpdateAllocationTokensCommand extends UpdateOrDeleteAllocationTokens
     if (!dryRun) {
       tm().putAll(batch);
     }
-    System.out.printf(
+    printStream.printf(
         "%s tokens: %s\n",
         dryRun ? "Would update" : "Updated",
         JOINER.join(

--- a/core/src/main/java/google/registry/tools/javascrap/CreateCancellationsForBillingEventsCommand.java
+++ b/core/src/main/java/google/registry/tools/javascrap/CreateCancellationsForBillingEventsCommand.java
@@ -70,14 +70,14 @@ public class CreateCancellationsForBillingEventsCommand extends ConfirmingComman
               }
             });
     billingEventsToCancel = billingEventsBuilder.build();
-    System.out.printf("Found %d BillingEvent(s) to cancel\n", billingEventsToCancel.size());
+    printStream.printf("Found %d BillingEvent(s) to cancel\n", billingEventsToCancel.size());
     ImmutableSet<Long> missingIds = missingIdsBuilder.build();
     if (!missingIds.isEmpty()) {
-      System.out.printf("Missing BillingEvent(s) for IDs %s\n", missingIds);
+      printStream.printf("Missing BillingEvent(s) for IDs %s\n", missingIds);
     }
     ImmutableSet<Long> alreadyCancelledIds = alreadyCancelledIdsBuilder.build();
     if (!alreadyCancelledIds.isEmpty()) {
-      System.out.printf(
+      printStream.printf(
           "The following BillingEvent IDs were already cancelled: %s\n", alreadyCancelledIds);
     }
   }
@@ -96,7 +96,7 @@ public class CreateCancellationsForBillingEventsCommand extends ConfirmingComman
           tm().transact(
                   () -> {
                     if (alreadyCancelled(billingEvent)) {
-                      System.out.printf(
+                      printStream.printf(
                           "BillingEvent %d already cancelled, this is unexpected.\n",
                           billingEvent.getId());
                       return 0;
@@ -111,7 +111,7 @@ public class CreateCancellationsForBillingEventsCommand extends ConfirmingComman
                                 .setReason(BillingBase.Reason.ERROR)
                                 .setTargetId(billingEvent.getTargetId())
                                 .build());
-                    System.out.printf(
+                    printStream.printf(
                         "Added BillingCancellation for BillingEvent with ID %d\n",
                         billingEvent.getId());
                     return 1;

--- a/core/src/test/java/google/registry/tools/CommandTestCase.java
+++ b/core/src/test/java/google/registry/tools/CommandTestCase.java
@@ -198,7 +198,7 @@ public abstract class CommandTestCase<C extends Command> {
   }
 
   void assertInStderr(String... expected) {
-    String stderror = new String(stderr.toByteArray(), UTF_8);
+    String stderror = getStderrAsString();
     for (String line : expected) {
       assertThat(stderror).contains(line);
     }

--- a/core/src/test/java/google/registry/tools/CreateDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateDomainCommandTest.java
@@ -38,6 +38,7 @@ class CreateDomainCommandTest extends EppToolCommandTestCase<CreateDomainCommand
   @BeforeEach
   void beforeEach() {
     command.passwordGenerator = new DeterministicStringGenerator("abcdefghijklmnopqrstuvwxyz");
+    command.printStream = System.out;
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/CreateRegistrarCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateRegistrarCommandTest.java
@@ -68,6 +68,7 @@ class CreateRegistrarCommandTest extends CommandTestCase<CreateRegistrarCommand>
             2048,
             ImmutableSet.of("secp256r1", "secp384r1"),
             fakeClock);
+    command.printStream = System.out;
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/CreateRegistrarGroupsCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateRegistrarGroupsCommandTest.java
@@ -37,6 +37,7 @@ class CreateRegistrarGroupsCommandTest extends CommandTestCase<CreateRegistrarGr
 
   @Test
   void test_createGroupsForTwoRegistrars() throws Exception {
+    command.printStream = System.out;
     runCommandForced("NewRegistrar", "TheRegistrar");
     verify(connection)
         .sendPostRequest(

--- a/core/src/test/java/google/registry/tools/CreateTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateTldCommandTest.java
@@ -521,6 +521,7 @@ class CreateTldCommandTest extends CommandTestCase<CreateTldCommand> {
 
   @Test
   void testSuccess_setCommonAndReservedListFromOtherTld_withOverride() throws Exception {
+    command.errorPrintStream = System.err;
     runReservedListsTestOverride("common_abuse,tld_banned");
     String errMsg =
         "Error overridden: The reserved list(s) tld_banned "

--- a/core/src/test/java/google/registry/tools/DeleteAllocationTokensCommandTest.java
+++ b/core/src/test/java/google/registry/tools/DeleteAllocationTokensCommandTest.java
@@ -53,6 +53,7 @@ class DeleteAllocationTokensCommandTest extends CommandTestCase<DeleteAllocation
     preNot2 = persistToken("prefix8ZZZhs8", null, false);
     othrRed = persistToken("h97987sasdfhh", null, true);
     othrNot = persistToken("asdgfho7HASDS", null, false);
+    command.printStream = System.out;
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/LoadTestCommandTest.java
+++ b/core/src/test/java/google/registry/tools/LoadTestCommandTest.java
@@ -37,6 +37,8 @@ class LoadTestCommandTest extends CommandTestCase<LoadTestCommand> {
     command.setConnection(connection);
     createTld("example");
     persistNewRegistrar("acme", "ACME", Registrar.Type.REAL, 99L);
+    command.printStream = System.out;
+    command.errorPrintStream = System.err;
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/LockDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/LockDomainCommandTest.java
@@ -50,6 +50,7 @@ class LockDomainCommandTest extends CommandTestCase<LockDomainCommand> {
             new DeterministicStringGenerator(Alphabets.BASE_58),
             "adminreg",
             new CloudTasksHelper(fakeClock).getTestCloudTasksUtils());
+    command.printStream = System.out;
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/UniformRapidSuspensionCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UniformRapidSuspensionCommandTest.java
@@ -61,6 +61,7 @@ class UniformRapidSuspensionCommandTest
         ImmutableSet.of(
             DomainDsData.create(1, 2, 3, new HexBinaryAdapter().unmarshal("dead")),
             DomainDsData.create(4, 5, 6, new HexBinaryAdapter().unmarshal("beef")));
+    command.printStream = System.out;
   }
 
   private void persistDomainWithHosts(

--- a/core/src/test/java/google/registry/tools/UnlockDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UnlockDomainCommandTest.java
@@ -53,6 +53,7 @@ class UnlockDomainCommandTest extends CommandTestCase<UnlockDomainCommand> {
             new DeterministicStringGenerator(Alphabets.BASE_58),
             "adminreg",
             new CloudTasksHelper(fakeClock).getTestCloudTasksUtils());
+    command.printStream = System.out;
   }
 
   private Domain persistLockedDomain(String domainName, String registrarId) {

--- a/core/src/test/java/google/registry/tools/UnrenewDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UnrenewDomainCommandTest.java
@@ -179,6 +179,7 @@ public class UnrenewDomainCommandTest extends CommandTestCase<UnrenewDomainComma
 
   @Test
   void test_varietyOfInvalidDomains_displaysErrors() {
+    command.errorPrintStream = System.err;
     DateTime now = fakeClock.nowUtc();
     persistResource(
         DatabaseHelper.newDomain("deleting.tld")

--- a/core/src/test/java/google/registry/tools/UnrenewDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UnrenewDomainCommandTest.java
@@ -55,6 +55,7 @@ public class UnrenewDomainCommandTest extends CommandTestCase<UnrenewDomainComma
     createTld("tld");
     fakeClock.setTo(DateTime.parse("2016-12-06T13:55:01Z"));
     command.clock = fakeClock;
+    command.printStream = System.out;
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/UpdateTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateTldCommandTest.java
@@ -1048,6 +1048,7 @@ class UpdateTldCommandTest extends CommandTestCase<UpdateTldCommand> {
 
   @Test
   void testSuccess_setCommonAndReservedListFromOtherTld_withOverride() throws Exception {
+    command.errorPrintStream = System.err;
     runReservedListsTestOverride("common_abuse,tld_banned");
     String errMsg =
         "Error overridden: The reserved list(s) tld_banned "

--- a/core/src/test/java/google/registry/tools/javascrap/CreateCancellationsForBillingEventsCommandTest.java
+++ b/core/src/test/java/google/registry/tools/javascrap/CreateCancellationsForBillingEventsCommandTest.java
@@ -34,6 +34,7 @@ import google.registry.model.reporting.HistoryEntryDao;
 import google.registry.persistence.VKey;
 import google.registry.testing.DatabaseHelper;
 import google.registry.tools.CommandTestCase;
+import java.io.PrintStream;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
 import org.junit.jupiter.api.BeforeEach;
@@ -59,6 +60,7 @@ public class CreateCancellationsForBillingEventsCommandTest
             fakeClock.nowUtc(),
             fakeClock.nowUtc().plusYears(2));
     billingEventToCancel = createBillingEvent();
+    command.printStream = System.out;
   }
 
   @Test
@@ -97,8 +99,10 @@ public class CreateCancellationsForBillingEventsCommandTest
   @Test
   void testAlreadyCancelled() throws Exception {
     // multiple runs / cancellations should be a no-op
+    command.printStream = new PrintStream(tmpDir.resolve("test.txt").toFile());
     runCommandForced(String.valueOf(billingEventToCancel.getId()));
     assertBillingEventCancelled();
+    command.printStream = System.out;
     runCommandForced(String.valueOf(billingEventToCancel.getId()));
     assertBillingEventCancelled();
     assertThat(DatabaseHelper.loadAllOf(BillingCancellation.class)).hasSize(1);


### PR DESCRIPTION
Simply using System.out will use the platform's default charset which can cause issues such as in Cloud Build. Using PrintStream allows us to define the charset.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2140)
<!-- Reviewable:end -->
