### PR TITLE
Fix typo in BsaRefreshAction

### DIFF
--- a/core/src/main/java/google/registry/bsa/BsaRefreshAction.java
+++ b/core/src/main/java/google/registry/bsa/BsaRefreshAction.java
@@ -162,7 +162,7 @@ public class BsaRefreshAction implements Runnable {
                       .filter(UnblockableDomainChange::isNewOrChange)
                       .map(UnblockableDomainChange::newValue));
           if (report.isPresent()) {
-            gcsClient.logRemovedUnblockableDomainsReport(
+            gcsClient.logAddedUnblockableDomainsReport(
                 schedule.jobName(), LINE_SPLITTER.splitToStream(report.get()));
             bsaReportSender.addUnblockableDomainsUpdates(report.get());
           } else {

--- a/core/src/main/java/google/registry/bsa/BsaTransactions.java
+++ b/core/src/main/java/google/registry/bsa/BsaTransactions.java
@@ -48,7 +48,8 @@ public final class BsaTransactions {
   @CanIgnoreReturnValue
   public static <T> T bsaQuery(Callable<T> work) {
     verify(!isInTransaction(), "May only be used for top-level transactions.");
-    return replicaTm().transact(work, TRANSACTION_REPEATABLE_READ);
+    // TRANSACTION_REPEATABLE_READ is default on replica.
+    return replicaTm().transact(work);
   }
 
   private BsaTransactions() {}


### PR DESCRIPTION
The http payload for the report of new unblockable domains s was logged to the wrong file.

This log is for verification and troubleshooting purpose. It does not affect the BSA side.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2297)
<!-- Reviewable:end -->
