### PR TITLE
Make sure unsafe names can be sent in emails

### DIFF
--- a/core/src/main/java/google/registry/reporting/spec11/Spec11EmailUtils.java
+++ b/core/src/main/java/google/registry/reporting/spec11/Spec11EmailUtils.java
@@ -171,7 +171,7 @@ public class Spec11EmailUtils {
     gmailClient.sendEmail(
         EmailMessage.newBuilder()
             .setSubject(subject)
-            .setBody(getContent(date, soyTemplateInfo, registrarThreatMatches))
+            .setBody(getEmailBody(date, soyTemplateInfo, registrarThreatMatches))
             .setContentType(MediaType.HTML_UTF_8)
             .setFrom(outgoingEmailAddress)
             .addRecipient(getEmailAddressForRegistrar(registrarThreatMatches.clientId()))
@@ -179,7 +179,7 @@ public class Spec11EmailUtils {
             .build());
   }
 
-  private String getContent(
+  private String getEmailBody(
       LocalDate date,
       SoyTemplateInfo soyTemplateInfo,
       RegistrarThreatMatches registrarThreatMatches) {
@@ -190,7 +190,7 @@ public class Spec11EmailUtils {
             .map(
                 threatMatch ->
                     ImmutableMap.of(
-                        "domainName", threatMatch.domainName(),
+                        "domainName", toEmailSafeString(threatMatch.domainName()),
                         "threatType", threatMatch.threatType()))
             .collect(toImmutableList());
 
@@ -203,6 +203,12 @@ public class Spec11EmailUtils {
             "resources", spec11WebResources);
     renderer.setData(data);
     return renderer.render();
+  }
+
+  // Mutates a known bad domain to pass spam checks by Email sender and clients, as suggested by
+  // the Gmail abuse-detection team.
+  private String toEmailSafeString(String knownUnsafeDomain) {
+    return knownUnsafeDomain.replace(".", "[.]");
   }
 
   /** Sends an e-mail indicating the state of the spec11 pipeline, with a given subject and body. */

--- a/core/src/test/java/google/registry/reporting/spec11/Spec11EmailUtilsTest.java
+++ b/core/src/test/java/google/registry/reporting/spec11/Spec11EmailUtilsTest.java
@@ -165,7 +165,7 @@ class Spec11EmailUtilsTest {
         "the.registrar@example.com",
         ImmutableList.of("abuse@test.com", "bcc@test.com"),
         "Super Cool Registry Monthly Threat Detector [2018-07-15]",
-        String.format(MONTHLY_EMAIL_FORMAT, "<tr><td>a.com</td><td>MALWARE</td></tr>"),
+        String.format(MONTHLY_EMAIL_FORMAT, "<tr><td>a[.]com</td><td>MALWARE</td></tr>"),
         Optional.of(MediaType.HTML_UTF_8));
     validateMessage(
         capturedContents.get(1),
@@ -175,7 +175,7 @@ class Spec11EmailUtilsTest {
         "Super Cool Registry Monthly Threat Detector [2018-07-15]",
         String.format(
             MONTHLY_EMAIL_FORMAT,
-            "<tr><td>b.com</td><td>MALWARE</td></tr><tr><td>c.com</td><td>MALWARE</td></tr>"),
+            "<tr><td>b[.]com</td><td>MALWARE</td></tr><tr><td>c[.]com</td><td>MALWARE</td></tr>"),
         Optional.of(MediaType.HTML_UTF_8));
     validateMessage(
         capturedContents.get(2),
@@ -203,7 +203,7 @@ class Spec11EmailUtilsTest {
         "the.registrar@example.com",
         ImmutableList.of("abuse@test.com", "bcc@test.com"),
         "Super Cool Registry Daily Threat Detector [2018-07-15]",
-        String.format(DAILY_EMAIL_FORMAT, "<tr><td>a.com</td><td>MALWARE</td></tr>"),
+        String.format(DAILY_EMAIL_FORMAT, "<tr><td>a[.]com</td><td>MALWARE</td></tr>"),
         Optional.of(MediaType.HTML_UTF_8));
     validateMessage(
         capturedMessages.get(1),
@@ -213,7 +213,7 @@ class Spec11EmailUtilsTest {
         "Super Cool Registry Daily Threat Detector [2018-07-15]",
         String.format(
             DAILY_EMAIL_FORMAT,
-            "<tr><td>b.com</td><td>MALWARE</td></tr><tr><td>c.com</td><td>MALWARE</td></tr>"),
+            "<tr><td>b[.]com</td><td>MALWARE</td></tr><tr><td>c[.]com</td><td>MALWARE</td></tr>"),
         Optional.of(MediaType.HTML_UTF_8));
     validateMessage(
         capturedMessages.get(2),
@@ -244,7 +244,7 @@ class Spec11EmailUtilsTest {
         "new.registrar@example.com",
         ImmutableList.of("abuse@test.com", "bcc@test.com"),
         "Super Cool Registry Monthly Threat Detector [2018-07-15]",
-        String.format(MONTHLY_EMAIL_FORMAT, "<tr><td>c.com</td><td>MALWARE</td></tr>"),
+        String.format(MONTHLY_EMAIL_FORMAT, "<tr><td>c[.]com</td><td>MALWARE</td></tr>"),
         Optional.of(MediaType.HTML_UTF_8));
     validateMessage(
         capturedContents.get(1),
@@ -277,7 +277,7 @@ class Spec11EmailUtilsTest {
         "the.registrar@example.com",
         ImmutableList.of("abuse@test.com", "bcc@test.com"),
         "Super Cool Registry Monthly Threat Detector [2018-07-15]",
-        String.format(MONTHLY_EMAIL_FORMAT, "<tr><td>a.com</td><td>MALWARE</td></tr>"),
+        String.format(MONTHLY_EMAIL_FORMAT, "<tr><td>a[.]com</td><td>MALWARE</td></tr>"),
         Optional.of(MediaType.HTML_UTF_8));
     validateMessage(
         capturedContents.get(1),
@@ -287,7 +287,7 @@ class Spec11EmailUtilsTest {
         "Super Cool Registry Monthly Threat Detector [2018-07-15]",
         String.format(
             MONTHLY_EMAIL_FORMAT,
-            "<tr><td>b.com</td><td>MALWARE</td></tr><tr><td>c.com</td><td>MALWARE</td></tr>"),
+            "<tr><td>b[.]com</td><td>MALWARE</td></tr><tr><td>c[.]com</td><td>MALWARE</td></tr>"),
         Optional.of(MediaType.HTML_UTF_8));
     validateMessage(
         capturedContents.get(2),
@@ -332,7 +332,7 @@ class Spec11EmailUtilsTest {
         "the.registrar@example.com",
         ImmutableList.of("abuse@test.com", "bcc@test.com"),
         "Super Cool Registry Monthly Threat Detector [2018-07-15]",
-        String.format(MONTHLY_EMAIL_FORMAT, "<tr><td>a.com</td><td>MALWARE</td></tr>"),
+        String.format(MONTHLY_EMAIL_FORMAT, "<tr><td>a[.]com</td><td>MALWARE</td></tr>"),
         Optional.of(MediaType.HTML_UTF_8));
     validateMessage(
         capturedMessages.get(1),
@@ -342,7 +342,7 @@ class Spec11EmailUtilsTest {
         "Super Cool Registry Monthly Threat Detector [2018-07-15]",
         String.format(
             MONTHLY_EMAIL_FORMAT,
-            "<tr><td>b.com</td><td>MALWARE</td></tr><tr><td>c.com</td><td>MALWARE</td></tr>"),
+            "<tr><td>b[.]com</td><td>MALWARE</td></tr><tr><td>c[.]com</td><td>MALWARE</td></tr>"),
         Optional.of(MediaType.HTML_UTF_8));
     validateMessage(
         capturedMessages.get(2),


### PR DESCRIPTION
Surround the dot in unsafe domain names with a square bracket. This is suggested by Gmail abuse-detection and allows outgoing messages to pass Gmail's check. This should also help with recipients' checks.