### PR TITLE
Make the BSA upload unvailable domains task work with HTTP GET as well

### DIFF
--- a/core/src/main/java/google/registry/bsa/UploadBsaUnavailableDomainsAction.java
+++ b/core/src/main/java/google/registry/bsa/UploadBsaUnavailableDomainsAction.java
@@ -21,6 +21,7 @@ import static google.registry.model.tld.label.ReservedList.loadReservedLists;
 import static google.registry.persistence.PersistenceModule.TransactionIsolationLevel.TRANSACTION_REPEATABLE_READ;
 import static google.registry.persistence.transaction.TransactionManagerFactory.replicaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.request.Action.Method.GET;
 import static google.registry.request.Action.Method.POST;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
@@ -70,7 +71,7 @@ import org.joda.time.DateTime;
 @Action(
     service = Service.BSA,
     path = "/_dr/task/uploadBsaUnavailableNames",
-    method = POST,
+    method = {GET, POST},
     auth = Auth.AUTH_API_ADMIN)
 public class UploadBsaUnavailableDomainsAction implements Runnable {
 

--- a/core/src/test/resources/google/registry/module/bsa/bsa_routing.txt
+++ b/core/src/test/resources/google/registry/module/bsa/bsa_routing.txt
@@ -1,4 +1,4 @@
 PATH                                CLASS                             METHODS  OK AUTH_METHODS MIN USER_POLICY
 /_dr/task/bsaDownload               BsaDownloadAction                 GET,POST n  API          APP ADMIN
 /_dr/task/bsaRefresh                BsaRefreshAction                  GET,POST n  API          APP ADMIN
-/_dr/task/uploadBsaUnavailableNames UploadBsaUnavailableDomainsAction POST     n  API          APP ADMIN
+/_dr/task/uploadBsaUnavailableNames UploadBsaUnavailableDomainsAction GET,POST n  API          APP ADMIN


### PR DESCRIPTION
Apparently Google Cloud Scheduler can only do GET, not POST, for some reason.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2287)
<!-- Reviewable:end -->
