### PR TITLE
Refactor transact() related methods.

### DIFF
--- a/core/src/main/java/google/registry/beam/common/RegistryJpaIO.java
+++ b/core/src/main/java/google/registry/beam/common/RegistryJpaIO.java
@@ -209,7 +209,7 @@ public final class RegistryJpaIO {
 
       @ProcessElement
       public void processElement(OutputReceiver<T> outputReceiver) {
-        tm().transactNoRetry(
+        tm().transact(
                 () -> {
                   query.stream().map(resultMapper::apply).forEach(outputReceiver::output);
                 });

--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -1548,9 +1548,9 @@ public final class RegistryConfig {
     return CONFIG_SETTINGS.get().hibernate.connectionIsolation;
   }
 
-  /** Returns true if per-transaction isolation level is enabled. */
-  public static boolean getHibernatePerTransactionIsolationEnabled() {
-    return CONFIG_SETTINGS.get().hibernate.perTransactionIsolation;
+  /** Returns true if nested calls to {@code tm().transact()} are allowed. */
+  public static boolean getHibernateAllowNestedTransactions() {
+    return CONFIG_SETTINGS.get().hibernate.allowNestedTransactions;
   }
 
   /** Returns true if hibernate.show_sql is enabled. */

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -113,7 +113,7 @@ public class RegistryConfigSettings {
 
   /** Configuration for Hibernate. */
   public static class Hibernate {
-    public boolean perTransactionIsolation;
+    public boolean allowNestedTransactions;
     public String connectionIsolation;
     public String logSqlQueries;
     public String hikariConnectionTimeout;

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -189,11 +189,13 @@ registryPolicy:
   sunriseDomainCreateDiscount: 0.15
 
 hibernate:
-  # Make it possible to specify the isolation level for each transaction. If set
-  # to true, nested transactions will throw an exception. If set to false, a
-  # transaction with the isolation override specified will still execute at the
-  # default level (specified below).
-  perTransactionIsolation: true
+  # If set to false, calls to tm().transact() cannot be nested. If set to true,
+  # nested calls to tm().transact() are allowed, as long as they do not specify
+  # a transaction isolation level override. These nested transactions should
+  # either be refactored to non-nested transactions, or changed to
+  # tm().reTransact(), which explicitly allows nested transactions, but does not
+  # allow setting an isolation level override.
+  allowNestedTransactions: true
 
   # Make 'SERIALIZABLE' the default isolation level to ensure correctness.
   #

--- a/core/src/main/java/google/registry/persistence/transaction/DatabaseException.java
+++ b/core/src/main/java/google/registry/persistence/transaction/DatabaseException.java
@@ -62,7 +62,7 @@ class DatabaseException extends PersistenceException {
    * <p>If the {@code original Throwable} has at least one {@link SQLException} in its chain of
    * causes, a {@link DatabaseException} is thrown; otherwise this does nothing.
    */
-  static void tryWrapAndThrow(Throwable original) {
+  static void throwIfSqlException(Throwable original) {
     Throwable t = original;
     do {
       if (t instanceof SQLException) {

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManager.java
@@ -16,7 +16,6 @@ package google.registry.persistence.transaction;
 
 import google.registry.persistence.PersistenceModule.TransactionIsolationLevel;
 import google.registry.persistence.VKey;
-import java.util.function.Supplier;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import javax.persistence.TypedQuery;
@@ -62,24 +61,6 @@ public interface JpaTransactionManager extends TransactionManager {
    */
   Query query(String sqlString);
 
-  /** Executes the work in a transaction with no retries and returns the result. */
-  <T> T transactNoRetry(Supplier<T> work);
-
-  /**
-   * Executes the work in a transaction at the given {@link TransactionIsolationLevel} with no
-   * retries and returns the result.
-   */
-  <T> T transactNoRetry(Supplier<T> work, TransactionIsolationLevel isolationLevel);
-
-  /** Executes the work in a transaction with no retries. */
-  void transactNoRetry(Runnable work);
-
-  /**
-   * Executes the work in a transaction at the given {@link TransactionIsolationLevel} with no
-   * retries.
-   */
-  void transactNoRetry(Runnable work, TransactionIsolationLevel isolationLevel);
-
   /** Deletes the entity by its id, throws exception if the entity is not deleted. */
   <T> void assertDelete(VKey<T> key);
 
@@ -103,7 +84,4 @@ public interface JpaTransactionManager extends TransactionManager {
 
   /** Return the {@link TransactionIsolationLevel} used in the current transaction. */
   TransactionIsolationLevel getCurrentTransactionIsolationLevel();
-
-  /** Asserts that the current transaction runs at the given level. */
-  void assertTransactionIsolationLevel(TransactionIsolationLevel expectedLevel);
 }

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -15,11 +15,12 @@
 package google.registry.persistence.transaction;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static google.registry.config.RegistryConfig.getHibernatePerTransactionIsolationEnabled;
-import static google.registry.persistence.transaction.DatabaseException.tryWrapAndThrow;
+import static google.registry.config.RegistryConfig.getHibernateAllowNestedTransactions;
+import static google.registry.persistence.transaction.DatabaseException.throwIfSqlException;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 import static java.util.AbstractMap.SimpleEntry;
 import static java.util.stream.Collectors.joining;
@@ -31,6 +32,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import com.google.common.flogger.FluentLogger;
+import com.google.common.flogger.StackSize;
 import google.registry.model.ImmutableObject;
 import google.registry.persistence.JpaRetries;
 import google.registry.persistence.PersistenceModule.TransactionIsolationLevel;
@@ -52,7 +54,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Supplier;
+import java.util.concurrent.Callable;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
@@ -76,6 +78,9 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
   private static final Retrier retrier = new Retrier(new SystemSleeper(), 3);
+  private static final String NESTED_TRANSACTION_MESSAGE =
+      "Nested transaction detected. Try refactoring to avoid nested transactions. If unachievable,"
+          + " use reTransact() in nested transactions";
 
   // EntityManagerFactory is thread safe.
   private final EntityManagerFactory emf;
@@ -138,21 +143,23 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   }
 
   @Override
-  public void assertTransactionIsolationLevel(TransactionIsolationLevel expectedLevel) {
-    assertInTransaction();
-    TransactionIsolationLevel currentLevel = getCurrentTransactionIsolationLevel();
-    if (currentLevel != expectedLevel) {
-      throw new IllegalStateException(
-          String.format(
-              "Current transaction isolation level (%s) is not as expected (%s)",
-              currentLevel, expectedLevel));
+  public <T> T reTransact(Callable<T> work) {
+    // This prevents inner transaction from retrying, thus avoiding a cascade retry effect.
+    if (inTransaction()) {
+      return transactNoRetry(work, null);
     }
+    return retrier.callWithRetry(
+        () -> transactNoRetry(work, null), JpaRetries::isFailedTxnRetriable);
   }
 
   @Override
-  public <T> T transact(Supplier<T> work, TransactionIsolationLevel isolationLevel) {
-    // This prevents inner transaction from retrying, thus avoiding a cascade retry effect.
+  public <T> T transact(Callable<T> work, TransactionIsolationLevel isolationLevel) {
     if (inTransaction()) {
+      if (!getHibernateAllowNestedTransactions()) {
+        throw new IllegalStateException(NESTED_TRANSACTION_MESSAGE);
+      }
+      logger.atWarning().withStackTrace(StackSize.MEDIUM).log(NESTED_TRANSACTION_MESSAGE);
+      // This prevents inner transaction from retrying, thus avoiding a cascade retry effect.
       return transactNoRetry(work, isolationLevel);
     }
     return retrier.callWithRetry(
@@ -160,30 +167,32 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   }
 
   @Override
-  public <T> T reTransact(Supplier<T> work) {
-    return transact(work);
-  }
-
-  @Override
-  public <T> T transact(Supplier<T> work) {
+  public <T> T transact(Callable<T> work) {
     return transact(work, null);
   }
 
-  @Override
   public <T> T transactNoRetry(
-      Supplier<T> work, @Nullable TransactionIsolationLevel isolationLevel) {
+      Callable<T> work, @Nullable TransactionIsolationLevel isolationLevel) {
     if (inTransaction()) {
-      if (isolationLevel != null && getHibernatePerTransactionIsolationEnabled()) {
-        TransactionIsolationLevel enclosingLevel = getCurrentTransactionIsolationLevel();
-        if (isolationLevel != enclosingLevel) {
-          throw new IllegalStateException(
-              String.format(
-                  "Isolation level conflict detected in nested transactions.\n"
-                      + "Enclosing transaction: %s\nCurrent transaction: %s",
-                  enclosingLevel, isolationLevel));
-        }
+      // This check will no longer be necessary when the transact() method always throws
+      // inside a nested transaction, as the only way to pass a non-null isolation level
+      // is by calling the transact() method (and its variants), which would have already
+      // thrown before calling transactNoRetry() when inside a nested transaction.
+      //
+      // For now, we still need it, so we don't accidentally call a nested transact() with an
+      // isolation level override. This buys us time to detect nested transact() calls and either
+      // remove them or change the call site to reTransact().
+      if (isolationLevel != null) {
+        throw new IllegalStateException(
+            "Transaction isolation level cannot be specified for nested transactions");
       }
-      return work.get();
+      try {
+        return work.call();
+      } catch (Exception e) {
+        throwIfSqlException(e);
+        throwIfUnchecked(e);
+        throw new RuntimeException(e);
+      }
     }
     TransactionInfo txnInfo = transactionInfo.get();
     txnInfo.entityManager = emf.createEntityManager();
@@ -191,43 +200,36 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
     try {
       txn.begin();
       txnInfo.start(clock);
-      if (isolationLevel != null) {
-        if (getHibernatePerTransactionIsolationEnabled()) {
-          getEntityManager()
-              .createNativeQuery(
-                  String.format("SET TRANSACTION ISOLATION LEVEL %s", isolationLevel.getMode()))
-              .executeUpdate();
-          logger.atInfo().log("Running transaction at %s", isolationLevel);
-        } else {
-          logger.atWarning().log(
-              "Per-transaction isolation level disabled, but %s was requested", isolationLevel);
-        }
+      if (isolationLevel != null && isolationLevel != getDefaultTransactionIsolationLevel()) {
+        getEntityManager()
+            .createNativeQuery(
+                String.format("SET TRANSACTION ISOLATION LEVEL %s", isolationLevel.getMode()))
+            .executeUpdate();
+        logger.atInfo().log(
+            "Overriding transaction isolation level from %s to %s",
+            getDefaultTransactionIsolationLevel(), isolationLevel);
       }
-      T result = work.get();
+      T result = work.call();
       txn.commit();
       return result;
-    } catch (RuntimeException | Error e) {
-      // Error is unchecked!
+    } catch (Throwable e) {
+      // Catch a Throwable here so even Errors would lead to a rollback.
       try {
         txn.rollback();
         logger.atWarning().log("Error during transaction; transaction rolled back.");
-      } catch (Throwable rollbackException) {
+      } catch (Exception rollbackException) {
         logger.atSevere().withCause(rollbackException).log("Rollback failed; suppressing error.");
       }
-      tryWrapAndThrow(e);
-      throw e;
+      throwIfSqlException(e);
+      throwIfUnchecked(e);
+      throw new RuntimeException(e);
     } finally {
       txnInfo.clear();
     }
   }
 
   @Override
-  public <T> T transactNoRetry(Supplier<T> work) {
-    return transactNoRetry(work, null);
-  }
-
-  @Override
-  public void transact(Runnable work, TransactionIsolationLevel isolationLevel) {
+  public void transact(ThrowingRunnable work, TransactionIsolationLevel isolationLevel) {
     transact(
         () -> {
           work.run();
@@ -237,28 +239,17 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   }
 
   @Override
-  public void reTransact(Runnable work) {
-    transact(work);
-  }
-
-  @Override
-  public void transact(Runnable work) {
+  public void transact(ThrowingRunnable work) {
     transact(work, null);
   }
 
   @Override
-  public void transactNoRetry(Runnable work, TransactionIsolationLevel isolationLevel) {
-    transactNoRetry(
+  public void reTransact(ThrowingRunnable work) {
+    reTransact(
         () -> {
           work.run();
           return null;
-        },
-        isolationLevel);
-  }
-
-  @Override
-  public void transactNoRetry(Runnable work) {
-    transactNoRetry(work, null);
+        });
   }
 
   @Override

--- a/core/src/test/java/google/registry/flows/FlowRunnerTest.java
+++ b/core/src/test/java/google/registry/flows/FlowRunnerTest.java
@@ -31,7 +31,6 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.testing.TestLogHandler;
-import google.registry.config.RegistryConfig;
 import google.registry.flows.certs.CertificateChecker;
 import google.registry.model.eppcommon.Trid;
 import google.registry.model.eppoutput.EppOutput.ResponseOrGreeting;
@@ -89,8 +88,8 @@ class FlowRunnerTest {
 
     @Override
     public ResponseOrGreeting run() {
-      tm().assertTransactionIsolationLevel(
-              isolationLevel.orElse(tm().getDefaultTransactionIsolationLevel()));
+      assertThat(tm().getCurrentTransactionIsolationLevel())
+          .isEqualTo(isolationLevel.orElse(tm().getDefaultTransactionIsolationLevel()));
       return mock(EppResponse.class);
     }
   }
@@ -136,10 +135,8 @@ class FlowRunnerTest {
         Optional.of(TransactionIsolationLevel.TRANSACTION_READ_UNCOMMITTED);
     flowRunner.flowClass = TestTransactionalFlow.class;
     flowRunner.flowProvider = () -> new TestTransactionalFlow(flowRunner.isolationLevelOverride);
-    if (RegistryConfig.getHibernatePerTransactionIsolationEnabled()) {
-      flowRunner.run(eppMetricBuilder);
-      assertThat(eppMetricBuilder.build().getCommandName()).hasValue("TestTransactional");
-    }
+    flowRunner.run(eppMetricBuilder);
+    assertThat(eppMetricBuilder.build().getCommandName()).hasValue("TestTransactional");
   }
 
   @Test

--- a/core/src/test/java/google/registry/persistence/transaction/DatabaseExceptionTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/DatabaseExceptionTest.java
@@ -18,7 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static google.registry.persistence.transaction.DatabaseException.getSqlError;
 import static google.registry.persistence.transaction.DatabaseException.getSqlExceptionDetails;
-import static google.registry.persistence.transaction.DatabaseException.tryWrapAndThrow;
+import static google.registry.persistence.transaction.DatabaseException.throwIfSqlException;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -99,13 +99,13 @@ public class DatabaseExceptionTest {
   @Test
   void tryWrapAndThrow_notSQLException() {
     RuntimeException orig = new RuntimeException(new Exception());
-    tryWrapAndThrow(orig);
+    throwIfSqlException(orig);
   }
 
   @Test
   void tryWrapAndThrow_hasSQLException() {
     Throwable orig = new Throwable(new SQLException());
-    assertThrows(DatabaseException.class, () -> tryWrapAndThrow(orig));
+    assertThrows(DatabaseException.class, () -> throwIfSqlException(orig));
   }
 
   @Test


### PR DESCRIPTION
  This PR makes a few changes to make it possible to turn on
  per-transaction isolation level with minimal disruption:

  1) Changed the signatures of transact() and reTransact() methods to allow
  passing in lambdas that throw checked exceptions. Previously one has
  always to wrap such lambdas in try-and-retrow blocks, which wasn't a
  big issue when one can liberally open nested transactions around small
  lambdas and keeps the "throwing" part outside the lambda. This becomes a
  much bigger hassle when the goal is to eliminate nested transactions and
  put as much code as possible within the top-level lambda. As a result,
  the transactNoRetry() method now handles checked exceptions by re-throwing
  them as runtime exceptions.

  2) Changed the name and meaning of the config file field that used to
  indicate if per-transaction isolation level is enabled or not. Now it
  decides if transact() is called within a transaction, whether to
  throw or to log, regardless whether the transaction could have
  succeeded based on the isolation override level (if provided). The
  flag will initially be set to false and would help us identify all
  instances of nested calls and either refactor them or use reTransact()
  instead. Once we are fairly certain that no nested calls to transact()
  exists, we flip the flag to true and start enforcing this logic.
  Eventually the flag will go away and nested calls to transact() will
  always throw.

  3) Per-transaction isolation level will now always be applied, if an
  override is provided. Because currently there should be no actual
  use of such feature (except for places where we explicitly use an
  override and have ensured no nested transactions exist, like in
  RefreshDnsForAllDomainsAction), we do not expect any issues with
  conflicting isolation levels, which would resulted in failure.

  3) transactNoRetry() is made package private and removed from the
  exposed API of JpaTransactionManager. This saves a lot of redundant
  methods that do not have a practical use. The only instances where this
  method was called outside the package was in the reader of
  RegistryJpaIO, which should have no problem with retrying.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2195)
<!-- Reviewable:end -->
