### PR TITLE
Add breakglass handling to configureTldCommand

### DIFF
--- a/core/src/main/java/google/registry/tools/ConfigureTldCommand.java
+++ b/core/src/main/java/google/registry/tools/ConfigureTldCommand.java
@@ -81,8 +81,8 @@ public class ConfigureTldCommand extends MutatingCommand {
   boolean newDiff = true;
 
   /**
-   * Indicates that the existing TLD is currently in breakglass mode and should not be modified
-   * unless the breakglass mode is set
+   * Indicates if the existing TLD is currently in breakglass mode and should not be modified unless
+   * the breakglass flag is used
    */
   boolean oldTldInBreakglass = false;
 
@@ -117,7 +117,7 @@ public class ConfigureTldCommand extends MutatingCommand {
     checkPremiumList(newTld);
     checkDnsWriters(newTld);
     checkCurrency(newTld);
-    // Set the new TLD to breakglass mode
+    // Set the new TLD to breakglass mode if breakglass flag was used
     if (breakglass) {
       newTld = newTld.asBuilder().setBreakglassMode(true).build();
     }
@@ -176,7 +176,9 @@ public class ConfigureTldCommand extends MutatingCommand {
 
   private void checkPremiumList(Tld newTld) {
     Optional<String> premiumListName = newTld.getPremiumListName();
-    if (!premiumListName.isPresent()) return;
+    if (!premiumListName.isPresent()) {
+      return;
+    }
     Optional<PremiumList> premiumList = PremiumListDao.getLatestRevision(premiumListName.get());
     checkArgument(
         premiumList.isPresent(),

--- a/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
@@ -473,4 +473,22 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
         assertThrows(IllegalArgumentException.class, () -> runCommandForced("--input=" + tldFile));
     assertThat(thrown.getMessage()).isEqualTo("The premium list must use the TLD's currency");
   }
+
+  // @Test
+  // void testFailure_breakglassNoChanges() throws Exception {
+  //   Tld tld = createTld("idns");
+  //   tld =
+  //       persistResource(
+  //           tld.asBuilder()
+  //               .setIdnTables(ImmutableSet.of(JA, UNCONFUSABLE_LATIN, EXTENDED_LATIN))
+  //               .setAllowedFullyQualifiedHostNames(
+  //                   ImmutableSet.of("zeta", "alpha", "gamma", "beta"))
+  //               .build());
+  //   File tldFile = tmpDir.resolve("idns.yaml").toFile();
+  //   Files.asCharSink(tldFile, UTF_8).write(loadFile(getClass(), "idns.yaml"));
+  //   IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
+  // runCommandForced("--input=" + tldFile, "-b"));
+  //   assertThat(thrown.getMessage()).isEqualTo("Breakglass mode can only be set when making new
+  // changes to a TLD configuration");
+  // }
 }

--- a/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
@@ -102,13 +102,11 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
   @Test
   void testSuccess_noDiff() throws Exception {
     Tld tld = createTld("idns");
-    tld =
-        persistResource(
-            tld.asBuilder()
-                .setIdnTables(ImmutableSet.of(JA, UNCONFUSABLE_LATIN, EXTENDED_LATIN))
-                .setAllowedFullyQualifiedHostNames(
-                    ImmutableSet.of("zeta", "alpha", "gamma", "beta"))
-                .build());
+    persistResource(
+        tld.asBuilder()
+            .setIdnTables(ImmutableSet.of(JA, UNCONFUSABLE_LATIN, EXTENDED_LATIN))
+            .setAllowedFullyQualifiedHostNames(ImmutableSet.of("zeta", "alpha", "gamma", "beta"))
+            .build());
     File tldFile = tmpDir.resolve("idns.yaml").toFile();
     Files.asCharSink(tldFile, UTF_8).write(loadFile(getClass(), "idns.yaml"));
     runCommandForced("--input=" + tldFile);
@@ -477,15 +475,13 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
   }
 
   @Test
-  void testFailure_breakglassNoChanges() throws Exception {
+  void testFailure_breakglassFlag_NoChanges() throws Exception {
     Tld tld = createTld("idns");
-    tld =
-        persistResource(
-            tld.asBuilder()
-                .setIdnTables(ImmutableSet.of(JA, UNCONFUSABLE_LATIN, EXTENDED_LATIN))
-                .setAllowedFullyQualifiedHostNames(
-                    ImmutableSet.of("zeta", "alpha", "gamma", "beta"))
-                .build());
+    persistResource(
+        tld.asBuilder()
+            .setIdnTables(ImmutableSet.of(JA, UNCONFUSABLE_LATIN, EXTENDED_LATIN))
+            .setAllowedFullyQualifiedHostNames(ImmutableSet.of("zeta", "alpha", "gamma", "beta"))
+            .build());
     File tldFile = tmpDir.resolve("idns.yaml").toFile();
     Files.asCharSink(tldFile, UTF_8).write(loadFile(getClass(), "idns.yaml"));
     IllegalArgumentException thrown =
@@ -526,14 +522,12 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
   @Test
   void testSuccess_NoDiffNoBreakglassFlag_endsBreakglassMode() throws Exception {
     Tld tld = createTld("idns");
-    tld =
-        persistResource(
-            tld.asBuilder()
-                .setIdnTables(ImmutableSet.of(JA, UNCONFUSABLE_LATIN, EXTENDED_LATIN))
-                .setAllowedFullyQualifiedHostNames(
-                    ImmutableSet.of("zeta", "alpha", "gamma", "beta"))
-                .setBreakglassMode(true)
-                .build());
+    persistResource(
+        tld.asBuilder()
+            .setIdnTables(ImmutableSet.of(JA, UNCONFUSABLE_LATIN, EXTENDED_LATIN))
+            .setAllowedFullyQualifiedHostNames(ImmutableSet.of("zeta", "alpha", "gamma", "beta"))
+            .setBreakglassMode(true)
+            .build());
     File tldFile = tmpDir.resolve("idns.yaml").toFile();
     Files.asCharSink(tldFile, UTF_8).write(loadFile(getClass(), "idns.yaml"));
     runCommandForced("--input=" + tldFile);
@@ -547,14 +541,12 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
   @Test
   void testSuccess_noDiffBreakglassFlag_continuesBreakglassMode() throws Exception {
     Tld tld = createTld("idns");
-    tld =
-        persistResource(
-            tld.asBuilder()
-                .setIdnTables(ImmutableSet.of(JA, UNCONFUSABLE_LATIN, EXTENDED_LATIN))
-                .setAllowedFullyQualifiedHostNames(
-                    ImmutableSet.of("zeta", "alpha", "gamma", "beta"))
-                .setBreakglassMode(true)
-                .build());
+    persistResource(
+        tld.asBuilder()
+            .setIdnTables(ImmutableSet.of(JA, UNCONFUSABLE_LATIN, EXTENDED_LATIN))
+            .setAllowedFullyQualifiedHostNames(ImmutableSet.of("zeta", "alpha", "gamma", "beta"))
+            .setBreakglassMode(true)
+            .build());
     File tldFile = tmpDir.resolve("idns.yaml").toFile();
     Files.asCharSink(tldFile, UTF_8).write(loadFile(getClass(), "idns.yaml"));
     runCommandForced("--input=" + tldFile, "-b");

--- a/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
@@ -64,6 +64,7 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
     command.mapper = objectMapper;
     premiumList = persistPremiumList("test", USD, "silver,USD 50", "gold,USD 80");
     command.validDnsWriterNames = ImmutableSet.of("VoidDnsWriter", "FooDnsWriter");
+    logger.addHandler(logHandler);
   }
 
   private void testTldConfiguredSuccessfully(Tld tld, String filename)
@@ -82,6 +83,7 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
     assertThat(tld.getDriveFolderId()).isEqualTo("driveFolder");
     assertThat(tld.getCreateBillingCost()).isEqualTo(Money.of(USD, 25));
     testTldConfiguredSuccessfully(tld, "tld.yaml");
+    assertThat(tld.getBreakglassMode()).isFalse();
   }
 
   @Test
@@ -94,11 +96,11 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
     Tld updatedTld = Tld.get("tld");
     assertThat(updatedTld.getCreateBillingCost()).isEqualTo(Money.of(USD, 25));
     testTldConfiguredSuccessfully(updatedTld, "tld.yaml");
+    assertThat(updatedTld.getBreakglassMode()).isFalse();
   }
 
   @Test
   void testSuccess_noDiff() throws Exception {
-    logger.addHandler(logHandler);
     Tld tld = createTld("idns");
     tld =
         persistResource(
@@ -474,21 +476,106 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
     assertThat(thrown.getMessage()).isEqualTo("The premium list must use the TLD's currency");
   }
 
-  // @Test
-  // void testFailure_breakglassNoChanges() throws Exception {
-  //   Tld tld = createTld("idns");
-  //   tld =
-  //       persistResource(
-  //           tld.asBuilder()
-  //               .setIdnTables(ImmutableSet.of(JA, UNCONFUSABLE_LATIN, EXTENDED_LATIN))
-  //               .setAllowedFullyQualifiedHostNames(
-  //                   ImmutableSet.of("zeta", "alpha", "gamma", "beta"))
-  //               .build());
-  //   File tldFile = tmpDir.resolve("idns.yaml").toFile();
-  //   Files.asCharSink(tldFile, UTF_8).write(loadFile(getClass(), "idns.yaml"));
-  //   IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, () ->
-  // runCommandForced("--input=" + tldFile, "-b"));
-  //   assertThat(thrown.getMessage()).isEqualTo("Breakglass mode can only be set when making new
-  // changes to a TLD configuration");
-  // }
+  @Test
+  void testFailure_breakglassNoChanges() throws Exception {
+    Tld tld = createTld("idns");
+    tld =
+        persistResource(
+            tld.asBuilder()
+                .setIdnTables(ImmutableSet.of(JA, UNCONFUSABLE_LATIN, EXTENDED_LATIN))
+                .setAllowedFullyQualifiedHostNames(
+                    ImmutableSet.of("zeta", "alpha", "gamma", "beta"))
+                .build());
+    File tldFile = tmpDir.resolve("idns.yaml").toFile();
+    Files.asCharSink(tldFile, UTF_8).write(loadFile(getClass(), "idns.yaml"));
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class, () -> runCommandForced("--input=" + tldFile, "-b"));
+    assertThat(thrown.getMessage())
+        .isEqualTo(
+            "Breakglass mode can only be set when making new changes to a TLD configuration");
+  }
+
+  @Test
+  void testSuccess_breakglassFlag_startsBreakglassMode() throws Exception {
+    Tld tld = createTld("tld");
+    assertThat(tld.getCreateBillingCost()).isEqualTo(Money.of(USD, 13));
+    File tldFile = tmpDir.resolve("tld.yaml").toFile();
+    Files.asCharSink(tldFile, UTF_8).write(loadFile(getClass(), "tld.yaml"));
+    runCommandForced("--input=" + tldFile, "--breakglass");
+    Tld updatedTld = Tld.get("tld");
+    assertThat(updatedTld.getCreateBillingCost()).isEqualTo(Money.of(USD, 25));
+    testTldConfiguredSuccessfully(updatedTld, "tld.yaml");
+    assertThat(updatedTld.getBreakglassMode()).isTrue();
+  }
+
+  @Test
+  void testSuccess_breakglassFlag_continuesBreakglassMode() throws Exception {
+    Tld tld = createTld("tld");
+    assertThat(tld.getCreateBillingCost()).isEqualTo(Money.of(USD, 13));
+    persistResource(tld.asBuilder().setBreakglassMode(true).build());
+    File tldFile = tmpDir.resolve("tld.yaml").toFile();
+    Files.asCharSink(tldFile, UTF_8).write(loadFile(getClass(), "tld.yaml"));
+    runCommandForced("--input=" + tldFile, "--breakglass");
+    Tld updatedTld = Tld.get("tld");
+    assertThat(updatedTld.getCreateBillingCost()).isEqualTo(Money.of(USD, 25));
+    testTldConfiguredSuccessfully(updatedTld, "tld.yaml");
+    assertThat(updatedTld.getBreakglassMode()).isTrue();
+  }
+
+  @Test
+  void testSuccess_NoDiffNoBreakglassFlag_endsBreakglassMode() throws Exception {
+    Tld tld = createTld("idns");
+    tld =
+        persistResource(
+            tld.asBuilder()
+                .setIdnTables(ImmutableSet.of(JA, UNCONFUSABLE_LATIN, EXTENDED_LATIN))
+                .setAllowedFullyQualifiedHostNames(
+                    ImmutableSet.of("zeta", "alpha", "gamma", "beta"))
+                .setBreakglassMode(true)
+                .build());
+    File tldFile = tmpDir.resolve("idns.yaml").toFile();
+    Files.asCharSink(tldFile, UTF_8).write(loadFile(getClass(), "idns.yaml"));
+    runCommandForced("--input=" + tldFile);
+    Tld updatedTld = Tld.get("idns");
+    assertThat(updatedTld.getBreakglassMode()).isFalse();
+    assertAboutLogs()
+        .that(logHandler)
+        .hasLogAtLevelWithMessage(INFO, "Breakglass mode removed from TLD: idns");
+  }
+
+  @Test
+  void testSuccess_noDiffBreakglassFlag_continuesBreakglassMode() throws Exception {
+    Tld tld = createTld("idns");
+    tld =
+        persistResource(
+            tld.asBuilder()
+                .setIdnTables(ImmutableSet.of(JA, UNCONFUSABLE_LATIN, EXTENDED_LATIN))
+                .setAllowedFullyQualifiedHostNames(
+                    ImmutableSet.of("zeta", "alpha", "gamma", "beta"))
+                .setBreakglassMode(true)
+                .build());
+    File tldFile = tmpDir.resolve("idns.yaml").toFile();
+    Files.asCharSink(tldFile, UTF_8).write(loadFile(getClass(), "idns.yaml"));
+    runCommandForced("--input=" + tldFile, "-b");
+    Tld updatedTld = Tld.get("idns");
+    assertThat(updatedTld.getBreakglassMode()).isTrue();
+    assertAboutLogs()
+        .that(logHandler)
+        .hasLogAtLevelWithMessage(INFO, "TLD YAML file contains no new changes");
+  }
+
+  @Test
+  void testFailure_noBreakglassFlag_inBreakglassMode() throws Exception {
+    Tld tld = createTld("tld");
+    persistResource(tld.asBuilder().setBreakglassMode(true).build());
+    File tldFile = tmpDir.resolve("tld.yaml").toFile();
+    Files.asCharSink(tldFile, UTF_8).write(loadFile(getClass(), "tld.yaml"));
+    IllegalArgumentException thrown =
+        assertThrows(IllegalArgumentException.class, () -> runCommandForced("--input=" + tldFile));
+    assertThat(thrown.getMessage())
+        .isEqualTo(
+            "Changes can not be applied since TLD is in breakglass mode but the breakglass flag"
+                + " was not used");
+  }
 }


### PR DESCRIPTION
The configure_tld command should not be run locally for the Production environment since the regularly running Cloud Build job will quickly overwrite the locally made changes with whatever configurations are stored in source control. 

In situations where a quick fix is needed the command can be used to make TLD changes locally and the breakglass flag can be used to set the TLD to breakglass mode indicating that Cloud Build should not overwrite it. Breakglass mode will be turned off once an automatic Cloud Build run of the command runs with a configuration equal to the the configuration stored in the database, indicating that the internal repo has caught up.

More info can be found in the Breakglass section of go/tldsourcecontrol

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2154)
<!-- Reviewable:end -->
