### PR TITLE
Add custom YAML serializer for Duration

### DIFF
--- a/core/src/main/java/google/registry/model/EntityYamlUtils.java
+++ b/core/src/main/java/google/registry/model/EntityYamlUtils.java
@@ -201,6 +201,24 @@ public class EntityYamlUtils {
     }
   }
 
+  /** A custom JSON serializer for a {@link Duration} object. */
+  public static class DurationSerializer extends StdSerializer<Duration> {
+
+    public DurationSerializer() {
+      this(null);
+    }
+
+    public DurationSerializer(Class<Duration> t) {
+      super(t);
+    }
+
+    @Override
+    public void serialize(Duration value, JsonGenerator gen, SerializerProvider provider)
+        throws IOException {
+      gen.writeString(value.toString());
+    }
+  }
+
   /** A custom JSON serializer for an Optional of a {@link Duration} object. */
   public static class OptionalDurationSerializer extends StdSerializer<Optional<Duration>> {
 
@@ -216,7 +234,7 @@ public class EntityYamlUtils {
     public void serialize(Optional<Duration> value, JsonGenerator gen, SerializerProvider provider)
         throws IOException {
       if (value.isPresent()) {
-        gen.writeNumber(value.get().getMillis());
+        gen.writeString(value.get().toString());
       } else {
         gen.writeNull();
       }

--- a/core/src/main/java/google/registry/model/EntityYamlUtils.java
+++ b/core/src/main/java/google/registry/model/EntityYamlUtils.java
@@ -58,13 +58,13 @@ public class EntityYamlUtils {
     SimpleModule module = new SimpleModule();
     module.addSerializer(Money.class, new MoneySerializer());
     module.addDeserializer(Money.class, new MoneyDeserializer());
+    module.addSerializer(Duration.class, new DurationSerializer());
     ObjectMapper mapper =
         JsonMapper.builder(new YAMLFactory().disable(Feature.WRITE_DOC_START_MARKER))
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
             .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
-            .build()
-            .registerModule(module);
-    mapper.findAndRegisterModules();
+            .build();
+    mapper.findAndRegisterModules().registerModule(module);
     return mapper;
   }
 

--- a/core/src/main/java/google/registry/model/tld/Tld.java
+++ b/core/src/main/java/google/registry/model/tld/Tld.java
@@ -51,7 +51,6 @@ import google.registry.model.CreateAutoTimestamp;
 import google.registry.model.EntityYamlUtils.CreateAutoTimestampDeserializer;
 import google.registry.model.EntityYamlUtils.CurrencyDeserializer;
 import google.registry.model.EntityYamlUtils.CurrencySerializer;
-import google.registry.model.EntityYamlUtils.DurationSerializer;
 import google.registry.model.EntityYamlUtils.OptionalDurationSerializer;
 import google.registry.model.EntityYamlUtils.OptionalStringSerializer;
 import google.registry.model.EntityYamlUtils.SortedEnumSetSerializer;
@@ -417,42 +416,34 @@ public class Tld extends ImmutableObject implements Buildable, UnsafeSerializabl
    * amount of time following creation.
    */
   @Column(nullable = false)
-  @JsonSerialize(using = DurationSerializer.class)
   Duration addGracePeriodLength = DEFAULT_ADD_GRACE_PERIOD;
 
   /** The length of the anchor tenant add grace period for this TLD. */
   @Column(nullable = false)
-  @JsonSerialize(using = DurationSerializer.class)
   Duration anchorTenantAddGracePeriodLength = DEFAULT_ANCHOR_TENANT_ADD_GRACE_PERIOD;
 
   /** The length of the autorenew grace period for this TLD. */
   @Column(nullable = false)
-  @JsonSerialize(using = DurationSerializer.class)
   Duration autoRenewGracePeriodLength = DEFAULT_AUTO_RENEW_GRACE_PERIOD;
 
   /** The length of the redemption grace period for this TLD. */
   @Column(nullable = false)
-  @JsonSerialize(using = DurationSerializer.class)
   Duration redemptionGracePeriodLength = DEFAULT_REDEMPTION_GRACE_PERIOD;
 
   /** The length of the renew grace period for this TLD. */
   @Column(nullable = false)
-  @JsonSerialize(using = DurationSerializer.class)
   Duration renewGracePeriodLength = DEFAULT_RENEW_GRACE_PERIOD;
 
   /** The length of the transfer grace period for this TLD. */
   @Column(nullable = false)
-  @JsonSerialize(using = DurationSerializer.class)
   Duration transferGracePeriodLength = DEFAULT_TRANSFER_GRACE_PERIOD;
 
   /** The length of time before a transfer is automatically approved for this TLD. */
   @Column(nullable = false)
-  @JsonSerialize(using = DurationSerializer.class)
   Duration automaticTransferLength = DEFAULT_AUTOMATIC_TRANSFER_LENGTH;
 
   /** The length of time a domain spends in the non-redeemable pending delete phase for this TLD. */
   @Column(nullable = false)
-  @JsonSerialize(using = DurationSerializer.class)
   Duration pendingDeleteLength = DEFAULT_PENDING_DELETE_LENGTH;
 
   /** The currency unit for all costs associated with this TLD. */

--- a/core/src/main/java/google/registry/model/tld/Tld.java
+++ b/core/src/main/java/google/registry/model/tld/Tld.java
@@ -51,6 +51,7 @@ import google.registry.model.CreateAutoTimestamp;
 import google.registry.model.EntityYamlUtils.CreateAutoTimestampDeserializer;
 import google.registry.model.EntityYamlUtils.CurrencyDeserializer;
 import google.registry.model.EntityYamlUtils.CurrencySerializer;
+import google.registry.model.EntityYamlUtils.DurationSerializer;
 import google.registry.model.EntityYamlUtils.OptionalDurationSerializer;
 import google.registry.model.EntityYamlUtils.OptionalStringSerializer;
 import google.registry.model.EntityYamlUtils.SortedEnumSetSerializer;
@@ -416,34 +417,42 @@ public class Tld extends ImmutableObject implements Buildable, UnsafeSerializabl
    * amount of time following creation.
    */
   @Column(nullable = false)
+  @JsonSerialize(using = DurationSerializer.class)
   Duration addGracePeriodLength = DEFAULT_ADD_GRACE_PERIOD;
 
   /** The length of the anchor tenant add grace period for this TLD. */
   @Column(nullable = false)
+  @JsonSerialize(using = DurationSerializer.class)
   Duration anchorTenantAddGracePeriodLength = DEFAULT_ANCHOR_TENANT_ADD_GRACE_PERIOD;
 
   /** The length of the autorenew grace period for this TLD. */
   @Column(nullable = false)
+  @JsonSerialize(using = DurationSerializer.class)
   Duration autoRenewGracePeriodLength = DEFAULT_AUTO_RENEW_GRACE_PERIOD;
 
   /** The length of the redemption grace period for this TLD. */
   @Column(nullable = false)
+  @JsonSerialize(using = DurationSerializer.class)
   Duration redemptionGracePeriodLength = DEFAULT_REDEMPTION_GRACE_PERIOD;
 
   /** The length of the renew grace period for this TLD. */
   @Column(nullable = false)
+  @JsonSerialize(using = DurationSerializer.class)
   Duration renewGracePeriodLength = DEFAULT_RENEW_GRACE_PERIOD;
 
   /** The length of the transfer grace period for this TLD. */
   @Column(nullable = false)
+  @JsonSerialize(using = DurationSerializer.class)
   Duration transferGracePeriodLength = DEFAULT_TRANSFER_GRACE_PERIOD;
 
   /** The length of time before a transfer is automatically approved for this TLD. */
   @Column(nullable = false)
+  @JsonSerialize(using = DurationSerializer.class)
   Duration automaticTransferLength = DEFAULT_AUTOMATIC_TRANSFER_LENGTH;
 
   /** The length of time a domain spends in the non-redeemable pending delete phase for this TLD. */
   @Column(nullable = false)
+  @JsonSerialize(using = DurationSerializer.class)
   Duration pendingDeleteLength = DEFAULT_PENDING_DELETE_LENGTH;
 
   /** The currency unit for all costs associated with this TLD. */

--- a/core/src/test/java/google/registry/tools/GetTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetTldCommandTest.java
@@ -45,7 +45,7 @@ class GetTldCommandTest extends CommandTestCase<GetTldCommand> {
     PremiumList premiumList = persistPremiumList("test", USD, "silver,USD 50", "gold,USD 80");
     persistResource(
         tld.asBuilder()
-            .setDnsAPlusAaaaTtl(Duration.standardSeconds(900))
+            .setDnsAPlusAaaaTtl(Duration.standardMinutes(15))
             .setDriveFolderId("driveFolder")
             .setCreateBillingCost(Money.of(USD, 25))
             .setPremiumList(premiumList)

--- a/core/src/test/java/google/registry/tools/GetTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetTldCommandTest.java
@@ -45,7 +45,7 @@ class GetTldCommandTest extends CommandTestCase<GetTldCommand> {
     PremiumList premiumList = persistPremiumList("test", USD, "silver,USD 50", "gold,USD 80");
     persistResource(
         tld.asBuilder()
-            .setDnsAPlusAaaaTtl(Duration.millis(900))
+            .setDnsAPlusAaaaTtl(Duration.standardSeconds(900))
             .setDriveFolderId("driveFolder")
             .setCreateBillingCost(Money.of(USD, 25))
             .setPremiumList(premiumList)

--- a/core/src/test/resources/google/registry/model/tld/tld.yaml
+++ b/core/src/test/resources/google/registry/model/tld/tld.yaml
@@ -1,10 +1,10 @@
-addGracePeriodLength: 432000000
+addGracePeriodLength: "PT432000S"
 allowedFullyQualifiedHostNames:
 - "foo"
 allowedRegistrantContactIds: []
-anchorTenantAddGracePeriodLength: 2592000000
-autoRenewGracePeriodLength: 3888000000
-automaticTransferLength: 432000000
+anchorTenantAddGracePeriodLength: "PT2592000S"
+autoRenewGracePeriodLength: "PT3888000S"
+automaticTransferLength: "PT432000S"
 claimsPeriodEnd: "294247-01-10T04:00:54.775Z"
 createBillingCost:
   currency: "USD"
@@ -13,7 +13,7 @@ creationTime: "1970-01-01T00:00:00.000Z"
 currency: "USD"
 defaultPromoTokens:
 - "bbbbb"
-dnsAPlusAaaaTtl: 3600000
+dnsAPlusAaaaTtl: "PT3600S"
 dnsDsTtl: null
 dnsNsTtl: null
 dnsPaused: false
@@ -38,10 +38,10 @@ idnTables:
 invoicingEnabled: false
 lordnUsername: null
 numDnsPublishLocks: 1
-pendingDeleteLength: 432000000
+pendingDeleteLength: "PT432000S"
 premiumListName: "tld"
 pricingEngineClassName: "google.registry.model.pricing.StaticPremiumListPricingEngine"
-redemptionGracePeriodLength: 2592000000
+redemptionGracePeriodLength: "PT2592000S"
 registryLockOrUnlockBillingCost:
   currency: "USD"
   amount: 0.00
@@ -49,7 +49,7 @@ renewBillingCostTransitions:
   "1970-01-01T00:00:00.000Z":
     currency: "USD"
     amount: 11.00
-renewGracePeriodLength: 432000000
+renewGracePeriodLength: "PT432000S"
 reservedListNames: []
 restoreBillingCost:
   currency: "USD"
@@ -63,4 +63,4 @@ tldStateTransitions:
 tldStr: "tld"
 tldType: "REAL"
 tldUnicode: "tld"
-transferGracePeriodLength: 432000000
+transferGracePeriodLength: "PT432000S"

--- a/core/src/test/resources/google/registry/tools/1tld.yaml
+++ b/core/src/test/resources/google/registry/tools/1tld.yaml
@@ -1,9 +1,9 @@
-addGracePeriodLength: 432000000
+addGracePeriodLength: "PT2592000S"
 allowedFullyQualifiedHostNames: []
 allowedRegistrantContactIds: []
-anchorTenantAddGracePeriodLength: 2592000000
-autoRenewGracePeriodLength: 3888000000
-automaticTransferLength: 432000000
+anchorTenantAddGracePeriodLength: "PT2592000S"
+autoRenewGracePeriodLength: "PT2592000S"
+automaticTransferLength: "PT2592000S"
 claimsPeriodEnd: "294247-01-10T04:00:54.775Z"
 createBillingCost:
   currency: "USD"
@@ -11,7 +11,7 @@ createBillingCost:
 creationTime: "2022-09-01T00:00:00.000Z"
 currency: "USD"
 defaultPromoTokens: []
-dnsAPlusAaaaTtl: 900
+dnsAPlusAaaaTtl: "PT900S"
 dnsDsTtl: null
 dnsNsTtl: null
 dnsPaused: false
@@ -27,10 +27,10 @@ idnTables: []
 invoicingEnabled: false
 lordnUsername: null
 numDnsPublishLocks: 1
-pendingDeleteLength: 432000000
+pendingDeleteLength: "PT2592000S"
 premiumListName: "test"
 pricingEngineClassName: "google.registry.model.pricing.StaticPremiumListPricingEngine"
-redemptionGracePeriodLength: 2592000000
+redemptionGracePeriodLength: "PT2592000S"
 registryLockOrUnlockBillingCost:
   currency: "USD"
   amount: 0.00
@@ -38,7 +38,7 @@ renewBillingCostTransitions:
   "1970-01-01T00:00:00.000Z":
     currency: "USD"
     amount: 11.00
-renewGracePeriodLength: 432000000
+renewGracePeriodLength: "PT2592000S"
 reservedListNames: []
 restoreBillingCost:
   currency: "USD"
@@ -52,4 +52,4 @@ tldStateTransitions:
 tldStr: "1tld"
 tldType: "REAL"
 tldUnicode: "1tld"
-transferGracePeriodLength: 432000000
+transferGracePeriodLength: "PT2592000S"

--- a/core/src/test/resources/google/registry/tools/badidn.yaml
+++ b/core/src/test/resources/google/registry/tools/badidn.yaml
@@ -1,9 +1,9 @@
-addGracePeriodLength: 432000000
+addGracePeriodLength: "PT2592000S"
 allowedFullyQualifiedHostNames: []
 allowedRegistrantContactIds: []
-anchorTenantAddGracePeriodLength: 2592000000
-autoRenewGracePeriodLength: 3888000000
-automaticTransferLength: 432000000
+anchorTenantAddGracePeriodLength: "PT2592000S"
+autoRenewGracePeriodLength: "PT2592000S"
+automaticTransferLength: "PT2592000S"
 claimsPeriodEnd: "294247-01-10T04:00:54.775Z"
 createBillingCost:
   currency: "USD"
@@ -11,7 +11,7 @@ createBillingCost:
 creationTime: "2022-09-01T00:00:00.000Z"
 currency: "USD"
 defaultPromoTokens: []
-dnsAPlusAaaaTtl: 900
+dnsAPlusAaaaTtl: "PT900S"
 dnsDsTtl: null
 dnsNsTtl: null
 dnsPaused: false
@@ -28,10 +28,10 @@ idnTables:
 invoicingEnabled: false
 lordnUsername: null
 numDnsPublishLocks: 1
-pendingDeleteLength: 432000000
+pendingDeleteLength: "PT2592000S"
 premiumListName: "test"
 pricingEngineClassName: "google.registry.model.pricing.StaticPremiumListPricingEngine"
-redemptionGracePeriodLength: 2592000000
+redemptionGracePeriodLength: "PT2592000S"
 registryLockOrUnlockBillingCost:
   currency: "USD"
   amount: 0.00
@@ -39,7 +39,7 @@ renewBillingCostTransitions:
   "1970-01-01T00:00:00.000Z":
     currency: "USD"
     amount: 11.00
-renewGracePeriodLength: 432000000
+renewGracePeriodLength: "PT2592000S"
 reservedListNames: []
 restoreBillingCost:
   currency: "USD"
@@ -53,4 +53,4 @@ tldStateTransitions:
 tldStr: "badidn"
 tldType: "REAL"
 tldUnicode: "badidn"
-transferGracePeriodLength: 432000000
+transferGracePeriodLength: "PT2592000S"

--- a/core/src/test/resources/google/registry/tools/badunicode.yaml
+++ b/core/src/test/resources/google/registry/tools/badunicode.yaml
@@ -1,9 +1,9 @@
-addGracePeriodLength: 432000000
+addGracePeriodLength: "PT2592000S"
 allowedFullyQualifiedHostNames: []
 allowedRegistrantContactIds: []
-anchorTenantAddGracePeriodLength: 2592000000
-autoRenewGracePeriodLength: 3888000000
-automaticTransferLength: 432000000
+anchorTenantAddGracePeriodLength: "PT2592000S"
+autoRenewGracePeriodLength: "PT2592000S"
+automaticTransferLength: "PT2592000S"
 claimsPeriodEnd: "294247-01-10T04:00:54.775Z"
 createBillingCost:
   currency: "USD"
@@ -11,7 +11,7 @@ createBillingCost:
 creationTime: "2022-09-01T00:00:00.000Z"
 currency: "USD"
 defaultPromoTokens: []
-dnsAPlusAaaaTtl: 900
+dnsAPlusAaaaTtl: "PT900S"
 dnsDsTtl: null
 dnsNsTtl: null
 dnsPaused: false
@@ -27,10 +27,10 @@ idnTables: []
 invoicingEnabled: false
 lordnUsername: null
 numDnsPublishLocks: 1
-pendingDeleteLength: 432000000
+pendingDeleteLength: "PT2592000S"
 premiumListName: "test"
 pricingEngineClassName: "google.registry.model.pricing.StaticPremiumListPricingEngine"
-redemptionGracePeriodLength: 2592000000
+redemptionGracePeriodLength: "PT2592000S"
 registryLockOrUnlockBillingCost:
   currency: "USD"
   amount: 0.00
@@ -38,7 +38,7 @@ renewBillingCostTransitions:
   "1970-01-01T00:00:00.000Z":
     currency: "USD"
     amount: 11.00
-renewGracePeriodLength: 432000000
+renewGracePeriodLength: "PT2592000S"
 reservedListNames: []
 restoreBillingCost:
   currency: "USD"
@@ -52,4 +52,4 @@ tldStateTransitions:
 tldStr: "badunicode"
 tldType: "REAL"
 tldUnicode: "tld"
-transferGracePeriodLength: 432000000
+transferGracePeriodLength: "PT2592000S"

--- a/core/src/test/resources/google/registry/tools/extrafield.yaml
+++ b/core/src/test/resources/google/registry/tools/extrafield.yaml
@@ -1,9 +1,9 @@
-addGracePeriodLength: 432000000
+addGracePeriodLength: "PT2592000S"
 allowedFullyQualifiedHostNames: []
 allowedRegistrantContactIds: []
-anchorTenantAddGracePeriodLength: 2592000000
-autoRenewGracePeriodLength: 3888000000
-automaticTransferLength: 432000000
+anchorTenantAddGracePeriodLength: "PT2592000S"
+autoRenewGracePeriodLength: "PT2592000S"
+automaticTransferLength: "PT2592000S"
 claimsPeriodEnd: "294247-01-10T04:00:54.775Z"
 createBillingCost:
   currency: "USD"
@@ -11,7 +11,7 @@ createBillingCost:
 creationTime: "2022-09-01T00:00:00.000Z"
 currency: "USD"
 defaultPromoTokens: []
-dnsAPlusAaaaTtl: 900
+dnsAPlusAaaaTtl: "PT900S"
 dnsDsTtl: null
 dnsNsTtl: null
 dnsPaused: false
@@ -27,10 +27,10 @@ idnTables: []
 invoicingEnabled: false
 lordnUsername: null
 numDnsPublishLocks: 1
-pendingDeleteLength: 432000000
+pendingDeleteLength: "PT2592000S"
 premiumListName: "test"
 pricingEngineClassName: "google.registry.model.pricing.StaticPremiumListPricingEngine"
-redemptionGracePeriodLength: 2592000000
+redemptionGracePeriodLength: "PT2592000S"
 registryLockOrUnlockBillingCost:
   currency: "USD"
   amount: 0.00
@@ -38,7 +38,7 @@ renewBillingCostTransitions:
   "1970-01-01T00:00:00.000Z":
     currency: "USD"
     amount: 11.00
-renewGracePeriodLength: 432000000
+renewGracePeriodLength: "PT2592000S"
 reservedListNames: []
 restoreBillingCost:
   currency: "USD"
@@ -52,5 +52,5 @@ tldStateTransitions:
 tldStr: "extrafield"
 tldType: "REAL"
 tldUnicode: "extrafield"
-transferGracePeriodLength: 432000000
+transferGracePeriodLength: "PT2592000S"
 extraField: "hello"

--- a/core/src/test/resources/google/registry/tools/idns.yaml
+++ b/core/src/test/resources/google/registry/tools/idns.yaml
@@ -1,13 +1,13 @@
-addGracePeriodLength: 432000000
+addGracePeriodLength: "PT432000S"
 allowedFullyQualifiedHostNames:
 - "beta"
 - "zeta"
 - "alpha"
 - "gamma"
 allowedRegistrantContactIds: []
-anchorTenantAddGracePeriodLength: 2592000000
-autoRenewGracePeriodLength: 3888000000
-automaticTransferLength: 432000000
+anchorTenantAddGracePeriodLength: "PT2592000S"
+autoRenewGracePeriodLength: "PT3888000S"
+automaticTransferLength: "PT432000S"
 claimsPeriodEnd: "294247-01-10T04:00:54.775Z"
 createBillingCost:
   currency: "USD"
@@ -34,10 +34,10 @@ idnTables:
 invoicingEnabled: false
 lordnUsername: null
 numDnsPublishLocks: 1
-pendingDeleteLength: 432000000
+pendingDeleteLength: "PT432000S"
 premiumListName: "idns"
 pricingEngineClassName: "google.registry.model.pricing.StaticPremiumListPricingEngine"
-redemptionGracePeriodLength: 2592000000
+redemptionGracePeriodLength: "PT2592000S"
 registryLockOrUnlockBillingCost:
   currency: "USD"
   amount: 0.00
@@ -45,7 +45,7 @@ renewBillingCostTransitions:
   "1970-01-01T00:00:00.000Z":
     currency: "USD"
     amount: 11.00
-renewGracePeriodLength: 432000000
+renewGracePeriodLength: "PT432000S"
 reservedListNames: []
 restoreBillingCost:
   currency: "USD"
@@ -59,4 +59,4 @@ tldStateTransitions:
 tldStr: "idns"
 tldType: "REAL"
 tldUnicode: "idns"
-transferGracePeriodLength: 432000000
+transferGracePeriodLength: "PT432000S"

--- a/core/src/test/resources/google/registry/tools/missingnullablefields.yaml
+++ b/core/src/test/resources/google/registry/tools/missingnullablefields.yaml
@@ -1,9 +1,9 @@
-addGracePeriodLength: 432000000
+addGracePeriodLength: "PT2592000S"
 allowedFullyQualifiedHostNames: []
 allowedRegistrantContactIds: []
-anchorTenantAddGracePeriodLength: 2592000000
-automaticTransferLength: 432000000
-autoRenewGracePeriodLength: 3888000000
+anchorTenantAddGracePeriodLength: "PT2592000S"
+automaticTransferLength: "PT2592000S"
+autoRenewGracePeriodLength: "PT2592000S"
 claimsPeriodEnd: "294247-01-10T04:00:54.775Z"
 createBillingCost:
   currency: "USD"
@@ -25,9 +25,9 @@ escrowEnabled: false
 idnTables: []
 invoicingEnabled: false
 lordnUsername: null
-pendingDeleteLength: 432000000
+pendingDeleteLength: "PT2592000S"
 pricingEngineClassName: "google.registry.model.pricing.StaticPremiumListPricingEngine"
-redemptionGracePeriodLength: 2592000000
+redemptionGracePeriodLength: "PT2592000S"
 registryLockOrUnlockBillingCost:
   currency: "USD"
   amount: 0.00
@@ -35,7 +35,7 @@ renewBillingCostTransitions:
   "1970-01-01T00:00:00.000Z":
     currency: "USD"
     amount: 11.00
-renewGracePeriodLength: 432000000
+renewGracePeriodLength: "PT2592000S"
 reservedListNames: []
 restoreBillingCost:
   currency: "USD"
@@ -47,4 +47,4 @@ serverStatusChangeBillingCost:
 tldStr: "missingnullablefields"
 tldType: "REAL"
 tldUnicode: "missingnullablefields"
-transferGracePeriodLength: 432000000
+transferGracePeriodLength: "PT2592000S"

--- a/core/src/test/resources/google/registry/tools/nullablefieldsallnull.yaml
+++ b/core/src/test/resources/google/registry/tools/nullablefieldsallnull.yaml
@@ -18,14 +18,14 @@ reservedListNames: null
 premiumListName: null
 escrowEnabled: false
 dnsPaused: false
-addGracePeriodLength: 432000000
-anchorTenantAddGracePeriodLength: 2592000000
-autoRenewGracePeriodLength: 3888000000
-redemptionGracePeriodLength: 2592000000
-renewGracePeriodLength: 432000000
-transferGracePeriodLength: 432000000
-automaticTransferLength: 432000000
-pendingDeleteLength: 432000000
+addGracePeriodLength: "PT2592000S"
+anchorTenantAddGracePeriodLength: "PT2592000S"
+autoRenewGracePeriodLength: "PT2592000S"
+redemptionGracePeriodLength: "PT2592000S"
+renewGracePeriodLength: "PT2592000S"
+transferGracePeriodLength: "PT2592000S"
+automaticTransferLength: "PT2592000S"
+pendingDeleteLength: "PT2592000S"
 currency: "USD"
 createBillingCost:
   currency: "USD"

--- a/core/src/test/resources/google/registry/tools/outoforderfields.yaml
+++ b/core/src/test/resources/google/registry/tools/outoforderfields.yaml
@@ -5,13 +5,13 @@ reservedListNames: []
 dnsPaused: false
 tldType: "REAL"
 escrowEnabled: false
-anchorTenantAddGracePeriodLength: 2592000000
+anchorTenantAddGracePeriodLength: "PT2592000S"
 dnsNsTtl: null
 tldStr: "outoforderfields"
 roidSuffix: "TLD"
 dnsWriters:
 - "VoidDnsWriter"
-dnsAPlusAaaaTtl: 900
+dnsAPlusAaaaTtl: "PT900S"
 dnsDsTtl: null
 tldUnicode: "outoforderfields"
 driveFolderId: "driveFolder"
@@ -19,13 +19,13 @@ invoicingEnabled: false
 tldStateTransitions:
   "1970-01-01T00:00:00.000Z": "GENERAL_AVAILABILITY"
 premiumListName: "test"
-addGracePeriodLength: 432000000
-autoRenewGracePeriodLength: 3888000000
-redemptionGracePeriodLength: 2592000000
-renewGracePeriodLength: 432000000
-transferGracePeriodLength: 432000000
-automaticTransferLength: 432000000
-pendingDeleteLength: 432000000
+addGracePeriodLength: "PT2592000S"
+autoRenewGracePeriodLength: "PT2592000S"
+redemptionGracePeriodLength: "PT2592000S"
+renewGracePeriodLength: "PT2592000S"
+transferGracePeriodLength: "PT2592000S"
+automaticTransferLength: "PT2592000S"
+pendingDeleteLength: "PT2592000S"
 currency: "USD"
 createBillingCost:
   currency: "USD"

--- a/core/src/test/resources/google/registry/tools/tld.yaml
+++ b/core/src/test/resources/google/registry/tools/tld.yaml
@@ -1,9 +1,9 @@
-addGracePeriodLength: 432000000
+addGracePeriodLength: "PT432000S"
 allowedFullyQualifiedHostNames: []
 allowedRegistrantContactIds: []
-anchorTenantAddGracePeriodLength: 2592000000
-autoRenewGracePeriodLength: 3888000000
-automaticTransferLength: 432000000
+anchorTenantAddGracePeriodLength: "PT2592000S"
+autoRenewGracePeriodLength: "PT3888000S"
+automaticTransferLength: "PT432000S"
 claimsPeriodEnd: "294247-01-10T04:00:54.775Z"
 createBillingCost:
   currency: "USD"
@@ -11,7 +11,7 @@ createBillingCost:
 creationTime: "2022-09-01T00:00:00.000Z"
 currency: "USD"
 defaultPromoTokens: []
-dnsAPlusAaaaTtl: 900
+dnsAPlusAaaaTtl: "PT900S"
 dnsDsTtl: null
 dnsNsTtl: null
 dnsPaused: false
@@ -27,10 +27,10 @@ idnTables: []
 invoicingEnabled: false
 lordnUsername: null
 numDnsPublishLocks: 1
-pendingDeleteLength: 432000000
+pendingDeleteLength: "PT432000S"
 premiumListName: "test"
 pricingEngineClassName: "google.registry.model.pricing.StaticPremiumListPricingEngine"
-redemptionGracePeriodLength: 2592000000
+redemptionGracePeriodLength: "PT2592000S"
 registryLockOrUnlockBillingCost:
   currency: "USD"
   amount: 0.00
@@ -38,7 +38,7 @@ renewBillingCostTransitions:
   "1970-01-01T00:00:00.000Z":
     currency: "USD"
     amount: 11.00
-renewGracePeriodLength: 432000000
+renewGracePeriodLength: "PT432000S"
 reservedListNames: []
 restoreBillingCost:
   currency: "USD"
@@ -52,4 +52,4 @@ tldStateTransitions:
 tldStr: "tld"
 tldType: "REAL"
 tldUnicode: "tld"
-transferGracePeriodLength: 432000000
+transferGracePeriodLength: "PT432000S"

--- a/core/src/test/resources/google/registry/tools/wildcard.yaml
+++ b/core/src/test/resources/google/registry/tools/wildcard.yaml
@@ -1,9 +1,9 @@
-addGracePeriodLength: 432000000
+addGracePeriodLength: "PT432000S"
 allowedFullyQualifiedHostNames: []
 allowedRegistrantContactIds: []
-anchorTenantAddGracePeriodLength: 2592000000
-autoRenewGracePeriodLength: 3888000000
-automaticTransferLength: 432000000
+anchorTenantAddGracePeriodLength: "PT2592000S"
+autoRenewGracePeriodLength: "PT3888000S"
+automaticTransferLength: "PT432000S"
 claimsPeriodEnd: "294247-01-10T04:00:54.775Z"
 createBillingCost:
   currency: "USD"
@@ -11,7 +11,7 @@ createBillingCost:
 creationTime: "2022-09-01T00:00:00.000Z"
 currency: "USD"
 defaultPromoTokens: []
-dnsAPlusAaaaTtl: 900
+dnsAPlusAaaaTtl: "PT900S"
 dnsDsTtl: null
 dnsNsTtl: null
 dnsPaused: false
@@ -27,10 +27,10 @@ idnTables: []
 invoicingEnabled: false
 lordnUsername: null
 numDnsPublishLocks: 1
-pendingDeleteLength: 432000000
+pendingDeleteLength: "PT432000S"
 premiumListName: "test"
 pricingEngineClassName: "google.registry.model.pricing.StaticPremiumListPricingEngine"
-redemptionGracePeriodLength: 2592000000
+redemptionGracePeriodLength: "PT2592000S"
 registryLockOrUnlockBillingCost:
   currency: "USD"
   amount: 0.00
@@ -38,7 +38,7 @@ renewBillingCostTransitions:
   "1970-01-01T00:00:00.000Z":
     currency: "USD"
     amount: 11.00
-renewGracePeriodLength: 432000000
+renewGracePeriodLength: "PT432000S"
 reservedListNames: []
 restoreBillingCost:
   currency: "USD"
@@ -52,4 +52,4 @@ tldStateTransitions:
 tldStr: %TLDSTR%
 tldType: "REAL"
 tldUnicode: %TLDUNICODE%
-transferGracePeriodLength: 432000000
+transferGracePeriodLength: "PT432000S"


### PR DESCRIPTION
This addresses b/301119144. This changes the YAML representation of a TLD to show Duration fields as a String reperesntation using the Java Duration object's toString() format. This eliminates the previous ambiguity over the time unit that is being used for each duration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2161)
<!-- Reviewable:end -->
