### PR TITLE
Avoid contention over the RefreshDnsRequest table

### DIFF
--- a/core/src/main/java/google/registry/dns/DnsUtils.java
+++ b/core/src/main/java/google/registry/dns/DnsUtils.java
@@ -14,7 +14,6 @@
 
 package google.registry.dns;
 
-import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static google.registry.persistence.PersistenceModule.TransactionIsolationLevel.TRANSACTION_REPEATABLE_READ;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
@@ -100,8 +99,6 @@ public final class DnsUtils {
    */
   public static ImmutableList<DnsRefreshRequest> readAndUpdateRequestsWithLatestProcessTime(
       String tld, Duration cooldown, int batchSize) {
-    // Give a user-friendly error message. If nested, the `transact` call below will throw.
-    verify(!tm().inTransaction(), "Cannot specify isolation level in nested transaction.");
     // It is critical that below query use repeatable-read. See b/337894387.
     return tm().transact(
             TRANSACTION_REPEATABLE_READ,
@@ -137,7 +134,7 @@ public final class DnsUtils {
    * error because all we care about is that it no longer exists after the method runs.
    */
   public static void deleteRequests(Collection<DnsRefreshRequest> requests) {
-    verify(!tm().inTransaction(), "Cannot specify isolation level in nested transaction.");
+    // It is critical that below query use repeatable-read. See b/337894387.
     tm().transact(
             TRANSACTION_REPEATABLE_READ,
             () ->


### PR DESCRIPTION
This table can be small at times, when PSQL may use table scan in queries by keys. At the SERIALIZABLE isolation level, updates to unrelated rows may conflict due to this `optimization`.

Lower the isolation level to repeatable read.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2428)
<!-- Reviewable:end -->
