### PR TITLE
Throttle outgoing emails

### DIFF
--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -880,6 +880,17 @@ public final class RegistryConfig {
     }
 
     /**
+     * Returns the desired delay between outgoing emails when sending in bulk.
+     *
+     * <p>Gmail apparently has unpublished limits on peak throughput over short period.
+     */
+    @Provides
+    @Config("emailThrottleDuration")
+    public static Duration provideEmailThrottleSeconds(RegistryConfigSettings config) {
+      return Duration.standardSeconds(config.misc.emailThrottleSeconds);
+    }
+
+    /**
      * Returns the email address we send various alert e-mails to.
      *
      * <p>This allows us to easily verify the success or failure of periodic tasks by passively

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -208,6 +208,7 @@ public class RegistryConfigSettings {
   public static class Misc {
     public String sheetExportId;
     public boolean isEmailSendingEnabled;
+    public int emailThrottleSeconds;
     public String alertRecipientEmailAddress;
     // TODO(b/279671974): remove below field after migration
     public String newAlertRecipientEmailAddress;

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -443,6 +443,9 @@ misc:
   # Whether emails may be sent. For Prod and Sandbox this should be true.
   isEmailSendingEnabled: false
 
+  # Delay between bulk messages to avoid triggering Gmail fraud checks
+  emailThrottleSeconds: 30
+
   # Address we send alert summary emails to.
   alertRecipientEmailAddress: email@example.com
 

--- a/core/src/main/java/google/registry/reporting/billing/BillingEmailUtils.java
+++ b/core/src/main/java/google/registry/reporting/billing/BillingEmailUtils.java
@@ -53,7 +53,7 @@ public class BillingEmailUtils {
       GmailClient gmailClient,
       YearMonth yearMonth,
       @Config("gSuiteOutgoingEmailAddress") InternetAddress outgoingEmailAddress,
-      @Config("alertRecipientEmailAddress") InternetAddress alertRecipientAddress,
+      @Config("newAlertRecipientEmailAddress") InternetAddress alertRecipientAddress,
       @Config("invoiceEmailRecipients") ImmutableList<InternetAddress> invoiceEmailRecipients,
       @Config("invoiceReplyToEmailAddress") Optional<InternetAddress> replyToEmailAddress,
       @Config("billingBucket") String billingBucket,


### PR DESCRIPTION
Adds a delay between emails sent in a tight loop. This helps avoid triggering Gmail abuse detections.

Also updated the recipient address for billing alerts.