### PR TITLE
Use equals() method to compare equality

### DIFF
--- a/core/src/main/java/google/registry/model/tld/Tld.java
+++ b/core/src/main/java/google/registry/model/tld/Tld.java
@@ -130,7 +130,7 @@ public class Tld extends ImmutableObject implements Buildable, UnsafeSerializabl
   public static final Money DEFAULT_REGISTRY_LOCK_OR_UNLOCK_BILLING_COST = Money.of(USD, 0);
 
   public boolean equalYaml(Tld tldToCompare) {
-    if (this == tldToCompare) {
+    if (this.equals(tldToCompare)) {
       return true;
     }
     ObjectMapper mapper = createObjectMapper();


### PR DESCRIPTION
It will call equalsImmutableObject(), which seems the right thing to do.
We only care if the two Tld objects have the same fields, not if they
are the same object. ErrorProne complained about comparison by identity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2158)
<!-- Reviewable:end -->
