### PR TITLE
Make transaction isolation level the first argument to transact()

### DIFF
--- a/core/src/main/java/google/registry/beam/common/RegistryJpaIO.java
+++ b/core/src/main/java/google/registry/beam/common/RegistryJpaIO.java
@@ -219,8 +219,7 @@ public final class RegistryJpaIO {
                 () -> {
                   query.stream().map(resultMapper::apply).forEach(outputReceiver::output);
                   return null;
-                },
-                null);
+                });
       }
     }
   }

--- a/core/src/main/java/google/registry/bsa/BsaTransactions.java
+++ b/core/src/main/java/google/registry/bsa/BsaTransactions.java
@@ -37,12 +37,12 @@ public final class BsaTransactions {
   @CanIgnoreReturnValue
   public static <T> T bsaTransact(Callable<T> work) {
     verify(!isInTransaction(), "May only be used for top-level transactions.");
-    return tm().transact(work, TRANSACTION_REPEATABLE_READ);
+    return tm().transact(TRANSACTION_REPEATABLE_READ, work);
   }
 
   public static void bsaTransact(ThrowingRunnable work) {
     verify(!isInTransaction(), "May only be used for top-level transactions.");
-    tm().transact(work, TRANSACTION_REPEATABLE_READ);
+    tm().transact(TRANSACTION_REPEATABLE_READ, work);
   }
 
   @CanIgnoreReturnValue

--- a/core/src/main/java/google/registry/bsa/persistence/LabelDiffUpdates.java
+++ b/core/src/main/java/google/registry/bsa/persistence/LabelDiffUpdates.java
@@ -67,6 +67,7 @@ public final class LabelDiffUpdates {
             labels.stream().collect(groupingBy(BlockLabel::labelType, toImmutableList())));
 
     tm().transact(
+            TRANSACTION_REPEATABLE_READ,
             () -> {
               for (Map.Entry<LabelType, ImmutableList<BlockLabel>> entry :
                   labelsByType.entrySet()) {
@@ -128,8 +129,7 @@ public final class LabelDiffUpdates {
                     break;
                 }
               }
-            },
-            TRANSACTION_REPEATABLE_READ);
+            });
     logger.atInfo().log("Processed %s of labels.", labels.size());
     return nonBlockedDomains.build();
   }

--- a/core/src/main/java/google/registry/flows/FlowRunner.java
+++ b/core/src/main/java/google/registry/flows/FlowRunner.java
@@ -81,6 +81,7 @@ public class FlowRunner {
       // TODO(mcilwain/weiminyu): Use transactReadOnly() here for TransactionalFlow and transact()
       //                          for MutatingFlow.
       return tm().transact(
+              isolationLevelOverride.orElse(null),
               () -> {
                 try {
                   EppOutput output = EppOutput.create(flowProvider.get().run());
@@ -96,8 +97,7 @@ public class FlowRunner {
                 } catch (EppException e) {
                   throw new EppRuntimeException(e);
                 }
-              },
-              isolationLevelOverride.orElse(null));
+              });
     } catch (DryRunException e) {
       return e.output;
     } catch (EppRuntimeException e) {

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
@@ -61,7 +61,19 @@ public interface TransactionManager {
    * Executes the work in a transaction at the given {@link TransactionIsolationLevel} and returns
    * the result.
    */
-  <T> T transact(Callable<T> work, TransactionIsolationLevel isolationLevel);
+  <T> T transact(TransactionIsolationLevel isolationLevel, Callable<T> work);
+
+  /**
+   * Executes the work in a transaction and returns the result, without retrying upon retryable
+   * exceptions.
+   *
+   * <p>This method should only be used when the transaction contains side effects that are not
+   * rolled back by the transaction manager, for example in {@link
+   * google.registry.beam.common.RegistryJpaIO} where the results from a query are streamed to the
+   * next transformation inside a transaction, as the result stream has to materialize to a list
+   * outside a transaction and doing so would greatly affect the parallelism of the pipeline.
+   */
+  <T> T transactNoRetry(Callable<T> work);
 
   /**
    * Executes the work in a transaction at the given {@link TransactionIsolationLevel} and returns
@@ -73,7 +85,7 @@ public interface TransactionManager {
    * next transformation inside a transaction, as the result stream has to materialize to a list
    * outside a transaction and doing so would greatly affect the parallelism of the pipeline.
    */
-  <T> T transactNoRetry(Callable<T> work, TransactionIsolationLevel isolationLevel);
+  <T> T transactNoRetry(TransactionIsolationLevel isolationLevel, Callable<T> work);
 
   /**
    * Executes the work in a (potentially wrapped) transaction and returns the result.
@@ -95,7 +107,7 @@ public interface TransactionManager {
   void transact(ThrowingRunnable work);
 
   /** Executes the work in a transaction at the given {@link TransactionIsolationLevel}. */
-  void transact(ThrowingRunnable work, TransactionIsolationLevel isolationLevel);
+  void transact(TransactionIsolationLevel isolationLevel, ThrowingRunnable work);
 
   /**
    * Executes the work in a (potentially wrapped) transaction and returns the result.

--- a/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
+++ b/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
@@ -97,7 +97,7 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
   public void run() {
     assertTldsExist(tlds);
     checkArgument(batchSize > 0, "Must specify a positive number for batch size");
-    Duration smear = tm().transact(this::calculateSmear, TRANSACTION_REPEATABLE_READ);
+    Duration smear = tm().transact(TRANSACTION_REPEATABLE_READ, this::calculateSmear);
 
     ImmutableList<String> domainsBatch;
     @Nullable String lastInPreviousBatch = null;
@@ -105,7 +105,7 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
       Optional<String> lastInPreviousBatchOpt = Optional.ofNullable(lastInPreviousBatch);
       domainsBatch =
           tm().transact(
-                  () -> refreshBatch(lastInPreviousBatchOpt, smear), TRANSACTION_REPEATABLE_READ);
+                  TRANSACTION_REPEATABLE_READ, () -> refreshBatch(lastInPreviousBatchOpt, smear));
       lastInPreviousBatch = domainsBatch.isEmpty() ? null : getLast(domainsBatch);
     } while (domainsBatch.size() == batchSize);
   }


### PR DESCRIPTION
This makes the callsites look neater, as the work to execute itself is often a many line lambda, whereas the transaction isolation level is not more than a couple dozen characters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2329)
<!-- Reviewable:end -->
