### PR TITLE
Do not log nested transactions in production

### DIFF
--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import com.google.common.flogger.FluentLogger;
 import com.google.common.flogger.StackSize;
+import google.registry.config.RegistryEnvironment;
 import google.registry.model.ImmutableObject;
 import google.registry.persistence.JpaRetries;
 import google.registry.persistence.PersistenceModule.TransactionIsolationLevel;
@@ -164,7 +165,10 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
       if (!getHibernateAllowNestedTransactions()) {
         throw new IllegalStateException(NESTED_TRANSACTION_MESSAGE);
       }
-      logger.atWarning().withStackTrace(StackSize.MEDIUM).log(NESTED_TRANSACTION_MESSAGE);
+      if (RegistryEnvironment.get() != RegistryEnvironment.PRODUCTION
+          && RegistryEnvironment.get() != RegistryEnvironment.UNITTEST) {
+        logger.atWarning().withStackTrace(StackSize.MEDIUM).log(NESTED_TRANSACTION_MESSAGE);
+      }
       // This prevents inner transaction from retrying, thus avoiding a cascade retry effect.
       return transactNoRetry(work, isolationLevel);
     }


### PR DESCRIPTION
This might be the cause of the SQL performance degradation that we are
observing during the recent launch. The change went in a month ago but
there hasn't been enough increase in mutating traffic to make it
problematic until the launch.

Note that presubmits will still run longer, but I think it is an
acceptable compromise to help us identify nested transactions and
refactor them away. Ultimately we will not log but just throw.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2251)
<!-- Reviewable:end -->
