### PR TITLE
Return the correct renewal fee for anchor tenants in domain checks

### DIFF
--- a/core/src/main/java/google/registry/model/tld/label/ReservedList.java
+++ b/core/src/main/java/google/registry/model/tld/label/ReservedList.java
@@ -199,7 +199,7 @@ public final class ReservedList
   public synchronized ImmutableMap<String, ReservedListEntry> getReservedListEntries() {
     if (reservedListMap == null) {
       reservedListMap =
-          tm().transact(
+          tm().reTransact(
                   () ->
                       tm()
                           .createQueryComposer(ReservedListEntry.class)

--- a/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
@@ -340,6 +340,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
         new AllocationToken.Builder()
             .setToken("abc123")
             .setTokenType(UNLIMITED_USE)
+            .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE))
             .setDiscountFraction(0.5)
             .setDiscountYears(2)
             .setTokenStatusTransitions(
@@ -364,6 +365,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setDiscountYears(2)
+            .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE))
             .setTokenStatusTransitions(
                 ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee.xml
@@ -34,6 +34,24 @@
           <fee:command>create</fee:command>
           <fee:period unit="y">1</fee:period>
         </fee:domain>
+        <fee:domain>
+          <fee:name>example1.tld</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>renew</fee:command>
+          <fee:period unit="y">1</fee:period>
+        </fee:domain>
+        <fee:domain>
+          <fee:name>example2.example</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>renew</fee:command>
+          <fee:period unit="y">1</fee:period>
+        </fee:domain>
+        <fee:domain>
+          <fee:name>reserved.tld</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>renew</fee:command>
+          <fee:period unit="y">1</fee:period>
+        </fee:domain>
       </fee:check>
     </extension>
     <clTRID>ABC-12345</clTRID>

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee_anchor_response.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee_anchor_response.xml
@@ -42,6 +42,28 @@
           <fee:period unit="y">1</fee:period>
           <fee:class>token-not-supported</fee:class>
         </fee:cd>
+        <fee:cd>
+          <fee:name>example1.tld</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>renew</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:fee description="renew">11.00</fee:fee>
+          <fee:class>premium</fee:class>
+        </fee:cd>
+        <fee:cd>
+          <fee:name>example2.example</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>renew</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:class>token-not-supported</fee:class>
+        </fee:cd>
+        <fee:cd>
+          <fee:name>reserved.tld</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>renew</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:class>token-not-supported</fee:class>
+        </fee:cd>
       </fee:chkData>
     </extension>
     <trID>

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee_response.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee_response.xml
@@ -41,6 +41,27 @@
           <fee:period unit="y">1</fee:period>
           <fee:class>reserved</fee:class>
         </fee:cd>
+        <fee:cd>
+          <fee:name>example1.tld</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>renew</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:class>token-not-supported</fee:class>
+        </fee:cd>
+        <fee:cd>
+          <fee:name>example2.example</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>renew</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:class>token-not-supported</fee:class>
+        </fee:cd>
+        <fee:cd>
+          <fee:name>reserved.tld</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>renew</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:class>token-not-supported</fee:class>
+        </fee:cd>
       </fee:chkData>
     </extension>
     <trID>


### PR DESCRIPTION
The code as previously written assumed that creation fees would be the same as renewal fees -- this is not the case for anchor tenants, where the renewal fee is always the standard cost for the TLD (instead of any premium cost). This was already handled properly in the actual billing implementation, but we didn't tell the user the right renewal cost in domain checks.

This also removes some warning logs related to nested transactions

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2238)
<!-- Reviewable:end -->
