### PR TITLE
Remove java.util.Date

### DIFF
--- a/config/presubmits.py
+++ b/config/presubmits.py
@@ -173,17 +173,24 @@ PRESUBMITS = {
     ):
         "JavaScript files should not include console logging.",
     PresubmitCheck(
-        r"org\.testcontainers\.shaded\.",
+        r".*org\.testcontainers\.shaded.*",
         "java",
         {"/node_modules/"},
     ):
         "Do not use shaded dependencies from testcontainers.",
     PresubmitCheck(
-        r"com\.google\.common\.truth\.Truth8",
+        r".*com\.google\.common\.truth\.Truth8.*",
         "java",
         {"/node_modules/"},
     ):
         "Truth8 is deprecated. Use Truth instead.",
+    PresubmitCheck(
+        r".*java\.util\.Date.*",
+        "java",
+        {"/node_modules/", "JpaTransactionManagerImpl.java"},
+    ):
+        "Do not use java.util.Date. Use classes in java.time package instead.",
+
 }
 
 # Note that this regex only works for one kind of Flyway file.  If we want to

--- a/core/src/main/java/google/registry/config/DelegatedCredentials.java
+++ b/core/src/main/java/google/registry/config/DelegatedCredentials.java
@@ -45,7 +45,6 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Map;
 import java.util.ServiceLoader;
 import org.apache.commons.codec.binary.Base64;
@@ -195,10 +194,7 @@ public class DelegatedCredentials extends GoogleCredentials {
     GenericData responseData = response.parseAs(GenericData.class);
     String accessToken = validateString(responseData, "access_token", PARSE_ERROR_PREFIX);
     int expiresInSeconds = validateInt32(responseData, "expires_in", PARSE_ERROR_PREFIX);
-    long expiresAtMilliseconds = clock.nowUtc().getMillis() + expiresInSeconds * 1000L;
-    @SuppressWarnings("JavaUtilDate")
-    AccessToken token = new AccessToken(accessToken, new Date(expiresAtMilliseconds));
-    return token;
+    return new AccessToken(accessToken, clock.nowUtc().plusSeconds(expiresInSeconds).toDate());
   }
 
   String createAssertion(JsonFactory jsonFactory, long currentTime) throws IOException {
@@ -257,8 +253,7 @@ public class DelegatedCredentials extends GoogleCredentials {
     if (value == null) {
       throw new IOException(String.format(VALUE_NOT_FOUND_MESSAGE, errorPrefix, key));
     }
-    if (value instanceof BigDecimal) {
-      BigDecimal bigDecimalValue = (BigDecimal) value;
+    if (value instanceof BigDecimal bigDecimalValue) {
       return bigDecimalValue.intValueExact();
     }
     if (!(value instanceof Integer)) {

--- a/core/src/main/java/google/registry/tmch/TmchCertificateAuthority.java
+++ b/core/src/main/java/google/registry/tmch/TmchCertificateAuthority.java
@@ -127,7 +127,7 @@ public final class TmchCertificateAuthority {
    */
   public void verify(X509Certificate cert) throws GeneralSecurityException {
     synchronized (TmchCertificateAuthority.class) {
-      X509Utils.verifyCertificate(getAndValidateRoot(), getCrl(), cert, clock.nowUtc().toDate());
+      X509Utils.verifyCertificate(getAndValidateRoot(), getCrl(), cert, clock.nowUtc());
     }
   }
 
@@ -151,7 +151,7 @@ public final class TmchCertificateAuthority {
     } catch (Exception e) {
       logger.atWarning().withCause(e).log("Old CRL is invalid, ignored during CRL update.");
     }
-    X509Utils.verifyCrl(getAndValidateRoot(), oldCrl, newCrl, clock.nowUtc().toDate());
+    X509Utils.verifyCrl(getAndValidateRoot(), oldCrl, newCrl, clock.nowUtc());
     TmchCrl.set(asciiCrl, url);
   }
 

--- a/core/src/main/java/google/registry/tools/CreateOrUpdateBulkPricingPackageCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdateBulkPricingPackageCommand.java
@@ -22,7 +22,7 @@ import google.registry.model.domain.token.AllocationToken;
 import google.registry.model.domain.token.AllocationToken.TokenType;
 import google.registry.model.domain.token.BulkPricingPackage;
 import google.registry.persistence.VKey;
-import java.util.Date;
+import google.registry.tools.params.DateTimeParameter;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -56,9 +56,11 @@ abstract class CreateOrUpdateBulkPricingPackageCommand extends MutatingCommand {
   @Nullable
   @Parameter(
       names = "--next_billing_date",
+      converter = DateTimeParameter.class,
+      validateWith = DateTimeParameter.class,
       description =
           "The next date that the bulk pricing package should be billed for its annual fee")
-  Date nextBillingDate;
+  DateTime nextBillingDate;
 
   /** Returns the existing BulkPricingPackage or null if it does not exist. */
   @Nullable
@@ -105,9 +107,7 @@ abstract class CreateOrUpdateBulkPricingPackageCommand extends MutatingCommand {
                 Optional.ofNullable(maxCreates).ifPresent(builder::setMaxCreates);
                 Optional.ofNullable(price).ifPresent(builder::setBulkPrice);
                 Optional.ofNullable(nextBillingDate)
-                    .ifPresent(
-                        nextBillingDate ->
-                            builder.setNextBillingDate(new DateTime(nextBillingDate)));
+                    .ifPresent(nextBillingDate -> builder.setNextBillingDate(nextBillingDate));
                 if (clearLastNotificationSent()) {
                   builder.setLastNotificationSent(null);
                 }

--- a/core/src/test/java/google/registry/module/RequestComponentTest.java
+++ b/core/src/test/java/google/registry/module/RequestComponentTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import google.registry.module.backend.BackendRequestComponent;
 import google.registry.module.bsa.BsaRequestComponent;
 import google.registry.module.frontend.FrontendRequestComponent;
@@ -28,7 +29,6 @@ import google.registry.testing.TestDataHelper;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 /** Unit tests for {@link RequestComponent}. */
 public class RequestComponentTest {

--- a/core/src/test/java/google/registry/testing/CloudTasksHelper.java
+++ b/core/src/test/java/google/registry/testing/CloudTasksHelper.java
@@ -40,7 +40,6 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.net.HttpHeaders;
 import com.google.common.net.MediaType;
-import com.google.common.truth.Truth8;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import dagger.Module;
@@ -133,7 +132,7 @@ public class CloudTasksHelper implements Serializable {
   public void assertTasksEnqueuedWithProperty(
       String queueName, Function<Task, String> propertyGetter, String... expectedTaskProperties) {
     // Ordering is irrelevant but duplicates should be considered independently.
-    Truth8.assertThat(getTestTasksFor(queueName).stream().map(propertyGetter))
+    assertThat(getTestTasksFor(queueName).stream().map(propertyGetter))
         .containsExactly((Object[]) expectedTaskProperties);
   }
 

--- a/core/src/test/java/google/registry/tools/CreateBulkPricingPackageCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateBulkPricingPackageCommandTest.java
@@ -53,7 +53,7 @@ public class CreateBulkPricingPackageCommandTest
         "--max_domains=100",
         "--max_creates=500",
         "--price=USD 1000.00",
-        "--next_billing_date=2012-03-17",
+        "--next_billing_date=2012-03-17T00:00:00Z",
         "abc123");
 
     Optional<BulkPricingPackage> bulkPricingPackageOptional =
@@ -161,7 +161,7 @@ public class CreateBulkPricingPackageCommandTest
             .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE))
             .setDiscountFraction(1)
             .build());
-    runCommandForced("--price=USD 1000.00", "--next_billing_date=2012-03-17", "abc123");
+    runCommandForced("--price=USD 1000.00", "--next_billing_date=2012-03-17T00:00:00Z", "abc123");
     Optional<BulkPricingPackage> bulkPricingPackageOptional =
         tm().transact(() -> BulkPricingPackage.loadByTokenString("abc123"));
     assertThat(bulkPricingPackageOptional).isPresent();

--- a/core/src/test/java/google/registry/tools/UpdateBulkPricingPackageCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateBulkPricingPackageCommandTest.java
@@ -69,7 +69,7 @@ public class UpdateBulkPricingPackageCommandTest
         "--max_domains=200",
         "--max_creates=1000",
         "--price=USD 2000.00",
-        "--next_billing_date=2013-03-17",
+        "--next_billing_date=2013-03-17T00:00:00Z",
         "--clear_last_notification_sent",
         "abc123");
 
@@ -106,7 +106,7 @@ public class UpdateBulkPricingPackageCommandTest
                     "--max_domains=100",
                     "--max_creates=500",
                     "--price=USD 1000.00",
-                    "--next_billing_date=2012-03-17",
+                    "--next_billing_date=2012-03-17T00:00:00Z",
                     "nullPackage"));
     Truth.assertThat(thrown.getMessage())
         .isEqualTo("BulkPricingPackage with token nullPackage does not exist");
@@ -117,7 +117,7 @@ public class UpdateBulkPricingPackageCommandTest
     runCommandForced(
         "--max_creates=1000",
         "--price=USD 2000.00",
-        "--next_billing_date=2013-03-17",
+        "--next_billing_date=2013-03-17T00:00:00Z",
         "--clear_last_notification_sent",
         "abc123");
 
@@ -159,7 +159,7 @@ public class UpdateBulkPricingPackageCommandTest
     runCommandForced(
         "--max_domains=200",
         "--max_creates=1000",
-        "--next_billing_date=2013-03-17",
+        "--next_billing_date=2013-03-17T00:00:00Z",
         "--clear_last_notification_sent",
         "abc123");
 

--- a/networking/src/test/java/google/registry/networking/handler/SslInitializerTestUtils.java
+++ b/networking/src/test/java/google/registry/networking/handler/SslInitializerTestUtils.java
@@ -15,6 +15,7 @@
 package google.registry.networking.handler;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.base.Throwables;
@@ -27,9 +28,6 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.Date;
 import java.util.concurrent.ExecutionException;
 import javax.net.ssl.SSLSession;
 import org.bouncycastle.asn1.x500.X500Name;
@@ -40,6 +38,7 @@ import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.joda.time.DateTime;
 
 /**
  * Utility class that provides methods used by {@link SslClientInitializerTest} and {@link
@@ -67,13 +66,13 @@ public final class SslInitializerTestUtils {
   }
 
   /**
-   * Signs the given key pair with the given self signed certificate to generate a certificate with
+   * Signs the given key pair with the given self-signed certificate to generate a certificate with
    * the given validity range.
    *
    * @return signed public key (of the key pair) certificate
    */
   public static X509Certificate signKeyPair(
-      SelfSignedCaCertificate ssc, KeyPair keyPair, String hostname, Date from, Date to)
+      SelfSignedCaCertificate ssc, KeyPair keyPair, String hostname, DateTime from, DateTime to)
       throws Exception {
     X500Name subjectDnName = new X500Name("CN=" + hostname);
     BigInteger serialNumber = BigInteger.valueOf(System.currentTimeMillis());
@@ -81,7 +80,12 @@ public final class SslInitializerTestUtils {
     ContentSigner sigGen = new JcaContentSignerBuilder("SHA256WithRSAEncryption").build(ssc.key());
     X509v3CertificateBuilder v3CertGen =
         new JcaX509v3CertificateBuilder(
-            issuerDnName, serialNumber, from, to, subjectDnName, keyPair.getPublic());
+            issuerDnName,
+            serialNumber,
+            from.toDate(),
+            to.toDate(),
+            subjectDnName,
+            keyPair.getPublic());
 
     X509CertificateHolder certificateHolder = v3CertGen.build(sigGen);
     return new JcaX509CertificateConverter()
@@ -90,7 +94,7 @@ public final class SslInitializerTestUtils {
   }
 
   /**
-   * Signs the given key pair with the given self signed certificate to generate a certificate that
+   * Signs the given key pair with the given self-signed certificate to generate a certificate that
    * is valid from yesterday to tomorrow.
    *
    * @return signed public key (of the key pair) certificate
@@ -98,11 +102,7 @@ public final class SslInitializerTestUtils {
   public static X509Certificate signKeyPair(
       SelfSignedCaCertificate ssc, KeyPair keyPair, String hostname) throws Exception {
     return signKeyPair(
-        ssc,
-        keyPair,
-        hostname,
-        Date.from(Instant.now().minus(Duration.ofDays(1))),
-        Date.from(Instant.now().plus(Duration.ofDays(1))));
+        ssc, keyPair, hostname, DateTime.now(UTC).minusDays(1), DateTime.now(UTC).plusDays(1));
   }
 
   /**
@@ -110,7 +110,7 @@ public final class SslInitializerTestUtils {
    * and verifies if it is echoed back correctly.
    *
    * @param certs The certificate that the server should provide.
-   * @return The SSL session in current channel, can be used for further validation.
+   * @return The SSL session in the current channel, can be used for further validation.
    */
   static SSLSession setUpSslChannel(Channel channel, X509Certificate... certs) throws Exception {
     SslHandler sslHandler = channel.pipeline().get(SslHandler.class);

--- a/util/src/main/java/google/registry/util/X509Utils.java
+++ b/util/src/main/java/google/registry/util/X509Utils.java
@@ -41,11 +41,11 @@ import java.security.cert.X509CRL;
 import java.security.cert.X509CRLEntry;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
-import java.util.Date;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.annotation.Tainted;
+import org.joda.time.DateTime;
 import org.joda.time.DateTimeComparator;
 
 /** X.509 Public Key Infrastructure (PKI) helper functions. */
@@ -140,13 +140,13 @@ public final class X509Utils {
    * <p>Support for certificate chains has not been implemented.
    *
    * @throws GeneralSecurityException for unsupported protocols, certs not signed by the TMCH,
-   *         parsing errors, encoding errors, if the CRL is expired, or if the CRL is older than the
-   *         one currently in memory.
+   *     parsing errors, encoding errors, if the CRL is expired, or if the CRL is older than the one
+   *     currently in memory.
    */
   public static void verifyCertificate(
-      X509Certificate rootCert, X509CRL crl, @Tainted X509Certificate cert, Date now)
-          throws GeneralSecurityException {
-    cert.checkValidity(checkNotNull(now, "now"));
+      X509Certificate rootCert, X509CRL crl, @Tainted X509Certificate cert, DateTime now)
+      throws GeneralSecurityException {
+    cert.checkValidity(checkNotNull(now, "now").toDate());
     cert.verify(rootCert.getPublicKey());
     if (crl.isRevoked(cert)) {
       X509CRLEntry entry = crl.getRevokedCertificate(cert);
@@ -168,7 +168,7 @@ public final class X509Utils {
    *     incorrect keys, and for invalid, old, not-yet-valid or revoked certificates.
    */
   public static void verifyCrl(
-      X509Certificate rootCert, @Nullable X509CRL oldCrl, @Tainted X509CRL newCrl, Date now)
+      X509Certificate rootCert, @Nullable X509CRL oldCrl, @Tainted X509CRL newCrl, DateTime now)
       throws GeneralSecurityException {
     if (oldCrl != null
         && DateTimeComparator.getInstance().compare(newCrl.getThisUpdate(), oldCrl.getThisUpdate())
@@ -178,7 +178,7 @@ public final class X509Utils {
               "New CRL is more out of date than our current CRL. %s < %s\n%s",
               newCrl.getThisUpdate(), oldCrl.getThisUpdate(), newCrl));
     }
-    if (DateTimeComparator.getInstance().compare(newCrl.getNextUpdate(), now) < 0) {
+    if (DateTimeComparator.getInstance().compare(new DateTime(newCrl.getNextUpdate()), now) < 0) {
       throw new CRLException("CRL has expired.\n" + newCrl);
     }
     newCrl.verify(rootCert.getPublicKey());


### PR DESCRIPTION
There is one remaining instance in JpaTransactionManagerImpl that cannot
be removed because DetachingTypedQuery is implementing TypedQuery, which has
a method that expectred java.util.Date.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2373)
<!-- Reviewable:end -->
