### PR TITLE
Download scheduler for BSA

### DIFF
--- a/core/src/main/java/google/registry/bsa/DownloadStage.java
+++ b/core/src/main/java/google/registry/bsa/DownloadStage.java
@@ -18,6 +18,10 @@ package google.registry.bsa;
 public enum DownloadStage {
   DOWNLOAD,
   MAKE_DIFF,
+  APPLY_DIFF,
+  START_UPLOADING,
+  UPLOAD_DOMAINS_IN_USE,
+  FINISH_UPLOADING,
   DONE,
   NOP,
   CHECKSUMS_NOT_MATCH;

--- a/core/src/main/java/google/registry/bsa/DownloadStage.java
+++ b/core/src/main/java/google/registry/bsa/DownloadStage.java
@@ -16,13 +16,31 @@ package google.registry.bsa;
 
 /** The processing stages of a download. */
 public enum DownloadStage {
+  /** Downloads BSA block list files. */
   DOWNLOAD,
+  /** Generates block list diffs with the previous download. */
   MAKE_DIFF,
+  /** Applies the label diffs to the database tables. */
   APPLY_DIFF,
+  /**
+   * Makes a REST API call to BSA endpoint, declaring that processing starts for new orders in the
+   * diffs.
+   */
   START_UPLOADING,
+  /** Makes a REST API call to BSA endpoint, sending the domains that cannot be blocked. */
   UPLOAD_DOMAINS_IN_USE,
+  /** Makes a REST API call to BSA endpoint, declaring the completion of order processing. */
   FINISH_UPLOADING,
+  /** The terminal stage after processing succeeds. */
   DONE,
+  /**
+   * The terminal stage indicating that the downloads are discarded because their checksums are the
+   * same as that of the previous download.
+   */
   NOP,
+  /**
+   * The terminal stage indicating that the downloads are not processed because their BSA-generated
+   * checksums do not match those calculated by us.
+   */
   CHECKSUMS_NOT_MATCH;
 }

--- a/core/src/main/java/google/registry/bsa/DownloadStage.java
+++ b/core/src/main/java/google/registry/bsa/DownloadStage.java
@@ -16,5 +16,9 @@ package google.registry.bsa;
 
 /** The processing stages of a download. */
 public enum DownloadStage {
-  DOWNLOAD;
+  DOWNLOAD,
+  MAKE_DIFF,
+  DONE,
+  NOP,
+  CHECKSUMS_NOT_MATCH;
 }

--- a/core/src/main/java/google/registry/bsa/persistence/BsaDownload.java
+++ b/core/src/main/java/google/registry/bsa/persistence/BsaDownload.java
@@ -65,8 +65,12 @@ public class BsaDownload {
 
   BsaDownload() {}
 
-  public long getJobId() {
+  long getJobId() {
     return jobId;
+  }
+
+  DateTime getCreationTime() {
+    return creationTime.getTimestamp();
   }
 
   /**
@@ -74,7 +78,7 @@ public class BsaDownload {
    * storing download data.
    */
   public String getJobName() {
-    return creationTime.getTimestamp().toString();
+    return getCreationTime().toString();
   }
 
   public DownloadStage getStage() {
@@ -86,17 +90,13 @@ public class BsaDownload {
     return this;
   }
 
-  DateTime getCreationTime() {
-    return creationTime.getTimestamp();
-  }
-
   BsaDownload setChecksums(ImmutableMap<BlockList, String> checksums) {
     blockListChecksums =
         CSV_JOINER.withKeyValueSeparator("=").join(ImmutableSortedMap.copyOf(checksums));
     return this;
   }
 
-  public ImmutableMap<BlockList, String> getChecksums() {
+  ImmutableMap<BlockList, String> getChecksums() {
     if (blockListChecksums.isEmpty()) {
       return ImmutableMap.of();
     }

--- a/core/src/main/java/google/registry/bsa/persistence/BsaDownload.java
+++ b/core/src/main/java/google/registry/bsa/persistence/BsaDownload.java
@@ -90,13 +90,13 @@ public class BsaDownload {
     return creationTime.getTimestamp();
   }
 
-  BsaDownload setBlockListChecksums(ImmutableMap<BlockList, String> checksums) {
+  BsaDownload setChecksums(ImmutableMap<BlockList, String> checksums) {
     blockListChecksums =
         CSV_JOINER.withKeyValueSeparator("=").join(ImmutableSortedMap.copyOf(checksums));
     return this;
   }
 
-  ImmutableMap<BlockList, String> getChecksums() {
+  public ImmutableMap<BlockList, String> getChecksums() {
     if (blockListChecksums.isEmpty()) {
       return ImmutableMap.of();
     }

--- a/core/src/main/java/google/registry/bsa/persistence/DownloadSchedule.java
+++ b/core/src/main/java/google/registry/bsa/persistence/DownloadSchedule.java
@@ -1,0 +1,52 @@
+// Copyright 2023 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.bsa.persistence;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
+import google.registry.bsa.BlockList;
+import google.registry.bsa.DownloadStage;
+import java.util.Optional;
+
+/** Information needed when handling a download from BSA. */
+@AutoValue
+public abstract class DownloadSchedule {
+
+  abstract long jobId();
+
+  public abstract String jobName();
+
+  public abstract DownloadStage stage();
+
+  public abstract Optional<CompletedJob> latestCompleted();
+
+  static DownloadSchedule of(BsaDownload currentJob, Optional<CompletedJob> latestCompleted) {
+    return new AutoValue_DownloadSchedule(
+        currentJob.getJobId(), currentJob.getJobName(), currentJob.getStage(), latestCompleted);
+  }
+
+  /** Information about a completed BSA download job. */
+  @AutoValue
+  public abstract static class CompletedJob {
+    public abstract String jobName();
+
+    public abstract ImmutableMap<BlockList, String> checksums();
+
+    static CompletedJob of(BsaDownload completedJob) {
+      return new AutoValue_DownloadSchedule_CompletedJob(
+          completedJob.getJobName(), completedJob.getChecksums());
+    }
+  }
+}

--- a/core/src/main/java/google/registry/bsa/persistence/DownloadSchedule.java
+++ b/core/src/main/java/google/registry/bsa/persistence/DownloadSchedule.java
@@ -30,11 +30,32 @@ public abstract class DownloadSchedule {
 
   public abstract DownloadStage stage();
 
+  /** The most recently job that ended in the {@code DONE} stage. */
   public abstract Optional<CompletedJob> latestCompleted();
 
-  static DownloadSchedule of(BsaDownload currentJob, Optional<CompletedJob> latestCompleted) {
+  /**
+   * Returns true if download should be processed even if the checksums show that it has not changed
+   * from the previous one.
+   */
+  abstract boolean forceDownload();
+
+  static DownloadSchedule of(BsaDownload currentJob) {
     return new AutoValue_DownloadSchedule(
-        currentJob.getJobId(), currentJob.getJobName(), currentJob.getStage(), latestCompleted);
+        currentJob.getJobId(),
+        currentJob.getJobName(),
+        currentJob.getStage(),
+        Optional.empty(),
+        /* forceDownload= */ true);
+  }
+
+  static DownloadSchedule of(
+      BsaDownload currentJob, CompletedJob latestCompleted, boolean forceDownload) {
+    return new AutoValue_DownloadSchedule(
+        currentJob.getJobId(),
+        currentJob.getJobName(),
+        currentJob.getStage(),
+        Optional.of(latestCompleted),
+        /* forceDownload= */ forceDownload);
   }
 
   /** Information about a completed BSA download job. */

--- a/core/src/main/java/google/registry/bsa/persistence/DownloadSchedule.java
+++ b/core/src/main/java/google/registry/bsa/persistence/DownloadSchedule.java
@@ -30,14 +30,14 @@ public abstract class DownloadSchedule {
 
   public abstract DownloadStage stage();
 
-  /** The most recently job that ended in the {@code DONE} stage. */
+  /** The most recent job that ended in the {@code DONE} stage. */
   public abstract Optional<CompletedJob> latestCompleted();
 
   /**
    * Returns true if download should be processed even if the checksums show that it has not changed
    * from the previous one.
    */
-  abstract boolean forceDownload();
+  abstract boolean alwaysDownload();
 
   static DownloadSchedule of(BsaDownload currentJob) {
     return new AutoValue_DownloadSchedule(
@@ -45,17 +45,17 @@ public abstract class DownloadSchedule {
         currentJob.getJobName(),
         currentJob.getStage(),
         Optional.empty(),
-        /* forceDownload= */ true);
+        /* alwaysDownload= */ true);
   }
 
   static DownloadSchedule of(
-      BsaDownload currentJob, CompletedJob latestCompleted, boolean forceDownload) {
+      BsaDownload currentJob, CompletedJob latestCompleted, boolean alwaysDownload) {
     return new AutoValue_DownloadSchedule(
         currentJob.getJobId(),
         currentJob.getJobName(),
         currentJob.getStage(),
         Optional.of(latestCompleted),
-        /* forceDownload= */ forceDownload);
+        /* alwaysDownload= */ alwaysDownload);
   }
 
   /** Information about a completed BSA download job. */

--- a/core/src/main/java/google/registry/bsa/persistence/DownloadScheduler.java
+++ b/core/src/main/java/google/registry/bsa/persistence/DownloadScheduler.java
@@ -1,0 +1,79 @@
+// Copyright 2023 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.bsa.persistence;
+
+import static google.registry.bsa.DownloadStage.CHECKSUMS_NOT_MATCH;
+import static google.registry.bsa.DownloadStage.DONE;
+import static google.registry.bsa.DownloadStage.NOP;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+
+import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableList;
+import google.registry.bsa.persistence.DownloadSchedule.CompletedJob;
+import google.registry.util.Clock;
+import java.util.Optional;
+import javax.inject.Inject;
+import org.joda.time.Duration;
+
+public final class DownloadScheduler {
+
+  private final Duration downloadInterval;
+  private final Clock clock;
+
+  @Inject
+  DownloadScheduler(Duration downloadInterval, Clock clock) {
+    this.downloadInterval = downloadInterval;
+    this.clock = clock;
+  }
+
+  public Optional<DownloadSchedule> schedule() {
+    return tm().transact(
+            () -> {
+              ImmutableList<BsaDownload> recentJobs = loadRecentProcessedJobs();
+              if (recentJobs.isEmpty()) {
+                return scheduleNewJob();
+              }
+              BsaDownload mostRecent = recentJobs.get(0);
+              if (mostRecent.getStage().equals(DONE)) {
+                return mostRecent.getCreationTime().plus(downloadInterval).isBefore(clock.nowUtc())
+                    ? scheduleNewJob()
+                    : Optional.<DownloadSchedule>empty();
+              } else if (recentJobs.size() == 1) {
+                return scheduleNewJob();
+              } else {
+                BsaDownload prev = recentJobs.get(1);
+                Verify.verify(prev.getStage().equals(DONE), "Unexpectedly found two ongoing jobs.");
+                return Optional.of(
+                    DownloadSchedule.of(mostRecent, Optional.of(CompletedJob.of(prev))));
+              }
+            });
+  }
+
+  Optional<DownloadSchedule> scheduleNewJob() {
+    BsaDownload job = new BsaDownload();
+    tm().insert(job);
+    return Optional.of(DownloadSchedule.of(job, Optional.empty()));
+  }
+
+  ImmutableList<BsaDownload> loadRecentProcessedJobs() {
+    return ImmutableList.copyOf(
+        tm().getEntityManager()
+            .createQuery(
+                "FROM BsaDownload WHERE stage NOT IN :nop_stages ORDER BY creationTime DESC")
+            .setParameter("nop_stages", ImmutableList.of(CHECKSUMS_NOT_MATCH, NOP))
+            .setMaxResults(2)
+            .getResultList());
+  }
+}

--- a/core/src/test/java/google/registry/bsa/persistence/BsaDownloadTest.java
+++ b/core/src/test/java/google/registry/bsa/persistence/BsaDownloadTest.java
@@ -59,7 +59,7 @@ public class BsaDownloadTest {
     BsaDownload job = new BsaDownload();
     assertThat(job.getChecksums()).isEmpty();
     ImmutableMap<BlockList, String> checksums = ImmutableMap.of(BLOCK, "a", BLOCK_PLUS, "b");
-    job.setBlockListChecksums(checksums);
+    job.setChecksums(checksums);
     assertThat(job.getChecksums()).isEqualTo(checksums);
     assertThat(job.blockListChecksums).isEqualTo("BLOCK=a,BLOCK_PLUS=b");
   }

--- a/core/src/test/java/google/registry/bsa/persistence/DownloadSchedulerTest.java
+++ b/core/src/test/java/google/registry/bsa/persistence/DownloadSchedulerTest.java
@@ -1,0 +1,214 @@
+// Copyright 2023 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.bsa.persistence;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+import static google.registry.bsa.DownloadStage.CHECKSUMS_NOT_MATCH;
+import static google.registry.bsa.DownloadStage.DONE;
+import static google.registry.bsa.DownloadStage.DOWNLOAD;
+import static google.registry.bsa.DownloadStage.MAKE_DIFF;
+import static google.registry.bsa.DownloadStage.NOP;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static org.joda.time.DateTimeZone.UTC;
+import static org.joda.time.Duration.standardDays;
+import static org.joda.time.Duration.standardMinutes;
+import static org.joda.time.Duration.standardSeconds;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import google.registry.bsa.BlockList;
+import google.registry.bsa.DownloadStage;
+import google.registry.bsa.persistence.DownloadSchedule.CompletedJob;
+import google.registry.persistence.transaction.JpaTestExtensions;
+import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationWithCoverageExtension;
+import google.registry.testing.FakeClock;
+import java.util.Optional;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/** Unit tests for {@link DownloadScheduler} */
+public class DownloadSchedulerTest {
+
+  static final Duration DOWNLOAD_INTERVAL = standardMinutes(30);
+  static final Duration MAX_NOP_INTERVAL = standardDays(1);
+
+  protected FakeClock fakeClock = new FakeClock(DateTime.now(UTC));
+
+  @RegisterExtension
+  final JpaIntegrationWithCoverageExtension jpa =
+      new JpaTestExtensions.Builder().withClock(fakeClock).buildIntegrationWithCoverageExtension();
+
+  private DownloadScheduler scheduler;
+
+  @BeforeEach
+  void setup() {
+    scheduler = new DownloadScheduler(DOWNLOAD_INTERVAL, MAX_NOP_INTERVAL, fakeClock);
+  }
+
+  @AfterEach
+  void dbCheck() {
+    ImmutableSet<DownloadStage> terminalStages = ImmutableSet.of(DONE, NOP, CHECKSUMS_NOT_MATCH);
+    assertThat(
+            tm().transact(
+                    () ->
+                        tm().getEntityManager()
+                            .createQuery("FROM BsaDownload", BsaDownload.class)
+                            .getResultStream()
+                            .filter(job -> !terminalStages.contains(job.getStage()))
+                            .count()))
+        .isAtMost(1);
+  }
+
+  @Test
+  void firstJobEver() {
+    Optional<DownloadSchedule> scheduleOptional = scheduler.schedule();
+    assertThat(scheduleOptional).isPresent();
+    DownloadSchedule schedule = scheduleOptional.get();
+    assertThat(schedule.latestCompleted()).isEmpty();
+    assertThat(schedule.jobName()).isEqualTo(fakeClock.nowUtc().toString());
+    assertThat(schedule.stage()).isEqualTo(DownloadStage.DOWNLOAD);
+    assertThat(schedule.forceDownload()).isTrue();
+  }
+
+  @Test
+  void oneInProgressJob() {
+    BsaDownload inProgressJob = insertOneJobAndAdvanceClock(MAKE_DIFF);
+    Optional<DownloadSchedule> scheduleOptional = scheduler.schedule();
+    assertThat(scheduleOptional).isPresent();
+    DownloadSchedule schedule = scheduleOptional.get();
+    assertThat(schedule.jobId()).isEqualTo(inProgressJob.jobId);
+    assertThat(schedule.jobName()).isEqualTo(inProgressJob.getJobName());
+    assertThat(schedule.stage()).isEqualTo(MAKE_DIFF);
+    assertThat(schedule.latestCompleted()).isEmpty();
+    assertThat(schedule.forceDownload()).isTrue();
+  }
+
+  @Test
+  void oneInProgressJobOneCompletedJob() {
+    BsaDownload completed = insertOneJobAndAdvanceClock(DONE);
+    BsaDownload inProgressJob = insertOneJobAndAdvanceClock(MAKE_DIFF);
+    Optional<DownloadSchedule> scheduleOptional = scheduler.schedule();
+    assertThat(scheduleOptional).isPresent();
+    DownloadSchedule schedule = scheduleOptional.get();
+    assertThat(schedule.jobId()).isEqualTo(inProgressJob.jobId);
+    assertThat(schedule.jobName()).isEqualTo(inProgressJob.getJobName());
+    assertThat(schedule.stage()).isEqualTo(MAKE_DIFF);
+    assertThat(schedule.forceDownload()).isFalse();
+    assertThat(schedule.latestCompleted()).isPresent();
+    CompletedJob lastCompleted = schedule.latestCompleted().get();
+    assertThat(lastCompleted.jobName()).isEqualTo(completed.getJobName());
+    assertThat(lastCompleted.checksums()).isEqualTo(completed.getChecksums());
+  }
+
+  @Test
+  void doneJob_noNewSchedule() {
+    insertOneJobAndAdvanceClock(DONE);
+    assertThat(scheduler.schedule()).isEmpty();
+  }
+
+  @Test
+  void doneJob_newSchedule() {
+    BsaDownload completed = insertOneJobAndAdvanceClock(DONE);
+    fakeClock.advanceBy(DOWNLOAD_INTERVAL);
+    Optional<DownloadSchedule> scheduleOptional = scheduler.schedule();
+    assertThat(scheduleOptional).isPresent();
+    DownloadSchedule schedule = scheduleOptional.get();
+    assertThat(schedule.stage()).isEqualTo(DOWNLOAD);
+    assertThat(schedule.forceDownload()).isFalse();
+    assertThat(schedule.latestCompleted()).isPresent();
+    CompletedJob completedJob = schedule.latestCompleted().get();
+    assertThat(completedJob.jobName()).isEqualTo(completed.getJobName());
+    assertThat(completedJob.checksums()).isEqualTo(completedJob.checksums());
+  }
+
+  @Test
+  void doneJob_newSchedule_forceDownload() {
+    insertOneJobAndAdvanceClock(DONE);
+    fakeClock.advanceBy(MAX_NOP_INTERVAL);
+    Optional<DownloadSchedule> scheduleOptional = scheduler.schedule();
+    assertThat(scheduleOptional).isPresent();
+    DownloadSchedule schedule = scheduleOptional.get();
+    assertThat(schedule.forceDownload()).isTrue();
+  }
+
+  @Test
+  void doneJob_cronEarlyWithJitter_newSchedule() {
+    insertOneJobAndAdvanceClock(DONE);
+    fakeClock.advanceBy(DOWNLOAD_INTERVAL.minus(standardSeconds(5)));
+    assertThat(scheduler.schedule()).isPresent();
+  }
+
+  @Test
+  void doneJob_cronEarlyMoreThanJitter_newSchedule() {
+    insertOneJobAndAdvanceClock(DONE);
+    fakeClock.advanceBy(DOWNLOAD_INTERVAL.minus(standardSeconds(6)));
+    assertThat(scheduler.schedule()).isEmpty();
+  }
+
+  @Test
+  void loadRecentProcessedJobs_noneExists() {
+    assertThat(tm().transact(() -> scheduler.loadRecentProcessedJobs())).isEmpty();
+  }
+
+  @Test
+  void loadRecentProcessedJobs_nopJobsOnly() {
+    insertOneJobAndAdvanceClock(DownloadStage.NOP);
+    insertOneJobAndAdvanceClock(DownloadStage.CHECKSUMS_NOT_MATCH);
+    assertThat(tm().transact(() -> scheduler.loadRecentProcessedJobs())).isEmpty();
+  }
+
+  @Test
+  void loadRecentProcessedJobs_oneInProgressJob() {
+    BsaDownload job = insertOneJobAndAdvanceClock(MAKE_DIFF);
+    assertThat(tm().transact(() -> scheduler.loadRecentProcessedJobs())).containsExactly(job);
+  }
+
+  @Test
+  void loadRecentProcessedJobs_oneDoneJob() {
+    BsaDownload job = new BsaDownload();
+    job.setStage(DownloadStage.DONE);
+    tm().transact(() -> tm().insert(job));
+    ImmutableList<BsaDownload> downloads = tm().transact(() -> scheduler.loadRecentProcessedJobs());
+    assertThat(downloads).containsExactly(job);
+  }
+
+  @Test
+  void loadRecentProcessedJobs_multipleJobs() {
+    insertOneJobAndAdvanceClock(DownloadStage.DONE);
+    insertOneJobAndAdvanceClock(DownloadStage.DONE);
+    BsaDownload completed = insertOneJobAndAdvanceClock(DownloadStage.DONE);
+    insertOneJobAndAdvanceClock(DownloadStage.NOP);
+    insertOneJobAndAdvanceClock(DownloadStage.CHECKSUMS_NOT_MATCH);
+    BsaDownload inprogress = insertOneJobAndAdvanceClock(DownloadStage.APPLY_DIFF);
+    assertThat(tm().transact(() -> scheduler.loadRecentProcessedJobs()))
+        .containsExactly(inprogress, completed)
+        .inOrder();
+  }
+
+  private BsaDownload insertOneJobAndAdvanceClock(DownloadStage stage) {
+    BsaDownload job = new BsaDownload();
+    job.setStage(stage);
+    job.setChecksums(ImmutableMap.of(BlockList.BLOCK, "1", BlockList.BLOCK_PLUS, "2"));
+    tm().transact(() -> tm().insert(job));
+    fakeClock.advanceOneMilli();
+    return job;
+  }
+}


### PR DESCRIPTION
Adds a `DownloadScheduler` that generates work for the download action.

The scheduler is called during every run of the download cron job and tells the action what to do,
based on the work state stored in the `BsaDownload` table.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2209)
<!-- Reviewable:end -->
