### PR TITLE
Run BSA Validate without lock

### DIFF
--- a/core/src/main/java/google/registry/env/production/bsa/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/production/bsa/WEB-INF/appengine-web.xml
@@ -7,8 +7,8 @@
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4_1G</instance-class>
   <basic-scaling>
-    <max-instances>100</max-instances>
-    <idle-timeout>10m</idle-timeout>
+    <max-instances>3</max-instances>
+    <idle-timeout>60m</idle-timeout>
   </basic-scaling>
 
   <system-properties>

--- a/core/src/main/java/google/registry/env/sandbox/bsa/WEB-INF/appengine-web.xml
+++ b/core/src/main/java/google/registry/env/sandbox/bsa/WEB-INF/appengine-web.xml
@@ -7,8 +7,8 @@
   <sessions-enabled>true</sessions-enabled>
   <instance-class>B4</instance-class>
   <basic-scaling>
-    <max-instances>100</max-instances>
-    <idle-timeout>10m</idle-timeout>
+    <max-instances>3</max-instances>
+    <idle-timeout>60m</idle-timeout>
   </basic-scaling>
 
   <system-properties>


### PR DESCRIPTION
As a read-only action that tolerates inconsistency due to recent changes, locking is unnecessary. This should help with the lock contention we are observing.

Also reduces the number of VM instances provisioned for BSA and increase the idle timeout. This should reduce invocation delay. Longer delay may cause Cloud Scheduler to report a cron job as failure on its dashboard even though the job succeeds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2399)
<!-- Reviewable:end -->
