### PR TITLE
Change the default config for perTransactionIsolation to true

### DIFF
--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -193,7 +193,7 @@ hibernate:
   # to true, nested transactions will throw an exception. If set to false, a
   # transaction with the isolation override specified will still execute at the
   # default level (specified below).
-  perTransactionIsolation: false
+  perTransactionIsolation: true
 
   # Make 'SERIALIZABLE' the default isolation level to ensure correctness.
   #


### PR DESCRIPTION
This was already set to true in all environments except prod last week. Now that the release has gone out and we have not seen any issues, we should feel safe turning this on in production as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2196)
<!-- Reviewable:end -->
