### PR TITLE
Reduce query batch size for BSA unavailables

### DIFF
--- a/core/src/main/java/google/registry/bsa/UploadBsaUnavailableDomainsAction.java
+++ b/core/src/main/java/google/registry/bsa/UploadBsaUnavailableDomainsAction.java
@@ -80,7 +80,7 @@ public class UploadBsaUnavailableDomainsAction implements Runnable {
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
-  private static final int BATCH_SIZE = 50000;
+  private static final int BATCH_SIZE = 40000;
 
   Clock clock;
 


### PR DESCRIPTION
Query size is borderline too-large for the replica.

At 50000, about 2 out of 30 took more than 30 seconds and were aborted. Lower to 40000 and we will keep monitoring the executions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2313)
<!-- Reviewable:end -->
