### PR TITLE
Redact OAuth access token in prod

### DIFF
--- a/core/src/main/java/google/registry/request/auth/OAuthAuthenticationMechanism.java
+++ b/core/src/main/java/google/registry/request/auth/OAuthAuthenticationMechanism.java
@@ -26,6 +26,7 @@ import com.google.appengine.api.users.User;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.FluentLogger;
 import google.registry.config.RegistryConfig.Config;
+import google.registry.config.RegistryEnvironment;
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 
@@ -80,7 +81,10 @@ public class OAuthAuthenticationMechanism implements AuthenticationMechanism {
     // Assume that, if a bearer token is found, it's what OAuthService will use to attempt
     // authentication. This is not technically guaranteed by the contract of OAuthService; see
     // OAuthTokenInfo for more information.
-    String rawAccessToken = header.substring(BEARER_PREFIX.length());
+    String rawAccessToken =
+        RegistryEnvironment.get() == RegistryEnvironment.PRODUCTION
+            ? "Raw token redacted in prod"
+            : header.substring(BEARER_PREFIX.length());
 
     // Get the OAuth information. The various oauthService method calls use a single cached
     // authentication result, so we can call them one by one.


### PR DESCRIPTION
This token is only ever used for logging. The GAE OAuth service will
parse the header directly when called to retrieve the current user and
user id. Logging it in prod could be a security risk if the logs are
leaked.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2148)
<!-- Reviewable:end -->
