### PR TITLE
Add type conversion to TimedTransitionProperty<Money> deserializer to handle JPY currency

### DIFF
--- a/core/src/main/java/google/registry/model/EntityYamlUtils.java
+++ b/core/src/main/java/google/registry/model/EntityYamlUtils.java
@@ -359,7 +359,7 @@ public class EntityYamlUtils {
                       key ->
                           Money.of(
                               CurrencyUnit.of(valueMap.get(key).get("currency").toString()),
-                              (double) valueMap.get(key).get("amount")))));
+                              new BigDecimal(String.valueOf(valueMap.get(key).get("amount")))))));
     }
   }
 

--- a/core/src/main/java/google/registry/model/EntityYamlUtils.java
+++ b/core/src/main/java/google/registry/model/EntityYamlUtils.java
@@ -349,7 +349,7 @@ public class EntityYamlUtils {
     @Override
     public TimedTransitionProperty<Money> deserialize(JsonParser jp, DeserializationContext context)
         throws IOException {
-      SortedMap<String, LinkedHashMap> valueMap = jp.readValueAs(SortedMap.class);
+      SortedMap<String, LinkedHashMap<String, Object>> valueMap = jp.readValueAs(SortedMap.class);
       return TimedTransitionProperty.fromValueMap(
           valueMap.keySet().stream()
               .collect(

--- a/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
@@ -99,10 +99,8 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
     runCommandForced("--input=" + tldFile);
     Tld tld = Tld.get("jpy");
     assertThat(tld).isNotNull();
-    assertThat(tld.getDriveFolderId()).isEqualTo("driveFolder");
     assertThat(tld.getCreateBillingCost()).isEqualTo(Money.of(JPY, new BigDecimal("250")));
     testTldConfiguredSuccessfully(tld, "jpy.yaml");
-    assertThat(tld.getBreakglassMode()).isFalse();
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
@@ -29,6 +29,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.logging.Level.INFO;
 import static org.joda.money.CurrencyUnit.JPY;
 import static org.joda.money.CurrencyUnit.USD;
+import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -51,7 +52,6 @@ import java.util.Optional;
 import java.util.logging.Logger;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -100,7 +100,7 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
     Tld tld = Tld.get("jpy");
     assertThat(tld).isNotNull();
     assertThat(tld.getCreateBillingCost()).isEqualTo(Money.of(JPY, new BigDecimal("250")));
-    assertThat(tld.getEapFeeFor(DateTime.now()).getCost()).isEqualTo(new BigDecimal(0));
+    assertThat(tld.getEapFeeFor(DateTime.now(UTC)).getCost()).isEqualTo(new BigDecimal(0));
     testTldConfiguredSuccessfully(tld, "jpy.yaml");
   }
 
@@ -121,7 +121,7 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
   @Test
   void testSuccess_updateTld_existingBsaTimeCarriedOver() throws Exception {
     Tld tld = createTld("tld");
-    DateTime bsaStartTime = DateTime.now(DateTimeZone.UTC);
+    DateTime bsaStartTime = DateTime.now(UTC);
     persistResource(tld.asBuilder().setBsaEnrollStartTime(Optional.of(bsaStartTime)).build());
     File tldFile = tmpDir.resolve("tld.yaml").toFile();
     Files.asCharSink(tldFile, UTF_8).write(loadFile(getClass(), "tld.yaml"));

--- a/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
@@ -46,6 +46,7 @@ import google.registry.model.tld.Tld.TldNotFoundException;
 import google.registry.model.tld.label.PremiumList;
 import google.registry.model.tld.label.PremiumListDao;
 import java.io.File;
+import java.math.BigDecimal;
 import java.util.Optional;
 import java.util.logging.Logger;
 import org.joda.money.Money;
@@ -88,6 +89,19 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
     assertThat(tld.getDriveFolderId()).isEqualTo("driveFolder");
     assertThat(tld.getCreateBillingCost()).isEqualTo(Money.of(USD, 25));
     testTldConfiguredSuccessfully(tld, "tld.yaml");
+    assertThat(tld.getBreakglassMode()).isFalse();
+  }
+
+  @Test
+  void testSuccess_createNewTldJPY() throws Exception {
+    File tldFile = tmpDir.resolve("jpy.yaml").toFile();
+    Files.asCharSink(tldFile, UTF_8).write(loadFile(getClass(), "jpy.yaml"));
+    runCommandForced("--input=" + tldFile);
+    Tld tld = Tld.get("jpy");
+    assertThat(tld).isNotNull();
+    assertThat(tld.getDriveFolderId()).isEqualTo("driveFolder");
+    assertThat(tld.getCreateBillingCost()).isEqualTo(Money.of(JPY, new BigDecimal("250")));
+    testTldConfiguredSuccessfully(tld, "jpy.yaml");
     assertThat(tld.getBreakglassMode()).isFalse();
   }
 

--- a/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
@@ -100,6 +100,7 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
     Tld tld = Tld.get("jpy");
     assertThat(tld).isNotNull();
     assertThat(tld.getCreateBillingCost()).isEqualTo(Money.of(JPY, new BigDecimal("250")));
+    assertThat(tld.getEapFeeFor(DateTime.now()).getCost()).isEqualTo(new BigDecimal(0));
     testTldConfiguredSuccessfully(tld, "jpy.yaml");
   }
 

--- a/core/src/test/resources/google/registry/tools/jpy.yaml
+++ b/core/src/test/resources/google/registry/tools/jpy.yaml
@@ -1,0 +1,55 @@
+addGracePeriodLength: "PT432000S"
+allowedFullyQualifiedHostNames: []
+allowedRegistrantContactIds: []
+anchorTenantAddGracePeriodLength: "PT2592000S"
+autoRenewGracePeriodLength: "PT3888000S"
+automaticTransferLength: "PT432000S"
+claimsPeriodEnd: "294247-01-10T04:00:54.775Z"
+createBillingCost:
+  currency: "JPY"
+  amount: 250
+creationTime: "2022-09-01T00:00:00.000Z"
+currency: "JPY"
+defaultPromoTokens: []
+dnsAPlusAaaaTtl: "PT900S"
+dnsDsTtl: null
+dnsNsTtl: null
+dnsPaused: false
+dnsWriters:
+- "VoidDnsWriter"
+driveFolderId: "driveFolder"
+eapFeeSchedule:
+  "1970-01-01T00:00:00.000Z":
+    currency: "JPY"
+    amount: 0
+escrowEnabled: false
+idnTables: []
+invoicingEnabled: false
+lordnUsername: null
+numDnsPublishLocks: 1
+pendingDeleteLength: "PT432000S"
+premiumListName: null
+pricingEngineClassName: "google.registry.model.pricing.StaticPremiumListPricingEngine"
+redemptionGracePeriodLength: "PT2592000S"
+registryLockOrUnlockBillingCost:
+  currency: "JPY"
+  amount: 0
+renewBillingCostTransitions:
+  "1970-01-01T00:00:00.000Z":
+    currency: "JPY"
+    amount: 100
+renewGracePeriodLength: "PT432000S"
+reservedListNames: []
+restoreBillingCost:
+  currency: "JPY"
+  amount: 70
+roidSuffix: "JPY"
+serverStatusChangeBillingCost:
+  currency: "JPY"
+  amount: 100
+tldStateTransitions:
+  "1970-01-01T00:00:00.000Z": "GENERAL_AVAILABILITY"
+tldStr: "jpy"
+tldType: "REAL"
+tldUnicode: "jpy"
+transferGracePeriodLength: "PT432000S"


### PR DESCRIPTION
JPY prices do not have cent values, whereas USD prices do. Therefore the Jackson deserializer reads in the prices from the YAML file as a Double object if it is in USD and as an Integer object if it is in JPY. The `MoneyDeserializer` class already handled this issue cleanly because it parses the object into a `MoneyJson` object which indicates that the amount should be parsed as a BigDecimal object. However, the `TimedTransitionProperty<Money>` deserializer was failing since it was attempting to cast the money value to a double which would fail when the value was an Integer for JPY TLDs. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2258)
<!-- Reviewable:end -->
