### PR TITLE
Refactor some code related to the transaction manager

### DIFF
--- a/core/src/main/java/google/registry/bsa/BsaTransactions.java
+++ b/core/src/main/java/google/registry/bsa/BsaTransactions.java
@@ -16,7 +16,6 @@ package google.registry.bsa;
 
 import static com.google.common.base.Verify.verify;
 import static google.registry.persistence.PersistenceModule.TransactionIsolationLevel.TRANSACTION_REPEATABLE_READ;
-import static google.registry.persistence.transaction.JpaTransactionManagerImpl.isInTransaction;
 import static google.registry.persistence.transaction.TransactionManagerFactory.replicaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
@@ -36,18 +35,18 @@ public final class BsaTransactions {
 
   @CanIgnoreReturnValue
   public static <T> T bsaTransact(Callable<T> work) {
-    verify(!isInTransaction(), "May only be used for top-level transactions.");
+    verify(!tm().inTransaction(), "May only be used for top-level transactions.");
     return tm().transact(TRANSACTION_REPEATABLE_READ, work);
   }
 
   public static void bsaTransact(ThrowingRunnable work) {
-    verify(!isInTransaction(), "May only be used for top-level transactions.");
+    verify(!tm().inTransaction(), "May only be used for top-level transactions.");
     tm().transact(TRANSACTION_REPEATABLE_READ, work);
   }
 
   @CanIgnoreReturnValue
   public static <T> T bsaQuery(Callable<T> work) {
-    verify(!isInTransaction(), "May only be used for top-level transactions.");
+    verify(!tm().inTransaction(), "May only be used for top-level transactions.");
     // TRANSACTION_REPEATABLE_READ is default on replica.
     return replicaTm().transact(work);
   }

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManager.java
@@ -36,12 +36,10 @@ public interface JpaTransactionManager extends TransactionManager {
    *
    * <p>The returned instance is closed when the current transaction completes.
    *
-   * @deprecated Use the static {@link JpaTransactionManagerImpl#em} method for now. In current
-   *     implementation the entity manager is obtained from a static {@code ThreadLocal} object that
-   *     is set up by the outermost {@link #transact} call. As an instance method, this method gives
-   *     the illusion that the call site has control over which database instance to use.
+   * <p>Note that in the current implementation the entity manager is obtained from a static {@code
+   * ThreadLocal} object that is set up by the outermost {@link #transact} call. Nested call sites
+   * have no control over which database instance to use.
    */
-  @Deprecated // See Javadoc above.
   EntityManager getEntityManager();
 
   /**

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -91,26 +91,6 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
   private static final ThreadLocal<TransactionInfo> transactionInfo =
       ThreadLocal.withInitial(TransactionInfo::new);
 
-  /** Returns true if inside a transaction; returns false otherwise. */
-  public static boolean isInTransaction() {
-    return transactionInfo.get().inTransaction;
-  }
-
-  /**
-   * Returns the {@link EntityManager} for the current database transaction.
-   *
-   * <p>This method must be call from inside a transaction.
-   */
-  public static EntityManager em() {
-    EntityManager entityManager = transactionInfo.get().entityManager;
-    if (entityManager == null) {
-      throw new PersistenceException(
-          "No EntityManager has been initialized. getEntityManager() must be invoked in the scope"
-              + " of a transaction");
-    }
-    return entityManager;
-  }
-
   public JpaTransactionManagerImpl(EntityManagerFactory emf, Clock clock, boolean readOnly) {
     this.emf = emf;
     this.clock = clock;
@@ -131,16 +111,10 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
     return emf.createEntityManager();
   }
 
-  @Deprecated // See Javadoc of interface method.
   @Override
   public EntityManager getEntityManager() {
-    EntityManager entityManager = transactionInfo.get().entityManager;
-    if (entityManager == null) {
-      throw new PersistenceException(
-          "No EntityManager has been initialized. getEntityManager() must be invoked in the scope"
-              + " of a transaction");
-    }
-    return entityManager;
+    assertInTransaction();
+    return transactionInfo.get().entityManager;
   }
 
   @Override
@@ -158,7 +132,6 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
     return getEntityManager().createQuery(sqlString);
   }
 
-  @Deprecated // See Javadoc of instance method.
   @Override
   public boolean inTransaction() {
     return transactionInfo.get().inTransaction;

--- a/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
+++ b/core/src/main/java/google/registry/persistence/transaction/TransactionManager.java
@@ -34,16 +34,10 @@ public interface TransactionManager {
   /**
    * Returns {@code true} if the caller is in a transaction.
    *
-   * <p>Note that this function is kept for backward compatibility. We will review the use case
-   * later when adding the cloud sql implementation.
-   *
-   * @deprecated Use the static {@link JpaTransactionManagerImpl#isInTransaction()} method for now.
-   *     In current implementation the entity manager is obtained from a static {@code ThreadLocal}
-   *     object that is set up by the outermost {@link #transact} call. As an instance method, this
-   *     method gives the illusion that the call site has control over which database instance to
-   *     use.
+   * <p>Note that in the current implementation the entity manager is obtained from a static {@code
+   * ThreadLocal} object that is set up by the outermost {@link #transact} call. Nested call sites
+   * have no control over which database instance to use.
    */
-  @Deprecated // See Javadoc above.
   boolean inTransaction();
 
   /**


### PR DESCRIPTION
Removed the deprecation mark as it is natural to expose methods related
to a transaction like getting the entity manager or checking if one is
in a transaction through the transaction manager interface.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2366)
<!-- Reviewable:end -->
