### PR TITLE
Don't include a nextUrl when accessing the console homepage

### DIFF
--- a/console-webapp/src/app/registrar/emptyRegistrar.component.ts
+++ b/console-webapp/src/app/registrar/emptyRegistrar.component.ts
@@ -14,8 +14,9 @@
 
 import { Component } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { RegistrarService } from './registrar.service';
 import { Subscription } from 'rxjs';
+
+import { RegistrarService } from './registrar.service';
 
 @Component({
   selector: 'app-empty-registrar',

--- a/console-webapp/src/app/registrar/registrar.guard.ts
+++ b/console-webapp/src/app/registrar/registrar.guard.ts
@@ -31,7 +31,8 @@ export class RegistrarGuard {
       return true;
     }
     // Get the full URL including any nested children (skip the initial '#/')
-    const nextUrl = location.hash.split('#/')[1];
+    // NB: an empty nextUrl takes the user to the home page
+    const nextUrl = location.hash.split('#/')[1] || '';
     return this.router.navigate([`/empty-registrar`, { nextUrl }]);
   }
 }


### PR DESCRIPTION
In this case we should just display the standard page, no need to redirect anywhere since there's nothing to redirect to.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2149)
<!-- Reviewable:end -->
