### PR TITLE
Filter in SQL when updating/deleting alloc tokens

### DIFF
--- a/core/src/main/java/google/registry/tools/UpdateOrDeleteAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdateOrDeleteAllocationTokensCommand.java
@@ -67,9 +67,12 @@ abstract class UpdateOrDeleteAllocationTokensCommand extends ConfirmingCommand {
       checkArgument(!prefix.isEmpty(), "Provided prefix should not be blank");
       return tm().transact(
               () ->
-                  tm().loadAllOf(AllocationToken.class).stream()
-                      .filter(token -> token.getToken().startsWith(prefix))
-                      .map(AllocationToken::createVKey)
+                  tm().query(
+                          "SELECT token FROM AllocationToken WHERE token LIKE :prefix",
+                          String.class)
+                      .setParameter("prefix", String.format("%s%%", prefix))
+                      .getResultStream()
+                      .map(token -> VKey.create(AllocationToken.class, token))
                       .collect(toImmutableList()));
     }
   }


### PR DESCRIPTION
This doesn't fix any issues with dead/livelocks when deleting or updating allocation tokens, but it at least will significantly reduce the time to load the tokens that we'll want to update/delete.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2244)
<!-- Reviewable:end -->
