### PR TITLE
Open resources link in new tab

### DIFF
--- a/console-webapp/src/app/home/widgets/resources-widget.component.html
+++ b/console-webapp/src/app/home/widgets/resources-widget.component.html
@@ -4,6 +4,7 @@
       <a
         class="console-app__widget_left"
         href="{{ userDataService.userData?.technicalDocsUrl }}"
+        target="_blank"
       >
         <mat-icon class="console-app__widget-icon">menu_book</mat-icon>
         <h1 class="console-app__widget-title">Resources</h1>


### PR DESCRIPTION
We want to do this because it takes the user to an external site, which could potentially lead to confusion if they tried to use the back button without a new tab.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2163)
<!-- Reviewable:end -->
