### PR TITLE
Don't override existing registrar email address when setting referral email

### DIFF
--- a/core/src/main/java/google/registry/tools/CreateOrUpdateRegistrarCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdateRegistrarCommand.java
@@ -292,8 +292,8 @@ abstract class CreateOrUpdateRegistrarCommand extends MutatingCommand {
       }
       if (!isNullOrEmpty(email)) {
         builder.setEmailAddress(email);
-      } else if (!isNullOrEmpty(
-          icannReferralEmail)) { // fall back to ICANN referral email if present
+      } else if (!isNullOrEmpty(icannReferralEmail) && oldRegistrar == null) {
+        // On creates, fall back to ICANN referral email (if present).
         builder.setEmailAddress(icannReferralEmail);
       }
       if (url != null) {

--- a/core/src/test/java/google/registry/tools/UpdateRegistrarCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateRegistrarCommandTest.java
@@ -637,10 +637,12 @@ class UpdateRegistrarCommandTest extends CommandTestCase<UpdateRegistrarCommand>
 
   @Test
   void testSuccess_setIcannEmail() throws Exception {
-    runCommand("--icann_referral_email=foo@bar.test", "--force", "TheRegistrar");
     Registrar registrar = loadRegistrar("TheRegistrar");
-    assertThat(registrar.getIcannReferralEmail()).isEqualTo("foo@bar.test");
-    assertThat(registrar.getEmailAddress()).isEqualTo("foo@bar.test");
+    assertThat(registrar.getEmailAddress()).isEqualTo("the.registrar@example.com");
+    runCommand("--icann_referral_email=foo@bar.test", "--force", "TheRegistrar");
+    Registrar updatedRegistrar = loadRegistrar("TheRegistrar");
+    assertThat(updatedRegistrar.getIcannReferralEmail()).isEqualTo("foo@bar.test");
+    assertThat(updatedRegistrar.getEmailAddress()).isEqualTo("the.registrar@example.com");
   }
 
   @Test


### PR DESCRIPTION
The fallback should only apply on creates, not on updates, otherwise it can override an existing value for the email address when only the referral email should be what's updated.

This fixes a bug introduced back in commit in 0ead4f8d9d19b938a7f959a70df41cafd9b5c966.

BUG= http://b/322026165

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2300)
<!-- Reviewable:end -->
