### PR TITLE
Update runtime to Java 21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -422,11 +422,15 @@ subprojects {
   }
 }
 
-// Force SDK download to be sequential, otherwise parallel tasks will try to
-// write to the same location to upgrade gcloud and fail.
+// Force SDK download and deployment to be sequential, otherwise parallel tasks
+// will fail. For SDK download, they will try to write to the same location to
+// upgrade gcloud. For deployment, they will try to deploy different services to
+// the same project at the same time.
 for (int i = 1; i < services.size(); i++) {
   project("${services[i]}").downloadCloudSdk
           .dependsOn(project("${services[i - 1]}").downloadCloudSdk)
+  project("${services[i]}").appengineDeployAll
+          .dependsOn(project("${services[i - 1]}").appengineDeployAll)
 }
 
 // If "-P verboseTestOutput=true" is passed in, configure all subprojects to dump all of their

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/distroless/java17-debian11:debug
+FROM eclipse-temurin:21
 ADD build/libs/nomulus.jar /nomulus.jar
-ENTRYPOINT ["/usr/bin/java", "-jar", "/nomulus.jar"]
+ENTRYPOINT ["java", "-jar", "/nomulus.jar"]

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -762,7 +762,7 @@ if (environment == 'alpha') {
             gs://${gcpProject}-deploy/live/beam/${metaDataBaseName} \
             --image-gcr-path ${imageName}:live \
             --sdk-language JAVA \
-            --flex-template-base-image JAVA17 \
+            --flex-template-base-image gcr.io/dataflow-templates-base/java21-template-launcher-base:latest \
             --metadata-file ${projectDir}/src/main/resources/${metaData} \
             --jar ${uberJarName} \
             --env FLEX_TEMPLATE_JAVA_MAIN_CLASS=${mainClass} \

--- a/core/src/main/java/google/registry/env/alpha/backend/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/alpha/backend/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>backend</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="alpha"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1m"/>

--- a/core/src/main/java/google/registry/env/alpha/bsa/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/alpha/bsa/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>bsa</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,12 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="alpha"/>
   </system-properties>
 
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <!-- Enable external traffic to go through VPC, required for static ip -->
   <vpc-access-connector>

--- a/core/src/main/java/google/registry/env/alpha/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/alpha/default/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>default</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="alpha"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1m"/>

--- a/core/src/main/java/google/registry/env/alpha/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/alpha/pubapi/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>pubapi</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="alpha"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1m"/>

--- a/core/src/main/java/google/registry/env/alpha/tools/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/alpha/tools/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>tools</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="alpha"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1m"/>

--- a/core/src/main/java/google/registry/env/crash/backend/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/crash/backend/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>backend</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="crash"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1m"/>

--- a/core/src/main/java/google/registry/env/crash/bsa/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/crash/bsa/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>bsa</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="crash"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <!-- Enable external traffic to go through VPC, required for static ip -->
   <vpc-access-connector>

--- a/core/src/main/java/google/registry/env/crash/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/crash/default/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>default</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="crash"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1m"/>

--- a/core/src/main/java/google/registry/env/crash/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/crash/pubapi/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>pubapi</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="crash"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1m"/>

--- a/core/src/main/java/google/registry/env/crash/tools/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/crash/tools/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>tools</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="crash"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1m"/>

--- a/core/src/main/java/google/registry/env/local/backend/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/local/backend/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>backend</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,6 +12,7 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
@@ -19,6 +20,10 @@
     <property name="appengine.generated.dir"
               value="/tmp/domain-registry-appengine-generated/local/"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html">

--- a/core/src/main/java/google/registry/env/local/bsa/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/local/bsa/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>bsa</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,6 +12,7 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
@@ -19,6 +20,10 @@
     <property name="appengine.generated.dir"
               value="/tmp/domain-registry-appengine-generated/local/"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html">

--- a/core/src/main/java/google/registry/env/local/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/local/default/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>default</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,6 +12,7 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
@@ -19,6 +20,10 @@
     <property name="appengine.generated.dir"
               value="/tmp/domain-registry-appengine-generated/local/"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html">

--- a/core/src/main/java/google/registry/env/local/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/local/pubapi/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>pubapi</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,6 +12,7 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
@@ -19,6 +20,10 @@
     <property name="appengine.generated.dir"
               value="/tmp/domain-registry-appengine-generated/local/"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html">

--- a/core/src/main/java/google/registry/env/local/tools/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/local/tools/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>tools</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,6 +12,7 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
@@ -19,6 +20,10 @@
     <property name="appengine.generated.dir"
               value="/tmp/domain-registry-appengine-generated/local/"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html">

--- a/core/src/main/java/google/registry/env/production/backend/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/backend/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>backend</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="production"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1d"/>

--- a/core/src/main/java/google/registry/env/production/bsa/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/bsa/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>bsa</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="production"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <!-- Enable external traffic to go through VPC, required for static ip -->
   <vpc-access-connector>

--- a/core/src/main/java/google/registry/env/production/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/default/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>default</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -11,11 +11,16 @@
   </manual-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="production"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1d"/>

--- a/core/src/main/java/google/registry/env/production/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/pubapi/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>pubapi</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -11,11 +11,16 @@
   </manual-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="production"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1d"/>

--- a/core/src/main/java/google/registry/env/production/tools/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/tools/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>tools</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="production"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1d"/>

--- a/core/src/main/java/google/registry/env/qa/backend/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/qa/backend/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>backend</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="qa"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1h"/>

--- a/core/src/main/java/google/registry/env/qa/bsa/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/qa/bsa/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>bsa</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="qa"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1h"/>

--- a/core/src/main/java/google/registry/env/qa/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/qa/default/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>default</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -15,11 +15,16 @@
   </automatic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="qa"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1h"/>

--- a/core/src/main/java/google/registry/env/qa/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/qa/pubapi/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>pubapi</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="qa"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1h"/>

--- a/core/src/main/java/google/registry/env/qa/tools/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/qa/tools/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>tools</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="qa"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1h"/>

--- a/core/src/main/java/google/registry/env/sandbox/backend/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/backend/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>backend</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="sandbox"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1d"/>

--- a/core/src/main/java/google/registry/env/sandbox/bsa/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/bsa/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>bsa</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="sandbox"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1d"/>

--- a/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/default/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>default</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -11,11 +11,16 @@
   </manual-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="sandbox"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1d"/>

--- a/core/src/main/java/google/registry/env/sandbox/pubapi/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/pubapi/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>pubapi</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -11,11 +11,16 @@
   </manual-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="sandbox"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1d"/>

--- a/core/src/main/java/google/registry/env/sandbox/tools/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/tools/WEB-INF/appengine-web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
 
-  <runtime>java17</runtime>
+  <runtime>java21</runtime>
   <service>tools</service>
   <app-engine-apis>true</app-engine-apis>
   <sessions-enabled>true</sessions-enabled>
@@ -12,11 +12,16 @@
   </basic-scaling>
 
   <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
     <property name="java.util.logging.config.file"
               value="WEB-INF/logging.properties"/>
     <property name="google.registry.environment"
               value="sandbox"/>
   </system-properties>
+
+  <env-variables>
+    <env-var name="GOOGLE_APPLICATION_CREDENTIALS_SKIP_APP_ENGINE" value="true"/>
+  </env-variables>
 
   <static-files>
     <include path="/*.html" expiration="1d"/>

--- a/jetty/Dockerfile
+++ b/jetty/Dockerfile
@@ -1,4 +1,4 @@
-FROM jetty:12-jdk17
+FROM jetty:12-jdk21
 ADD --chown=jetty:jetty build/jetty-base /jetty-base
 ENV JETTY_BASE=/jetty-base
 WORKDIR "$JETTY_BASE"

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/java
+FROM eclipse-temurin:21
 ADD build/libs/proxy_server.jar .
 ENTRYPOINT ["java", "-jar", "proxy_server.jar"]
 EXPOSE 30000 30001 30002 30010 30012

--- a/release/stage_beam_pipeline.sh
+++ b/release/stage_beam_pipeline.sh
@@ -71,7 +71,7 @@ while (( "$#" > 0 )); do
     "gs://${dev_project}-deploy/${release_tag}/beam/${metadata_basename}" \
     --image-gcr-path "${image_name}:${release_tag}" \
     --sdk-language "JAVA" \
-    --flex-template-base-image JAVA17 \
+    --flex-template-base-image gcr.io/dataflow-templates-base/java21-template-launcher-base:latest \
     --metadata-file "./core/src/main/resources/${metadata_pathname}" \
     --jar "./core/build/libs/${uberjar_name}.jar" \
     --env FLEX_TEMPLATE_JAVA_MAIN_CLASS="${main_class}" \


### PR DESCRIPTION
This PR makes the runtime of most of our workload Java 21.

1. App Engine. Java 21 is in GA and it supports Java EE 8. I had to add
   an environmental variable so that we don't get an
   AppEngineCredentails by default (we have been using
   ComputeEngineCredentials for a couple of years). The uprade to Java
   21 runtime changed a system property that controls how jetty logging
   works, which also control if AppEngineCredential is return. Tested by
   deploying to alpha.
2. Proxy base image upgraded to Java 21 (distroless still doesn't
   support Java 21 and it looks like Temurin is the way to go
   b/306728455). Tested by deploying to alpha.
3. Nomulus tool image upgrade to Temurin 21 as well. Tested locally.
4. Beam pipeline base image upgrade to Java 21. The JAVA21 flag is not
   supported by gcloud yet, but specifying the image URL directly works
   (and is supported). Tested by running in alpha.
5. Jetty base image upgraded to Java 21. Tested locally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2353)
<!-- Reviewable:end -->
