### PR TITLE
Greatly increase the upper limit of proxy instances in production

### DIFF
--- a/proxy/kubernetes/proxy-service.yaml
+++ b/proxy/kubernetes/proxy-service.yaml
@@ -46,5 +46,5 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: proxy-deployment
-  maxReplicas: 10
-  minReplicas: 1
+  maxReplicas: 50
+  minReplicas: 10


### PR DESCRIPTION
From our investigation, the Monday night WHOIS storm does not cause any
strain to the backend system. The backend latency metrics are all well within
the limits. The latency measured from the proxy matches observed latency
by the prober, and we see that the "used" CPU is 1.5x of "requested" CPU
during the time when the latency is above the threshold.

Making this change hopefully removes the proxy as the bottleneck and
ameliorate the pages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2259)
<!-- Reviewable:end -->
