### PR TITLE
Use reTransact when loading the cache for database objects

### DIFF
--- a/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
+++ b/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
@@ -305,14 +305,14 @@ public class AllocationToken extends UpdateAutoTimestampEntity implements Builda
                   new CacheLoader<VKey<AllocationToken>, Optional<AllocationToken>>() {
                     @Override
                     public Optional<AllocationToken> load(VKey<AllocationToken> key) {
-                      return tm().transact(() -> tm().loadByKeyIfPresent(key));
+                      return tm().reTransact(() -> tm().loadByKeyIfPresent(key));
                     }
 
                     @Override
                     public Map<VKey<AllocationToken>, Optional<AllocationToken>> loadAll(
                         Iterable<? extends VKey<AllocationToken>> keys) {
                       ImmutableSet<VKey<AllocationToken>> keySet = ImmutableSet.copyOf(keys);
-                      return tm().transact(
+                      return tm().reTransact(
                               () ->
                                   keySet.stream()
                                       .collect(

--- a/core/src/main/java/google/registry/model/registrar/Registrar.java
+++ b/core/src/main/java/google/registry/model/registrar/Registrar.java
@@ -200,7 +200,11 @@ public class Registrar extends UpdateAutoTimestampEntity implements Buildable, J
 
   /** A caching {@link Supplier} of a registrarId to {@link Registrar} map. */
   private static final Supplier<ImmutableMap<String, Registrar>> CACHE_BY_REGISTRAR_ID =
-      memoizeWithShortExpiration(() -> Maps.uniqueIndex(loadAll(), Registrar::getRegistrarId));
+      memoizeWithShortExpiration(
+          () ->
+              Maps.uniqueIndex(
+                  tm().reTransact(() -> tm().loadAllOf(Registrar.class)),
+                  Registrar::getRegistrarId));
 
   /**
    * Unique registrar client id. Must conform to "clIDType" as defined in RFC5730.

--- a/core/src/main/java/google/registry/model/smd/SignedMarkRevocationListDao.java
+++ b/core/src/main/java/google/registry/model/smd/SignedMarkRevocationListDao.java
@@ -28,7 +28,7 @@ public class SignedMarkRevocationListDao {
   /** Loads the {@link SignedMarkRevocationList}. */
   static SignedMarkRevocationList load() {
     Optional<SignedMarkRevocationList> smdrl =
-        tm().transact(
+        tm().reTransact(
                 () -> {
                   Long revisionId =
                       tm().query("SELECT MAX(revisionId) FROM SignedMarkRevocationList", Long.class)

--- a/core/src/main/java/google/registry/model/tld/Tld.java
+++ b/core/src/main/java/google/registry/model/tld/Tld.java
@@ -233,7 +233,8 @@ public class Tld extends ImmutableObject implements Buildable, UnsafeSerializabl
               new CacheLoader<String, Tld>() {
                 @Override
                 public Tld load(final String tld) {
-                  return tm().transact(() -> tm().loadByKeyIfPresent(createVKey(tld))).orElse(null);
+                  return tm().reTransact(() -> tm().loadByKeyIfPresent(createVKey(tld)))
+                      .orElse(null);
                 }
 
                 @Override
@@ -241,7 +242,7 @@ public class Tld extends ImmutableObject implements Buildable, UnsafeSerializabl
                   ImmutableMap<String, VKey<Tld>> keysMap =
                       toMap(ImmutableSet.copyOf(tlds), Tld::createVKey);
                   Map<VKey<? extends Tld>, Tld> entities =
-                      tm().transact(() -> tm().loadByKeysIfPresent(keysMap.values()));
+                      tm().reTransact(() -> tm().loadByKeysIfPresent(keysMap.values()));
                   return Maps.transformEntries(keysMap, (k, v) -> entities.getOrDefault(v, null));
                 }
               });

--- a/core/src/main/java/google/registry/model/tld/Tlds.java
+++ b/core/src/main/java/google/registry/model/tld/Tlds.java
@@ -56,7 +56,7 @@ public final class Tlds {
   private static Supplier<ImmutableMap<String, TldType>> createFreshCache() {
     return memoizeWithShortExpiration(
         () ->
-            tm().transact(
+            tm().reTransact(
                     () -> {
                       EntityManager entityManager = tm().getEntityManager();
                       Stream<?> resultStream =


### PR DESCRIPTION
Cache loads will likely always be inner transactions, if they have a transaction at all. Cache loads do not always call a transaction since they are only necessary if the cache is not fresh at the time it is called. Since the cache itself needs to decide whether or not a DB transaction is necessary, it should use the reTransact method to safely indicate that the isolation level of the outer transaction is what should be used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2179)
<!-- Reviewable:end -->
