### PR TITLE
Check for missing BSA unblockable domains

### DIFF
--- a/core/src/test/java/google/registry/bsa/BsaValidateActionTest.java
+++ b/core/src/test/java/google/registry/bsa/BsaValidateActionTest.java
@@ -15,13 +15,18 @@
 package google.registry.bsa;
 
 import static com.google.common.base.Throwables.getStackTraceAsString;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.truth.Truth.assertThat;
+import static google.registry.bsa.ReservedDomainsTestingUtils.addReservedListsToTld;
+import static google.registry.bsa.ReservedDomainsTestingUtils.createReservedList;
 import static google.registry.bsa.persistence.BsaTestingUtils.persistBsaLabel;
 import static google.registry.bsa.persistence.BsaTestingUtils.persistDownloadSchedule;
 import static google.registry.bsa.persistence.BsaTestingUtils.persistUnblockableDomain;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistDeletedDomain;
+import static google.registry.testing.DatabaseHelper.persistResource;
+import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.startsWith;
@@ -43,13 +48,16 @@ import google.registry.bsa.persistence.BsaTestingUtils;
 import google.registry.gcs.GcsUtils;
 import google.registry.groups.GmailClient;
 import google.registry.model.domain.Domain;
+import google.registry.model.tld.label.ReservationType;
 import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationWithCoverageExtension;
 import google.registry.request.Response;
 import google.registry.testing.FakeClock;
 import google.registry.tldconfig.idn.IdnTableEnum;
 import google.registry.util.EmailMessage;
+import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.stream.Stream;
 import javax.mail.internet.InternetAddress;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
@@ -269,7 +277,7 @@ public class BsaValidateActionTest {
     persistUnblockableDomain(UnblockableDomain.of("label", "app", Reason.REGISTERED));
     when(idnChecker.getAllValidIdns(anyString())).thenReturn(ImmutableSet.of(IdnTableEnum.JA));
 
-    assertThat(action.checkUnblockableDomains()).isEmpty();
+    assertThat(action.checkWronglyReportedUnblockableDomains()).isEmpty();
   }
 
   @Test
@@ -280,8 +288,49 @@ public class BsaValidateActionTest {
     persistUnblockableDomain(UnblockableDomain.of("label", "app", Reason.RESERVED));
     when(idnChecker.getAllValidIdns(anyString())).thenReturn(ImmutableSet.of(IdnTableEnum.JA));
 
-    assertThat(action.checkUnblockableDomains())
+    assertThat(action.checkWronglyReportedUnblockableDomains())
         .containsExactly("label.app: should be REGISTERED, found RESERVED");
+  }
+
+  @Test
+  void checkForMissingReservedUnblockables_success() {
+    persistResource(
+        createTld("app").asBuilder().setBsaEnrollStartTime(Optional.of(START_OF_TIME)).build());
+    persistBsaLabel("registered-reserved");
+    persistBsaLabel("reserved-only");
+    persistBsaLabel("reserved-missing");
+    persistBsaLabel("invalid-in-app");
+
+    persistUnblockableDomain(UnblockableDomain.of("registered-reserved", "app", Reason.REGISTERED));
+    persistUnblockableDomain(UnblockableDomain.of("reserved-only", "app", Reason.RESERVED));
+    persistUnblockableDomain(UnblockableDomain.of("invalid-in-app", "dev", Reason.RESERVED));
+
+    createReservedList(
+        "rl",
+        Stream.of("registered-reserved", "reserved-only", "reserved-missing")
+            .collect(toImmutableMap(x -> x, x -> ReservationType.RESERVED_FOR_SPECIFIC_USE)));
+    addReservedListsToTld("app", ImmutableList.of("rl"));
+
+    ImmutableList<String> errors = action.checkForMissingReservedUnblockables(fakeClock.nowUtc());
+    assertThat(errors)
+        .containsExactly("Missing unblockable domain: reserved-missing.app is reserved.");
+  }
+
+  @Test
+  void checkForMissingRegisteredUnblockables_success() {
+    persistResource(
+        createTld("app").asBuilder().setBsaEnrollStartTime(Optional.of(START_OF_TIME)).build());
+    persistBsaLabel("registered");
+    persistBsaLabel("registered-missing");
+    persistUnblockableDomain(UnblockableDomain.of("registered", "app", Reason.REGISTERED));
+    persistUnblockableDomain(UnblockableDomain.of("registered-missing", "app", Reason.RESERVED));
+    persistActiveDomain("registered.app");
+    persistActiveDomain("registered-missing.app");
+
+    ImmutableList<String> errors = action.checkForMissingRegisteredUnblockables(fakeClock.nowUtc());
+    assertThat(errors)
+        .containsExactly(
+            "Registered domain registered-missing.app missing or not recorded as REGISTERED");
   }
 
   @Test

--- a/core/src/test/java/google/registry/bsa/persistence/QueriesTest.java
+++ b/core/src/test/java/google/registry/bsa/persistence/QueriesTest.java
@@ -21,18 +21,22 @@ import static google.registry.bsa.persistence.Queries.batchReadBsaLabelText;
 import static google.registry.bsa.persistence.Queries.deleteBsaLabelByLabels;
 import static google.registry.bsa.persistence.Queries.queryBsaLabelByLabels;
 import static google.registry.bsa.persistence.Queries.queryBsaUnblockableDomainByLabels;
+import static google.registry.bsa.persistence.Queries.queryMissedRegisteredUnblockables;
 import static google.registry.bsa.persistence.Queries.queryNewlyCreatedDomains;
 import static google.registry.bsa.persistence.Queries.queryUnblockablesByNames;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.createTlds;
 import static google.registry.testing.DatabaseHelper.newDomain;
+import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistDomainAsDeleted;
 import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
-import static google.registry.testing.DatabaseHelper.persistResource;
+import static google.registry.util.DateTimeUtils.END_OF_TIME;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import google.registry.bsa.api.UnblockableDomain;
 import google.registry.bsa.persistence.BsaUnblockableDomain.Reason;
+import google.registry.bsa.persistence.Queries.DomainLifeSpan;
 import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationWithCoverageExtension;
 import google.registry.testing.FakeClock;
@@ -200,16 +204,14 @@ class QueriesTest {
     createTlds("tld");
     persistNewRegistrar("TheRegistrar");
     // time 0:
-    persistResource(
-        newDomain("d1.tld").asBuilder().setCreationTimeForTest(fakeClock.nowUtc()).build());
+    persistActiveDomain("d1.tld", fakeClock.nowUtc());
     // time 0, deletion time 1
     persistDomainAsDeleted(
         newDomain("will-delete.tld").asBuilder().setCreationTimeForTest(fakeClock.nowUtc()).build(),
         fakeClock.nowUtc().plusMillis(1));
     fakeClock.advanceOneMilli();
     // time 1
-    persistResource(
-        newDomain("d2.tld").asBuilder().setCreationTimeForTest(fakeClock.nowUtc()).build());
+    persistActiveDomain("d2.tld", fakeClock.nowUtc());
     fakeClock.advanceOneMilli();
     // Now is time 2
     assertThat(
@@ -226,16 +228,14 @@ class QueriesTest {
     createTlds("tld");
     persistNewRegistrar("TheRegistrar");
     // time 0:
-    persistResource(
-        newDomain("d1.tld").asBuilder().setCreationTimeForTest(fakeClock.nowUtc()).build());
+    persistActiveDomain("d1.tld", fakeClock.nowUtc());
     // time 0, deletion time 1
     persistDomainAsDeleted(
         newDomain("will-delete.tld").asBuilder().setCreationTimeForTest(fakeClock.nowUtc()).build(),
         fakeClock.nowUtc().plusMillis(1));
     fakeClock.advanceOneMilli();
     // time 1
-    persistResource(
-        newDomain("d2.tld").asBuilder().setCreationTimeForTest(fakeClock.nowUtc()).build());
+    persistActiveDomain("d2.tld", fakeClock.nowUtc());
     fakeClock.advanceOneMilli();
     // Now is time 2, ask for domains created since time 1
     assertThat(
@@ -251,10 +251,8 @@ class QueriesTest {
     DateTime testStartTime = fakeClock.nowUtc();
     createTlds("tld", "tld2");
     persistNewRegistrar("TheRegistrar");
-    persistResource(
-        newDomain("d1.tld").asBuilder().setCreationTimeForTest(fakeClock.nowUtc()).build());
-    persistResource(
-        newDomain("d2.tld2").asBuilder().setCreationTimeForTest(fakeClock.nowUtc()).build());
+    persistActiveDomain("d1.tld", fakeClock.nowUtc());
+    persistActiveDomain("d2.tld2", fakeClock.nowUtc());
     fakeClock.advanceOneMilli();
     assertThat(
             bsaQuery(
@@ -262,5 +260,39 @@ class QueriesTest {
                     queryNewlyCreatedDomains(
                         ImmutableList.of("tld"), testStartTime, fakeClock.nowUtc())))
         .containsExactly("d1.tld");
+  }
+
+  @Test
+  void queryMissedRegisteredUnblockables_success() {
+    createTlds("tld", "tld2");
+    persistNewRegistrar("TheRegistrar");
+    DateTime time1 = fakeClock.nowUtc();
+    persistActiveDomain("unblocked1.tld", fakeClock.nowUtc());
+    persistActiveDomain("unblocked2.tld2", fakeClock.nowUtc());
+    persistActiveDomain("label1.tld", fakeClock.nowUtc());
+    persistActiveDomain("label2.tld2", fakeClock.nowUtc());
+    fakeClock.advanceOneMilli();
+    DateTime time2 = fakeClock.nowUtc();
+    persistDomainAsDeleted(
+        newDomain("label3.tld").asBuilder().setCreationTimeForTest(fakeClock.nowUtc()).build(),
+        fakeClock.nowUtc().plusMillis(1));
+    // Deleted in the future
+    persistDomainAsDeleted(
+        newDomain("label3.tld2").asBuilder().setCreationTimeForTest(fakeClock.nowUtc()).build(),
+        fakeClock.nowUtc().plusHours(1));
+    fakeClock.advanceOneMilli();
+    assertThat(bsaQuery(() -> queryMissedRegisteredUnblockables("tld", fakeClock.nowUtc())))
+        .containsExactly(new DomainLifeSpan("label1.tld", time1, END_OF_TIME));
+    assertThat(bsaQuery(() -> queryMissedRegisteredUnblockables("tld2", fakeClock.nowUtc())))
+        .containsExactly(
+            new DomainLifeSpan("label2.tld2", time1, END_OF_TIME),
+            new DomainLifeSpan("label3.tld2", time2, time2.plusHours(1)));
+
+    BsaTestingUtils.persistUnblockableDomain(
+        UnblockableDomain.of("label2", "tld2", UnblockableDomain.Reason.REGISTERED));
+    BsaTestingUtils.persistUnblockableDomain(
+        UnblockableDomain.of("label3", "tld2", UnblockableDomain.Reason.RESERVED));
+    assertThat(bsaQuery(() -> queryMissedRegisteredUnblockables("tld2", fakeClock.nowUtc())))
+        .containsExactly(new DomainLifeSpan("label3.tld2", time2, time2.plusHours(1)));
   }
 }


### PR DESCRIPTION
All unblockable domains created before the last refresh run should be reported as unblockable (registered).

All reserved domains that are not registered should be reported as unblockable (reserved). Note that transient errors may be reported for newly added reserved domains since we do not maintain update time for when a reserved label is associated with a TLD. However, this scenario is extremely rare in operations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2394)
<!-- Reviewable:end -->
