### PR TITLE
Pin Flyway tool jar to 9.22.3

### DIFF
--- a/release/schema-deployer/Dockerfile
+++ b/release/schema-deployer/Dockerfile
@@ -30,8 +30,7 @@ FROM gcr.io/${PROJECT_ID}/builder:${TAG_NAME}
 COPY deploy_sql_schema.sh /usr/local/bin/
 RUN \
   FLYWAY_MAVEN=https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline \
-  && FLYWAY_VERSION=$(curl ${FLYWAY_MAVEN}/maven-metadata.xml \
-                       | grep -oP "<release>\K.*(?=</release>)") \
+  && FLYWAY_VERSION="9.22.3" \
   && echo "Downloading Flyway-commandline-${FLYWAY_VERSION}" \
   && mkdir -p /flyway \
   && curl -L ${FLYWAY_MAVEN}/${FLYWAY_VERSION}/flyway-commandline-${FLYWAY_VERSION}.tar.gz \


### PR DESCRIPTION
Flyway 10+ is not compatible with Java 8.

Rollback this change after we upgrade to Java 11.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2222)
<!-- Reviewable:end -->
