### PR TITLE
Reduce the QPS of the refresh DNS for all domains action

### DIFF
--- a/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
+++ b/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
@@ -81,4 +81,10 @@ public class ToolsServerModule {
   static Optional<Integer> provideBatchSize(HttpServletRequest req) {
     return extractOptionalIntParameter(req, "batchSize");
   }
+
+  @Provides
+  @Parameter("refreshQps")
+  static Optional<Integer> provideRefreshQps(HttpServletRequest req) {
+    return extractOptionalIntParameter(req, "refreshQps");
+  }
 }

--- a/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
+++ b/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
@@ -35,6 +35,7 @@ import google.registry.testing.FakeResponse;
 import java.util.Optional;
 import java.util.Random;
 import org.joda.time.DateTime;
+import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -55,7 +56,7 @@ public class RefreshDnsForAllDomainsActionTest {
     createTld("bar");
     action =
         new RefreshDnsForAllDomainsAction(
-            response, ImmutableSet.of("bar"), Optional.of(10), new Random());
+            response, ImmutableSet.of("bar"), Optional.of(10), Optional.empty(), new Random());
   }
 
   @Test
@@ -74,9 +75,9 @@ public class RefreshDnsForAllDomainsActionTest {
     // Set batch size to 1 since each batch will be enqueud at the same time
     action =
         new RefreshDnsForAllDomainsAction(
-            response, ImmutableSet.of("bar"), Optional.of(1), new Random());
-    tm().transact(() -> action.refreshBatch(Optional.empty(), 1000));
-    tm().transact(() -> action.refreshBatch(Optional.empty(), 1000));
+            response, ImmutableSet.of("bar"), Optional.of(1), Optional.of(7), new Random());
+    tm().transact(() -> action.refreshBatch(Optional.empty(), Duration.standardMinutes(1000)));
+    tm().transact(() -> action.refreshBatch(Optional.empty(), Duration.standardMinutes(1000)));
     ImmutableList<DnsRefreshRequest> refreshRequests =
         tm().transact(
                 () ->


### PR DESCRIPTION
This also adds a targeted QPS as a parameter in case we need to manually bump it up (or down) for some reason without having to make code changes and re-deploy.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2212)
<!-- Reviewable:end -->
