### PR TITLE
Increase delete allocation tokens command DB batch size

### DIFF
--- a/core/src/main/java/google/registry/tools/DeleteAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/DeleteAllocationTokensCommand.java
@@ -46,7 +46,7 @@ final class DeleteAllocationTokensCommand extends UpdateOrDeleteAllocationTokens
       description = "Allow deletion of allocation tokens with specified domains; defaults to false")
   private boolean withDomains;
 
-  private static final int BATCH_SIZE = 20;
+  private static final int BATCH_SIZE = 200;
   private static final Joiner JOINER = Joiner.on(", ");
 
   private ImmutableList<VKey<AllocationToken>> tokensToDelete;


### PR DESCRIPTION
The existing figure of 20 is likely a remnant from Datastore (what with its max 25 entity groups per transaction limit), but in PostgreSQL this limit doesn't exist and we want to do bigger batches so that the command executes faster.