### PR TITLE
Add a disposition header to email attachments

### DIFF
--- a/core/src/main/java/google/registry/groups/GmailClient.java
+++ b/core/src/main/java/google/registry/groups/GmailClient.java
@@ -138,6 +138,7 @@ public final class GmailClient {
         BodyPart attachmentPart = new MimeBodyPart();
         attachmentPart.setContent(attachment.content(), attachment.contentType().toString());
         attachmentPart.setFileName(attachment.filename());
+        attachmentPart.setDisposition(MimeBodyPart.ATTACHMENT);
         multipart.addBodyPart(attachmentPart);
       }
       msg.addRecipients(RecipientType.BCC, toArray(emailMessage.bccs(), Address.class));

--- a/core/src/test/java/google/registry/groups/GmailClientTest.java
+++ b/core/src/test/java/google/registry/groups/GmailClientTest.java
@@ -138,6 +138,7 @@ public class GmailClientTest {
     assertThat(attachment.getContentType()).startsWith(CSV_UTF_8.toString());
     assertThat(attachment.getContentType()).endsWith("name=filename");
     assertThat(attachment.getContent()).isEqualTo("foo,bar\nbaz,qux");
+    assertThat(attachment.getDisposition()).isEqualTo("attachment");
   }
 
   @Test


### PR DESCRIPTION
This may help with the billing-team with attached invoices.

This is a standard header that should do no harm.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2223)
<!-- Reviewable:end -->
