### PR TITLE
Add support for Ubuntu20 on kokoro

### DIFF
--- a/core/src/nonprod/java/google/registry/tools/DumpGoldenSchemaCommand.java
+++ b/core/src/nonprod/java/google/registry/tools/DumpGoldenSchemaCommand.java
@@ -16,11 +16,9 @@ package google.registry.tools;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import org.flywaydb.core.Flyway;
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.Container;
 
 /**
@@ -35,9 +33,6 @@ public class DumpGoldenSchemaCommand extends PostgresqlCommand {
 
   // The mount point in the container.
   private static final String CONTAINER_MOUNT_POINT = "/tmp/pg_dump.out";
-
-  // Temporary workaround to fix permission issues on certain Linux distro (e. g. Arch Linux).
-  private static final String CONTAINER_MOUNT_POINT_TMP = "/tmp/pg_dump.tmp";
 
   @Parameter(
       names = {"--output", "-o"},
@@ -64,19 +59,7 @@ public class DumpGoldenSchemaCommand extends PostgresqlCommand {
     if (result.getExitCode() != 0) {
       throw new RuntimeException(result.toString());
     }
-    result =
-        postgresContainer.execInContainer("cp", CONTAINER_MOUNT_POINT_TMP, CONTAINER_MOUNT_POINT);
-    if (result.getExitCode() != 0) {
-      throw new RuntimeException(result.toString());
-    }
-  }
-
-  @Override
-  protected void onContainerCreate() throws IOException {
-    // open the output file for write so we can mount it.
-    new FileOutputStream(output.toFile()).close();
-    postgresContainer.withFileSystemBind(
-        output.toString(), CONTAINER_MOUNT_POINT, BindMode.READ_WRITE);
+    postgresContainer.copyFileFromContainer(CONTAINER_MOUNT_POINT, output.toString());
   }
 
   private static String[] getSchemaDumpCommand(String username, String dbName) {
@@ -87,7 +70,7 @@ public class DumpGoldenSchemaCommand extends PostgresqlCommand {
       "-U",
       username,
       "-f",
-      CONTAINER_MOUNT_POINT_TMP,
+      CONTAINER_MOUNT_POINT,
       "--schema-only",
       "--no-owner",
       "--no-privileges",


### PR DESCRIPTION
We've had 3 blockers for kokoro ubuntu update which are now resolved and we can move forward with kokoro os update:

1. missing dependency - fixed separately in kokoro config
2. DumpGoldenSchemaCommandTest failure - this apparently is not new and has been happening in GCP Cloud Build docker where it'd been simply disabled (See https://cs.opensource.google/nomulus/nomulus/+/master:core/build.gradle;l=49) . I've found a way to make it work, which I will later enable in CB as well after this runs well
3. PathParameterTest failures - Pretty much the same story as 2 - it's been failing on GCP Cloud Build docker where the entire test suite has been disabled. My change disables only 2 tests affected test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2279)
<!-- Reviewable:end -->
