### PR TITLE
Pretty-print reserved list updates in the CLI

### DIFF
--- a/core/src/main/java/google/registry/tools/CreateOrUpdateTldCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdateTldCommand.java
@@ -463,8 +463,7 @@ abstract class CreateOrUpdateTldCommand extends MutatingCommand {
     }
   }
 
-  private void checkReservedListValidityForTld(String tld, Set<String> reservedListNames)
-      throws UnsupportedEncodingException {
+  private void checkReservedListValidityForTld(String tld, Set<String> reservedListNames) {
     ImmutableList.Builder<String> builder = new ImmutableList.Builder<>();
     for (String reservedListName : reservedListNames) {
       if (!reservedListName.startsWith("common_") && !reservedListName.startsWith(tld + "_")) {

--- a/core/src/test/java/google/registry/tools/UpdateReservedListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateReservedListCommandTest.java
@@ -130,8 +130,8 @@ class UpdateReservedListCommandTest
     command.init();
 
     assertThat(command.prompt()).contains("Update reserved list for xn--q9jyb4c_common-reserved?");
-    assertThat(command.prompt()).contains("Old list: [(helicopter,FULLY_BLOCKED)]");
-    assertThat(command.prompt())
-        .contains("New list: [(baddies,FULLY_BLOCKED), (ford,FULLY_BLOCKED # random comment)]");
+    assertThat(command.prompt()).contains("helicopter: helicopter,FULLY_BLOCKED -> null");
+    assertThat(command.prompt()).contains("baddies: null -> baddies,FULLY_BLOCKED");
+    assertThat(command.prompt()).contains("ford: null -> ford,FULLY_BLOCKED # random comment");
   }
 }


### PR DESCRIPTION
We shouldn't have to parse through every single entry to see what changed

Note: we don't do this for premium lists because those can be HUGE and we don't want/need to load and display every entry. This was an explicit choice made in https://github.com/google/nomulus/pull/1482