### PR TITLE
Add ICANN csv response GZIP decoding

### DIFF
--- a/core/src/main/java/google/registry/request/UrlConnectionUtils.java
+++ b/core/src/main/java/google/registry/request/UrlConnectionUtils.java
@@ -25,12 +25,15 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import com.google.common.base.Strings;
 import com.google.common.io.ByteStreams;
 import com.google.common.net.MediaType;
+import java.io.ByteArrayInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URLConnection;
 import java.util.Random;
+import java.util.zip.GZIPInputStream;
+import org.apache.commons.compress.utils.IOUtils;
 
 /** Utilities for common functionality relating to {@link URLConnection}s. */
 public final class UrlConnectionUtils {
@@ -53,6 +56,20 @@ public final class UrlConnectionUtils {
     } catch (NullPointerException e) {
       return new byte[] {};
     }
+  }
+
+  /** Decodes compressed data in GZIP format. */
+  public static byte[] gUnzipBytes(byte[] bytes) throws IOException {
+    try (GZIPInputStream inputStream = new GZIPInputStream(new ByteArrayInputStream(bytes))) {
+      return IOUtils.toByteArray(inputStream);
+    }
+  }
+
+  /** Checks whether {@code bytes} are GZIP encoded. */
+  public static boolean isGZipped(byte[] bytes) {
+    // See GzipOutputStream.writeHeader()
+    return (bytes.length > 2 && bytes[0] == (byte) (GZIPInputStream.GZIP_MAGIC))
+        && (bytes[1] == (byte) (GZIPInputStream.GZIP_MAGIC >> 8));
   }
 
   /** Sets auth on the given connection with the given username/password. */


### PR DESCRIPTION
Thanks for the hint with GZIP, I naturally assumed the response was already successfully decoded, since the header was present for a quite some time now. 
 
Tested in alpha, job succeeded

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2269)
<!-- Reviewable:end -->
