### PR TITLE
Add some updates to UpdateReservedListCommand to facilitate internal config presubmits and syncing

### DIFF
--- a/core/src/main/java/google/registry/tools/UpdatePremiumListCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdatePremiumListCommand.java
@@ -43,14 +43,16 @@ class UpdatePremiumListCommand extends CreateOrUpdatePremiumListCommand {
               + " from the command line.")
   boolean buildEnv;
 
-  // TODO(sarahbot): Add break glass handling to this command and require buildEnv or breakGlass in
-  // production environment
-
   // Indicates if there is a new change made by this command
   private boolean newChange = false;
 
   @Override
   protected String prompt() throws Exception {
+    // TODO(sarahbot): uncomment once go/r3pr/2292 is deployed
+    // checkArgument(
+    //     !RegistryToolEnvironment.get().equals(RegistryToolEnvironment.PRODUCTION) || buildEnv,
+    //     "The --build_environment flag must be used when running update_premium_list in
+    // production");
     name = Strings.isNullOrEmpty(name) ? convertFilePathToName(inputFile) : name;
     PremiumList existingList =
         PremiumListDao.getLatestRevision(name)

--- a/core/src/main/java/google/registry/tools/UpdatePremiumListCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdatePremiumListCommand.java
@@ -46,7 +46,7 @@ class UpdatePremiumListCommand extends CreateOrUpdatePremiumListCommand {
   // TODO(sarahbot): Add break glass handling to this command and require buildEnv or breakGlass in
   // production environment
 
-  // indicates if there is a new change made by this command
+  // Indicates if there is a new change made by this command
   private boolean newChange = false;
 
   @Override

--- a/core/src/main/java/google/registry/tools/UpdatePremiumListCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdatePremiumListCommand.java
@@ -35,6 +35,17 @@ class UpdatePremiumListCommand extends CreateOrUpdatePremiumListCommand {
       description = "Does not execute the entity mutation")
   boolean dryRun;
 
+  @Parameter(
+      names = {"--build_environment"},
+      description =
+          "DO NOT USE THIS FLAG ON THE COMMAND LINE! This flag indicates the command is being run"
+              + " by the build environment tools. This flag should never be used by a human user"
+              + " from the command line.")
+  boolean buildEnv;
+
+  // TODO(sarahbot): Add break glass handling to this command and require buildEnv or breakGlass in
+  // production environment
+
   // indicates if there is a new change made by this command
   private boolean newChange = false;
 

--- a/core/src/main/java/google/registry/tools/UpdateReservedListCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdateReservedListCommand.java
@@ -42,14 +42,16 @@ final class UpdateReservedListCommand extends CreateOrUpdateReservedListCommand 
               + " from the command line.")
   boolean buildEnv;
 
-  // TODO(sarahbot): Add break glass handling to this command and require buildEnv or breakGlass in
-  // production environment
-
   // indicates if there is a new change made by this command
   private boolean newChange = true;
 
   @Override
   protected String prompt() throws Exception {
+    // TODO(sarahbot): uncomment once go/r3pr/2292 is deployed
+    // checkArgument(
+    //     !RegistryToolEnvironment.get().equals(RegistryToolEnvironment.PRODUCTION) || buildEnv,
+    //     "The --build_environment flag must be used when running update_reserved_list in"
+    //         + " production");
     name = Strings.isNullOrEmpty(name) ? convertFilePathToName(input) : name;
     ReservedList existingReservedList =
         ReservedList.get(name)

--- a/core/src/test/java/google/registry/tools/UpdatePremiumListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdatePremiumListCommandTest.java
@@ -205,4 +205,40 @@ class UpdatePremiumListCommandTest<C extends UpdatePremiumListCommand>
         .comparingElementsUsing(immutableObjectCorrespondence("revisionId"))
         .containsExactly(PremiumEntry.create(0L, new BigDecimal("9090.00"), "doge"));
   }
+
+  // TODO(sarahbot): uncomment once go/r3pr/2292 is deployed
+  // @Test
+  // void testFailure_runCommandOnProduction_noFlag() throws Exception {
+  //   File tmpFile = tmpDir.resolve(String.format("%s.txt", TLD_TEST)).toFile();
+  //   String newPremiumListData = "eth,USD 9999";
+  //   Files.asCharSink(tmpFile, UTF_8).write(newPremiumListData);
+  //   IllegalArgumentException thrown =
+  //       assertThrows(
+  //           IllegalArgumentException.class,
+  //           () ->
+  //               runCommandInEnvironment(
+  //                   RegistryToolEnvironment.PRODUCTION,
+  //                   "--name=" + TLD_TEST,
+  //                   "--input=" + Paths.get(tmpFile.getPath())));
+  //   assertThat(thrown.getMessage())
+  //       .isEqualTo(
+  //           "The --build_environment flag must be used when running update_premium_list in"
+  //               + " production");
+  // }
+  //
+  // @Test
+  // void testSuccess_runCommandOnProduction_buildEnvFlag() throws Exception {
+  //   File tmpFile = tmpDir.resolve(String.format("%s.txt", TLD_TEST)).toFile();
+  //   String newPremiumListData = "eth,USD 9999";
+  //   Files.asCharSink(tmpFile, UTF_8).write(newPremiumListData);
+  //   runCommandInEnvironment(
+  //       RegistryToolEnvironment.PRODUCTION,
+  //       "--name=" + TLD_TEST,
+  //       "--input=" + Paths.get(tmpFile.getPath()),
+  //       "--build_environment",
+  //       "-f");
+  //   assertThat(PremiumListDao.loadAllPremiumEntries(TLD_TEST))
+  //       .comparingElementsUsing(immutableObjectCorrespondence("revisionId"))
+  //       .containsExactly(PremiumEntry.create(0L, new BigDecimal("9999.00"), "eth"));
+  // }
 }

--- a/core/src/test/java/google/registry/tools/UpdateReservedListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateReservedListCommandTest.java
@@ -142,4 +142,14 @@ class UpdateReservedListCommandTest
     assertThat(command.prompt()).contains("baddies: null -> baddies,FULLY_BLOCKED");
     assertThat(command.prompt()).contains("ford: null -> ford,FULLY_BLOCKED # random comment");
   }
+
+  @Test
+  void testSuccess_dryRun() throws Exception {
+    runCommandForced("--input=" + reservedTermsPath, "--dry_run");
+    assertThat(command.prompt()).contains("Update reserved list for xn--q9jyb4c_common-reserved?");
+    assertThat(ReservedList.get("xn--q9jyb4c_common-reserved")).isPresent();
+    ReservedList reservedList = ReservedList.get("xn--q9jyb4c_common-reserved").get();
+    assertThat(reservedList.getReservedListEntries()).hasSize(1);
+    assertThat(reservedList.getReservationInList("helicopter")).hasValue(FULLY_BLOCKED);
+  }
 }

--- a/core/src/test/java/google/registry/tools/UpdateReservedListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateReservedListCommandTest.java
@@ -152,4 +152,41 @@ class UpdateReservedListCommandTest
     assertThat(reservedList.getReservedListEntries()).hasSize(1);
     assertThat(reservedList.getReservationInList("helicopter")).hasValue(FULLY_BLOCKED);
   }
+
+  // TODO(sarahbot): uncomment once go/r3pr/2292 is deployed
+  // @Test
+  // void testFailure_runCommandOnProduction_noFlag() throws Exception {
+  //   IllegalArgumentException thrown =
+  //       assertThrows(
+  //           IllegalArgumentException.class,
+  //           () ->
+  //               runCommandInEnvironment(
+  //                   RegistryToolEnvironment.PRODUCTION,
+  //                   "--name=xn--q9jyb4c_common-reserved",
+  //                   "--input=" + reservedTermsPath));
+  //   assertThat(thrown.getMessage())
+  //       .isEqualTo(
+  //           "The --build_environment flag must be used when running update_reserved_list in"
+  //               + " production");
+  // }
+  //
+  // @Test
+  // void testSuccess_runCommandOnProduction_buildEnvFlag() throws Exception {
+  //   runCommandInEnvironment(
+  //       RegistryToolEnvironment.PRODUCTION,
+  //       "--name=xn--q9jyb4c_common-reserved",
+  //       "--input=" + reservedTermsPath,
+  //       "--build_environment",
+  //       "-f");
+  //   assertThat(ReservedList.get("xn--q9jyb4c_common-reserved")).isPresent();
+  //   ReservedList reservedList = ReservedList.get("xn--q9jyb4c_common-reserved").get();
+  //   assertThat(reservedList.getReservedListEntries()).hasSize(2);
+  //   assertThat(reservedList.getReservationInList("baddies")).hasValue(FULLY_BLOCKED);
+  //   assertThat(reservedList.getReservationInList("ford")).hasValue(FULLY_BLOCKED);
+  //   assertThat(reservedList.getReservationInList("helicopter")).isEmpty();
+  //   assertInStdout("Update reserved list for xn--q9jyb4c_common-reserved?");
+  //   assertInStdout("helicopter: helicopter,FULLY_BLOCKED -> null");
+  //   assertInStdout("baddies: null -> baddies,FULLY_BLOCKED");
+  //   assertInStdout("ford: null -> ford,FULLY_BLOCKED # random comment");
+  // }
 }


### PR DESCRIPTION
Added a dry-run tag for presubmit tests

Added early exit behavior when there are no new changes to the list

Added a new --build_environment tag to be used to indicate command runs from build tools. This tag was also added to UpdatePremiumListCommand. Once this new tag is deployed, and break glass behavior is added, these commands will be modified to prevent runs on the command line in the production environment unless the --build_environment or --break_glass flag is used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2292)
<!-- Reviewable:end -->
