### PR TITLE
Remove node.js download instruction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,9 +60,8 @@ dependencyLocking {
 }
 
 node {
-  download = true
-  version = "16.14.0"
-  npmVersion = "6.14.11"
+  download = false
+  version = "16.19.0"
 }
 
 wrapper {


### PR DESCRIPTION
node.js is already installed as a part of gradle-runner.sh, so I don't think this download is necessary

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2192)
<!-- Reviewable:end -->
