### PR TITLE
Deprecate the OAuth header in Nomulus tool

### DIFF
--- a/core/src/main/java/google/registry/tools/RegistryToolComponent.java
+++ b/core/src/main/java/google/registry/tools/RegistryToolComponent.java
@@ -123,6 +123,7 @@ interface RegistryToolComponent {
   void inject(GetDomainCommand command);
 
   void inject(GetHostCommand command);
+
   void inject(GetKeyringSecretCommand command);
 
   void inject(GetSqlCredentialCommand command);
@@ -189,6 +190,9 @@ interface RegistryToolComponent {
 
     @BindsInstance
     Builder sqlAccessInfoFile(@Nullable @Config("sqlAccessInfoFile") String sqlAccessInfoFile);
+
+    @BindsInstance
+    Builder addOAuthHeader(@Config("addOauthHeader") boolean addOauthHeader);
 
     RegistryToolComponent build();
   }

--- a/core/src/main/java/google/registry/tools/RequestFactoryModule.java
+++ b/core/src/main/java/google/registry/tools/RequestFactoryModule.java
@@ -42,7 +42,8 @@ final class RequestFactoryModule {
   @Provides
   static HttpRequestFactory provideHttpRequestFactory(
       @ApplicationDefaultCredential GoogleCredentialsBundle credentialsBundle,
-      @Config("oauthClientId") String oauthClientId) {
+      @Config("oauthClientId") String oauthClientId,
+      @Config("addOauthHeader") boolean addOauthHeader) {
     if (RegistryConfig.areServersLocal()) {
       return new NetHttpTransport()
           .createRequestFactory(
@@ -54,8 +55,10 @@ final class RequestFactoryModule {
       return new NetHttpTransport()
           .createRequestFactory(
               request -> {
-                // Use the standard credential initializer to set the Authorization header
-                credentialsBundle.getHttpRequestInitializer().initialize(request);
+                if (addOauthHeader) {
+                  // Use the standard credential initializer to set the Authorization header
+                  credentialsBundle.getHttpRequestInitializer().initialize(request);
+                }
                 // Set OIDC token as the alternative bearer token.
                 request
                     .getHeaders()


### PR DESCRIPTION
Unless an --oauth flag is used, the nomulus tool will only send the OIDC
header. The server still accepts both headers and the user should use
`create_user` command to create an admin User (with the --oauth flag on), which
will then allow one to use the nomulus tool without the --oauth flag.

The --oauth flag and the server's ability to support OAuth-based
authentication will be removed soon. Users are urged to create the User
object in time to avoid service interruption.

TESTED=verified on alpha.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2160)
<!-- Reviewable:end -->
