### PR TITLE
Add new token that allow bypassing BSA blocks

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainCheckFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCheckFlow.java
@@ -26,6 +26,7 @@ import static google.registry.flows.domain.DomainFlowUtils.checkHasBillingAccoun
 import static google.registry.flows.domain.DomainFlowUtils.getReservationTypes;
 import static google.registry.flows.domain.DomainFlowUtils.handleFeeRequest;
 import static google.registry.flows.domain.DomainFlowUtils.isAnchorTenant;
+import static google.registry.flows.domain.DomainFlowUtils.isBypassBsaCreate;
 import static google.registry.flows.domain.DomainFlowUtils.isReserved;
 import static google.registry.flows.domain.DomainFlowUtils.isValidReservedCreate;
 import static google.registry.flows.domain.DomainFlowUtils.validateDomainName;
@@ -269,13 +270,12 @@ public final class DomainCheckFlow implements TransactionalFlow {
     if (tokenResult.isPresent()) {
       return tokenResult;
     }
-    if (bsaBlockedDomains.contains(domainName)) {
+    if (isBypassBsaCreate(domainName, allocationToken) || !bsaBlockedDomains.contains(domainName)) {
+      return Optional.empty();
+    }
       // TODO(weiminyu): extract to a constant for here and CheckApiAction.
       // Excerpt from BSA's custom message. Max len 32 chars by EPP XML schema.
       return Optional.of("Blocked by a GlobalBlock service");
-    } else {
-      return Optional.empty();
-    }
   }
 
   /** Handle the fee check extension. */

--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -27,6 +27,7 @@ import static google.registry.flows.domain.DomainFlowUtils.cloneAndLinkReference
 import static google.registry.flows.domain.DomainFlowUtils.createFeeCreateResponse;
 import static google.registry.flows.domain.DomainFlowUtils.getReservationTypes;
 import static google.registry.flows.domain.DomainFlowUtils.isAnchorTenant;
+import static google.registry.flows.domain.DomainFlowUtils.isBypassBsaCreate;
 import static google.registry.flows.domain.DomainFlowUtils.isReserved;
 import static google.registry.flows.domain.DomainFlowUtils.isValidReservedCreate;
 import static google.registry.flows.domain.DomainFlowUtils.validateCreateCommandContactsAndNameservers;
@@ -330,7 +331,9 @@ public final class DomainCreateFlow implements MutatingFlow {
               .verifySignedMarks(launchCreate.get().getSignedMarks(), domainLabel, now)
               .getId();
     }
-    verifyNotBlockedByBsa(domainLabel, tld, now);
+    if (!isBypassBsaCreate(domainName, allocationToken)) {
+      verifyNotBlockedByBsa(domainLabel, tld, now);
+    }
     flowCustomLogic.afterValidation(
         DomainCreateFlowCustomLogic.AfterValidationParameters.newBuilder()
             .setDomainName(domainName)

--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -27,6 +27,7 @@ import static com.google.common.collect.Sets.intersection;
 import static com.google.common.collect.Sets.union;
 import static google.registry.bsa.persistence.BsaLabelUtils.isLabelBlocked;
 import static google.registry.model.domain.Domain.MAX_REGISTRATION_YEARS;
+import static google.registry.model.domain.token.AllocationToken.RegistrationBehavior.BYPASS_BSA;
 import static google.registry.model.tld.Tld.TldState.GENERAL_AVAILABILITY;
 import static google.registry.model.tld.Tld.TldState.PREDELEGATION;
 import static google.registry.model.tld.Tld.TldState.QUIET_PERIOD;
@@ -307,6 +308,15 @@ public class DomainFlowUtils {
     // is for this domain.
     return getReservationTypes(domainName).contains(RESERVED_FOR_SPECIFIC_USE)
         && token.isPresent()
+        && token.get().getDomainName().isPresent()
+        && token.get().getDomainName().get().equals(domainName.toString());
+  }
+
+  /** Returns whether a given domain create request may bypass the BSA block check. */
+  public static boolean isBypassBsaCreate(
+      InternetDomainName domainName, Optional<AllocationToken> token) {
+    return token.isPresent()
+        && token.get().getRegistrationBehavior().equals(BYPASS_BSA)
         && token.get().getDomainName().isPresent()
         && token.get().getDomainName().get().equals(domainName.toString());
   }

--- a/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
+++ b/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
@@ -114,7 +114,9 @@ public class AllocationToken extends UpdateAutoTimestampEntity implements Builda
      */
     BYPASS_TLD_STATE,
     /** Bypasses most checks and creates the domain as an anchor tenant, with all that implies. */
-    ANCHOR_TENANT
+    ANCHOR_TENANT,
+    /** Bypass the BSA-block check during domain creation IF other checks have passed. */
+    BYPASS_BSA,
   }
 
   /** Type of the token that indicates how and where it should be used. */
@@ -381,6 +383,9 @@ public class AllocationToken extends UpdateAutoTimestampEntity implements Builda
       if (getInstance().registrationBehavior.equals(RegistrationBehavior.ANCHOR_TENANT)) {
         checkArgumentNotNull(
             getInstance().domainName, "ANCHOR_TENANT tokens must be tied to a domain");
+      }
+      if (getInstance().registrationBehavior.equals(RegistrationBehavior.BYPASS_BSA)) {
+        checkArgumentNotNull(getInstance().domainName, "ALLOW_BSA tokens must be tied to a domain");
       }
       if (getInstance().domainName != null) {
         try {

--- a/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
+++ b/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
@@ -524,7 +524,7 @@ public class AllocationTokenTest extends EntityTestCase {
   }
 
   @Test
-  void testBuild_registrationBehaviors() {
+  void testBuild_registrationBehaviors_bypassTldState() {
     createTld("tld");
     // BYPASS_TLD_STATE doesn't require a domain
     AllocationToken token =
@@ -533,22 +533,36 @@ public class AllocationTokenTest extends EntityTestCase {
             .setTokenType(SINGLE_USE)
             .setRegistrationBehavior(RegistrationBehavior.BYPASS_TLD_STATE)
             .build();
-    // ANCHOR_TENANT does
-    assertThat(
-            assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                    token
-                        .asBuilder()
-                        .setRegistrationBehavior(RegistrationBehavior.ANCHOR_TENANT)
-                        .build()))
+  }
+
+  @Test
+  void testBuild_registrationBehaviors_anchorTenant() {
+    createTld("tld");
+    // ANCHOR_TENANT requires a domain
+    AllocationToken.Builder token =
+        new AllocationToken.Builder()
+            .setToken("abc")
+            .setTokenType(SINGLE_USE)
+            .setRegistrationBehavior(RegistrationBehavior.ANCHOR_TENANT);
+    assertThat(assertThrows(IllegalArgumentException.class, () -> token.build()))
         .hasMessageThat()
         .isEqualTo("ANCHOR_TENANT tokens must be tied to a domain");
-    token
-        .asBuilder()
-        .setRegistrationBehavior(RegistrationBehavior.ANCHOR_TENANT)
-        .setDomainName("example.tld")
-        .build();
+    token.setDomainName("example.tld").build();
+  }
+
+  @Test
+  void testBuild_registrationBehaviors_allowBsa() {
+    createTld("tld");
+    // ALLOW_BSA requires a domain
+    AllocationToken.Builder token =
+        new AllocationToken.Builder()
+            .setToken("abc")
+            .setTokenType(SINGLE_USE)
+            .setRegistrationBehavior(RegistrationBehavior.BYPASS_BSA);
+    assertThat(assertThrows(IllegalArgumentException.class, () -> token.build()))
+        .hasMessageThat()
+        .isEqualTo("ALLOW_BSA tokens must be tied to a domain");
+    token.setDomainName("example.tld").build();
   }
 
   private void assertBadInitialTransition(TokenStatus status) {


### PR DESCRIPTION
Add a new AllocationToken behavior named `BYPASS_BSA` that applies to a single domain. The BSA block check for this domain is bypassed during DomainCreation and DomainCheck flows.

Updated DomainCreate and DomainCheck flows.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2311)
<!-- Reviewable:end -->
