### PR TITLE
Update jetty's console build path

### DIFF
--- a/jetty/build.gradle
+++ b/jetty/build.gradle
@@ -59,7 +59,7 @@ dependencies {
 }
 
 tasks.register('copyConsole', Copy) {
-    from("${rootDir}/console-webapp/dist/console-webapp") {
+    from("${rootDir}/console-webapp/staged/dist") {
         include "**/*"
     }
     into layout.buildDirectory.dir('jetty-base/webapps/console')


### PR DESCRIPTION
This is a follow up on a last comment in https://github.com/google/nomulus/pull/2433.


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2439)
<!-- Reviewable:end -->
