### PR TITLE
Add a cron schedule for the BSA upload unavailable domains task

### DIFF
--- a/core/src/main/java/google/registry/env/alpha/default/WEB-INF/cloud-scheduler-tasks.xml
+++ b/core/src/main/java/google/registry/env/alpha/default/WEB-INF/cloud-scheduler-tasks.xml
@@ -138,4 +138,15 @@
     </description>
     <schedule>*/1 * * * *</schedule>
   </task>
+
+  <task>
+    <url><![CDATA[/_dr/task/uploadBsaUnavailableNames]]></url>
+    <name>uploadBsaUnavailableNames</name>
+    <description>
+      This job uploads all unavailable domain names (those registered and
+      reserved) to the BSA.
+    </description>
+    <service>bsa</service>
+    <schedule>23 8,20 * * *</schedule>
+  </task>
 </entries>


### PR DESCRIPTION
Also fixes the action taken in the case where zero unavailable domains are found, and temporarily changes over to using the primary DB (because the replica transaction was timing out at 30 seconds on large databases). I'll switch this over to use batching and move it back to replica afterwards, but this should unblock us temporarily.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2280)
<!-- Reviewable:end -->
