### PR TITLE
Refactor common exception handling in ConsoleApiAction

### DIFF
--- a/core/src/main/java/google/registry/ui/server/console/ConsoleDomainListAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleDomainListAction.java
@@ -14,6 +14,7 @@
 
 package google.registry.ui.server.console;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.model.console.ConsolePermission.DOWNLOAD_DOMAINS;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
@@ -82,22 +83,11 @@ public class ConsoleDomainListAction extends ConsoleApiAction {
 
   @Override
   protected void getHandler(User user) {
-    if (!user.getUserRoles().hasPermission(registrarId, DOWNLOAD_DOMAINS)) {
-      consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_FORBIDDEN);
-      return;
-    }
-    if (resultsPerPage < 1 || resultsPerPage > 500) {
-      setFailedResponse(
-          "Results per page must be between 1 and 500 inclusive",
-          HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
-      return;
-    }
-    if (pageNumber < 0) {
-      setFailedResponse(
-          "Page number must be non-negative", HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
-      return;
-    }
-
+    checkPermission(user, registrarId, DOWNLOAD_DOMAINS);
+    checkArgument(
+        resultsPerPage > 0 && resultsPerPage <= 500,
+        "Results per page must be between 1 and 500 inclusive");
+    checkArgument(pageNumber >= 0, "Page number must be non-negative");
     tm().transact(this::runInTransaction);
   }
 

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleDumDownloadAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleDumDownloadAction.java
@@ -58,7 +58,7 @@ public class ConsoleDumDownloadAction extends ConsoleApiAction {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   public static final String PATH = "/console-api/dum-download";
-  private Clock clock;
+  private final Clock clock;
   private final String registrarId;
   private final String dumFileName;
 
@@ -76,11 +76,7 @@ public class ConsoleDumDownloadAction extends ConsoleApiAction {
 
   @Override
   protected void getHandler(User user) {
-    if (!user.getUserRoles().hasPermission(registrarId, ConsolePermission.DOWNLOAD_DOMAINS)) {
-      consoleApiParams.response().setStatus(HttpServletResponse.SC_FORBIDDEN);
-      return;
-    }
-
+    checkPermission(user, registrarId, ConsolePermission.DOWNLOAD_DOMAINS);
     consoleApiParams.response().setContentType(MediaType.CSV_UTF_8);
     consoleApiParams
         .response()

--- a/core/src/main/java/google/registry/ui/server/console/settings/SecurityAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/settings/SecurityAction.java
@@ -14,6 +14,7 @@
 
 package google.registry.ui.server.console.settings;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.Action.Method.POST;
 
@@ -62,16 +63,8 @@ public class SecurityAction extends ConsoleApiAction {
 
   @Override
   protected void postHandler(User user) {
-    if (!user.getUserRoles().hasPermission(registrarId, ConsolePermission.EDIT_REGISTRAR_DETAILS)) {
-      consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_FORBIDDEN);
-      return;
-    }
-
-    if (registrar.isEmpty()) {
-      setFailedResponse(
-          "'registrar' parameter is not present", HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
-      return;
-    }
+    checkPermission(user, registrarId, ConsolePermission.EDIT_REGISTRAR_DETAILS);
+    checkArgument(registrar.isPresent(), "'registrar' parameter is not present");
 
     Registrar savedRegistrar;
     try {


### PR DESCRIPTION
There are a bunch of cases where we want common exception handling and it's annoying to have to deal with the common "set failed response and make sure to return" a bunch of times.

This allows us to break up request methods more easily, since we can now often throw exceptions that will break all the way back up to ConsoleApiAction. Previously, any error handling had to exist in the primary handler method so it could return.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2443)
<!-- Reviewable:end -->
