### PR TITLE
Update Debian 10 -> 11, replace node.js installation method

### DIFF
--- a/release/builder/Dockerfile
+++ b/release/builder/Dockerfile
@@ -28,7 +28,7 @@ COPY go.sum ./
 COPY go.mod ./
 RUN go build -o /deployCloudSchedulerAndQueue
 
-FROM marketplace.gcr.io/google/debian10
+FROM marketplace.gcr.io/google/debian11
 ENV DEBIAN_FRONTEND=noninteractive LANG=en_US.UTF-8
 # Add script for cloud scheduler and cloud tasks deployment
 COPY --from=deployCloudSchedulerAndQueueBuilder /deployCloudSchedulerAndQueue /usr/local/bin/deployCloudSchedulerAndQueue

--- a/release/builder/build.sh
+++ b/release/builder/build.sh
@@ -24,7 +24,7 @@ apt-get install gnupg2 -y
 # Install Java
 apt-get install openjdk-11-jdk-headless -y
 # Install Python
-apt-get install python -y
+apt-get install python3 -y
 # As of March 2021 python3 is at v3.6. Get pip then install dataclasses
 # (introduced in 3.7) for nom_build
 apt-get install python3-pip -y
@@ -32,8 +32,10 @@ python3 -m pip install dataclasses
 # Install curl.
 apt-get install curl -y
 # Install Node
-curl -sL https://deb.nodesource.com/setup_current.x | bash -
-apt-get install -y nodejs
+apt-get install npm -y
+npm cache clean -f
+npm install -g n
+n 16.19.0
 # Install gcloud
 # Cribbed from https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu
 apt-get install lsb-release -y


### PR DESCRIPTION
Updated builder docker base image from Debian10 to Debian11.
Updated node.js installation method. The version it used to install wasn't inline with the version we use everywhere else, now that's fixed.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2206)
<!-- Reviewable:end -->
