### PR TITLE
Fix nomulus tool when the environment is localhost

### DIFF
--- a/config/nom_build.py
+++ b/config/nom_build.py
@@ -47,7 +47,7 @@ class GradleFlag:
 
 
 PROPERTIES_HEADER = """\
-# This file defines properties used by the gradle build.  It must be kept in
+# This file defines properties used by the gradle build. It must be kept in
 # sync with config/nom_build.py.
 #
 # To regenerate, run ./nom_build --generate-gradle-properties

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionManagerFactory.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionManagerFactory.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
 import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableSet;
 import google.registry.persistence.DaggerPersistenceComponent;
 import google.registry.tools.RegistryToolEnvironment;
 import google.registry.util.NonFinalForTesting;
@@ -26,6 +27,9 @@ import java.util.function.Supplier;
 
 /** Factory class to create {@link TransactionManager} instance. */
 public final class TransactionManagerFactory {
+
+  private static final ImmutableSet<RegistryEnvironment> NON_SERVING_ENVS =
+      ImmutableSet.of(RegistryEnvironment.UNITTEST, RegistryEnvironment.LOCAL);
 
   /** Supplier for jpaTm so that it is initialized only once, upon first usage. */
   @NonFinalForTesting
@@ -41,7 +45,7 @@ public final class TransactionManagerFactory {
   private static JpaTransactionManager createJpaTransactionManager() {
     // If we are running a nomulus command, jpaTm will be injected in RegistryCli.java
     // by calling setJpaTm().
-    if (RegistryEnvironment.get() != RegistryEnvironment.UNITTEST) {
+    if (!NON_SERVING_ENVS.contains(RegistryEnvironment.get())) {
       return DaggerPersistenceComponent.create().jpaTransactionManager();
     } else {
       return DummyJpaTransactionManager.create();


### PR DESCRIPTION
Also only caches/resets the original TM when in unit tests (TBT I'm not so sure
that even this is necessary as we don't seem to call the tool from tests
that often. There is only ShellCommandTest that calls the run() function
in RegistryCli and we could just put these tests in fragileTest and make
them run sequentially and fork every time to get around issue with
inference).

The issue with caching is that it tries to first create the to-be-cached
TM, and when the environment given is prod/sandbox/... It will try to
retrieve SQL credentials from prod/sandbox/... secret manager. This
works fine locally as we all have access to prod/sandbox/..., but fails
in Cloud Build jobs such as sync-db-objects where it provides it own
credential that has direct SQL access, but not access to
prod/sandbox/... secret manager.

TESTED=ran `./gradlew devTool --args="-e localhost generate_sql_er_diagram -o ../db/src/main/resources/sql/er_diagram"`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2365)
<!-- Reviewable:end -->
