### PR TITLE
Temporarily revert builder to Java 17

### DIFF
--- a/release/builder/build.sh
+++ b/release/builder/build.sh
@@ -22,7 +22,7 @@ apt-get upgrade -y
 # Install GPG2 (in case it was not included)
 apt-get install gnupg2 -y
 # Install Java
-apt-get install openjdk-21-jdk-headless -y
+apt-get install openjdk-17-jdk-headless -y
 # Install Python
 apt-get install python3 -y
 # As of March 2021 python3 is at v3.6. Get pip then install dataclasses


### PR DESCRIPTION
Debian 11 repo does not have Java 21. Revert to Java 17 for now so we
can build the builder image, which is needed for release.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2351)
<!-- Reviewable:end -->
