### PR TITLE
Prevent reusing ianaId for real registrars

### DIFF
--- a/core/src/test/java/google/registry/model/registrar/RegistrarTest.java
+++ b/core/src/test/java/google/registry/model/registrar/RegistrarTest.java
@@ -202,6 +202,23 @@ class RegistrarTest extends EntityTestCase {
   }
 
   @Test
+  void testFailure_duplicateIanaId() {
+    persistResource(
+        registrar.asBuilder().setRegistrarId("registrar1").setIanaIdentifier(10L).build());
+
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                registrar.asBuilder().setRegistrarId("registrar2").setIanaIdentifier(10L).build());
+
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains(
+            "Rejected attempt to create a registrar with ianaId that's already in the system");
+  }
+
+  @Test
   void testSetCertificateHash_alsoSetsHash() {
     registrar = registrar.asBuilder().setClientCertificate(null, fakeClock.nowUtc()).build();
     fakeClock.advanceOneMilli();

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -778,7 +778,7 @@ public final class DatabaseHelper {
 
   /** Persists and returns a {@link Registrar} with the specified registrarId. */
   public static Registrar persistNewRegistrar(String registrarId) {
-    return persistNewRegistrar(registrarId, registrarId + " name", Registrar.Type.REAL, 100L);
+    return persistNewRegistrar(registrarId, registrarId + " name", Registrar.Type.REAL, 8L);
   }
 
   /** Persists and returns a list of {@link Registrar}s with the specified registrarIds. */


### PR DESCRIPTION
This should resolve b/315349245 and prevent reusing ianaId that's already in the system

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2257)
<!-- Reviewable:end -->
