### PR TITLE
Convert a bunch more @AutoValues to records

### DIFF
--- a/core/src/main/java/google/registry/beam/billing/BillingEvent.java
+++ b/core/src/main/java/google/registry/beam/billing/BillingEvent.java
@@ -14,7 +14,6 @@
 
 package google.registry.beam.billing;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import google.registry.reporting.billing.BillingModule;
@@ -34,9 +33,39 @@ import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-/** A POJO representing a single billable event, parsed from a {@code SchemaAndRecord}. */
-@AutoValue
-public abstract class BillingEvent {
+/**
+ * A record representing a single billable event, parsed from a {@code SchemaAndRecord}.
+ *
+ * @param id The unique ID for the {@code BillingEvent} associated with this event.
+ * @param billingTime The DateTime (in UTC) this event becomes billable.
+ * @param eventTime The DateTime (in UTC) this event was generated.
+ * @param registrarId The billed registrar's name.
+ * @param billingId The billed registrar's billing account key.
+ * @param poNumber The Purchase Order number.
+ * @param tld The TLD this event was generated for.
+ * @param action The billable action this event was generated for (CREATE, RENEW, TRANSFER...).
+ * @param domain The fully qualified domain name this event was generated for.
+ * @param repositoryId The unique RepoID associated with the billed domain.
+ * @param years The number of years this billing event is made out for.
+ * @param currency The 3-letter currency code for the billing event (USD or JPY).
+ * @param amount The total cost associated with this billing event.
+ * @param flags A list of space-delimited flags associated with the event.
+ */
+public record BillingEvent(
+    long id,
+    DateTime billingTime,
+    DateTime eventTime,
+    String registrarId,
+    String billingId,
+    String poNumber,
+    String tld,
+    String action,
+    String domain,
+    String repositoryId,
+    int years,
+    String currency,
+    double amount,
+    String flags) {
 
   private static final DateTimeFormatter DATE_TIME_FORMATTER =
       DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss zzz");
@@ -60,48 +89,6 @@ public abstract class BillingEvent {
           "amount",
           "flags");
 
-  /** Returns the unique ID for the {@code BillingEvent} associated with this event. */
-  abstract long id();
-
-  /** Returns the UTC DateTime this event becomes billable. */
-  abstract DateTime billingTime();
-
-  /** Returns the UTC DateTime this event was generated. */
-  abstract DateTime eventTime();
-
-  /** Returns the billed registrar's name. */
-  abstract String registrarId();
-
-  /** Returns the billed registrar's billing account key. */
-  abstract String billingId();
-
-  /** Returns the Purchase Order number. */
-  abstract String poNumber();
-
-  /** Returns the tld this event was generated for. */
-  abstract String tld();
-
-  /** Returns the billable action this event was generated for (i.e., RENEW, CREATE, TRANSFER...) */
-  abstract String action();
-
-  /** Returns the fully qualified domain name this event was generated for. */
-  abstract String domain();
-
-  /** Returns the unique RepoID associated with the billed domain. */
-  abstract String repositoryId();
-
-  /** Returns the number of years this billing event is made out for. */
-  abstract int years();
-
-  /** Returns the 3-letter currency code for the billing event (i.e., USD or JPY.) */
-  abstract String currency();
-
-  /** Returns the cost associated with this billing event. */
-  abstract double amount();
-
-  /** Returns a list of space-delimited flags associated with the event. */
-  abstract String flags();
-
   /** Creates a concrete {@link BillingEvent}. */
   static BillingEvent create(
       long id,
@@ -118,7 +105,7 @@ public abstract class BillingEvent {
       String currency,
       double amount,
       String flags) {
-    return new AutoValue_BillingEvent(
+    return new BillingEvent(
         id,
         billingTime,
         eventTime,
@@ -338,7 +325,7 @@ public abstract class BillingEvent {
 
     @Override
     public BillingEvent decode(InputStream inStream) throws IOException {
-      return new AutoValue_BillingEvent(
+      return new BillingEvent(
           longCoder.decode(inStream),
           DATE_TIME_FORMATTER.parseDateTime(stringCoder.decode(inStream)),
           DATE_TIME_FORMATTER.parseDateTime(stringCoder.decode(inStream)),

--- a/core/src/main/java/google/registry/beam/spec11/DomainNameInfo.java
+++ b/core/src/main/java/google/registry/beam/spec11/DomainNameInfo.java
@@ -14,30 +14,23 @@
 
 package google.registry.beam.spec11;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.Serializable;
 
 /**
- * A POJO representing a domain name and associated info, parsed from a {@code SchemaAndRecord}.
+ * A record representing a domain name and associated info, parsed from a {@code SchemaAndRecord}.
  *
  * <p>This is a trivially serializable class that allows Beam to transform the results of a SQL
  * query into a standard Java representation.
+ *
+ * @param domainName The fully qualified domain name.
+ * @param domainRepoId The domain repo ID (the primary key of the domain table).
+ * @param registrarId The registrar ID of the associated registrar for this domain.
+ * @param registrarEmailAddress The email address of the registrar associated with this domain.
  */
-@AutoValue
-public abstract class DomainNameInfo implements Serializable {
-
-  /** Returns the fully qualified domain name. */
-  abstract String domainName();
-
-  /** Returns the domain repo ID (the primary key of the domain table). */
-  abstract String domainRepoId();
-
-  /** Returns the registrar ID of the associated registrar for this domain. */
-  abstract String registrarId();
-
-  /** Returns the email address of the registrar associated with this domain. */
-  abstract String registrarEmailAddress();
+public record DomainNameInfo(
+    String domainName, String domainRepoId, String registrarId, String registrarEmailAddress)
+    implements Serializable {
 
   /**
    * Creates a concrete {@link DomainNameInfo}.
@@ -45,7 +38,6 @@ public abstract class DomainNameInfo implements Serializable {
   @VisibleForTesting
   static DomainNameInfo create(
       String domainName, String domainRepoId, String registrarId, String registrarEmailAddress) {
-    return new AutoValue_DomainNameInfo(
-        domainName, domainRepoId, registrarId, registrarEmailAddress);
+    return new DomainNameInfo(domainName, domainRepoId, registrarId, registrarEmailAddress);
   }
 }

--- a/core/src/main/java/google/registry/beam/spec11/ThreatMatch.java
+++ b/core/src/main/java/google/registry/beam/spec11/ThreatMatch.java
@@ -14,28 +14,26 @@
 
 package google.registry.beam.spec11;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.Serializable;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-/** A POJO representing a threat match response from the {@code SafeBrowsing API}. */
-@AutoValue
-public abstract class ThreatMatch implements Serializable {
+/**
+ * A record representing a threat match response from the {@code SafeBrowsing API}.
+ *
+ * @param threatType What kind of threat this is (malware, phishing, etc.).
+ * @param domainName The fully qualified domain name of the matched threat.
+ */
+public record ThreatMatch(String threatType, String domainName) implements Serializable {
 
   private static final String THREAT_TYPE_FIELD = "threatType";
   private static final String DOMAIN_NAME_FIELD = "domainName";
   private static final String OUTDATED_NAME_FIELD = "fullyQualifiedDomainName";
 
-  /** Returns what kind of threat it is (malware, phishing etc.) */
-  public abstract String threatType();
-  /** Returns the fully qualified domain name [SLD].[TLD] of the matched threat. */
-  public abstract String domainName();
-
   @VisibleForTesting
   static ThreatMatch create(String threatType, String domainName) {
-    return new AutoValue_ThreatMatch(threatType, domainName);
+    return new ThreatMatch(threatType, domainName);
   }
 
   /** Returns a {@link JSONObject} representing a subset of this object's data. */
@@ -49,7 +47,7 @@ public abstract class ThreatMatch implements Serializable {
   public static ThreatMatch fromJSON(JSONObject threatMatch) throws JSONException {
     // TODO: delete OUTDATED_NAME_FIELD once we no longer process reports saved with
     // fullyQualifiedDomainName in them, likely 2023
-    return new AutoValue_ThreatMatch(
+    return new ThreatMatch(
         threatMatch.getString(THREAT_TYPE_FIELD),
         threatMatch.has(OUTDATED_NAME_FIELD)
             ? threatMatch.getString(OUTDATED_NAME_FIELD)

--- a/core/src/main/java/google/registry/model/tld/label/DomainLabelMetrics.java
+++ b/core/src/main/java/google/registry/model/tld/label/DomainLabelMetrics.java
@@ -14,7 +14,6 @@
 
 package google.registry.model.tld.label;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import com.google.monitoring.metrics.EventMetric;
@@ -43,16 +42,11 @@ class DomainLabelMetrics {
     UNCACHED_POSITIVE
   }
 
-  @AutoValue
-  abstract static class MetricsReservedListMatch {
+  record MetricsReservedListMatch(String reservedListName, ReservationType reservationType) {
     static MetricsReservedListMatch create(
         String reservedListName, ReservationType reservationType) {
-      return new AutoValue_DomainLabelMetrics_MetricsReservedListMatch(
-          reservedListName, reservationType);
+      return new MetricsReservedListMatch(reservedListName, reservationType);
     }
-
-    abstract String reservedListName();
-    abstract ReservationType reservationType();
   }
 
   /**

--- a/core/src/main/java/google/registry/model/tld/label/PremiumListDao.java
+++ b/core/src/main/java/google/registry/model/tld/label/PremiumListDao.java
@@ -23,7 +23,6 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.util.CollectionUtils.isNullOrEmpty;
 
 import com.github.benmanes.caffeine.cache.LoadingCache;
-import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -236,14 +235,10 @@ public final class PremiumListDao {
         .collect(toImmutableList());
   }
 
-  @AutoValue
-  abstract static class RevisionIdAndLabel {
-    abstract long revisionId();
-
-    abstract String label();
+  record RevisionIdAndLabel(long revisionId, String label) {
 
     static RevisionIdAndLabel create(long revisionId, String label) {
-      return new AutoValue_PremiumListDao_RevisionIdAndLabel(revisionId, label);
+      return new RevisionIdAndLabel(revisionId, label);
     }
   }
 

--- a/core/src/main/java/google/registry/monitoring/whitebox/CheckApiMetric.java
+++ b/core/src/main/java/google/registry/monitoring/whitebox/CheckApiMetric.java
@@ -16,14 +16,18 @@ package google.registry.monitoring.whitebox;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.auto.value.AutoValue;
+import com.google.auto.value.AutoBuilder;
 import google.registry.util.Clock;
 import java.util.Optional;
 import org.joda.time.DateTime;
 
-/** A value class for recording attributes of a domain check metric. */
-@AutoValue
-public abstract class CheckApiMetric {
+/** A record for recording attributes of a domain check metric. */
+public record CheckApiMetric(
+    DateTime startTimestamp,
+    DateTime endTimestamp,
+    Status status,
+    Optional<Tier> tier,
+    Optional<Availability> availability) {
 
   /** Price tier of a domain name. */
   public enum Tier {
@@ -77,24 +81,13 @@ public abstract class CheckApiMetric {
     }
   }
 
-  public abstract DateTime startTimestamp();
-
-  public abstract DateTime endTimestamp();
-
-  public abstract Status status();
-
-  public abstract Optional<Tier> tier();
-
-  public abstract Optional<Availability> availability();
 
   public static Builder builder(Clock clock) {
-    return new AutoValue_CheckApiMetric.Builder().startTimestamp(clock.nowUtc()).setClock(clock);
+    return new AutoBuilder_CheckApiMetric_Builder().startTimestamp(clock.nowUtc()).setClock(clock);
   }
 
-  CheckApiMetric() {}
-
   /** Builder for {@link CheckApiMetric}. */
-  @AutoValue.Builder
+  @AutoBuilder
   public abstract static class Builder {
 
     private Clock clock;

--- a/core/src/main/java/google/registry/privileges/secretmanager/SecretManagerClient.java
+++ b/core/src/main/java/google/registry/privileges/secretmanager/SecretManagerClient.java
@@ -14,7 +14,6 @@
 
 package google.registry.privileges.secretmanager;
 
-import com.google.auto.value.AutoValue;
 import com.google.cloud.secretmanager.v1.SecretVersion;
 import com.google.common.collect.Streams;
 import java.util.Optional;
@@ -116,18 +115,11 @@ public interface SecretManagerClient {
   void deleteSecret(String secretId);
 
   /** Contains the {@link SecretVersion.State State} of an secret version. */
-  @AutoValue
-  abstract class SecretVersionState {
+  record SecretVersionState(String secretId, String version, SecretVersion.State state) {
 
-    public abstract String secretId();
-
-    public abstract String version();
-
-    public abstract SecretVersion.State state();
-
-    public static SecretVersionState of(
+    public static SecretVersionState create(
         String secretId, String version, SecretVersion.State state) {
-      return new AutoValue_SecretManagerClient_SecretVersionState(secretId, version, state);
+      return new SecretVersionState(secretId, version, state);
     }
   }
 

--- a/core/src/main/java/google/registry/privileges/secretmanager/SecretManagerClientImpl.java
+++ b/core/src/main/java/google/registry/privileges/secretmanager/SecretManagerClientImpl.java
@@ -94,7 +94,7 @@ public class SecretManagerClientImpl implements SecretManagerClient {
 
   private static SecretVersionState toSecretVersionState(SecretVersion secretVersion) {
     SecretVersionName name = SecretVersionName.parse(secretVersion.getName());
-    return SecretVersionState.of(
+    return SecretVersionState.create(
         name.getSecret(), name.getSecretVersion(), secretVersion.getState());
   }
 

--- a/core/src/main/java/google/registry/privileges/secretmanager/SqlCredential.java
+++ b/core/src/main/java/google/registry/privileges/secretmanager/SqlCredential.java
@@ -16,7 +16,6 @@ package google.registry.privileges.secretmanager;
 
 import static avro.shaded.com.google.common.base.Preconditions.checkState;
 
-import com.google.auto.value.AutoValue;
 import java.util.List;
 
 /**
@@ -24,32 +23,27 @@ import java.util.List;
  *
  * <p>User must take care not to include the {@link #SEPARATOR} in property values.
  */
-@AutoValue
-public abstract class SqlCredential {
+public record SqlCredential(String login, String password) {
 
   public static final Character SEPARATOR = ' ';
 
-  public abstract String login();
-
-  public abstract String password();
-
   @Override
-  public final String toString() {
-    // Use Object.toString(), which does not show object data.
-    return super.toString();
+  public String toString() {
+    // Use the Object.toString() implementation, which does not show the sensitive date in fields.
+    return this.getClass().getName() + "@" + Integer.toHexString(this.hashCode());
   }
 
-  public final String toFormattedString() {
+  public String toFormattedString() {
     return String.format("%s%c%s", login(), SEPARATOR, password());
   }
 
   public static SqlCredential fromFormattedString(String sqlCredential) {
     List<String> items = com.google.common.base.Splitter.on(SEPARATOR).splitToList(sqlCredential);
     checkState(items.size() == 2, "Invalid SqlCredential string.");
-    return of(items.get(0), items.get(1));
+    return create(items.get(0), items.get(1));
   }
 
-  public static SqlCredential of(String login, String password) {
-    return new AutoValue_SqlCredential(login, password);
+  public static SqlCredential create(String login, String password) {
+    return new SqlCredential(login, password);
   }
 }

--- a/core/src/main/java/google/registry/privileges/secretmanager/SqlCredentialStore.java
+++ b/core/src/main/java/google/registry/privileges/secretmanager/SqlCredentialStore.java
@@ -79,7 +79,7 @@ public class SqlCredentialStore {
     String credentialVersion =
         csmClient.addSecretVersion(
             credentialDataSecretId,
-            SqlCredential.of(createDatabaseLoginName(user), password).toFormattedString());
+            SqlCredential.create(createDatabaseLoginName(user), password).toFormattedString());
     return SecretVersionName.of(csmClient.getProject(), credentialDataSecretId, credentialVersion);
   }
 

--- a/core/src/main/java/google/registry/rdap/RdapAuthorization.java
+++ b/core/src/main/java/google/registry/rdap/RdapAuthorization.java
@@ -14,13 +14,16 @@
 
 package google.registry.rdap;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableSet;
-import google.registry.model.ImmutableObject;
 
-/** Authorization information for RDAP data access. */
-@AutoValue
-public abstract class RdapAuthorization extends ImmutableObject {
+/**
+ * Authorization information for RDAP data access.
+ *
+ * @param role The role to be used for access.
+ * @param registrarIds The registrar client IDs for which access is granted (used only if the role
+ *     is REGISTRAR.
+ */
+public record RdapAuthorization(Role role, ImmutableSet<String> registrarIds) {
 
   enum Role {
     ADMINISTRATOR,
@@ -28,29 +31,20 @@ public abstract class RdapAuthorization extends ImmutableObject {
     PUBLIC
   }
 
-  /** The role to be used for access. */
-  public abstract Role role();
-
-  /** The registrar client IDs for which access is granted (used only if the role is REGISTRAR. */
-  public abstract ImmutableSet<String> registrarIds();
-
   static RdapAuthorization create(Role role, String registrarId) {
-    return new AutoValue_RdapAuthorization(role, ImmutableSet.of(registrarId));
+    return create(role, ImmutableSet.of(registrarId));
   }
 
   static RdapAuthorization create(Role role, ImmutableSet<String> clientIds) {
-    return new AutoValue_RdapAuthorization(role, clientIds);
+    return new RdapAuthorization(role, clientIds);
   }
 
   boolean isAuthorizedForRegistrar(String registrarId) {
-    switch (role()) {
-      case ADMINISTRATOR:
-        return true;
-      case REGISTRAR:
-        return registrarIds().contains(registrarId);
-      default:
-        return false;
-    }
+    return switch (role()) {
+      case ADMINISTRATOR -> true;
+      case REGISTRAR -> registrarIds().contains(registrarId);
+      default -> false;
+    };
   }
 
   public static final RdapAuthorization PUBLIC_AUTHORIZATION =

--- a/core/src/main/java/google/registry/rde/DepositFragment.java
+++ b/core/src/main/java/google/registry/rde/DepositFragment.java
@@ -14,22 +14,16 @@
 
 package google.registry.rde;
 
-import com.google.auto.value.AutoValue;
+import java.io.Serial;
 import java.io.Serializable;
 
 /** Container of RDE resource marshalled by {@link RdeMarshaller}. */
-@AutoValue
-public abstract class DepositFragment implements Serializable {
+public record DepositFragment(RdeResourceType type, String xml, String error)
+    implements Serializable {
 
-  private static final long serialVersionUID = -5241410684255467454L;
-
-  public abstract RdeResourceType type();
-  public abstract String xml();
-  public abstract String error();
+  @Serial private static final long serialVersionUID = -5241410684255467454L;
 
   public static DepositFragment create(RdeResourceType type, String xml, String error) {
-    return new AutoValue_DepositFragment(type, xml, error);
+    return new DepositFragment(type, xml, error);
   }
-
-  DepositFragment() {}
 }

--- a/core/src/main/java/google/registry/rde/RdeFragmenter.java
+++ b/core/src/main/java/google/registry/rde/RdeFragmenter.java
@@ -17,7 +17,6 @@ package google.registry.rde;
 import static google.registry.model.EppResourceUtils.loadAtPointInTime;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.EppResource;
 import google.registry.model.contact.Contact;
@@ -96,14 +95,10 @@ public class RdeFragmenter {
   }
 
   /** Map key for {@link RdeFragmenter} cache. */
-  @AutoValue
-  abstract static class WatermarkModePair {
-    abstract DateTime watermark();
-
-    abstract RdeMode mode();
+  record WatermarkModePair(DateTime watermark, RdeMode mode) {
 
     static WatermarkModePair create(DateTime watermark, RdeMode mode) {
-      return new AutoValue_RdeFragmenter_WatermarkModePair(watermark, mode);
+      return new WatermarkModePair(watermark, mode);
     }
   }
 }

--- a/core/src/main/java/google/registry/reporting/spec11/RegistrarThreatMatches.java
+++ b/core/src/main/java/google/registry/reporting/spec11/RegistrarThreatMatches.java
@@ -14,20 +14,14 @@
 
 package google.registry.reporting.spec11;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import google.registry.beam.spec11.ThreatMatch;
 import java.util.List;
 
-/** Value class representing the registrar and list-of-threat-matches pair stored in GCS. */
-@AutoValue
-public abstract class RegistrarThreatMatches {
-
-  public abstract String clientId();
-
-  public abstract ImmutableList<ThreatMatch> threatMatches();
+/** Value record representing the registrar and list-of-threat-matches pair stored in GCS. */
+public record RegistrarThreatMatches(String clientId, ImmutableList<ThreatMatch> threatMatches) {
 
   static RegistrarThreatMatches create(String clientId, List<ThreatMatch> threatMatches) {
-    return new AutoValue_RegistrarThreatMatches(clientId, ImmutableList.copyOf(threatMatches));
+    return new RegistrarThreatMatches(clientId, ImmutableList.copyOf(threatMatches));
   }
 }

--- a/core/src/main/java/google/registry/request/Route.java
+++ b/core/src/main/java/google/registry/request/Route.java
@@ -14,7 +14,6 @@
 
 package google.registry.request;
 
-import com.google.auto.value.AutoValue;
 import java.util.function.Function;
 
 /**
@@ -22,17 +21,12 @@ import java.util.function.Function;
  *
  * @see Router
  */
-@AutoValue
-abstract class Route {
+record Route(Action action, Function<Object, Runnable> instantiator, Class<?> actionClass) {
 
   static Route create(
       Action action, Function<Object, Runnable> instantiator, Class<?> actionClass) {
-    return new AutoValue_Route(action, instantiator, actionClass);
+    return new Route(action, instantiator, actionClass);
   }
-
-  abstract Action action();
-  abstract Function<Object, Runnable> instantiator();
-  abstract Class<?> actionClass();
 
   boolean isMethodAllowed(Action.Method requestMethod) {
     for (Action.Method method : action().method()) {

--- a/core/src/main/java/google/registry/request/auth/AuthResult.java
+++ b/core/src/main/java/google/registry/request/auth/AuthResult.java
@@ -18,7 +18,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.request.auth.AuthSettings.AuthLevel.APP;
 import static google.registry.request.auth.AuthSettings.AuthLevel.USER;
 
-import com.google.auto.value.AutoValue;
 import google.registry.request.auth.AuthSettings.AuthLevel;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -26,18 +25,13 @@ import javax.annotation.Nullable;
 /**
  * Results of authentication for a given HTTP request, as emitted by an {@link
  * AuthenticationMechanism}.
+ *
+ * @param userAuthInfo Information about the authenticated user, if there is one.
+ * @param appServiceAccount Service account email of the authenticated app, if there is one. This
+ *     will be logged upon successful login.
  */
-@AutoValue
-public abstract class AuthResult {
-
-  public abstract AuthLevel authLevel();
-
-  /** Information about the authenticated user, if there is one. */
-  public abstract Optional<UserAuthInfo> userAuthInfo();
-
-  /** Service account email of the authenticated app, if there is one. */
-  @SuppressWarnings("unused") // The service account will be logged upon successful login.
-  public abstract Optional<String> appServiceAccount();
+public record AuthResult(
+    AuthLevel authLevel, Optional<UserAuthInfo> userAuthInfo, Optional<String> appServiceAccount) {
 
   public boolean isAuthenticated() {
     return authLevel() != AuthLevel.NONE;
@@ -72,8 +66,7 @@ public abstract class AuthResult {
     checkArgument(
         authLevel != APP || email != null,
         "Service account email must be specified for auth level APP");
-    return new AutoValue_AuthResult(
-        authLevel, Optional.ofNullable(userAuthInfo), Optional.ofNullable(email));
+    return new AuthResult(authLevel, Optional.ofNullable(userAuthInfo), Optional.ofNullable(email));
   }
 
   /**

--- a/core/src/main/java/google/registry/request/auth/AuthSettings.java
+++ b/core/src/main/java/google/registry/request/auth/AuthSettings.java
@@ -14,7 +14,6 @@
 
 package google.registry.request.auth;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import google.registry.model.console.UserRoles;
@@ -26,18 +25,12 @@ import google.registry.model.console.UserRoles;
  * values.
  */
 @Immutable
-@AutoValue
-public abstract class AuthSettings {
-
-  public abstract ImmutableList<AuthMethod> methods();
-
-  public abstract AuthLevel minimumLevel();
-
-  public abstract UserPolicy userPolicy();
+public record AuthSettings(
+    ImmutableList<AuthMethod> methods, AuthLevel minimumLevel, UserPolicy userPolicy) {
 
   static AuthSettings create(
       ImmutableList<AuthMethod> methods, AuthLevel minimumLevel, UserPolicy userPolicy) {
-    return new AutoValue_AuthSettings(methods, minimumLevel, userPolicy);
+    return new AuthSettings(methods, minimumLevel, userPolicy);
   }
 
   /** Available methods for authentication. */

--- a/core/src/main/java/google/registry/request/auth/UserAuthInfo.java
+++ b/core/src/main/java/google/registry/request/auth/UserAuthInfo.java
@@ -15,26 +15,21 @@
 package google.registry.request.auth;
 
 import com.google.appengine.api.users.User;
-import com.google.auto.value.AutoValue;
 import java.util.Optional;
 
-/** Extra information provided by the authentication mechanism about the user. */
-@AutoValue
-public abstract class UserAuthInfo {
-
-  public abstract Optional<google.registry.model.console.User> consoleUser();
-
-  /** User object from the AppEngine Users API. */
-  public abstract Optional<User> appEngineUser();
-
-  /**
-   * Whether the user is an admin.
-   *
-   * <p>Note that, in App Engine parlance, an admin is any user who is a project owner, editor, OR
-   * viewer (as well as the specific role App Engine Admin). So even users with read-only access to
-   * the App Engine product qualify as an "admin".
-   */
-  public abstract boolean isUserAdmin();
+/**
+ * Extra information provided by the authentication mechanism about the user.
+ *
+ * @param appEngineUser User object from the AppEngine Users API.
+ * @param isUserAdmin Whether the user is an admin.
+ *     <p>Note that, in App Engine parlance, an admin is any user who is a project owner, editor, OR
+ *     viewer (as well as the specific role App Engine Admin). So even users with read-only access
+ *     to the App Engine product qualify as an "admin".
+ */
+public record UserAuthInfo(
+    Optional<google.registry.model.console.User> consoleUser,
+    Optional<User> appEngineUser,
+    boolean isUserAdmin) {
 
   public String getEmailAddress() {
     return appEngineUser()
@@ -49,11 +44,10 @@ public abstract class UserAuthInfo {
   }
 
   public static UserAuthInfo create(User user, boolean isUserAdmin) {
-    return new AutoValue_UserAuthInfo(Optional.empty(), Optional.of(user), isUserAdmin);
+    return new UserAuthInfo(Optional.empty(), Optional.of(user), isUserAdmin);
   }
 
   public static UserAuthInfo create(google.registry.model.console.User user) {
-    return new AutoValue_UserAuthInfo(
-        Optional.of(user), Optional.empty(), user.getUserRoles().isAdmin());
+    return new UserAuthInfo(Optional.of(user), Optional.empty(), user.getUserRoles().isAdmin());
   }
 }

--- a/core/src/main/java/google/registry/tools/DsRecord.java
+++ b/core/src/main/java/google/registry/tools/DsRecord.java
@@ -19,7 +19,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static google.registry.util.PreconditionsUtils.checkArgumentPresent;
 
 import com.beust.jcommander.IStringConverter;
-import com.google.auto.value.AutoValue;
 import com.google.common.base.Ascii;
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Splitter;
@@ -29,17 +28,9 @@ import com.google.template.soy.data.SoyMapData;
 import google.registry.flows.domain.DomainFlowUtils;
 import java.util.List;
 
-@AutoValue
-abstract class DsRecord {
+record DsRecord(int keyTag, int alg, int digestType, String digest) {
+
   private static final Splitter SPLITTER = Splitter.on(CharMatcher.whitespace()).omitEmptyStrings();
-
-  public abstract int keyTag();
-
-  public abstract int alg();
-
-  public abstract int digestType();
-
-  public abstract String digest();
 
   private static DsRecord create(int keyTag, int alg, int digestType, String digest) {
     digest = Ascii.toUpperCase(digest);
@@ -62,7 +53,7 @@ abstract class DsRecord {
           String.format("DS record uses an unrecognized algorithm: %d", alg));
     }
 
-    return new AutoValue_DsRecord(keyTag, alg, digestType, digest);
+    return new DsRecord(keyTag, alg, digestType, digest);
   }
 
   /**

--- a/core/src/main/java/google/registry/ui/server/registrar/ConsoleApiParams.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/ConsoleApiParams.java
@@ -14,28 +14,22 @@
 
 package google.registry.ui.server.registrar;
 
-import com.google.auto.value.AutoValue;
 import google.registry.request.Response;
 import google.registry.request.auth.AuthResult;
 import google.registry.security.XsrfTokenManager;
 import jakarta.servlet.http.HttpServletRequest;
 
 /** Groups necessary dependencies for Console API actions * */
-@AutoValue
-public abstract class ConsoleApiParams {
+public record ConsoleApiParams(
+    HttpServletRequest request,
+    Response response,
+    AuthResult authResult,
+    XsrfTokenManager xsrfTokenManager) {
   public static ConsoleApiParams create(
       HttpServletRequest request,
       Response response,
       AuthResult authResult,
       XsrfTokenManager xsrfTokenManager) {
-    return new AutoValue_ConsoleApiParams(request, response, authResult, xsrfTokenManager);
+    return new ConsoleApiParams(request, response, authResult, xsrfTokenManager);
   }
-
-  public abstract HttpServletRequest request();
-
-  public abstract Response response();
-
-  public abstract AuthResult authResult();
-
-  public abstract XsrfTokenManager xsrfTokenManager();
 }

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
@@ -24,7 +24,6 @@ import static google.registry.security.JsonResponseHelper.Status.SUCCESS;
 import static google.registry.util.PreconditionsUtils.checkArgumentPresent;
 import static google.registry.util.RegistryEnvironment.PRODUCTION;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.base.Ascii;
 import com.google.common.base.Strings;
 import com.google.common.collect.HashMultimap;
@@ -180,38 +179,29 @@ public class RegistrarSettingsAction implements Runnable, JsonActionRunner.JsonA
     }
   }
 
-  @AutoValue
-  abstract static class RegistrarResult {
-    abstract String message();
-
-    abstract Registrar registrar();
+  record RegistrarResult(String message, Registrar registrar) {
 
     Map<String, Object> toJsonResponse() {
       return JsonResponseHelper.create(SUCCESS, message(), registrar().toJsonMap());
     }
 
     static RegistrarResult create(String message, Registrar registrar) {
-      return new AutoValue_RegistrarSettingsAction_RegistrarResult(message, registrar);
+      return new RegistrarResult(message, registrar);
     }
   }
 
-  @AutoValue
-  abstract static class EmailInfo {
-    abstract Registrar registrar();
-
-    abstract Registrar updatedRegistrar();
-
-    abstract ImmutableSet<RegistrarPoc> contacts();
-
-    abstract ImmutableSet<RegistrarPoc> updatedContacts();
+  record EmailInfo(
+      Registrar registrar,
+      Registrar updatedRegistrar,
+      ImmutableSet<RegistrarPoc> contacts,
+      ImmutableSet<RegistrarPoc> updatedContacts) {
 
     static EmailInfo create(
         Registrar registrar,
         Registrar updatedRegistrar,
         ImmutableSet<RegistrarPoc> contacts,
         ImmutableSet<RegistrarPoc> updatedContacts) {
-      return new AutoValue_RegistrarSettingsAction_EmailInfo(
-          registrar, updatedRegistrar, contacts, updatedContacts);
+      return new EmailInfo(registrar, updatedRegistrar, contacts, updatedContacts);
     }
   }
 

--- a/core/src/main/java/google/registry/whois/DomainLookupCommand.java
+++ b/core/src/main/java/google/registry/whois/DomainLookupCommand.java
@@ -23,7 +23,6 @@ import static google.registry.model.tld.Tlds.getTlds;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Verify;
 import com.google.common.net.InternetDomainName;
@@ -100,12 +99,8 @@ public class DomainLookupCommand implements WhoisCommand {
         domain -> new DomainWhoisResponse(domain, fullOutput, whoisRedactedEmailText, now));
   }
 
-  @AutoValue
-  abstract static class ResponseOrException {
-
-    abstract Optional<WhoisResponse> whoisResponse();
-
-    abstract Optional<WhoisException> exception();
+  record ResponseOrException(
+      Optional<WhoisResponse> whoisResponse, Optional<WhoisException> exception) {
 
     WhoisResponse returnOrThrow() throws WhoisException {
       Verify.verify(
@@ -115,13 +110,11 @@ public class DomainLookupCommand implements WhoisCommand {
     }
 
     static ResponseOrException of(WhoisResponse response) {
-      return new AutoValue_DomainLookupCommand_ResponseOrException(
-          Optional.of(response), Optional.empty());
+      return new ResponseOrException(Optional.of(response), Optional.empty());
     }
 
     static ResponseOrException of(WhoisException exception) {
-      return new AutoValue_DomainLookupCommand_ResponseOrException(
-          Optional.empty(), Optional.of(exception));
+      return new ResponseOrException(Optional.empty(), Optional.of(exception));
     }
   }
 }

--- a/core/src/main/java/google/registry/whois/WhoisMetrics.java
+++ b/core/src/main/java/google/registry/whois/WhoisMetrics.java
@@ -17,7 +17,7 @@ package google.registry.whois;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.monitoring.metrics.EventMetric.DEFAULT_FITTER;
 
-import com.google.auto.value.AutoValue;
+import com.google.auto.value.AutoBuilder;
 import com.google.common.collect.ImmutableSet;
 import com.google.monitoring.metrics.EventMetric;
 import com.google.monitoring.metrics.IncrementableMetric;
@@ -73,18 +73,12 @@ public class WhoisMetrics {
   }
 
   /** A value class for recording attributes of a WHOIS metric. */
-  @AutoValue
-  public abstract static class WhoisMetric {
-
-    public abstract Optional<String> commandName();
-
-    public abstract int numResults();
-
-    public abstract int status();
-
-    public abstract DateTime startTimestamp();
-
-    public abstract DateTime endTimestamp();
+  public record WhoisMetric(
+      Optional<String> commandName,
+      int numResults,
+      int status,
+      DateTime startTimestamp,
+      DateTime endTimestamp) {
 
     /**
      * Create a {@link WhoisMetric.Builder} for a request context, with the start and end timestamps
@@ -98,11 +92,11 @@ public class WhoisMetrics {
 
     /** Create a {@link WhoisMetric.Builder}. */
     public static Builder builder() {
-      return new AutoValue_WhoisMetrics_WhoisMetric.Builder();
+      return new AutoBuilder_WhoisMetrics_WhoisMetric_Builder();
     }
 
     /** A builder to create instances of {@link WhoisMetric}. */
-    @AutoValue.Builder
+    @AutoBuilder
     public abstract static class Builder {
 
       boolean wasBuilt = false;

--- a/core/src/main/java/google/registry/whois/WhoisResponse.java
+++ b/core/src/main/java/google/registry/whois/WhoisResponse.java
@@ -14,7 +14,6 @@
 
 package google.registry.whois;
 
-import com.google.auto.value.AutoValue;
 import org.joda.time.DateTime;
 
 /** Representation of a WHOIS query response. */
@@ -36,13 +35,10 @@ public interface WhoisResponse {
   DateTime getTimestamp();
 
   /** A wrapper class for the plaintext response of a WHOIS command and its number of results. */
-  @AutoValue
-  abstract class WhoisResponseResults {
-    public abstract String plainTextOutput();
-    public abstract int numResults();
+  record WhoisResponseResults(String plainTextOutput, int numResults) {
 
     static WhoisResponseResults create(String plainTextOutput, int numResults) {
-      return new AutoValue_WhoisResponse_WhoisResponseResults(plainTextOutput, numResults);
+      return new WhoisResponseResults(plainTextOutput, numResults);
     }
   }
 }

--- a/core/src/test/java/google/registry/privileges/secretmanager/FakeSecretManagerClient.java
+++ b/core/src/test/java/google/registry/privileges/secretmanager/FakeSecretManagerClient.java
@@ -200,7 +200,8 @@ public class FakeSecretManagerClient implements SecretManagerClient {
     Iterable<SecretVersionState> listVersions() {
       ImmutableList.Builder<SecretVersionState> builder = new ImmutableList.Builder<>();
       for (int i = 0; i < versions.size(); i++) {
-        builder.add(SecretVersionState.of(secretId, String.valueOf(i), versions.get(i).getState()));
+        builder.add(
+            SecretVersionState.create(secretId, String.valueOf(i), versions.get(i).getState()));
       }
       return builder.build();
     }

--- a/core/src/test/java/google/registry/privileges/secretmanager/SqlCredentialTest.java
+++ b/core/src/test/java/google/registry/privileges/secretmanager/SqlCredentialTest.java
@@ -1,4 +1,4 @@
-// Copyright 2017 The Nomulus Authors. All Rights Reserved.
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package google.registry.server;
+package google.registry.privileges.secretmanager;
 
-import jakarta.servlet.http.HttpServlet;
+import static com.google.common.truth.Truth.assertThat;
 
-/** Pair of servlet path and servlet instance object. */
-public record Route(String path, Class<? extends HttpServlet> servletClass) {
+import org.junit.jupiter.api.Test;
 
-  /** Creates a new route mapping between a path (may have wildcards) and a servlet. */
-  public static Route route(String path, Class<? extends HttpServlet> servletClass) {
-    return new Route(path, servletClass);
+/** Unit tests for {@link SqlCredential}. */
+public class SqlCredentialTest {
+
+  @Test
+  void secrets_arentWrittenOutByToString() {
+    SqlCredential cred = SqlCredential.create("joshua", "rosebud");
+    String credStr = cred.toString();
+    assertThat(credStr).doesNotContain("joshua");
+    assertThat(credStr).doesNotContain("rosebud");
   }
 }

--- a/core/src/test/java/google/registry/testing/TestDataHelper.java
+++ b/core/src/test/java/google/registry/testing/TestDataHelper.java
@@ -21,7 +21,6 @@ import static google.registry.util.CollectionUtils.nullToEmpty;
 import static google.registry.util.ResourceUtils.readResourceBytes;
 import static google.registry.util.ResourceUtils.readResourceUtf8;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSource;
 import com.google.common.io.MoreFiles;
@@ -40,14 +39,9 @@ import javax.annotation.Nullable;
 /** Contains helper methods for dealing with test data. */
 public final class TestDataHelper {
 
-  @AutoValue
-  abstract static class FileKey {
-    abstract Class<?> context();
-
-    abstract String filename();
-
+  record FileKey(Class<?> context, String filename) {
     static FileKey create(Class<?> context, String filename) {
-      return new AutoValue_TestDataHelper_FileKey(context, filename);
+      return new FileKey(context, filename);
     }
   }
 

--- a/core/src/test/java/google/registry/testing/UserInfo.java
+++ b/core/src/test/java/google/registry/testing/UserInfo.java
@@ -14,35 +14,25 @@
 
 package google.registry.testing;
 
-import com.google.auto.value.AutoValue;
-
 /**
  * Container for values passed to {@link UserServiceExtension} to set the logged-in user for tests.
  */
-@AutoValue
-public abstract class UserInfo {
-
-  abstract String email();
-  abstract String authDomain();
-  abstract boolean isAdmin();
-  abstract boolean isLoggedIn();
+public record UserInfo(String email, String authDomain, boolean isAdmin, boolean isLoggedIn) {
 
   /** Creates a new logged-in non-admin user instance. */
   public static UserInfo create(String email) {
     String authDomain = email.substring(email.indexOf('@') + 1);
-    return new AutoValue_UserInfo(email, authDomain, false, true);
+    return new UserInfo(email, authDomain, false, true);
   }
 
   /** Creates a new logged-in admin user instance. */
   public static UserInfo createAdmin(String email) {
     String authDomain = email.substring(email.indexOf('@') + 1);
-    return new AutoValue_UserInfo(email, authDomain, true, true);
+    return new UserInfo(email, authDomain, true, true);
   }
 
   /** Returns a logged-out user instance. */
   public static UserInfo loggedOut() {
-    return new AutoValue_UserInfo("", "", false, false);
+    return new UserInfo("", "", false, false);
   }
-
-  UserInfo() {}
 }

--- a/core/src/test/java/google/registry/webdriver/WebDriverScreenDiffer.java
+++ b/core/src/test/java/google/registry/webdriver/WebDriverScreenDiffer.java
@@ -18,7 +18,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Math.abs;
 import static java.util.stream.Collectors.joining;
 
-import com.google.auto.value.AutoValue;
+import com.google.auto.value.AutoBuilder;
 import com.google.common.collect.Lists;
 import com.google.common.flogger.FluentLogger;
 import java.awt.Color;
@@ -59,35 +59,30 @@ class WebDriverScreenDiffer implements ScreenDiffer {
     this.actualScreenshots = Lists.newArrayList();
   }
 
-  @AutoValue
-  abstract static class ComparisonResult {
-    abstract ActualScreenshot actualScreenshot();
-
-    abstract boolean isConsideredSimilar();
-
-    abstract boolean isMissingGoldenImage();
-
-    abstract boolean isSizeDifferent();
-
-    abstract int numDiffPixels();
+  record ComparisonResult(
+      ActualScreenshot actualScreenshot,
+      boolean isConsideredSimilar,
+      boolean isMissingGoldenImage,
+      boolean isSizeDifferent,
+      int numDiffPixels) {
 
     static Builder builder() {
-      return new AutoValue_WebDriverScreenDiffer_ComparisonResult.Builder();
+      return new AutoBuilder_WebDriverScreenDiffer_ComparisonResult_Builder();
     }
 
-    @AutoValue.Builder
-    abstract static class Builder {
-      abstract Builder setActualScreenshot(ActualScreenshot actualScreenshot);
+    @AutoBuilder
+    interface Builder {
+      Builder setActualScreenshot(ActualScreenshot actualScreenshot);
 
-      abstract Builder setIsConsideredSimilar(boolean isConsideredSimilar);
+      Builder setIsConsideredSimilar(boolean isConsideredSimilar);
 
-      abstract Builder setIsMissingGoldenImage(boolean isMissingGoldenImage);
+      Builder setIsMissingGoldenImage(boolean isMissingGoldenImage);
 
-      abstract Builder setIsSizeDifferent(boolean isSizeDifferent);
+      Builder setIsSizeDifferent(boolean isSizeDifferent);
 
-      abstract Builder setNumDiffPixels(int numDiffPixels);
+      Builder setNumDiffPixels(int numDiffPixels);
 
-      abstract ComparisonResult build();
+      ComparisonResult build();
     }
   }
 

--- a/prober/src/main/java/google/registry/monitoring/blackbox/ProbingStep.java
+++ b/prober/src/main/java/google/registry/monitoring/blackbox/ProbingStep.java
@@ -14,6 +14,7 @@
 
 package google.registry.monitoring.blackbox;
 
+import com.google.auto.value.AutoBuilder;
 import com.google.auto.value.AutoValue;
 import google.registry.monitoring.blackbox.connection.ProbingAction;
 import google.registry.monitoring.blackbox.connection.Protocol;
@@ -31,30 +32,23 @@ import org.joda.time.Duration;
  * {@link OutboundMessageType}, {@link Protocol}, {@link Duration}, and {@link Bootstrap} instances.
  * It then modifies these components on each loop iteration with the consumed {@link Token} and from
  * that, generates a new {@link ProbingAction} to call.
+ *
+ * @param duration Time delay duration between actions.
+ * @param protocol {@link Protocol} type for this step.
+ * @param messageTemplate {@link OutboundMessageType} instance that serves as template to be
+ *     modified by {@link Token}.
+ * @param bootstrap {@link Bootstrap} instance provided by parent {@link ProbingSequence} that
+ *     allows for creation of new channels.
  */
-@AutoValue
-public abstract class ProbingStep {
+public record ProbingStep(
+    Duration duration,
+    Protocol protocol,
+    OutboundMessageType messageTemplate,
+    Bootstrap bootstrap) {
 
   public static Builder builder() {
-    return new AutoValue_ProbingStep.Builder();
+    return new AutoBuilder_ProbingStep_Builder();
   }
-
-  /** Time delay duration between actions. */
-  abstract Duration duration();
-
-  /** {@link Protocol} type for this step. */
-  abstract Protocol protocol();
-
-  /**
-   * {@link OutboundMessageType} instance that serves as template to be modified by {@link Token}.
-   */
-  abstract OutboundMessageType messageTemplate();
-
-  /**
-   * {@link Bootstrap} instance provided by parent {@link ProbingSequence} that allows for creation
-   * of new channels.
-   */
-  abstract Bootstrap bootstrap();
 
   /**
    * Generates a new {@link ProbingAction} from {@code token} modified {@link OutboundMessageType}
@@ -84,18 +78,18 @@ public abstract class ProbingStep {
         protocol(), messageTemplate().getClass().getName());
   }
 
-  /** Standard {@link AutoValue.Builder} for {@link ProbingStep}. */
-  @AutoValue.Builder
-  public abstract static class Builder {
+  /** Builder for {@link ProbingStep}. */
+  @AutoBuilder
+  public interface Builder {
 
-    public abstract Builder setDuration(Duration value);
+    Builder setDuration(Duration value);
 
-    public abstract Builder setProtocol(Protocol value);
+    Builder setProtocol(Protocol value);
 
-    public abstract Builder setMessageTemplate(OutboundMessageType value);
+    Builder setMessageTemplate(OutboundMessageType value);
 
-    public abstract Builder setBootstrap(Bootstrap value);
+    Builder setBootstrap(Bootstrap value);
 
-    public abstract ProbingStep build();
+    ProbingStep build();
   }
 }

--- a/proxy/src/main/java/google/registry/proxy/quota/TokenStore.java
+++ b/proxy/src/main/java/google/registry/proxy/quota/TokenStore.java
@@ -18,7 +18,6 @@ import static google.registry.proxy.quota.QuotaConfig.SENTINEL_UNLIMITED_TOKENS;
 import static java.lang.StrictMath.max;
 import static java.lang.StrictMath.min;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.flogger.FluentLogger;
 import google.registry.util.Clock;
@@ -49,16 +48,11 @@ import org.joda.time.Duration;
 public class TokenStore {
 
   /** Value class representing a timestamped integer. */
-  @AutoValue
-  abstract static class TimestampedInteger {
+  record TimestampedInteger(int value, DateTime timestamp) {
 
     static TimestampedInteger create(int value, DateTime timestamp) {
-      return new AutoValue_TokenStore_TimestampedInteger(value, timestamp);
+      return new TimestampedInteger(value, timestamp);
     }
-
-    abstract int value();
-
-    abstract DateTime timestamp();
   }
 
   /**

--- a/util/src/main/java/google/registry/util/EmailMessage.java
+++ b/util/src/main/java/google/registry/util/EmailMessage.java
@@ -14,7 +14,7 @@
 
 package google.registry.util;
 
-import com.google.auto.value.AutoValue;
+import com.google.auto.value.AutoBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.MediaType;
@@ -23,16 +23,25 @@ import java.util.Optional;
 import javax.mail.internet.InternetAddress;
 
 /**
- * Value class representing the content and metadata of an email.
+ * Record representing the content and metadata of an email.
  *
  * <p>The sender address and display name are set by the email client and are not customizable by
  * the user.
+ *
+ * @param replyToEmailAddress Optional return email address that overrides the default.
  */
-@AutoValue
-public abstract class EmailMessage {
+public record EmailMessage(
+    String subject,
+    String body,
+    ImmutableSet<InternetAddress> recipients,
+    Optional<InternetAddress> replyToEmailAddress,
+    ImmutableSet<InternetAddress> ccs,
+    ImmutableSet<InternetAddress> bccs,
+    Optional<MediaType> contentType,
+    Optional<Attachment> attachment) {
 
   public static Builder newBuilder() {
-    return new AutoValue_EmailMessage.Builder();
+    return new AutoBuilder_EmailMessage_Builder();
   }
 
   public static EmailMessage create(String subject, String body, InternetAddress recipient) {
@@ -43,92 +52,68 @@ public abstract class EmailMessage {
         .build();
   }
 
-  public abstract String subject();
-
-  public abstract String body();
-
-  public abstract ImmutableSet<InternetAddress> recipients();
-
-  /** Optional return email address that overrides the default. */
-  public abstract Optional<InternetAddress> replyToEmailAddress();
-
-  public abstract ImmutableSet<InternetAddress> ccs();
-
-  public abstract ImmutableSet<InternetAddress> bccs();
-
-  public abstract Optional<MediaType> contentType();
-
-  public abstract Optional<Attachment> attachment();
-
   /** Builder for {@link EmailMessage}. */
-  @AutoValue.Builder
-  public abstract static class Builder {
+  @AutoBuilder
+  public interface Builder {
 
-    public abstract Builder setSubject(String subject);
+    Builder setSubject(String subject);
 
-    public abstract Builder setBody(String body);
+    Builder setBody(String body);
 
-    public abstract Builder setRecipients(Collection<InternetAddress> recipients);
+    Builder setRecipients(Collection<InternetAddress> recipients);
 
-    public abstract Builder setReplyToEmailAddress(InternetAddress replyToEmailAddress);
+    Builder setReplyToEmailAddress(InternetAddress replyToEmailAddress);
 
-    public abstract Builder setReplyToEmailAddress(Optional<InternetAddress> replyToEmailAddress);
+    Builder setReplyToEmailAddress(Optional<InternetAddress> replyToEmailAddress);
 
-    public abstract Builder setBccs(Collection<InternetAddress> bccs);
+    Builder setBccs(Collection<InternetAddress> bccs);
 
-    public abstract Builder setCcs(Collection<InternetAddress> ccs);
+    Builder setCcs(Collection<InternetAddress> ccs);
 
-    public abstract Builder setContentType(MediaType contentType);
+    Builder setContentType(MediaType contentType);
 
-    public abstract Builder setAttachment(Attachment attachment);
+    Builder setAttachment(Attachment attachment);
 
-    abstract ImmutableSet.Builder<InternetAddress> recipientsBuilder();
+    ImmutableSet.Builder<InternetAddress> recipientsBuilder();
 
-    abstract ImmutableSet.Builder<InternetAddress> bccsBuilder();
+    ImmutableSet.Builder<InternetAddress> bccsBuilder();
 
-    abstract ImmutableSet.Builder<InternetAddress> ccsBuilder();
+    ImmutableSet.Builder<InternetAddress> ccsBuilder();
 
-    public Builder addRecipient(InternetAddress value) {
+    default Builder addRecipient(InternetAddress value) {
       recipientsBuilder().add(value);
       return this;
     }
 
-    public Builder addBcc(InternetAddress bcc) {
+    default Builder addBcc(InternetAddress bcc) {
       bccsBuilder().add(bcc);
       return this;
     }
 
-    public Builder addCc(InternetAddress cc) {
+    default Builder addCc(InternetAddress cc) {
       ccsBuilder().add(cc);
       return this;
     }
 
-    public abstract EmailMessage build();
+    EmailMessage build();
   }
 
   /** An attachment to the email, if one exists. */
-  @AutoValue
-  public abstract static class Attachment {
+  public record Attachment(MediaType contentType, String filename, String content) {
     public static Builder newBuilder() {
-      return new AutoValue_EmailMessage_Attachment.Builder();
+      return new AutoBuilder_EmailMessage_Attachment_Builder();
     }
 
-    public abstract MediaType contentType();
-
-    public abstract String filename();
-
-    public abstract String content();
-
     /** Builder for {@link Attachment}. */
-    @AutoValue.Builder
-    public abstract static class Builder {
-      public abstract Builder setContentType(MediaType contentType);
+    @AutoBuilder
+    public interface Builder {
+      Builder setContentType(MediaType contentType);
 
-      public abstract Builder setFilename(String filename);
+      Builder setFilename(String filename);
 
-      public abstract Builder setContent(String content);
+      Builder setContent(String content);
 
-      public abstract Attachment build();
+      Attachment build();
     }
   }
 }

--- a/util/src/test/java/google/registry/util/EmailMessageTest.java
+++ b/util/src/test/java/google/registry/util/EmailMessageTest.java
@@ -1,0 +1,38 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import javax.mail.internet.InternetAddress;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link EmailMessage} record. */
+public class EmailMessageTest {
+
+  @Test
+  void testBuilderAddMethods_successfullyAddEverything() throws Exception {
+    EmailMessage em =
+        EmailMessage.newBuilder()
+            .setSubject("Foo")
+            .setBody("We have been trying to reach you about your vehicle's extended warranty.")
+            .addCc(new InternetAddress("foo@bar.baz"))
+            .addCc(new InternetAddress("jimbob@jimbo.google"))
+            .build();
+    assertThat(em.ccs())
+        .containsExactly(
+            new InternetAddress("foo@bar.baz"), new InternetAddress("jimbob@jimbo.google"));
+  }
+}


### PR DESCRIPTION
I think this is all the last low-hanging fruit.  All the remaining `@AutoValue`s are pretty complicated, using a lot of inheritance for behavior, that isn't really suitable for replacing with Java `record`s.  So we could either leave them as is, or remove `@AutoValue` and just have them be Javabeans/POJOs, but for now I'm touching them.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2412)
<!-- Reviewable:end -->
