### PR TITLE
Refactor some registry lock verification code

### DIFF
--- a/core/src/main/java/google/registry/ui/server/console/ConsoleRegistryLockAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleRegistryLockAction.java
@@ -194,7 +194,6 @@ public class ConsoleRegistryLockAction extends ConsoleApiAction {
               // TODO: replace this with the PATH in ConsoleRegistryLockVerifyAction once it exists
               .setPath("/console-api/registry-lock-verify")
               .setParameter("lockVerificationCode", lock.getVerificationCode())
-              .setParameter("isLock", String.valueOf(isLock))
               .build()
               .toString();
       String body = String.format(VERIFICATION_EMAIL_TEMPLATE, lock.getDomainName(), url);

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistryLockPostAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistryLockPostAction.java
@@ -160,7 +160,6 @@ public class RegistryLockPostAction implements Runnable, JsonActionRunner.JsonAc
               .setHost(req.getServerName())
               .setPath("registry-lock-verify")
               .setParameter("lockVerificationCode", lock.getVerificationCode())
-              .setParameter("isLock", String.valueOf(isLock))
               .build()
               .toString();
       String body = String.format(VERIFICATION_EMAIL_TEMPLATE, lock.getDomainName(), url);

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistryLockVerifyAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistryLockVerifyAction.java
@@ -50,29 +50,22 @@ public final class RegistryLockVerifyAction extends HtmlAction {
 
   private final DomainLockUtils domainLockUtils;
   private final String lockVerificationCode;
-  private final Boolean isLock;
 
   @Inject
   public RegistryLockVerifyAction(
       DomainLockUtils domainLockUtils,
-      @Parameter("lockVerificationCode") String lockVerificationCode,
-      @Parameter("isLock") Boolean isLock) {
+      @Parameter("lockVerificationCode") String lockVerificationCode) {
     this.domainLockUtils = domainLockUtils;
     this.lockVerificationCode = lockVerificationCode;
-    this.isLock = isLock;
   }
 
   @Override
   public void runAfterLogin(Map<String, Object> data) {
     try {
       boolean isAdmin = authResult.userAuthInfo().get().isUserAdmin();
-      final RegistryLock resultLock;
-      if (isLock) {
-        resultLock = domainLockUtils.verifyAndApplyLock(lockVerificationCode, isAdmin);
-      } else {
-        resultLock = domainLockUtils.verifyAndApplyUnlock(lockVerificationCode, isAdmin);
-      }
-      data.put("isLock", isLock);
+      RegistryLock resultLock =
+          domainLockUtils.verifyVerificationCode(lockVerificationCode, isAdmin);
+      data.put("isLock", resultLock.getUnlockCompletionTime().isEmpty());
       data.put("success", true);
       data.put("domainName", resultLock.getDomainName());
     } catch (Throwable t) {

--- a/core/src/test/java/google/registry/tools/DomainLockUtilsTest.java
+++ b/core/src/test/java/google/registry/tools/DomainLockUtilsTest.java
@@ -124,7 +124,7 @@ public final class DomainLockUtilsTest {
     clock.advanceBy(standardDays(1));
     RegistryLock lock =
         domainLockUtils.saveNewRegistryLockRequest(DOMAIN_NAME, "TheRegistrar", POC_ID, false);
-    domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), false);
+    domainLockUtils.verifyVerificationCode(lock.getVerificationCode(), false);
     verifyProperlyLockedDomain(false);
   }
 
@@ -137,7 +137,7 @@ public final class DomainLockUtilsTest {
     RegistryLock unlockRequest =
         domainLockUtils.saveNewRegistryUnlockRequest(
             DOMAIN_NAME, "TheRegistrar", false, Optional.empty());
-    domainLockUtils.verifyAndApplyUnlock(unlockRequest.getVerificationCode(), false);
+    domainLockUtils.verifyVerificationCode(unlockRequest.getVerificationCode(), false);
     assertThat(loadByEntity(domain).getStatusValues()).containsNoneIn(REGISTRY_LOCK_STATUSES);
   }
 
@@ -145,7 +145,7 @@ public final class DomainLockUtilsTest {
   void testSuccess_applyLockDomain() {
     RegistryLock lock =
         domainLockUtils.saveNewRegistryLockRequest(DOMAIN_NAME, "TheRegistrar", POC_ID, false);
-    domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), false);
+    domainLockUtils.verifyVerificationCode(lock.getVerificationCode(), false);
     verifyProperlyLockedDomain(false);
   }
 
@@ -155,7 +155,7 @@ public final class DomainLockUtilsTest {
     RegistryLock unlock =
         domainLockUtils.saveNewRegistryUnlockRequest(
             DOMAIN_NAME, "TheRegistrar", false, Optional.empty());
-    domainLockUtils.verifyAndApplyUnlock(unlock.getVerificationCode(), false);
+    domainLockUtils.verifyVerificationCode(unlock.getVerificationCode(), false);
     verifyProperlyUnlockedDomain(false);
   }
 
@@ -163,7 +163,7 @@ public final class DomainLockUtilsTest {
   void testSuccess_applyAdminLock_onlyHistoryEntry() {
     RegistryLock lock =
         domainLockUtils.saveNewRegistryLockRequest(DOMAIN_NAME, "TheRegistrar", null, true);
-    domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), true);
+    domainLockUtils.verifyVerificationCode(lock.getVerificationCode(), true);
     verifyProperlyLockedDomain(true);
   }
 
@@ -171,11 +171,11 @@ public final class DomainLockUtilsTest {
   void testSuccess_applyAdminUnlock_onlyHistoryEntry() {
     RegistryLock lock =
         domainLockUtils.saveNewRegistryLockRequest(DOMAIN_NAME, "TheRegistrar", null, true);
-    domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), true);
+    domainLockUtils.verifyVerificationCode(lock.getVerificationCode(), true);
     RegistryLock unlock =
         domainLockUtils.saveNewRegistryUnlockRequest(
             DOMAIN_NAME, "TheRegistrar", true, Optional.empty());
-    domainLockUtils.verifyAndApplyUnlock(unlock.getVerificationCode(), true);
+    domainLockUtils.verifyVerificationCode(unlock.getVerificationCode(), true);
     verifyProperlyUnlockedDomain(true);
   }
 
@@ -196,7 +196,7 @@ public final class DomainLockUtilsTest {
   void testSuccess_administrativelyUnlock_nonAdmin() {
     RegistryLock lock =
         domainLockUtils.saveNewRegistryLockRequest(DOMAIN_NAME, "TheRegistrar", POC_ID, false);
-    domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), false);
+    domainLockUtils.verifyVerificationCode(lock.getVerificationCode(), false);
     domainLockUtils.administrativelyApplyUnlock(
         DOMAIN_NAME, "TheRegistrar", false, Optional.empty());
     verifyProperlyUnlockedDomain(false);
@@ -206,7 +206,7 @@ public final class DomainLockUtilsTest {
   void testSuccess_administrativelyUnlock_admin() {
     RegistryLock lock =
         domainLockUtils.saveNewRegistryLockRequest(DOMAIN_NAME, "TheRegistrar", null, true);
-    domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), true);
+    domainLockUtils.verifyVerificationCode(lock.getVerificationCode(), true);
     domainLockUtils.administrativelyApplyUnlock(
         DOMAIN_NAME, "TheRegistrar", true, Optional.empty());
     verifyProperlyUnlockedDomain(true);
@@ -220,7 +220,7 @@ public final class DomainLockUtilsTest {
             DOMAIN_NAME, "TheRegistrar", false, Optional.empty());
     RegistryLock newLock =
         domainLockUtils.saveNewRegistryLockRequest(DOMAIN_NAME, "TheRegistrar", POC_ID, false);
-    newLock = domainLockUtils.verifyAndApplyLock(newLock.getVerificationCode(), false);
+    newLock = domainLockUtils.verifyVerificationCode(newLock.getVerificationCode(), false);
     assertThat(
             getRegistryLockByRevisionId(oldLock.getRevisionId()).get().getRelock().getRevisionId())
         .isEqualTo(newLock.getRevisionId());
@@ -254,7 +254,7 @@ public final class DomainLockUtilsTest {
     RegistryLock lock =
         domainLockUtils.saveNewRegistryUnlockRequest(
             DOMAIN_NAME, "TheRegistrar", false, Optional.of(standardHours(6)));
-    domainLockUtils.verifyAndApplyUnlock(lock.getVerificationCode(), false);
+    domainLockUtils.verifyVerificationCode(lock.getVerificationCode(), false);
     cloudTasksHelper.assertTasksEnqueued(
         QUEUE_ASYNC_ACTIONS,
         new TaskMatcher()
@@ -304,7 +304,7 @@ public final class DomainLockUtilsTest {
   void testFailure_createUnlock_alreadyPendingUnlock() {
     RegistryLock lock =
         domainLockUtils.saveNewRegistryLockRequest(DOMAIN_NAME, "TheRegistrar", POC_ID, false);
-    domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), false);
+    domainLockUtils.verifyVerificationCode(lock.getVerificationCode(), false);
     domainLockUtils.saveNewRegistryUnlockRequest(
         DOMAIN_NAME, "TheRegistrar", false, Optional.empty());
 
@@ -323,7 +323,7 @@ public final class DomainLockUtilsTest {
   void testFailure_createUnlock_nonAdminUnlockingAdmin() {
     RegistryLock lock =
         domainLockUtils.saveNewRegistryLockRequest(DOMAIN_NAME, "TheRegistrar", null, true);
-    domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), true);
+    domainLockUtils.verifyVerificationCode(lock.getVerificationCode(), true);
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,
@@ -387,13 +387,15 @@ public final class DomainLockUtilsTest {
   void testFailure_applyLock_alreadyApplied() {
     RegistryLock lock =
         domainLockUtils.saveNewRegistryLockRequest(DOMAIN_NAME, "TheRegistrar", POC_ID, false);
-    domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), false);
+    domainLockUtils.verifyVerificationCode(lock.getVerificationCode(), false);
     domain = loadByEntity(domain);
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), false));
-    assertThat(thrown).hasMessageThat().isEqualTo("Domain example.tld is already locked");
+            () -> domainLockUtils.verifyVerificationCode(lock.getVerificationCode(), false));
+    assertThat(thrown)
+        .hasMessageThat()
+        .isEqualTo("Lock/unlock with code 123456789ABCDEFGHJKLMNPQRSTUVWXY is already completed");
     assertNoDomainChanges();
   }
 
@@ -405,7 +407,7 @@ public final class DomainLockUtilsTest {
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), true));
+            () -> domainLockUtils.verifyVerificationCode(lock.getVerificationCode(), true));
     assertThat(thrown).hasMessageThat().isEqualTo("The pending lock has expired; please try again");
     assertNoDomainChanges();
   }
@@ -417,7 +419,7 @@ public final class DomainLockUtilsTest {
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), false));
+            () -> domainLockUtils.verifyVerificationCode(lock.getVerificationCode(), false));
     assertThat(thrown).hasMessageThat().isEqualTo("Non-admin user cannot complete admin lock");
     assertNoDomainChanges();
   }
@@ -426,17 +428,19 @@ public final class DomainLockUtilsTest {
   void testFailure_applyUnlock_alreadyUnlocked() {
     RegistryLock lock =
         domainLockUtils.saveNewRegistryLockRequest(DOMAIN_NAME, "TheRegistrar", POC_ID, false);
-    domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), false);
+    domainLockUtils.verifyVerificationCode(lock.getVerificationCode(), false);
     RegistryLock unlock =
         domainLockUtils.saveNewRegistryUnlockRequest(
             DOMAIN_NAME, "TheRegistrar", false, Optional.empty());
-    domainLockUtils.verifyAndApplyUnlock(unlock.getVerificationCode(), false);
+    domainLockUtils.verifyVerificationCode(unlock.getVerificationCode(), false);
 
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> domainLockUtils.verifyAndApplyUnlock(unlock.getVerificationCode(), false));
-    assertThat(thrown).hasMessageThat().isEqualTo("Domain example.tld is already unlocked");
+            () -> domainLockUtils.verifyVerificationCode(unlock.getVerificationCode(), false));
+    assertThat(thrown)
+        .hasMessageThat()
+        .isEqualTo("Lock/unlock with code Zabcdefghijkmnopqrstuvwxyz123456 is already completed");
     assertNoDomainChanges();
   }
 
@@ -451,7 +455,7 @@ public final class DomainLockUtilsTest {
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> domainLockUtils.verifyAndApplyLock(verificationCode, false));
+            () -> domainLockUtils.verifyVerificationCode(verificationCode, false));
     assertThat(thrown).hasMessageThat().isEqualTo("Domain example.tld is already locked");
 
     // Failure during the lock acquisition portion shouldn't affect the SQL object

--- a/core/src/test/java/google/registry/tools/UnlockDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UnlockDomainCommandTest.java
@@ -60,7 +60,7 @@ class UnlockDomainCommandTest extends CommandTestCase<UnlockDomainCommand> {
     Domain domain = persistResource(DatabaseHelper.newDomain(domainName));
     RegistryLock lock =
         command.domainLockUtils.saveNewRegistryLockRequest(domainName, registrarId, null, true);
-    command.domainLockUtils.verifyAndApplyLock(lock.getVerificationCode(), true);
+    command.domainLockUtils.verifyVerificationCode(lock.getVerificationCode(), true);
     return reloadResource(domain);
   }
 

--- a/core/src/test/java/google/registry/ui/server/console/ConsoleRegistryLockActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/ConsoleRegistryLockActionTest.java
@@ -73,11 +73,13 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class ConsoleRegistryLockActionTest {
 
-  private static final String EMAIL_MESSAGE_TEMPLATE =
-      "Please click the link below to perform the lock \\/ unlock action on domain example.test."
-          + " Note: this code will expire in one hour.\n\n"
-          + "https:\\/\\/registrarconsole.tld\\/console-api\\/registry-lock-verify\\?lockVerificationCode="
-          + "[0-9a-zA-Z_\\-]+&isLock=(true|false)";
+  private static final String EXPECTED_EMAIL_MESSAGE =
+      """
+      Please click the link below to perform the lock / unlock action on domain example.test. \
+      Note: this code will expire in one hour.
+
+      https://registrarconsole.tld/console-api/registry-lock-verify?lockVerificationCode=\
+      123456789ABCDEFGHJKLMNPQRSTUVWXY""";
 
   private static final Gson GSON = RequestModule.provideGson();
 
@@ -542,7 +544,7 @@ public class ConsoleRegistryLockActionTest {
     verify(gmailClient).sendEmail(emailCaptor.capture());
     EmailMessage sentMessage = emailCaptor.getValue();
     assertThat(sentMessage.subject()).matches("Registry (un)?lock verification");
-    assertThat(sentMessage.body()).matches(EMAIL_MESSAGE_TEMPLATE);
+    assertThat(sentMessage.body()).isEqualTo(EXPECTED_EMAIL_MESSAGE);
     assertThat(sentMessage.recipients())
         .containsExactly(new InternetAddress("registrylock@theregistrar.com"));
   }

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistryLockPostActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistryLockPostActionTest.java
@@ -77,11 +77,13 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 final class RegistryLockPostActionTest {
 
-  private static final String EMAIL_MESSAGE_TEMPLATE =
-      "Please click the link below to perform the lock \\/ unlock action on domain example.tld. "
-          + "Note: this code will expire in one hour.\n\n"
-          + "https:\\/\\/registrarconsole.tld\\/registry-lock-verify\\?lockVerificationCode="
-          + "[0-9a-zA-Z_\\-]+&isLock=(true|false)";
+  private static final String EXPECTED_EMAIL_MESSAGE =
+      """
+      Please click the link below to perform the lock / unlock action on domain example.tld. Note: \
+      this code will expire in one hour.
+
+      https://registrarconsole.tld/registry-lock-verify?lockVerificationCode=\
+      123456789ABCDEFGHJKLMNPQRSTUVWXY""";
 
   private final FakeClock clock = new FakeClock();
 
@@ -498,7 +500,7 @@ final class RegistryLockPostActionTest {
     verify(gmailClient).sendEmail(emailCaptor.capture());
     EmailMessage sentMessage = emailCaptor.getValue();
     assertThat(sentMessage.subject()).matches("Registry (un)?lock verification");
-    assertThat(sentMessage.body()).matches(EMAIL_MESSAGE_TEMPLATE);
+    assertThat(sentMessage.body()).isEqualTo(EXPECTED_EMAIL_MESSAGE);
     assertThat(sentMessage.recipients()).containsExactly(new InternetAddress(recipient));
   }
 


### PR DESCRIPTION
The user, on the front end, should not be required to provide whether or not they're trying to verify a lock or an unlock. They should only need the verification code. We can inspect the lock object itself (and the domain in question) to see whether or not we're verifying a lock or an unlock.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2434)
<!-- Reviewable:end -->
