### PR TITLE
Also load domains for domain checks of type renew/transfer

### DIFF
--- a/core/src/main/java/google/registry/model/domain/fee/FeeQueryCommandExtensionItem.java
+++ b/core/src/main/java/google/registry/model/domain/fee/FeeQueryCommandExtensionItem.java
@@ -34,12 +34,14 @@ public abstract class FeeQueryCommandExtensionItem extends ImmutableObject {
 
   /** The name of a command that might have an associated fee. */
   public enum CommandName {
-    UNKNOWN,
-    CREATE,
-    RENEW,
-    TRANSFER,
-    RESTORE,
-    UPDATE;
+    UNKNOWN(false),
+    CREATE(false),
+    RENEW(true),
+    TRANSFER(true),
+    RESTORE(true),
+    UPDATE(false);
+
+    private final boolean loadDomainForCheck;
 
     public static CommandName parseKnownCommand(String string) {
       try {
@@ -51,6 +53,14 @@ public abstract class FeeQueryCommandExtensionItem extends ImmutableObject {
             "Invalid EPP action name. Valid actions are CREATE, RENEW, TRANSFER, RESTORE, and"
                 + " UPDATE");
       }
+    }
+
+    CommandName(boolean loadDomainForCheck) {
+      this.loadDomainForCheck = loadDomainForCheck;
+    }
+
+    public boolean shouldLoadDomainForCheck() {
+      return this.loadDomainForCheck;
     }
   }
 

--- a/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
@@ -1073,6 +1073,30 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
   }
 
   @Test
+  void testFeeExtension_existingPremiumDomain_withNonPremiumRenewalBehavior_renewPriceOnly()
+      throws Exception {
+    createTld("example");
+    persistBillingRecurrenceForDomain(persistActiveDomain("rich.example"), NONPREMIUM, null);
+    setEppInput("domain_check_fee_premium_v06_renew_only.xml");
+    runFlowAssertResponse(
+        loadFile(
+            "domain_check_fee_response_domain_exists_v06_renew_only.xml",
+            ImmutableMap.of("RENEWPRICE", "11.00")));
+  }
+
+  @Test
+  void testFeeExtension_existingPremiumDomain_withNonPremiumRenewalBehavior_transferPriceOnly()
+      throws Exception {
+    createTld("example");
+    persistBillingRecurrenceForDomain(persistActiveDomain("rich.example"), NONPREMIUM, null);
+    setEppInput("domain_check_fee_premium_v06_transfer_only.xml");
+    runFlowAssertResponse(
+        loadFile(
+            "domain_check_fee_response_domain_exists_v06_transfer_only.xml",
+            ImmutableMap.of("RENEWPRICE", "11.00")));
+  }
+
+  @Test
   void testFeeExtension_existingPremiumDomain_withSpecifiedRenewalBehavior() throws Exception {
     createTld("example");
     persistBillingRecurrenceForDomain(
@@ -1203,6 +1227,18 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
     createTld("example");
     setEppInput("domain_check_fee_premium_v12.xml");
     runFlowAssertResponse(loadFile("domain_check_fee_premium_response_v12.xml"));
+  }
+
+  @Test
+  void testFeeExtension_premiumLabels_v12_specifiedPriceRenewal_renewPriceOnly() throws Exception {
+    createTld("example");
+    persistBillingRecurrenceForDomain(
+        persistActiveDomain("rich.example"), SPECIFIED, Money.of(USD, new BigDecimal("27.74")));
+    setEppInput("domain_check_fee_premium_v12_renew_only.xml");
+    runFlowAssertResponse(
+        loadFile(
+            "domain_check_fee_premium_response_v12_renew_only.xml",
+            ImmutableMap.of("RENEWPRICE", "27.74")));
   }
 
   @Test

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_fee_premium_response_v12_renew_only.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_fee_premium_response_v12_renew_only.xml
@@ -1,0 +1,33 @@
+domain_check_fee_premium_response_v12.xml<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <response>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
+    </result>
+    <resData>
+      <domain:chkData xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:cd>
+          <domain:name avail="false">rich.example</domain:name>
+          <domain:reason>In use</domain:reason>
+        </domain:cd>
+      </domain:chkData>
+    </resData>
+    <extension>
+      <fee:chkData xmlns:fee="urn:ietf:params:xml:ns:fee-0.12"
+       xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <fee:cd>
+          <fee:object>
+            <domain:name>rich.example</domain:name>
+          </fee:object>
+          <fee:command name="renew">
+            <fee:period unit="y">1</fee:period>
+            <fee:fee description="renew">%RENEWPRICE%</fee:fee>
+          </fee:command>
+        </fee:cd>
+      </fee:chkData>
+    </extension>
+    <trID>
+      <clTRID>ABC-12345</clTRID>
+      <svTRID>server-trid</svTRID>
+    </trID>
+  </response>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_fee_premium_v06_renew_only.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_fee_premium_v06_renew_only.xml
@@ -1,0 +1,18 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <command>
+    <check>
+      <domain:check xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>rich.example</domain:name>
+      </domain:check>
+    </check>
+    <extension>
+      <fee:check xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
+        <fee:domain>
+          <fee:name>rich.example</fee:name>
+          <fee:command>renew</fee:command>
+        </fee:domain>
+      </fee:check>
+    </extension>
+    <clTRID>ABC-12345</clTRID>
+  </command>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_fee_premium_v06_transfer_only.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_fee_premium_v06_transfer_only.xml
@@ -1,0 +1,18 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <command>
+    <check>
+      <domain:check xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>rich.example</domain:name>
+      </domain:check>
+    </check>
+    <extension>
+      <fee:check xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
+        <fee:domain>
+          <fee:name>rich.example</fee:name>
+          <fee:command>transfer</fee:command>
+        </fee:domain>
+      </fee:check>
+    </extension>
+    <clTRID>ABC-12345</clTRID>
+  </command>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_fee_premium_v12_renew_only.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_fee_premium_v12_renew_only.xml
@@ -1,0 +1,15 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <command>
+    <check>
+      <domain:check xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>rich.example</domain:name>
+      </domain:check>
+    </check>
+    <extension>
+      <fee:check xmlns:fee="urn:ietf:params:xml:ns:fee-0.12">
+        <fee:command name="renew" />
+      </fee:check>
+    </extension>
+    <clTRID>ABC-12345</clTRID>
+  </command>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_fee_response_domain_exists_v06_renew_only.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_fee_response_domain_exists_v06_renew_only.xml
@@ -1,0 +1,30 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <response>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
+    </result>
+    <resData>
+      <domain:chkData xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:cd>
+          <domain:name avail="0">rich.example</domain:name>
+          <domain:reason>In use</domain:reason>
+        </domain:cd>
+      </domain:chkData>
+    </resData>
+    <extension>
+      <fee:chkData xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
+        <fee:cd xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
+          <fee:name>rich.example</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>renew</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:fee description="renew">%RENEWPRICE%</fee:fee>
+        </fee:cd>
+      </fee:chkData>
+    </extension>
+    <trID>
+      <clTRID>ABC-12345</clTRID>
+      <svTRID>server-trid</svTRID>
+    </trID>
+  </response>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_fee_response_domain_exists_v06_transfer_only.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_fee_response_domain_exists_v06_transfer_only.xml
@@ -1,0 +1,30 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <response>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
+    </result>
+    <resData>
+      <domain:chkData xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:cd>
+          <domain:name avail="0">rich.example</domain:name>
+          <domain:reason>In use</domain:reason>
+        </domain:cd>
+      </domain:chkData>
+    </resData>
+    <extension>
+      <fee:chkData xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
+        <fee:cd xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
+          <fee:name>rich.example</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>transfer</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:fee description="renew">%RENEWPRICE%</fee:fee>
+        </fee:cd>
+      </fee:chkData>
+    </extension>
+    <trID>
+      <clTRID>ABC-12345</clTRID>
+      <svTRID>server-trid</svTRID>
+    </trID>
+  </response>
+</epp>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,18 @@
 {
   "name": "nomulus",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "google-closure-library": {
+  "packages": {
+    "": {
+      "name": "nomulus",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-closure-library": "20210406.0.0"
+      }
+    },
+    "node_modules/google-closure-library": {
       "version": "20210406.0.0",
       "resolved": "https://registry.npmjs.org/google-closure-library/-/google-closure-library-20210406.0.0.tgz",
       "integrity": "sha512-1lAC/KC9R2QM6nygniM0pRcGrv5bkCUrIZb2hXFxLtAkA+zRiVeWtRYpFWDHXXJzkavKjsn9upiffL4x/nmmVg=="


### PR DESCRIPTION
The domains (and their associated billing recurrences) were already being loaded to check restores, but they also now need to be loaded for renews and transfers as well, as the billing renewal behavior on the recurrence could be modifying the relevant renew price that should be shown. (The renew price is used for transfers as well.)

See https://buganizer.corp.google.com/issues/306212810

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2207)
<!-- Reviewable:end -->
