### PR TITLE
Do not use shaded dependencies from testcontainers

### DIFF
--- a/config/presubmits.py
+++ b/config/presubmits.py
@@ -172,6 +172,12 @@ PRESUBMITS = {
         {"/node_modules/", "google/registry/ui/js/util.js", "registrar_bin."},
     ):
         "JavaScript files should not include console logging.",
+    PresubmitCheck(
+        r"org\.testcontainers\.shaded\.",
+        "java",
+        {"/node_modules/"},
+    ):
+        "Do not use shaded dependencies from testcontainers.",
 }
 
 # Note that this regex only works for one kind of Flyway file.  If we want to

--- a/core/src/main/java/google/registry/model/billing/BillingRecurrence.java
+++ b/core/src/main/java/google/registry/model/billing/BillingRecurrence.java
@@ -181,7 +181,9 @@ public class BillingRecurrence extends BillingBase {
       checkNotNull(instance.reason);
       // Don't require recurrenceLastExpansion to be individually set on every new Recurrence.
       // The correct default value if not otherwise set is the event time of the recurrence minus
-      // 1 year.
+      // 1 year. This operation is leap-year safe as a billing event created on 2/29 will have its
+      // event time on 2/28 next year, and therefore the last expansion time on 2/28 this year. This
+      // ensures that it will be expanded on 2/28 next year and included in the February invoice.
       instance.recurrenceLastExpansion =
           Optional.ofNullable(instance.recurrenceLastExpansion)
               .orElse(instance.eventTime.minusYears(1));

--- a/core/src/test/java/google/registry/batch/CheckBulkComplianceActionTest.java
+++ b/core/src/test/java/google/registry/batch/CheckBulkComplianceActionTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.TestLogHandler;
 import google.registry.groups.GmailClient;
 import google.registry.model.billing.BillingBase.RenewalPriceBehavior;
@@ -52,7 +53,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
 
 /** Unit tests for {@link CheckBulkComplianceAction}. */
 public class CheckBulkComplianceActionTest {

--- a/core/src/test/java/google/registry/bsa/BsaDownloadFunctionalTest.java
+++ b/core/src/test/java/google/registry/bsa/BsaDownloadFunctionalTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import google.registry.bsa.BlockListFetcher.LazyBlockList;
 import google.registry.bsa.api.BsaReportSender;
 import google.registry.gcs.GcsUtils;
@@ -56,7 +57,6 @@ import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 /** Functional tests of BSA block list download and processing. */
 @ExtendWith(MockitoExtension.class)

--- a/core/src/test/java/google/registry/bsa/api/JsonSerializationsTest.java
+++ b/core/src/test/java/google/registry/bsa/api/JsonSerializationsTest.java
@@ -20,11 +20,11 @@ import static google.registry.bsa.api.JsonSerializations.toInProgressOrdersRepor
 import static google.registry.bsa.api.JsonSerializations.toUnblockableDomainsReport;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import google.registry.bsa.api.BlockOrder.OrderType;
 import google.registry.bsa.api.UnblockableDomain.Reason;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 /** Unit tests for {@link JsonSerializations}. */
 class JsonSerializationsTest {

--- a/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
+++ b/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
@@ -33,14 +33,14 @@ import google.registry.util.SelfSignedCaCertificate;
 import java.io.StringWriter;
 import java.security.cert.X509Certificate;
 import java.util.Optional;
+import org.bouncycastle.openssl.jcajce.JcaMiscPEMGenerator;
+import org.bouncycastle.util.io.pem.PemObjectGenerator;
+import org.bouncycastle.util.io.pem.PemWriter;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.shaded.org.bouncycastle.openssl.jcajce.JcaMiscPEMGenerator;
-import org.testcontainers.shaded.org.bouncycastle.util.io.pem.PemObjectGenerator;
-import org.testcontainers.shaded.org.bouncycastle.util.io.pem.PemWriter;
 
 /** Test logging in with TLS credentials. */
 class EppLoginTlsTest extends EppTestCase {

--- a/core/src/test/java/google/registry/groups/GmailClientTest.java
+++ b/core/src/test/java/google/registry/groups/GmailClientTest.java
@@ -33,6 +33,7 @@ import com.google.api.services.gmail.Gmail.Users;
 import com.google.api.services.gmail.Gmail.Users.Messages;
 import com.google.api.services.gmail.Gmail.Users.Messages.Send;
 import com.google.api.services.gmail.model.Message;
+import com.google.common.collect.ImmutableList;
 import google.registry.groups.GmailClient.RetriableGmailExceptionPredicate;
 import google.registry.util.EmailMessage;
 import google.registry.util.EmailMessage.Attachment;
@@ -50,7 +51,6 @@ import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.stubbing.Answer;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 /** Unit tests for {@link GmailClient}. */
 @ExtendWith(MockitoExtension.class)

--- a/core/src/test/java/google/registry/model/billing/BillingBaseTest.java
+++ b/core/src/test/java/google/registry/model/billing/BillingBaseTest.java
@@ -51,7 +51,7 @@ import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link BillingBase}. */
 public class BillingBaseTest extends EntityTestCase {
-  private final DateTime now = DateTime.now(UTC);
+  private final DateTime now = DateTime.parse("2012-01-23T22:33:44Z");
 
   BillingBaseTest() {
     super(JpaEntityCoverageCheck.ENABLED);

--- a/core/src/test/java/google/registry/model/domain/DomainSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainSqlTest.java
@@ -31,6 +31,7 @@ import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.joda.time.DateTimeZone.UTC;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Sets;
@@ -57,7 +58,6 @@ import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 /** Verify that we can store/retrieve Domain objects from a SQL database. */
 public class DomainSqlTest {

--- a/core/src/test/java/google/registry/model/domain/token/BulkPricingPackageTest.java
+++ b/core/src/test/java/google/registry/model/domain/token/BulkPricingPackageTest.java
@@ -21,6 +21,7 @@ import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.common.collect.ImmutableSet;
 import google.registry.model.EntityTestCase;
 import google.registry.model.billing.BillingBase.RenewalPriceBehavior;
 import google.registry.model.domain.fee.FeeQueryCommandExtensionItem.CommandName;
@@ -30,7 +31,6 @@ import org.joda.money.Money;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
 
 /** Unit tests for {@link BulkPricingPackage}. */
 public class BulkPricingPackageTest extends EntityTestCase {

--- a/core/src/test/java/google/registry/privileges/secretmanager/FakeSecretManagerClient.java
+++ b/core/src/test/java/google/registry/privileges/secretmanager/FakeSecretManagerClient.java
@@ -17,12 +17,12 @@ package google.registry.privileges.secretmanager;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.cloud.secretmanager.v1.SecretVersion.State;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Optional;
 import javax.inject.Inject;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 /** Implements {@link SecretManagerClient} for tests. */
 public class FakeSecretManagerClient implements SecretManagerClient {

--- a/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
+++ b/core/src/test/java/google/registry/tools/ConfigureTldCommandTest.java
@@ -39,6 +39,7 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.io.Files;
@@ -57,7 +58,6 @@ import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 /** Unit tests for {@link ConfigureTldCommand} */
 public class ConfigureTldCommandTest extends CommandTestCase<ConfigureTldCommand> {

--- a/core/src/test/java/google/registry/tools/CreateBulkPricingPackageCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateBulkPricingPackageCommandTest.java
@@ -21,6 +21,7 @@ import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.common.collect.ImmutableSet;
 import google.registry.model.billing.BillingBase.RenewalPriceBehavior;
 import google.registry.model.domain.fee.FeeQueryCommandExtensionItem.CommandName;
 import google.registry.model.domain.token.AllocationToken;
@@ -31,7 +32,6 @@ import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
 
 /** Unit tests for {@link CreateBulkPricingPackageCommand}. */
 public class CreateBulkPricingPackageCommandTest

--- a/core/src/test/java/google/registry/tools/RenewDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/RenewDomainCommandTest.java
@@ -22,6 +22,7 @@ import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.beust.jcommander.ParameterException;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.domain.Domain;
 import google.registry.model.registrar.Registrar;
@@ -30,7 +31,6 @@ import java.util.List;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableList;
 
 /** Unit tests for {@link RenewDomainCommand}. */
 public class RenewDomainCommandTest extends EppToolCommandTestCase<RenewDomainCommand> {

--- a/core/src/test/java/google/registry/tools/UpdateBulkPricingPackageCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateBulkPricingPackageCommandTest.java
@@ -19,6 +19,7 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.truth.Truth;
 import google.registry.model.billing.BillingBase.RenewalPriceBehavior;
 import google.registry.model.domain.fee.FeeQueryCommandExtensionItem.CommandName;
@@ -31,7 +32,6 @@ import org.joda.money.Money;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
 
 /** Unit tests for {@link UpdateBulkPricingPackageCommand}. */
 public class UpdateBulkPricingPackageCommandTest


### PR DESCRIPTION
Also fixed a flaky test where it depends on the current date. On a leap
day, now + 1 year - 1 year results in 2/28 instead of 2/29.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2343)
<!-- Reviewable:end -->
