### PR TITLE
Define the --build_environment flag and change --break_glass flag to a Boolean type

### DIFF
--- a/core/src/main/java/google/registry/tools/ConfigureTldCommand.java
+++ b/core/src/main/java/google/registry/tools/ConfigureTldCommand.java
@@ -64,22 +64,22 @@ public class ConfigureTldCommand extends MutatingCommand {
   Path inputFile;
 
   @Parameter(
-      names = {"-b", "--breakglass"},
+      names = {"-b", "--break_glass"},
       description =
-          "Sets the breakglass field on the TLD to true, preventing Cloud Build from overwriting"
+          "Sets the breakGlass field on the TLD to true, preventing Cloud Build from overwriting"
               + " these new changes until the TLD configuration file stored internally matches the"
               + " configuration in the database.")
-  boolean breakglass;
+  boolean breakGlass;
 
   @Parameter(
-      names = {"--end_breakglass"},
+      names = {"--end_break_glass"},
       description =
           "Sets the breakglass field on the TLD to false, indicating that whatever changes made to"
               + " the TLD should be overwritten by the internal config file on the next TLD sync."
-              + " If this flag is not used to end breakglass mode, breakglass mode will also end"
+              + " If this flag is not used to end break glass mode, break glass mode will also end"
               + " automatically if the configuration file stored internally is updated to match"
               + " the current state of the TLD.")
-  boolean endBreakglass;
+  boolean endBreakGlass;
 
   @Parameter(
       names = {"--build_environment"},
@@ -104,10 +104,10 @@ public class ConfigureTldCommand extends MutatingCommand {
   boolean newDiff = true;
 
   /**
-   * Indicates if the existing TLD is currently in breakglass mode and should not be modified unless
-   * the breakglass flag is used
+   * Indicates if the existing TLD is currently in break glass mode and should not be modified
+   * unless the --break_glass flag is used
    */
-  boolean oldTldInBreakglass = false;
+  boolean oldTldInBreakGlass = false;
 
   @Override
   protected void init() throws Exception {
@@ -118,23 +118,23 @@ public class ConfigureTldCommand extends MutatingCommand {
     Tld oldTld = getTlds().contains(name) ? Tld.get(name) : null;
     Tld newTld = mapper.readValue(inputFile.toFile(), Tld.class);
     if (oldTld != null) {
-      oldTldInBreakglass = oldTld.getBreakglassMode();
+      oldTldInBreakGlass = oldTld.getBreakglassMode();
       newDiff = !oldTld.equalYaml(newTld);
     }
 
-    if (!newDiff && !oldTldInBreakglass) {
+    if (!newDiff && !oldTldInBreakGlass) {
       // Don't construct a new object if there is no new diff
       return;
     }
 
-    if (oldTldInBreakglass && !breakglass) {
+    if (oldTldInBreakGlass && !breakGlass) {
       checkArgument(
           !newDiff,
-          "Changes can not be applied since TLD is in breakglass mode but the breakglass flag was"
-              + " not used");
+          "Changes can not be applied since TLD is in break glass mode but the --break_glass flag"
+              + " was not used");
       // if there are no new diffs, then the YAML file has caught up to the database and the
-      // breakglass mode should be removed
-      logger.atInfo().log("Breakglass mode removed from TLD: %s", name);
+      // break glass mode should be removed
+      logger.atInfo().log("Break glass mode removed from TLD: %s", name);
     }
 
     checkPremiumList(newTld);
@@ -147,8 +147,8 @@ public class ConfigureTldCommand extends MutatingCommand {
     if (bsaEnrollTime.isPresent()) {
       newTld = newTld.asBuilder().setBsaEnrollStartTime(bsaEnrollTime).build();
     }
-    // Set the new TLD to breakglass mode if breakglass flag was used
-    if (breakglass) {
+    // Set the new TLD to break glass mode if break glass flag was used
+    if (breakGlass) {
       newTld = newTld.asBuilder().setBreakglassMode(true).build();
     }
     stageEntityChange(oldTld, newTld);
@@ -160,14 +160,14 @@ public class ConfigureTldCommand extends MutatingCommand {
       return true;
     }
     if (!newDiff) {
-      if (oldTldInBreakglass && !breakglass) {
-        // Run command to remove breakglass mode
+      if (oldTldInBreakGlass && !breakGlass) {
+        // Run command to remove break glass mode
         return false;
       }
       logger.atInfo().log("TLD YAML file contains no new changes");
       checkArgument(
-          !breakglass || oldTldInBreakglass,
-          "Breakglass mode can only be set when making new changes to a TLD configuration");
+          !breakGlass || oldTldInBreakGlass,
+          "Break glass mode can only be set when making new changes to a TLD configuration");
       return true;
     }
     return false;

--- a/core/src/main/java/google/registry/tools/ConfigureTldCommand.java
+++ b/core/src/main/java/google/registry/tools/ConfigureTldCommand.java
@@ -72,6 +72,24 @@ public class ConfigureTldCommand extends MutatingCommand {
   boolean breakglass;
 
   @Parameter(
+      names = {"--end_breakglass"},
+      description =
+          "Sets the breakglass field on the TLD to false, indicating that whatever changes made to"
+              + " the TLD should be overwritten by the internal config file on the next TLD sync."
+              + " If this flag is not used to end breakglass mode, breakglass mode will also end"
+              + " automatically if the configuration file stored internally is updated to match"
+              + " the current state of the TLD.")
+  boolean endBreakglass;
+
+  @Parameter(
+      names = {"--build_environment"},
+      description =
+          "DO NOT USE THIS FLAG ON THE COMMAND LINE! This flag indicates the command is being run"
+              + " by the build environment tools. This flag should never be used by a human user"
+              + " from the command line.")
+  boolean buildEnv;
+
+  @Parameter(
       names = {"-d", "--dry_run"},
       description = "Does not execute the entity mutation")
   boolean dryRun;

--- a/core/src/main/java/google/registry/tools/ConfigureTldCommand.java
+++ b/core/src/main/java/google/registry/tools/ConfigureTldCommand.java
@@ -133,8 +133,7 @@ public class ConfigureTldCommand extends MutatingCommand {
               + " was not used");
       // if there are no new diffs, then the YAML file has caught up to the database and the
       // break glass mode should be removed. Also remove the break glass mode if the break glass
-      // flag
-      // was set to false.
+      // flag was set to false.
       logger.atInfo().log("Break glass mode removed from TLD: %s", name);
     }
 
@@ -163,7 +162,7 @@ public class ConfigureTldCommand extends MutatingCommand {
     if (!newDiff) {
       if (oldTldInBreakGlass && (breakGlass == null || !breakGlass)) {
         // Run command to remove break glass mode if there is no break glass flag or if the break
-        // glass flag is false
+        // glass flag is false.
         return false;
       }
       logger.atInfo().log("TLD YAML file contains no new changes");

--- a/core/src/main/java/google/registry/tools/ConfigureTldCommand.java
+++ b/core/src/main/java/google/registry/tools/ConfigureTldCommand.java
@@ -122,7 +122,7 @@ public class ConfigureTldCommand extends MutatingCommand {
     }
 
     checkArgument(
-        oldTldInBreakGlass || breakGlass == null || breakGlass,
+        oldTldInBreakGlass || !Boolean.FALSE.equals(breakGlass),
         "The --break_glass flag cannot be set to false to end break glass mode because the TLD is"
             + " not currently in break glass mode");
 
@@ -132,7 +132,8 @@ public class ConfigureTldCommand extends MutatingCommand {
           "Changes can not be applied since TLD is in break glass mode but the --break_glass flag"
               + " was not used");
       // if there are no new diffs, then the YAML file has caught up to the database and the
-      // break glass mode should be removed. Also remove the break glass mode the break glass flag
+      // break glass mode should be removed. Also remove the break glass mode if the break glass
+      // flag
       // was set to false.
       logger.atInfo().log("Break glass mode removed from TLD: %s", name);
     }

--- a/core/src/main/java/google/registry/tools/ConfigureTldCommand.java
+++ b/core/src/main/java/google/registry/tools/ConfigureTldCommand.java
@@ -147,7 +147,10 @@ public class ConfigureTldCommand extends MutatingCommand {
     if (bsaEnrollTime.isPresent()) {
       newTld = newTld.asBuilder().setBsaEnrollStartTime(bsaEnrollTime).build();
     }
-    // Set the new TLD to break glass mode if break glass flag was used
+    // Set the new TLD to break glass mode if break glass flag was used. Note that the break glass
+    // mode does not need to be set to false if the --break_glass flag was set to false since the
+    // field already defaults to false. Break glass mode will also automatically turn off if there
+    // is no new diff and the --break_glass flag is null.
     if (Boolean.TRUE.equals(breakGlass)) {
       newTld = newTld.asBuilder().setBreakglassMode(true).build();
     }

--- a/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
@@ -638,14 +638,16 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
     persistResource(
         tld.asBuilder()
             .setIdnTables(ImmutableSet.of(JA, UNCONFUSABLE_LATIN, EXTENDED_LATIN))
-            .setAllowedFullyQualifiedHostNames(ImmutableSet.of("zeta", "alpha", "gamma", "beta"))
+            .setAllowedFullyQualifiedHostNames(ImmutableSet.of("beta", "zeta", "alpha", "gamma"))
             .setBreakglassMode(true)
             .build());
     File tldFile = tmpDir.resolve("idns.yaml").toFile();
     Files.asCharSink(tldFile, UTF_8).write(loadFile(getClass(), "idns.yaml"));
+    // This update contains no diffs from whats in the config file
     runCommandForced("--input=" + tldFile, "--break_glass=false");
     Tld updatedTld = Tld.get("idns");
     assertThat(updatedTld.getBreakglassMode()).isFalse();
+    testTldConfiguredSuccessfully(updatedTld, "idns.yaml");
     assertAboutLogs()
         .that(logHandler)
         .hasLogAtLevelWithMessage(INFO, "Break glass mode removed from TLD: idns");

--- a/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
@@ -538,7 +538,7 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
   }
 
   @Test
-  void testSuccess_breaklassFlag_continuesBreakGlassMode() throws Exception {
+  void testSuccess_breakGlassFlag_continuesBreakGlassMode() throws Exception {
     Tld tld = createTld("tld");
     assertThat(tld.getCreateBillingCost()).isEqualTo(Money.of(USD, 13));
     persistResource(tld.asBuilder().setBreakglassMode(true).build());

--- a/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
@@ -506,7 +506,7 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
   }
 
   @Test
-  void testFailure_breakglassFlag_NoChanges() throws Exception {
+  void testFailure_breakGlassFlag_NoChanges() throws Exception {
     Tld tld = createTld("idns");
     persistResource(
         tld.asBuilder()
@@ -520,16 +520,16 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
             IllegalArgumentException.class, () -> runCommandForced("--input=" + tldFile, "-b"));
     assertThat(thrown.getMessage())
         .isEqualTo(
-            "Breakglass mode can only be set when making new changes to a TLD configuration");
+            "Break glass mode can only be set when making new changes to a TLD configuration");
   }
 
   @Test
-  void testSuccess_breakglassFlag_startsBreakglassMode() throws Exception {
+  void testSuccess_breakGlassFlag_startsBreakGlassMode() throws Exception {
     Tld tld = createTld("tld");
     assertThat(tld.getCreateBillingCost()).isEqualTo(Money.of(USD, 13));
     File tldFile = tmpDir.resolve("tld.yaml").toFile();
     Files.asCharSink(tldFile, UTF_8).write(loadFile(getClass(), "tld.yaml"));
-    runCommandForced("--input=" + tldFile, "--breakglass");
+    runCommandForced("--input=" + tldFile, "--break_glass");
     Tld updatedTld = Tld.get("tld");
     assertThat(updatedTld.getCreateBillingCost()).isEqualTo(Money.of(USD, 25));
     testTldConfiguredSuccessfully(updatedTld, "tld.yaml");
@@ -537,13 +537,13 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
   }
 
   @Test
-  void testSuccess_breakglassFlag_continuesBreakglassMode() throws Exception {
+  void testSuccess_breaklassFlag_continuesBreakGlassMode() throws Exception {
     Tld tld = createTld("tld");
     assertThat(tld.getCreateBillingCost()).isEqualTo(Money.of(USD, 13));
     persistResource(tld.asBuilder().setBreakglassMode(true).build());
     File tldFile = tmpDir.resolve("tld.yaml").toFile();
     Files.asCharSink(tldFile, UTF_8).write(loadFile(getClass(), "tld.yaml"));
-    runCommandForced("--input=" + tldFile, "--breakglass");
+    runCommandForced("--input=" + tldFile, "--break_glass");
     Tld updatedTld = Tld.get("tld");
     assertThat(updatedTld.getCreateBillingCost()).isEqualTo(Money.of(USD, 25));
     testTldConfiguredSuccessfully(updatedTld, "tld.yaml");
@@ -551,7 +551,7 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
   }
 
   @Test
-  void testSuccess_NoDiffNoBreakglassFlag_endsBreakglassMode() throws Exception {
+  void testSuccess_NoDiffNoBreakGlassFlag_endsBreakGlassMode() throws Exception {
     Tld tld = createTld("idns");
     persistResource(
         tld.asBuilder()
@@ -566,11 +566,11 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
     assertThat(updatedTld.getBreakglassMode()).isFalse();
     assertAboutLogs()
         .that(logHandler)
-        .hasLogAtLevelWithMessage(INFO, "Breakglass mode removed from TLD: idns");
+        .hasLogAtLevelWithMessage(INFO, "Break glass mode removed from TLD: idns");
   }
 
   @Test
-  void testSuccess_noDiffBreakglassFlag_continuesBreakglassMode() throws Exception {
+  void testSuccess_noDiffBreakGlassFlag_continuesBreakGlassMode() throws Exception {
     Tld tld = createTld("idns");
     persistResource(
         tld.asBuilder()
@@ -589,7 +589,7 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
   }
 
   @Test
-  void testFailure_noBreakglassFlag_inBreakglassMode() throws Exception {
+  void testFailure_noBreakGlassFlag_inBreakGlassMode() throws Exception {
     Tld tld = createTld("tld");
     persistResource(tld.asBuilder().setBreakglassMode(true).build());
     File tldFile = tmpDir.resolve("tld.yaml").toFile();
@@ -598,7 +598,7 @@ public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand
         assertThrows(IllegalArgumentException.class, () -> runCommandForced("--input=" + tldFile));
     assertThat(thrown.getMessage())
         .isEqualTo(
-            "Changes can not be applied since TLD is in breakglass mode but the breakglass flag"
+            "Changes can not be applied since TLD is in break glass mode but the --break_glass flag"
                 + " was not used");
   }
 

--- a/core/src/test/resources/google/registry/tools/idns.yaml
+++ b/core/src/test/resources/google/registry/tools/idns.yaml
@@ -1,9 +1,9 @@
 addGracePeriodLength: "PT432000S"
 allowedFullyQualifiedHostNames:
-- "beta"
-- "zeta"
 - "alpha"
+- "beta"
 - "gamma"
+- "zeta"
 allowedRegistrantContactIds: []
 anchorTenantAddGracePeriodLength: "PT2592000S"
 autoRenewGracePeriodLength: "PT3888000S"


### PR DESCRIPTION
It is necessary to define these flags in a deployment before merging go/r3pr/2273 in order to prevent breaking the exisitng TLD syncing and entity presubmit testing that has already been enabled.  

The --break_glass flag is now a Boolean parameter instead of a boolean to allow it to be used to also turn off break glass mode when it is set to false.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2277)
<!-- Reviewable:end -->
