### PR TITLE
Upgrade to Java 17 runtime

### DIFF
--- a/core/src/main/java/google/registry/env/alpha/backend/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/alpha/backend/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>backend</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/alpha/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/alpha/default/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>default</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/alpha/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/alpha/pubapi/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>pubapi</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/alpha/tools/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/alpha/tools/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>tools</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/crash/backend/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/crash/backend/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>backend</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/crash/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/crash/default/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>default</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/crash/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/crash/pubapi/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>pubapi</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/crash/tools/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/crash/tools/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>tools</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/local/backend/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/local/backend/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>backend</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/local/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/local/default/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>default</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/local/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/local/pubapi/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>pubapi</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/local/tools/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/local/tools/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>tools</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/production/backend/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/backend/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>backend</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/production/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/default/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>default</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <manual-scaling>

--- a/core/src/main/java/google/registry/env/production/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/pubapi/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>pubapi</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <manual-scaling>

--- a/core/src/main/java/google/registry/env/production/tools/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/tools/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>tools</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/qa/backend/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/qa/backend/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>backend</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/qa/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/qa/default/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>default</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>F4_1G</instance-class>
   <automatic-scaling>

--- a/core/src/main/java/google/registry/env/qa/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/qa/pubapi/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>pubapi</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/qa/tools/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/qa/tools/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>tools</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/sandbox/backend/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/backend/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>backend</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>default</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <manual-scaling>

--- a/core/src/main/java/google/registry/env/sandbox/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/pubapi/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>pubapi</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <manual-scaling>

--- a/core/src/main/java/google/registry/env/sandbox/tools/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/tools/WEB-INF/appengine-web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>tools</service>
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>


### PR DESCRIPTION
We finally fixed Spinnaker (I hope) to deploy bundled services with Java
17 runtime. Note that the bytecodes are still targeting Java 8. The only
change this PR introduces is to switch the runtime environment to Java
17.

TESTED=Used alpha spinnaker to deploy to crash.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2201)
<!-- Reviewable:end -->
