### PR TITLE
Update proxy k8s manifest

### DIFF
--- a/proxy/kubernetes/proxy-service-canary.yaml
+++ b/proxy/kubernetes/proxy-service-canary.yaml
@@ -34,7 +34,7 @@ spec:
     name: https-whois
   type: NodePort
 ---
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   namespace: default

--- a/proxy/kubernetes/proxy-service.yaml
+++ b/proxy/kubernetes/proxy-service.yaml
@@ -34,7 +34,7 @@ spec:
     name: https-whois
   type: NodePort
 ---
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   namespace: default


### PR DESCRIPTION
The beta API is deprecated.

TESTED=deployed the new manifest to alpha. Without the change, deploying
resulted in an error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2153)
<!-- Reviewable:end -->
