### PR TITLE
Lower the isolation level for RefreshDnsForAllDomainsAction

### DIFF
--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -193,7 +193,7 @@ hibernate:
   # to true, nested transactions will throw an exception. If set to false, a
   # transaction with the isolation override specified will still execute at the
   # default level (specified below).
-  perTransactionIsolation: true
+  perTransactionIsolation: false
 
   # Make 'SERIALIZABLE' the default isolation level to ensure correctness.
   #

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -193,7 +193,7 @@ hibernate:
   # to true, nested transactions will throw an exception. If set to false, a
   # transaction with the isolation override specified will still execute at the
   # default level (specified below).
-  perTransactionIsolation: false
+  perTransactionIsolation: true
 
   # Make 'SERIALIZABLE' the default isolation level to ensure correctness.
   #


### PR DESCRIPTION
 This lowers the isolation level to TRANSACTION_REPEATABLE_READ which will hopefully allow the action to run the entire action without timing out on our larger TLDs.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2182)
<!-- Reviewable:end -->
