### PR TITLE
Add bsa-refresh cron job to sandbox and prod

### DIFF
--- a/core/src/main/java/google/registry/env/production/default/WEB-INF/cloud-scheduler-tasks.xml
+++ b/core/src/main/java/google/registry/env/production/default/WEB-INF/cloud-scheduler-tasks.xml
@@ -286,6 +286,18 @@
   </task>
 
   <task>
+    <url><![CDATA[/_dr/task/bsaRefresh]]></url>
+    <name>bsaRefresh</name>
+    <service>bsa</service>
+    <description>
+      Checks for changes in registered domains and reserved labels, and updates
+      the unblockable domains list.
+    </description>
+    <!-- Runs every 30 minutes. -->
+    <schedule>15,45 * * * *</schedule>
+  </task>
+
+  <task>
     <url><![CDATA[/_dr/task/uploadBsaUnavailableNames]]></url>
     <name>uploadBsaUnavailableNames</name>
     <description>

--- a/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/cloud-scheduler-tasks.xml
+++ b/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/cloud-scheduler-tasks.xml
@@ -175,6 +175,18 @@
   </task>
 
   <task>
+    <url><![CDATA[/_dr/task/bsaRefresh]]></url>
+    <name>bsaRefresh</name>
+    <service>bsa</service>
+    <description>
+      Checks for changes in registered domains and reserved labels, and updates
+      the unblockable domains list.
+    </description>
+    <!-- Runs every 30 minutes. -->
+    <schedule>15,45 * * * *</schedule>
+  </task>
+
+  <task>
     <url><![CDATA[/_dr/task/uploadBsaUnavailableNames]]></url>
     <name>uploadBsaUnavailableNames</name>
     <description>


### PR DESCRIPTION
This is the job that updates the unblockable domains according to recent changes in domain registration and reservation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2290)
<!-- Reviewable:end -->
