### PR TITLE
Revert "Include a better error message to debug nomulus tool not working (#2275)"

### DIFF
--- a/core/src/main/java/google/registry/tools/RegistryCli.java
+++ b/core/src/main/java/google/registry/tools/RegistryCli.java
@@ -23,7 +23,6 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.ParametersDelegate;
-import com.google.common.base.Ascii;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
@@ -219,21 +218,12 @@ final class RegistryCli implements CommandRunner {
 
     // Reset the JPA transaction manager after every command to avoid a situation where a test can
     // interfere with other tests
-    try {
-      JpaTransactionManager cachedJpaTm = tm();
-      TransactionManagerFactory.setJpaTm(() -> component.nomulusToolJpaTransactionManager().get());
-      TransactionManagerFactory.setReplicaJpaTm(
-          () -> component.nomulusToolReplicaJpaTransactionManager().get());
-      command.run();
-      TransactionManagerFactory.setJpaTm(() -> cachedJpaTm);
-    } catch (Exception e) {
-      String env = Ascii.toLowerCase(environment.name());
-      System.err.printf(
-          "Could not get tool transaction manager; try running nomulus -e %s logout "
-              + "and then nomulus -e %s login.\n",
-          env, env);
-      throw e;
-    }
+    JpaTransactionManager cachedJpaTm = tm();
+    TransactionManagerFactory.setJpaTm(() -> component.nomulusToolJpaTransactionManager().get());
+    TransactionManagerFactory.setReplicaJpaTm(
+        () -> component.nomulusToolReplicaJpaTransactionManager().get());
+    command.run();
+    TransactionManagerFactory.setJpaTm(() -> cachedJpaTm);
   }
 
   void setEnvironment(RegistryToolEnvironment environment) {


### PR DESCRIPTION
This reverts commit 64f59712758941a35b000e81642966dc7e6473ad.

The catch block is too broad and most of the times the errors caught is
because `command.run()` failed and it had nothing to do with getting
the transaction manager. The `runCommand` method is already wrapped in a try
block that checks for `LoginRequiredException` and gives the appropriate
error message.

We need to re-assess the situation when the next time we encounter a
login issue that did not trigger `LoginRequiredException`. A blanket try
catch block is not the solution and only makes the situation more
confusing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2342)
<!-- Reviewable:end -->
