### PR TITLE
Use Java 8 runtime on sandbox and production

### DIFF
--- a/core/src/main/java/google/registry/env/production/backend/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/backend/WEB-INF/appengine-web.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java8</runtime>
   <service>backend</service>
-  <app-engine-apis>true</app-engine-apis>
+  <!--app-engine-apis>true</app-engine-apis-->
+  <threadsafe>true</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/production/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/default/WEB-INF/appengine-web.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java8</runtime>
   <service>default</service>
-  <app-engine-apis>true</app-engine-apis>
+  <!--app-engine-apis>true</app-engine-apis-->
+  <threadsafe>true</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <manual-scaling>

--- a/core/src/main/java/google/registry/env/production/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/pubapi/WEB-INF/appengine-web.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java8</runtime>
   <service>pubapi</service>
-  <app-engine-apis>true</app-engine-apis>
+  <!--app-engine-apis>true</app-engine-apis-->
+  <threadsafe>true</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <manual-scaling>

--- a/core/src/main/java/google/registry/env/production/tools/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/tools/WEB-INF/appengine-web.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java8</runtime>
   <service>tools</service>
-  <app-engine-apis>true</app-engine-apis>
+  <!--app-engine-apis>true</app-engine-apis-->
+  <threadsafe>true</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/sandbox/backend/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/backend/WEB-INF/appengine-web.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java8</runtime>
   <service>backend</service>
-  <app-engine-apis>true</app-engine-apis>
+  <!--app-engine-apis>true</app-engine-apis-->
+  <threadsafe>true</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/appengine-web.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java8</runtime>
   <service>default</service>
-  <app-engine-apis>true</app-engine-apis>
+  <!--app-engine-apis>true</app-engine-apis-->
+  <threadsafe>true</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <manual-scaling>

--- a/core/src/main/java/google/registry/env/sandbox/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/pubapi/WEB-INF/appengine-web.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java8</runtime>
   <service>pubapi</service>
-  <app-engine-apis>true</app-engine-apis>
+  <!--app-engine-apis>true</app-engine-apis-->
+  <threadsafe>true</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <manual-scaling>

--- a/core/src/main/java/google/registry/env/sandbox/tools/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/tools/WEB-INF/appengine-web.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java8</runtime>
   <service>tools</service>
-  <app-engine-apis>true</app-engine-apis>
+  <!--app-engine-apis>true</app-engine-apis-->
+  <threadsafe>true</threadsafe>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>


### PR DESCRIPTION
Java 17 injects unexpected headers to X-Forwarded-For, which causes
issues with validating incoming IP addresses.

This is a partial reversion of #2201. We are still keeping Java 17 in other environment but sandbox and production needs to be able to parse the header to accept incoming EPP connections from registrars. Once we fix it we will re-enable Java 17 in these environment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2218)
<!-- Reviewable:end -->
