### PR TITLE
Add nomulus deployment and service manifests

### DIFF
--- a/jetty/build.gradle
+++ b/jetty/build.gradle
@@ -49,6 +49,15 @@ tasks.register('buildNomulusImage', Exec) {
     dependsOn(tasks.named('stage'))
 }
 
+tasks.register('tagNomulusImage', Exec) {
+    commandLine 'docker', 'tag', 'nomulus', "gcr.io/${rootProject.gcpProject}/nomulus"
+    dependsOn(tasks.named('buildNomulusImage'))
+}
+
+tasks.register('pushNomulusImage', Exec) {
+    commandLine 'docker', 'push', "gcr.io/${rootProject.gcpProject}/nomulus"
+}
+
 tasks.register('run', JavaExec) {
     // We do the check when the task actually runs, not when we define it.
     // This way if one doesn't set the value, one can still run other tasks.
@@ -64,6 +73,12 @@ tasks.register('run', JavaExec) {
     classpath = files(jetty_home + '/start.jar')
     systemProperty('google.registry.environment', environment)
     dependsOn(tasks.named('stage'))
+}
+
+tasks.register('deployNomulus', Exec) {
+    dependsOn(tasks.named('pushNomulusImage'), tasks.named(":proxy:pushProxyImage"))
+    configure verifyDeploymentConfig
+    commandLine './deploy-nomulus-for-env.sh', "${rootProject.environment}"
 }
 
 project.build.dependsOn(tasks.named('buildNomulusImage'))

--- a/jetty/kubernetes/nomulus-deployment.yaml
+++ b/jetty/kubernetes/nomulus-deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nomulus
+  labels:
+    app: nomulus
+spec:
+  selector:
+    matchLabels:
+      app: nomulus
+  template:
+    metadata:
+      labels:
+        app: nomulus
+    spec:
+      containers:
+      - name: nomulus
+        image: gcr.io/GCP_PROJECT/nomulus
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          requests:
+            cpu: "500m"
+        args: [ENVIRONMENT]
+      - name: proxy
+        image: gcr.io/GCP_PROJECT/proxy
+        ports:
+        - containerPort: 30001
+          name: whois
+        - containerPort: 30002
+          name: epp
+        resources:
+          requests:
+            cpu: "500m"
+        args: [--env, ENVIRONMENT, --log, --local]
+        env:
+        - name: POD_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: NAMESPACE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: CONTAINER_NAME
+          value: proxy
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: nomulus
+  labels:
+    app: nomulus
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: nomulus
+  minReplicas: 1
+  maxReplicas: 20
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 100
+

--- a/jetty/kubernetes/nomulus-gateway.yaml
+++ b/jetty/kubernetes/nomulus-gateway.yaml
@@ -1,0 +1,31 @@
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: nomulus
+spec:
+  gatewayClassName: gke-l7-global-external-managed-mc
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      kinds:
+      - kind: HTTPRoute
+---
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: nomulus
+  labels:
+    app: nomulus
+spec:
+  parentRefs:
+  - kind: Gateway
+    name: nomulus
+  rules:
+  - backendRefs:
+    - group: net.gke.io
+      kind: ServiceImport
+      name: nomulus
+      port: 80
+

--- a/jetty/kubernetes/nomulus-service.yaml
+++ b/jetty/kubernetes/nomulus-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nomulus
+spec:
+  selector:
+    app: nomulus
+  ports:
+    - port: 80
+      targetPort: http
+      name: http
+    - port: 43
+      targetPort: whois
+      name: whois
+    - port: 700
+      targetPort: epp
+      name: epp
+#---
+#kind: ServiceExport
+#apiVersion: net.gke.io/v1
+#metadata:
+#  name: nomulus

--- a/proxy/build.gradle
+++ b/proxy/build.gradle
@@ -18,19 +18,17 @@ task buildProxyImage(dependsOn: deployJar, type: Exec) {
   commandLine 'docker', 'build', '-t', 'proxy', '.'
 }
 
-task deployProxy(dependsOn: buildProxyImage) {
+task tagProxyImage(dependsOn: buildProxyImage, type: Exec) {
+  commandLine 'docker', 'tag', 'proxy', "gcr.io/${rootProject.gcpProject}/proxy"
+}
+
+task pushProxyImage(dependsOn: tagProxyImage, type: Exec) {
+  commandLine 'docker', 'push', "gcr.io/${rootProject.gcpProject}/proxy"
+}
+
+task deployProxy(dependsOn: pushProxyImage, type: Exec) {
   configure verifyDeploymentConfig
-  doLast {
-    exec {
-      commandLine 'docker', 'tag', 'proxy', "gcr.io/${rootProject.gcpProject}/proxy"
-    }
-    exec {
-      commandLine 'docker', 'push', "gcr.io/${rootProject.gcpProject}/proxy"
-    }
-    exec {
-      commandLine './deploy-proxy-for-env.sh', "${rootProject.environment}"
-    }
-  }
+  commandLine './deploy-proxy-for-env.sh', "${rootProject.environment}"
 }
 
 project.build.dependsOn buildProxyImage

--- a/proxy/src/main/java/google/registry/proxy/EppProtocolModule.java
+++ b/proxy/src/main/java/google/registry/proxy/EppProtocolModule.java
@@ -70,12 +70,14 @@ public final class EppProtocolModule {
       ProxyConfig config,
       @EppProtocol int eppPort,
       @EppProtocol ImmutableList<Provider<? extends ChannelHandler>> handlerProviders,
-      @HttpsRelayProtocol BackendProtocol.Builder backendProtocolBuilder) {
+      @HttpsRelayProtocol BackendProtocol.Builder backendProtocolBuilder,
+      @HttpsRelayProtocol boolean localRelay) {
     return Protocol.frontendBuilder()
         .name(PROTOCOL_NAME)
         .port(eppPort)
         .handlerProviders(handlerProviders)
-        .relayProtocol(backendProtocolBuilder.host(config.epp.relayHost).build())
+        .relayProtocol(
+            backendProtocolBuilder.host(localRelay ? "localhost" : config.epp.relayHost).build())
         .build();
   }
 
@@ -114,7 +116,7 @@ public final class EppProtocolModule {
         config.epp.headerLengthBytes,
         // Adjustment applied to the header field value in order to obtain message length.
         -config.epp.headerLengthBytes,
-        // Initial bytes to strip (i.e. strip the length header).
+        // Initial bytes to strip (i.e., strip the length header).
         config.epp.headerLengthBytes);
   }
 
@@ -150,9 +152,14 @@ public final class EppProtocolModule {
       @Named("idToken") Supplier<String> idTokenSupplier,
       @Named("hello") byte[] helloBytes,
       FrontendMetrics metrics,
-      ProxyConfig config) {
+      ProxyConfig config,
+      @HttpsRelayProtocol boolean localRelay) {
     return new EppServiceHandler(
-        config.epp.relayHost, config.epp.relayPath, idTokenSupplier, helloBytes, metrics);
+        localRelay ? "localhost" : config.epp.relayHost,
+        config.epp.relayPath,
+        idTokenSupplier,
+        helloBytes,
+        metrics);
   }
 
   @Singleton

--- a/proxy/src/main/java/google/registry/proxy/Protocol.java
+++ b/proxy/src/main/java/google/registry/proxy/Protocol.java
@@ -47,8 +47,9 @@ public interface Protocol {
     return new AutoValue_Protocol_FrontendProtocol.Builder().hasBackend(true);
   }
 
+  /** A builder for {@link FrontendProtocol}, by default it connects to a remote host. */
   static BackendProtocol.Builder backendBuilder() {
-    return new AutoValue_Protocol_BackendProtocol.Builder();
+    return new AutoValue_Protocol_BackendProtocol.Builder().isLocal(false);
   }
 
   /**
@@ -121,10 +122,26 @@ public interface Protocol {
     /** The hostname that the proxy connects to. */
     public abstract String host();
 
+    /** Whether the protocol is expected to connect to localhost. */
+    public abstract boolean isLocal();
+
     /** Builder of {@link BackendProtocol}. */
     @AutoValue.Builder
     public abstract static class Builder extends Protocol.Builder<Builder, BackendProtocol> {
       public abstract Builder host(String value);
+
+      public abstract Builder isLocal(boolean value);
+
+      abstract BackendProtocol autoBuild();
+
+      @Override
+      public BackendProtocol build() {
+        BackendProtocol protocol = autoBuild();
+        Preconditions.checkState(
+            !protocol.isLocal() || protocol.host().equals("localhost"),
+            "Local backend protocol must connect to localhost");
+        return autoBuild();
+      }
     }
   }
 }

--- a/proxy/src/main/java/google/registry/proxy/ProxyConfig.java
+++ b/proxy/src/main/java/google/registry/proxy/ProxyConfig.java
@@ -103,6 +103,7 @@ public class ProxyConfig {
   /** Configuration options that apply to HTTPS relay protocol. */
   public static class HttpsRelay {
     public int port;
+    public int localPort;
     public int maxMessageLengthBytes;
   }
 

--- a/proxy/src/main/java/google/registry/proxy/WhoisProtocolModule.java
+++ b/proxy/src/main/java/google/registry/proxy/WhoisProtocolModule.java
@@ -61,12 +61,14 @@ public final class WhoisProtocolModule {
       ProxyConfig config,
       @WhoisProtocol int whoisPort,
       @WhoisProtocol ImmutableList<Provider<? extends ChannelHandler>> handlerProviders,
-      @HttpsRelayProtocol BackendProtocol.Builder backendProtocolBuilder) {
+      @HttpsRelayProtocol BackendProtocol.Builder backendProtocolBuilder,
+      @HttpsRelayProtocol boolean localRelay) {
     return Protocol.frontendBuilder()
         .name(PROTOCOL_NAME)
         .port(whoisPort)
         .handlerProviders(handlerProviders)
-        .relayProtocol(backendProtocolBuilder.host(config.whois.relayHost).build())
+        .relayProtocol(
+            backendProtocolBuilder.host(localRelay ? "localhost" : config.whois.relayHost).build())
         .build();
   }
 
@@ -94,9 +96,13 @@ public final class WhoisProtocolModule {
   static WhoisServiceHandler provideWhoisServiceHandler(
       ProxyConfig config,
       @Named("idToken") Supplier<String> idTokenSupplier,
-      FrontendMetrics metrics) {
+      FrontendMetrics metrics,
+      @HttpsRelayProtocol boolean localRelay) {
     return new WhoisServiceHandler(
-        config.whois.relayHost, config.whois.relayPath, idTokenSupplier, metrics);
+        localRelay ? "localhost" : config.whois.relayHost,
+        config.whois.relayPath,
+        idTokenSupplier,
+        metrics);
   }
 
   @Provides

--- a/proxy/src/main/java/google/registry/proxy/config/default-config.yaml
+++ b/proxy/src/main/java/google/registry/proxy/config/default-config.yaml
@@ -177,7 +177,7 @@ healthCheck:
 
 httpsRelay:
   port: 443
-
+  localPort: 8080
   # Maximum size of an HTTP message in bytes.
   maxMessageLengthBytes: 524288
 

--- a/proxy/src/test/java/google/registry/proxy/ProtocolModuleTest.java
+++ b/proxy/src/test/java/google/registry/proxy/ProtocolModuleTest.java
@@ -67,7 +67,7 @@ import org.junit.jupiter.api.BeforeEach;
 /**
  * Base class for end-to-end tests of a {@link Protocol}.
  *
- * <p>The end-to-end tests ensures that the business logic that a {@link Protocol} defines are
+ * <p>The end-to-end tests ensure that the business logic that a {@link Protocol} defines are
  * correctly performed by various handlers attached to its pipeline. Non-business essential handlers
  * should be excluded.
  *
@@ -91,7 +91,7 @@ public abstract class ProtocolModuleTest {
           // The PROXY protocol is only used when the proxy is behind the GCP load balancer. It is
           // not part of any business logic.
           ProxyProtocolHandler.class,
-          // SSL is part of the business logic for some protocol (EPP for example), but its
+          // SSL is part of the business logic for some protocol (EPP, for example), but its
           // impact is isolated. Including it makes tests much more complicated. It should be tested
           // separately in its own unit tests.
           SslClientInitializer.class,
@@ -152,7 +152,7 @@ public abstract class ProtocolModuleTest {
   void initializeChannel(Consumer<Channel> initializer) {
     channel =
         new EmbeddedChannel(
-            new ChannelInitializer<Channel>() {
+            new ChannelInitializer<>() {
               @Override
               protected void initChannel(Channel ch) {
                 initializer.accept(ch);
@@ -218,8 +218,8 @@ public abstract class ProtocolModuleTest {
    *
    * <p>Most of the binding provided in this module should be either a fake, or a {@link
    * ChannelHandler} that is excluded, and annotated with {@code @Singleton}. This module acts as a
-   * replacement for {@link ProxyModule} used in production component. Providing a handler that is
-   * part of the business logic of a {@link Protocol} from this module is a sign that the binding
+   * replacement for {@link ProxyModule} used in the production component. Providing a handler that
+   * is part of the business logic of a {@link Protocol} from this module is a sign that the binding
    * should be provided in the respective {@code ProtocolModule} instead.
    */
   @Module
@@ -306,12 +306,19 @@ public abstract class ProtocolModuleTest {
     }
 
     // This method is only here to satisfy Dagger binding, but is never used. In test environment,
-    // it is the self-signed certificate and its key that end up being used.
+    // it is the self-signed certificate and its key that ends up being used.
     @Singleton
     @Provides
     @Named("pemBytes")
     static byte[] providePemBytes() {
       return new byte[0];
+    }
+
+    @Singleton
+    @Provides
+    @HttpsRelayProtocol
+    static boolean provideLocalRelay() {
+      return false;
     }
   }
 }


### PR DESCRIPTION
This PR makes changes to the proxy so that it is able to relay WHOIS/EPP traffic to localhost via plain HTTP. This allows us to package both the proxy and nomulus image in the same pod and bypass the need to  send the packets across the network.

The functionality is tested on local minikube clusters by forwarding the service to a local port and sending HTTP and WHOIS traffic to the forwarded port. EPP is untested as we don't have a readily available local EPP client, but the same logic follows.

Exposing the service via external load balancer is not yet tested.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2389)
<!-- Reviewable:end -->
