### PR TITLE
Require the --break_glass or --build_environment flag in production for configureTldCommand

### DIFF
--- a/core/src/main/java/google/registry/tools/ConfigureTldCommand.java
+++ b/core/src/main/java/google/registry/tools/ConfigureTldCommand.java
@@ -105,6 +105,12 @@ public class ConfigureTldCommand extends MutatingCommand {
 
   @Override
   protected void init() throws Exception {
+    if (RegistryToolEnvironment.get().equals(RegistryToolEnvironment.PRODUCTION)) {
+      checkArgument(
+          buildEnv || breakGlass != null,
+          "Either the --break_glass or --build_environment flag must be used when"
+              + " running the configure_tld command on Production");
+    }
     String name = convertFilePathToName(inputFile);
     Map<String, Object> tldData = new Yaml().load(Files.newBufferedReader(inputFile));
     checkName(name, tldData);


### PR DESCRIPTION
When running the configureTldCommand in Production, require either a break glass flag or a build-environment flag. The --build_environment flag should not be used on the command line by a human user and should be reserved for use by build tools such as Kokoro and Cloud Build.

This PR cannot be merged until after the changes in go/r3pr/2277 have been deployed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2273)
<!-- Reviewable:end -->
