### PR TITLE
Add equals() and hashCode() methods to BsaDomainInUseId

### DIFF
--- a/core/src/main/java/google/registry/bsa/persistence/BsaDomainInUse.java
+++ b/core/src/main/java/google/registry/bsa/persistence/BsaDomainInUse.java
@@ -88,11 +88,26 @@ public class BsaDomainInUse {
     private String tld;
 
     // For Hibernate
+    @SuppressWarnings("unused")
     BsaDomainInUseId() {}
 
     BsaDomainInUseId(String label, String tld) {
       this.label = label;
       this.tld = tld;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (other instanceof BsaDomainInUseId) {
+        BsaDomainInUseId otherId = (BsaDomainInUseId) other;
+        return Objects.equal(otherId.label, label) && Objects.equal(otherId.tld, tld);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(label, tld);
     }
   }
 


### PR DESCRIPTION
Hibernate complains when a composite ID doesn't implement these two
methods.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2231)
<!-- Reviewable:end -->
