### PR TITLE
Use Java 17 runtime on sandbox and production

### DIFF
--- a/core/src/main/java/google/registry/env/production/backend/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/backend/WEB-INF/appengine-web.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>backend</service>
-  <!--app-engine-apis>true</app-engine-apis-->
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/production/bsa/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/bsa/WEB-INF/appengine-web.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>bsa</service>
-  <!--app-engine-apis>true</app-engine-apis-->
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/production/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/default/WEB-INF/appengine-web.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>default</service>
-  <!--app-engine-apis>true</app-engine-apis-->
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <manual-scaling>

--- a/core/src/main/java/google/registry/env/production/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/pubapi/WEB-INF/appengine-web.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>pubapi</service>
-  <!--app-engine-apis>true</app-engine-apis-->
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <manual-scaling>

--- a/core/src/main/java/google/registry/env/production/tools/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/tools/WEB-INF/appengine-web.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>tools</service>
-  <!--app-engine-apis>true</app-engine-apis-->
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/sandbox/backend/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/backend/WEB-INF/appengine-web.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>backend</service>
-  <!--app-engine-apis>true</app-engine-apis-->
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/sandbox/bsa/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/bsa/WEB-INF/appengine-web.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>bsa</service>
-  <!--app-engine-apis>true</app-engine-apis-->
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>

--- a/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/appengine-web.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>default</service>
-  <!--app-engine-apis>true</app-engine-apis-->
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <manual-scaling>

--- a/core/src/main/java/google/registry/env/sandbox/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/pubapi/WEB-INF/appengine-web.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>pubapi</service>
-  <!--app-engine-apis>true</app-engine-apis-->
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <manual-scaling>

--- a/core/src/main/java/google/registry/env/sandbox/tools/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/tools/WEB-INF/appengine-web.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java8</runtime>
+  <runtime>java17</runtime>
   <service>tools</service>
-  <!--app-engine-apis>true</app-engine-apis-->
-  <threadsafe>true</threadsafe>
+  <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>


### PR DESCRIPTION
The blocking issue is fixed in
https://github.com/google/nomulus/pull/2224.

Java 8 support is being deprecated on 2024-01-31 and no further deployment is
possible afterwards without exception:

https://cloud.google.com/appengine/docs/legacy/standard/java/deprecations

We have been using Java 17 on alpha/crash/qa for several months and have
not oberved any other blocking issue other than possible missing email
attachements, which is being mitigated by including a link to the
attachments saved in GCS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2296)
<!-- Reviewable:end -->
