### PR TITLE
Add REGISTER_BSA allocation type

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainCheckFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCheckFlow.java
@@ -26,7 +26,7 @@ import static google.registry.flows.domain.DomainFlowUtils.checkHasBillingAccoun
 import static google.registry.flows.domain.DomainFlowUtils.getReservationTypes;
 import static google.registry.flows.domain.DomainFlowUtils.handleFeeRequest;
 import static google.registry.flows.domain.DomainFlowUtils.isAnchorTenant;
-import static google.registry.flows.domain.DomainFlowUtils.isBypassBsaCreate;
+import static google.registry.flows.domain.DomainFlowUtils.isRegisterBsaCreate;
 import static google.registry.flows.domain.DomainFlowUtils.isReserved;
 import static google.registry.flows.domain.DomainFlowUtils.isValidReservedCreate;
 import static google.registry.flows.domain.DomainFlowUtils.validateDomainName;
@@ -270,7 +270,8 @@ public final class DomainCheckFlow implements TransactionalFlow {
     if (tokenResult.isPresent()) {
       return tokenResult;
     }
-    if (isBypassBsaCreate(domainName, allocationToken) || !bsaBlockedDomains.contains(domainName)) {
+    if (isRegisterBsaCreate(domainName, allocationToken)
+        || !bsaBlockedDomains.contains(domainName)) {
       return Optional.empty();
     }
     // TODO(weiminyu): extract to a constant for here and CheckApiAction.

--- a/core/src/main/java/google/registry/flows/domain/DomainCheckFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCheckFlow.java
@@ -26,6 +26,7 @@ import static google.registry.flows.domain.DomainFlowUtils.checkHasBillingAccoun
 import static google.registry.flows.domain.DomainFlowUtils.getReservationTypes;
 import static google.registry.flows.domain.DomainFlowUtils.handleFeeRequest;
 import static google.registry.flows.domain.DomainFlowUtils.isAnchorTenant;
+import static google.registry.flows.domain.DomainFlowUtils.isBypassBsaCreate;
 import static google.registry.flows.domain.DomainFlowUtils.isReserved;
 import static google.registry.flows.domain.DomainFlowUtils.isValidReservedCreate;
 import static google.registry.flows.domain.DomainFlowUtils.validateDomainName;
@@ -269,13 +270,12 @@ public final class DomainCheckFlow implements TransactionalFlow {
     if (tokenResult.isPresent()) {
       return tokenResult;
     }
-    if (bsaBlockedDomains.contains(domainName)) {
-      // TODO(weiminyu): extract to a constant for here and CheckApiAction.
-      // Excerpt from BSA's custom message. Max len 32 chars by EPP XML schema.
-      return Optional.of("Blocked by a GlobalBlock service");
-    } else {
+    if (isBypassBsaCreate(domainName, allocationToken) || !bsaBlockedDomains.contains(domainName)) {
       return Optional.empty();
     }
+    // TODO(weiminyu): extract to a constant for here and CheckApiAction.
+    // Excerpt from BSA's custom message. Max len 32 chars by EPP XML schema.
+    return Optional.of("Blocked by a GlobalBlock service");
   }
 
   /** Handle the fee check extension. */

--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -27,7 +27,7 @@ import static google.registry.flows.domain.DomainFlowUtils.cloneAndLinkReference
 import static google.registry.flows.domain.DomainFlowUtils.createFeeCreateResponse;
 import static google.registry.flows.domain.DomainFlowUtils.getReservationTypes;
 import static google.registry.flows.domain.DomainFlowUtils.isAnchorTenant;
-import static google.registry.flows.domain.DomainFlowUtils.isBypassBsaCreate;
+import static google.registry.flows.domain.DomainFlowUtils.isRegisterBsaCreate;
 import static google.registry.flows.domain.DomainFlowUtils.isReserved;
 import static google.registry.flows.domain.DomainFlowUtils.isValidReservedCreate;
 import static google.registry.flows.domain.DomainFlowUtils.validateCreateCommandContactsAndNameservers;
@@ -331,7 +331,7 @@ public final class DomainCreateFlow implements MutatingFlow {
               .verifySignedMarks(launchCreate.get().getSignedMarks(), domainLabel, now)
               .getId();
     }
-    if (!isBypassBsaCreate(domainName, allocationToken)) {
+    if (!isRegisterBsaCreate(domainName, allocationToken)) {
       verifyNotBlockedByBsa(domainLabel, tld, now);
     }
     flowCustomLogic.afterValidation(

--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -27,7 +27,6 @@ import static google.registry.flows.domain.DomainFlowUtils.cloneAndLinkReference
 import static google.registry.flows.domain.DomainFlowUtils.createFeeCreateResponse;
 import static google.registry.flows.domain.DomainFlowUtils.getReservationTypes;
 import static google.registry.flows.domain.DomainFlowUtils.isAnchorTenant;
-import static google.registry.flows.domain.DomainFlowUtils.isRegisterBsaCreate;
 import static google.registry.flows.domain.DomainFlowUtils.isReserved;
 import static google.registry.flows.domain.DomainFlowUtils.isValidReservedCreate;
 import static google.registry.flows.domain.DomainFlowUtils.validateCreateCommandContactsAndNameservers;
@@ -331,9 +330,7 @@ public final class DomainCreateFlow implements MutatingFlow {
               .verifySignedMarks(launchCreate.get().getSignedMarks(), domainLabel, now)
               .getId();
     }
-    if (!isRegisterBsaCreate(domainName, allocationToken)) {
-      verifyNotBlockedByBsa(domainLabel, tld, now);
-    }
+    verifyNotBlockedByBsa(domainName, tld, now, allocationToken);
     flowCustomLogic.afterValidation(
         DomainCreateFlowCustomLogic.AfterValidationParameters.newBuilder()
             .setDomainName(domainName)

--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -266,9 +266,14 @@ public class DomainFlowUtils {
    * Verifies that the {@code domainLabel} is not blocked by any BSA block label for the given
    * {@code tld} at the specified time.
    */
-  public static void verifyNotBlockedByBsa(String domainLabel, Tld tld, DateTime now)
+  public static void verifyNotBlockedByBsa(
+      InternetDomainName domainName,
+      Tld tld,
+      DateTime now,
+      Optional<AllocationToken> allocationToken)
       throws DomainLabelBlockedByBsaException {
-    if (isBlockedByBsa(domainLabel, tld, now)) {
+    if (!isRegisterBsaCreate(domainName, allocationToken)
+        && isBlockedByBsa(domainName.parts().get(0), tld, now)) {
       throw new DomainLabelBlockedByBsaException();
     }
   }

--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -27,6 +27,7 @@ import static com.google.common.collect.Sets.intersection;
 import static com.google.common.collect.Sets.union;
 import static google.registry.bsa.persistence.BsaLabelUtils.isLabelBlocked;
 import static google.registry.model.domain.Domain.MAX_REGISTRATION_YEARS;
+import static google.registry.model.domain.token.AllocationToken.TokenType.ALLOW_BSA;
 import static google.registry.model.tld.Tld.TldState.GENERAL_AVAILABILITY;
 import static google.registry.model.tld.Tld.TldState.PREDELEGATION;
 import static google.registry.model.tld.Tld.TldState.QUIET_PERIOD;
@@ -307,6 +308,15 @@ public class DomainFlowUtils {
     // is for this domain.
     return getReservationTypes(domainName).contains(RESERVED_FOR_SPECIFIC_USE)
         && token.isPresent()
+        && token.get().getDomainName().isPresent()
+        && token.get().getDomainName().get().equals(domainName.toString());
+  }
+
+  /** Returns whether a given domain create request may bypass the BSA block check. */
+  public static boolean isBypassBsaCreate(
+      InternetDomainName domainName, Optional<AllocationToken> token) {
+    return token.isPresent()
+        && token.get().getTokenType().equals(ALLOW_BSA)
         && token.get().getDomainName().isPresent()
         && token.get().getDomainName().get().equals(domainName.toString());
   }

--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -27,7 +27,7 @@ import static com.google.common.collect.Sets.intersection;
 import static com.google.common.collect.Sets.union;
 import static google.registry.bsa.persistence.BsaLabelUtils.isLabelBlocked;
 import static google.registry.model.domain.Domain.MAX_REGISTRATION_YEARS;
-import static google.registry.model.domain.token.AllocationToken.TokenType.ALLOW_BSA;
+import static google.registry.model.domain.token.AllocationToken.TokenType.REGISTER_BSA;
 import static google.registry.model.tld.Tld.TldState.GENERAL_AVAILABILITY;
 import static google.registry.model.tld.Tld.TldState.PREDELEGATION;
 import static google.registry.model.tld.Tld.TldState.QUIET_PERIOD;
@@ -313,10 +313,10 @@ public class DomainFlowUtils {
   }
 
   /** Returns whether a given domain create request may bypass the BSA block check. */
-  public static boolean isBypassBsaCreate(
+  public static boolean isRegisterBsaCreate(
       InternetDomainName domainName, Optional<AllocationToken> token) {
     return token.isPresent()
-        && token.get().getTokenType().equals(ALLOW_BSA)
+        && token.get().getTokenType().equals(REGISTER_BSA)
         && token.get().getDomainName().isPresent()
         && token.get().getDomainName().get().equals(domainName.toString());
   }

--- a/core/src/main/java/google/registry/flows/domain/DomainRenewFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRenewFlow.java
@@ -73,7 +73,6 @@ import google.registry.model.domain.fee.FeeTransformResponseExtension;
 import google.registry.model.domain.metadata.MetadataExtension;
 import google.registry.model.domain.rgp.GracePeriodStatus;
 import google.registry.model.domain.token.AllocationToken;
-import google.registry.model.domain.token.AllocationToken.TokenType;
 import google.registry.model.domain.token.AllocationTokenExtension;
 import google.registry.model.eppcommon.AuthInfo;
 import google.registry.model.eppcommon.StatusValue;
@@ -258,8 +257,7 @@ public final class DomainRenewFlow implements MutatingFlow {
     ImmutableSet.Builder<ImmutableObject> entitiesToSave = new ImmutableSet.Builder<>();
     entitiesToSave.add(
         newDomain, domainHistory, explicitRenewEvent, newAutorenewEvent, newAutorenewPollMessage);
-    if (allocationToken.isPresent()
-        && TokenType.SINGLE_USE.equals(allocationToken.get().getTokenType())) {
+    if (allocationToken.isPresent() && allocationToken.get().getTokenType().isOneTimeUse()) {
       entitiesToSave.add(
           allocationTokenFlowUtils.redeemToken(
               allocationToken.get(), domainHistory.getHistoryEntryId()));

--- a/core/src/main/java/google/registry/flows/domain/token/AllocationTokenFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/token/AllocationTokenFlowUtils.java
@@ -36,7 +36,6 @@ import google.registry.model.domain.fee.FeeQueryCommandExtensionItem.CommandName
 import google.registry.model.domain.token.AllocationToken;
 import google.registry.model.domain.token.AllocationToken.TokenBehavior;
 import google.registry.model.domain.token.AllocationToken.TokenStatus;
-import google.registry.model.domain.token.AllocationToken.TokenType;
 import google.registry.model.domain.token.AllocationTokenExtension;
 import google.registry.model.reporting.HistoryEntry.HistoryEntryId;
 import google.registry.model.tld.Tld;
@@ -105,8 +104,7 @@ public class AllocationTokenFlowUtils {
   /** Redeems a SINGLE_USE {@link AllocationToken}, returning the redeemed copy. */
   public AllocationToken redeemToken(AllocationToken token, HistoryEntryId redemptionHistoryId) {
     checkArgument(
-        TokenType.SINGLE_USE.equals(token.getTokenType()),
-        "Only SINGLE_USE tokens can be marked as redeemed");
+        token.getTokenType().isOneTimeUse(), "Only SINGLE_USE tokens can be marked as redeemed");
     return token.asBuilder().setRedemptionHistoryId(redemptionHistoryId).build();
   }
 

--- a/core/src/main/java/google/registry/tools/DeleteAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/DeleteAllocationTokensCommand.java
@@ -18,7 +18,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.Iterables.partition;
 import static com.google.common.collect.Streams.stream;
-import static google.registry.model.domain.token.AllocationToken.TokenType.SINGLE_USE;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.beust.jcommander.Parameter;
@@ -78,7 +77,7 @@ final class DeleteAllocationTokensCommand extends UpdateOrDeleteAllocationTokens
     ImmutableSet<VKey<AllocationToken>> tokensToDelete =
         tm().loadByKeys(batch).values().stream()
             .filter(t -> withDomains || !t.getDomainName().isPresent())
-            .filter(t -> SINGLE_USE.equals(t.getTokenType()))
+            .filter(t -> t.getTokenType().isOneTimeUse())
             .filter(t -> !t.isRedeemed())
             .map(AllocationToken::createVKey)
             .collect(toImmutableSet());

--- a/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
@@ -18,8 +18,8 @@ import static google.registry.bsa.persistence.BsaTestingUtils.persistBsaLabel;
 import static google.registry.model.billing.BillingBase.RenewalPriceBehavior.DEFAULT;
 import static google.registry.model.billing.BillingBase.RenewalPriceBehavior.NONPREMIUM;
 import static google.registry.model.billing.BillingBase.RenewalPriceBehavior.SPECIFIED;
-import static google.registry.model.domain.token.AllocationToken.TokenType.ALLOW_BSA;
 import static google.registry.model.domain.token.AllocationToken.TokenType.DEFAULT_PROMO;
+import static google.registry.model.domain.token.AllocationToken.TokenType.REGISTER_BSA;
 import static google.registry.model.domain.token.AllocationToken.TokenType.SINGLE_USE;
 import static google.registry.model.domain.token.AllocationToken.TokenType.UNLIMITED_USE;
 import static google.registry.model.eppoutput.CheckData.DomainCheck.create;
@@ -197,7 +197,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
     persistResource(
         new AllocationToken.Builder()
             .setToken("abc123")
-            .setTokenType(ALLOW_BSA)
+            .setTokenType(REGISTER_BSA)
             .setDomainName("example1.tld")
             .build());
     doCheckTest(

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -27,9 +27,9 @@ import static google.registry.model.billing.BillingBase.RenewalPriceBehavior.DEF
 import static google.registry.model.billing.BillingBase.RenewalPriceBehavior.NONPREMIUM;
 import static google.registry.model.billing.BillingBase.RenewalPriceBehavior.SPECIFIED;
 import static google.registry.model.domain.fee.Fee.FEE_EXTENSION_URIS;
-import static google.registry.model.domain.token.AllocationToken.TokenType.ALLOW_BSA;
 import static google.registry.model.domain.token.AllocationToken.TokenType.BULK_PRICING;
 import static google.registry.model.domain.token.AllocationToken.TokenType.DEFAULT_PROMO;
+import static google.registry.model.domain.token.AllocationToken.TokenType.REGISTER_BSA;
 import static google.registry.model.domain.token.AllocationToken.TokenType.SINGLE_USE;
 import static google.registry.model.domain.token.AllocationToken.TokenType.UNLIMITED_USE;
 import static google.registry.model.eppcommon.EppXmlTransformer.marshal;
@@ -2602,13 +2602,13 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   }
 
   @Test
-  void testSuccess_blockedByBsa_hasAllowBsaToken() throws Exception {
+  void testSuccess_blockedByBsa_hasRegisterBsaToken() throws Exception {
     enrollTldInBsa();
     allocationToken =
         persistResource(
             new AllocationToken.Builder()
                 .setToken("abc123")
-                .setTokenType(ALLOW_BSA)
+                .setTokenType(REGISTER_BSA)
                 .setDomainName("example.tld")
                 .build());
     persistBsaLabel("example");
@@ -2627,7 +2627,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("abc123")
-                .setTokenType(ALLOW_BSA)
+                .setTokenType(REGISTER_BSA)
                 .setDomainName("resdom.tld")
                 .build());
     persistBsaLabel("resdom");
@@ -2648,7 +2648,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("abc123")
-                .setTokenType(ALLOW_BSA)
+                .setTokenType(REGISTER_BSA)
                 .setRegistrationBehavior(RegistrationBehavior.BYPASS_TLD_STATE)
                 .setDomainName("example.tld")
                 .build());
@@ -2673,7 +2673,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         persistResource(
             new AllocationToken.Builder()
                 .setToken("abcDEF23456")
-                .setTokenType(ALLOW_BSA)
+                .setTokenType(REGISTER_BSA)
                 .setDomainName("anchor.tld")
                 .build());
     setEppInput("domain_create_anchor_allocationtoken.xml");

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -27,6 +27,7 @@ import static google.registry.model.billing.BillingBase.RenewalPriceBehavior.DEF
 import static google.registry.model.billing.BillingBase.RenewalPriceBehavior.NONPREMIUM;
 import static google.registry.model.billing.BillingBase.RenewalPriceBehavior.SPECIFIED;
 import static google.registry.model.domain.fee.Fee.FEE_EXTENSION_URIS;
+import static google.registry.model.domain.token.AllocationToken.TokenType.ALLOW_BSA;
 import static google.registry.model.domain.token.AllocationToken.TokenType.BULK_PRICING;
 import static google.registry.model.domain.token.AllocationToken.TokenType.DEFAULT_PROMO;
 import static google.registry.model.domain.token.AllocationToken.TokenType.SINGLE_USE;
@@ -253,6 +254,14 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 persistReservedList("global-list", "resdom,FULLY_BLOCKED"))
             .build());
     persistClaimsList(ImmutableMap.of("example-one", CLAIMS_KEY, "test-validate", CLAIMS_KEY));
+  }
+
+  private void enrollTldInBsa() {
+    persistResource(
+        Tld.get("tld")
+            .asBuilder()
+            .setBsaEnrollStartTime(Optional.of(clock.nowUtc().minusSeconds(1)))
+            .build());
   }
 
   /**
@@ -2593,12 +2602,92 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   }
 
   @Test
-  void testFailure_blockedByBsa() throws Exception {
+  void testSuccess_blockedByBsa_hasAllowBsaToken() throws Exception {
+    enrollTldInBsa();
+    allocationToken =
+        persistResource(
+            new AllocationToken.Builder()
+                .setToken("abc123")
+                .setTokenType(ALLOW_BSA)
+                .setDomainName("example.tld")
+                .build());
+    persistBsaLabel("example");
+    persistContactsAndHosts();
+    setEppInput(
+        "domain_create_allocationtoken.xml",
+        ImmutableMap.of("DOMAIN", "example.tld", "YEARS", "2"));
+    runFlow();
+    assertSuccessfulCreate("tld", ImmutableSet.of(), allocationToken);
+  }
+
+  @Test
+  void testSuccess_blockedByBsa_reservedDomain_viaAllocationTokenExtension() throws Exception {
+    enrollTldInBsa();
+    allocationToken =
+        persistResource(
+            new AllocationToken.Builder()
+                .setToken("abc123")
+                .setTokenType(ALLOW_BSA)
+                .setDomainName("resdom.tld")
+                .build());
+    persistBsaLabel("resdom");
+    setEppInput(
+        "domain_create_allocationtoken.xml", ImmutableMap.of("DOMAIN", "resdom.tld", "YEARS", "2"));
+    persistContactsAndHosts();
+    runFlowAssertResponse(
+        loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "resdom.tld")));
+    assertSuccessfulCreate("tld", ImmutableSet.of(RESERVED), allocationToken);
+    assertNoLordn();
+    assertAllocationTokenWasRedeemed("abc123");
+  }
+
+  @Test
+  void testSuccess_blockedByBsa_quietPeriod_skipTldStateCheckWithToken() throws Exception {
+    enrollTldInBsa();
+    AllocationToken token =
+        persistResource(
+            new AllocationToken.Builder()
+                .setToken("abc123")
+                .setTokenType(ALLOW_BSA)
+                .setRegistrationBehavior(RegistrationBehavior.BYPASS_TLD_STATE)
+                .setDomainName("example.tld")
+                .build());
+    persistContactsAndHosts();
+    persistBsaLabel("example");
+    setEppInput(
+        "domain_create_allocationtoken.xml",
+        ImmutableMap.of("DOMAIN", "example.tld", "YEARS", "2"));
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setBsaEnrollStartTime(Optional.of(clock.nowUtc().minusSeconds(1)))
+            .setTldStateTransitions(ImmutableSortedMap.of(START_OF_TIME, QUIET_PERIOD))
             .build());
+    runFlow();
+    assertSuccessfulCreate("tld", ImmutableSet.of(), token);
+  }
+
+  @Test
+  void testSuccess_blockedByBsa_anchorTenant() throws Exception {
+    enrollTldInBsa();
+    allocationToken =
+        persistResource(
+            new AllocationToken.Builder()
+                .setToken("abcDEF23456")
+                .setTokenType(ALLOW_BSA)
+                .setDomainName("anchor.tld")
+                .build());
+    setEppInput("domain_create_anchor_allocationtoken.xml");
+    persistContactsAndHosts();
+    persistBsaLabel("anchor");
+    runFlowAssertResponse(loadFile("domain_create_anchor_response.xml"));
+    assertSuccessfulCreate("tld", ImmutableSet.of(ANCHOR_TENANT), allocationToken);
+    assertNoLordn();
+    assertAllocationTokenWasRedeemed("abcDEF23456");
+  }
+
+  @Test
+  void testFailure_blockedByBsa() throws Exception {
+    enrollTldInBsa();
     persistBsaLabel("example");
     persistContactsAndHosts();
     EppException thrown = assertThrows(DomainLabelBlockedByBsaException.class, this::runFlow);
@@ -2618,6 +2707,41 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     assertThat(new String(responseXmlBytes, StandardCharsets.UTF_8))
         .isEqualTo(loadFile("domain_create_blocked_by_bsa.xml"));
   }
+
+  @Test
+  void testFailure_blockedByBsa_hasWrongToken() throws Exception {
+    enrollTldInBsa();
+    allocationToken =
+        persistResource(
+            new AllocationToken.Builder()
+                .setToken("abc123")
+                .setTokenType(SINGLE_USE)
+                .setRegistrationBehavior(RegistrationBehavior.BYPASS_TLD_STATE)
+                .setDomainName("example.tld")
+                .build());
+    persistBsaLabel("example");
+    persistContactsAndHosts();
+    setEppInput(
+        "domain_create_allocationtoken.xml",
+        ImmutableMap.of("DOMAIN", "example.tld", "YEARS", "2"));
+    EppException thrown = assertThrows(DomainLabelBlockedByBsaException.class, this::runFlow);
+    assertAboutEppExceptions()
+        .that(thrown)
+        .marshalsToXml()
+        .and()
+        .hasMessage("Domain label is blocked by the Brand Safety Alliance");
+    byte[] responseXmlBytes =
+        marshal(
+            EppOutput.create(
+                new EppResponse.Builder()
+                    .setTrid(Trid.create(null, "server-trid"))
+                    .setResult(thrown.getResult())
+                    .build()),
+            ValidationMode.STRICT);
+    assertThat(new String(responseXmlBytes, StandardCharsets.UTF_8))
+        .isEqualTo(loadFile("domain_create_blocked_by_bsa.xml"));
+  }
+
 
   @Test
   void testFailure_uppercase() {

--- a/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
+++ b/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
@@ -20,6 +20,7 @@ import static google.registry.model.domain.token.AllocationToken.TokenStatus.CAN
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.ENDED;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.NOT_STARTED;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.VALID;
+import static google.registry.model.domain.token.AllocationToken.TokenType.ALLOW_BSA;
 import static google.registry.model.domain.token.AllocationToken.TokenType.BULK_PRICING;
 import static google.registry.model.domain.token.AllocationToken.TokenType.SINGLE_USE;
 import static google.registry.model.domain.token.AllocationToken.TokenType.UNLIMITED_USE;
@@ -246,6 +247,18 @@ public class AllocationTokenTest extends EntityTestCase {
   }
 
   @Test
+  void testBuild_allowBsa_missingDomain() {
+    createTld("tld");
+    // ALLOW_BSA requires a domain
+    AllocationToken.Builder token =
+        new AllocationToken.Builder().setToken("abc").setTokenType(ALLOW_BSA);
+    assertThat(assertThrows(IllegalArgumentException.class, () -> token.build()))
+        .hasMessageThat()
+        .isEqualTo("ALLOW_BSA tokens must be tied to a domain");
+    token.setDomainName("example.tld").build();
+  }
+
+  @Test
   void testFail_bulkTokenNullEppActions() {
     AllocationToken.Builder builder =
         new AllocationToken.Builder()
@@ -317,7 +330,7 @@ public class AllocationTokenTest extends EntityTestCase {
     IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, builder::build);
     assertThat(thrown)
         .hasMessageThat()
-        .isEqualTo("Domain name can only be specified for SINGLE_USE tokens");
+        .isEqualTo("Domain name can only be specified for SINGLE_USE or ALLOW_BSA tokens");
   }
 
   @Test
@@ -347,7 +360,8 @@ public class AllocationTokenTest extends EntityTestCase {
     IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, builder::build);
     assertThat(thrown)
         .hasMessageThat()
-        .isEqualTo("Redemption history entry can only be specified for SINGLE_USE tokens");
+        .isEqualTo(
+            "Redemption history entry can only be specified for SINGLE_USE or ALLOW_BSA tokens");
   }
 
   @Test

--- a/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
+++ b/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
@@ -20,8 +20,8 @@ import static google.registry.model.domain.token.AllocationToken.TokenStatus.CAN
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.ENDED;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.NOT_STARTED;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.VALID;
-import static google.registry.model.domain.token.AllocationToken.TokenType.ALLOW_BSA;
 import static google.registry.model.domain.token.AllocationToken.TokenType.BULK_PRICING;
+import static google.registry.model.domain.token.AllocationToken.TokenType.REGISTER_BSA;
 import static google.registry.model.domain.token.AllocationToken.TokenType.SINGLE_USE;
 import static google.registry.model.domain.token.AllocationToken.TokenType.UNLIMITED_USE;
 import static google.registry.testing.DatabaseHelper.createTld;
@@ -247,14 +247,14 @@ public class AllocationTokenTest extends EntityTestCase {
   }
 
   @Test
-  void testBuild_allowBsa_missingDomain() {
+  void testBuild_registerBsa_missingDomain() {
     createTld("tld");
-    // ALLOW_BSA requires a domain
+    // REGISTER_BSA requires a domain
     AllocationToken.Builder token =
-        new AllocationToken.Builder().setToken("abc").setTokenType(ALLOW_BSA);
+        new AllocationToken.Builder().setToken("abc").setTokenType(REGISTER_BSA);
     assertThat(assertThrows(IllegalArgumentException.class, () -> token.build()))
         .hasMessageThat()
-        .isEqualTo("ALLOW_BSA tokens must be tied to a domain");
+        .isEqualTo("REGISTER_BSA tokens must be tied to a domain");
     token.setDomainName("example.tld").build();
   }
 
@@ -330,7 +330,7 @@ public class AllocationTokenTest extends EntityTestCase {
     IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, builder::build);
     assertThat(thrown)
         .hasMessageThat()
-        .isEqualTo("Domain name can only be specified for SINGLE_USE or ALLOW_BSA tokens");
+        .isEqualTo("Domain name can only be specified for SINGLE_USE or REGISTER_BSA tokens");
   }
 
   @Test
@@ -361,7 +361,7 @@ public class AllocationTokenTest extends EntityTestCase {
     assertThat(thrown)
         .hasMessageThat()
         .isEqualTo(
-            "Redemption history entry can only be specified for SINGLE_USE or ALLOW_BSA tokens");
+            "Redemption history entry can only be specified for SINGLE_USE or REGISTER_BSA tokens");
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/GenerateAllocationTokensCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateAllocationTokensCommandTest.java
@@ -380,7 +380,7 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
         .hasMessageThat()
         .isEqualTo(
             "Invalid value for -t parameter. Allowed values:[BULK_PRICING, DEFAULT_PROMO, PACKAGE,"
-                + " SINGLE_USE, UNLIMITED_USE, ALLOW_BSA]");
+                + " SINGLE_USE, UNLIMITED_USE, REGISTER_BSA]");
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/GenerateAllocationTokensCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateAllocationTokensCommandTest.java
@@ -380,7 +380,7 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
         .hasMessageThat()
         .isEqualTo(
             "Invalid value for -t parameter. Allowed values:[BULK_PRICING, DEFAULT_PROMO, PACKAGE,"
-                + " SINGLE_USE, UNLIMITED_USE]");
+                + " SINGLE_USE, UNLIMITED_USE, ALLOW_BSA]");
   }
 
   @Test


### PR DESCRIPTION
Add a new type to allow creation of domains blocked by BSA.

Except for the BSA semantics, the new type behaves exactly like SINGLE_USE.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2319)
<!-- Reviewable:end -->
