### PR TITLE
Add the ability to add/remove console users from a Google Group

### DIFF
--- a/config/presubmits.py
+++ b/config/presubmits.py
@@ -196,6 +196,12 @@ PRESUBMITS = {
         {"/node_modules/"},
     ):
         "Use status code from jakarta.servlet.http.HttpServletResponse.",
+    PresubmitCheck(
+        r".*mock\(Response\.class\).*",
+        "java",
+        {"/node_modules/"},
+    ):
+        "Do not mock Response, use FakeResponse.",
 }
 
 # Note that this regex only works for one kind of Flyway file.  If we want to

--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -492,6 +492,18 @@ public final class RegistryConfig {
     }
 
     /**
+     * Returns the email address of the group containing emails of console users.
+     *
+     * <p>This group should be granted the {@code roles/iap.httpsResourceAccessor} role.
+     */
+    @Provides
+    @Config("gSuiteConsoleUserGroupEmailAddress")
+    public static Optional<String> provideGSuiteConsoleUserGroupEmailAddress(
+        RegistryConfigSettings config) {
+      return Optional.ofNullable(Strings.emptyToNull(config.gSuite.consoleUserGroupEmailAddress));
+    }
+
+    /**
      * Returns the email address(es) that notifications of registrar and/or registrar contact
      * updates should be sent to, or the empty list if updates should not be sent.
      *

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -83,6 +83,7 @@ public class RegistryConfigSettings {
     public String outgoingEmailDisplayName;
     public String adminAccountEmailAddress;
     public String supportGroupEmailAddress;
+    public String consoleUserGroupEmailAddress;
   }
 
   /** Configuration options for registry policy. */

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -47,6 +47,11 @@ gSuite:
   # given "ADMIN" role on the registrar console.
   supportGroupEmailAddress: support@example.com
 
+  # Group containing the emails of console users. This group should be granted
+  # roles/iap.httpsResourceAccessor out-of-band. If this field is empty, each
+  # console user will be granted to the role individually when they are created.
+  consoleUserGroupEmailAddress:
+
 registryPolicy:
   # Repository identifier (ROID) suffix for contacts and hosts.
   contactAndHostRoidSuffix: ROID

--- a/core/src/main/java/google/registry/env/common/tools/WEB-INF/web.xml
+++ b/core/src/main/java/google/registry/env/common/tools/WEB-INF/web.xml
@@ -14,6 +14,11 @@
 
   <servlet-mapping>
     <servlet-name>tools-servlet</servlet-name>
+    <url-pattern>/_dr/admin/updateUserGroup</url-pattern>
+  </servlet-mapping>
+
+  <servlet-mapping>
+    <servlet-name>tools-servlet</servlet-name>
     <url-pattern>/_dr/admin/verifyOte</url-pattern>
   </servlet-mapping>
 

--- a/core/src/main/java/google/registry/module/RequestComponent.java
+++ b/core/src/main/java/google/registry/module/RequestComponent.java
@@ -107,6 +107,7 @@ import google.registry.tools.server.ListReservedListsAction;
 import google.registry.tools.server.ListTldsAction;
 import google.registry.tools.server.RefreshDnsForAllDomainsAction;
 import google.registry.tools.server.ToolsServerModule;
+import google.registry.tools.server.UpdateUserGroupAction;
 import google.registry.tools.server.VerifyOteAction;
 import google.registry.ui.server.console.ConsoleDomainGetAction;
 import google.registry.ui.server.console.ConsoleDomainListAction;
@@ -322,6 +323,8 @@ interface RequestComponent {
   TmchSmdrlAction tmchSmdrlAction();
 
   UpdateRegistrarRdapBaseUrlsAction updateRegistrarRdapBaseUrlsAction();
+
+  UpdateUserGroupAction updateUserGroupAction();
 
   UploadBsaUnavailableDomainsAction uploadBsaUnavailableDomains();
 

--- a/core/src/main/java/google/registry/module/tools/ToolsRequestComponent.java
+++ b/core/src/main/java/google/registry/module/tools/ToolsRequestComponent.java
@@ -36,6 +36,7 @@ import google.registry.tools.server.ListReservedListsAction;
 import google.registry.tools.server.ListTldsAction;
 import google.registry.tools.server.RefreshDnsForAllDomainsAction;
 import google.registry.tools.server.ToolsServerModule;
+import google.registry.tools.server.UpdateUserGroupAction;
 import google.registry.tools.server.VerifyOteAction;
 
 /** Dagger component with per-request lifetime for "tools" App Engine module. */
@@ -50,9 +51,10 @@ import google.registry.tools.server.VerifyOteAction;
       WhiteboxModule.class,
     })
 public interface ToolsRequestComponent {
+  FlowComponent.Builder flowComponentBuilder();
+
   CreateGroupsAction createGroupsAction();
   EppToolAction eppToolAction();
-  FlowComponent.Builder flowComponentBuilder();
   GenerateZoneFilesAction generateZoneFilesAction();
   ListDomainsAction listDomainsAction();
   ListHostsAction listHostsAction();
@@ -62,6 +64,9 @@ public interface ToolsRequestComponent {
   ListTldsAction listTldsAction();
   LoadTestAction loadTestAction();
   RefreshDnsForAllDomainsAction refreshDnsForAllDomainsAction();
+
+  UpdateUserGroupAction updateUserGroupAction();
+
   VerifyOteAction verifyOteAction();
 
   @Subcomponent.Builder

--- a/core/src/main/java/google/registry/tools/CreateUserCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateUserCommand.java
@@ -17,18 +17,31 @@ package google.registry.tools;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.beust.jcommander.Parameters;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.flogger.FluentLogger;
+import com.google.common.net.MediaType;
+import google.registry.config.RegistryConfig.Config;
 import google.registry.model.console.User;
 import google.registry.model.console.UserDao;
+import google.registry.tools.server.UpdateUserGroupAction;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 /** Command to create a new User. */
 @Parameters(separators = " =", commandDescription = "Update a user account")
-public class CreateUserCommand extends CreateOrUpdateUserCommand {
+public class CreateUserCommand extends CreateOrUpdateUserCommand implements CommandWithConnection {
 
   static final String IAP_SECURED_WEB_APP_USER_ROLE = "roles/iap.httpsResourceAccessor";
+  static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
+  private ServiceConnection connection;
 
   @Inject IamClient iamClient;
+
+  @Inject
+  @Config("gSuiteConsoleUserGroupEmailAddress")
+  Optional<String> maybeGroupEmailAddress;
 
   @Nullable
   @Override
@@ -40,7 +53,29 @@ public class CreateUserCommand extends CreateOrUpdateUserCommand {
   @Override
   protected String execute() throws Exception {
     String ret = super.execute();
-    iamClient.addBinding(email, IAP_SECURED_WEB_APP_USER_ROLE);
+    String groupEmailAddress = maybeGroupEmailAddress.orElse(null);
+    if (groupEmailAddress != null) {
+      logger.atInfo().log("Adding %s to group %s", email, groupEmailAddress);
+      connection.sendPostRequest(
+          UpdateUserGroupAction.PATH,
+          ImmutableMap.of(
+              "userEmailAddress",
+              email,
+              "groupEmailAddress",
+              groupEmailAddress,
+              "groupUpdateMode",
+              "ADD"),
+          MediaType.PLAIN_TEXT_UTF_8,
+          new byte[0]);
+    } else {
+      logger.atInfo().log("Granting IAP role to user %s", email);
+      iamClient.addBinding(email, IAP_SECURED_WEB_APP_USER_ROLE);
+    }
     return ret;
+  }
+
+  @Override
+  public void setConnection(ServiceConnection connection) {
+    this.connection = connection;
   }
 }

--- a/core/src/main/java/google/registry/tools/DeleteUserCommand.java
+++ b/core/src/main/java/google/registry/tools/DeleteUserCommand.java
@@ -21,21 +21,38 @@ import static google.registry.util.PreconditionsUtils.checkArgumentPresent;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.flogger.FluentLogger;
+import com.google.common.net.MediaType;
+import google.registry.config.RegistryConfig.Config;
 import google.registry.model.console.User;
 import google.registry.model.console.UserDao;
+import google.registry.tools.server.UpdateUserGroupAction;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 
 /** Deletes a {@link User}. */
 @Parameters(separators = " =", commandDescription = "Delete a user account")
-public class DeleteUserCommand extends ConfirmingCommand {
+public class DeleteUserCommand extends ConfirmingCommand implements CommandWithConnection {
 
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
+  private ServiceConnection connection;
   @Inject IamClient iamClient;
+
+  @Inject
+  @Config("gSuiteConsoleUserGroupEmailAddress")
+  Optional<String> maybeGroupEmailAddress;
 
   @Nullable
   @Parameter(names = "--email", description = "Email address of the user", required = true)
   String email;
+
+  @Override
+  public void setConnection(ServiceConnection connection) {
+    this.connection = connection;
+  }
 
   @Override
   protected String prompt() {
@@ -52,7 +69,24 @@ public class DeleteUserCommand extends ConfirmingCommand {
               checkArgumentPresent(optionalUser, "Email no longer corresponds to a valid user");
               tm().delete(optionalUser.get());
             });
-    iamClient.removeBinding(email, IAP_SECURED_WEB_APP_USER_ROLE);
+    String groupEmailAddress = maybeGroupEmailAddress.orElse(null);
+    if (groupEmailAddress != null) {
+      logger.atInfo().log("Removing %s from group %s", email, groupEmailAddress);
+      connection.sendPostRequest(
+          UpdateUserGroupAction.PATH,
+          ImmutableMap.of(
+              "userEmailAddress",
+              email,
+              "groupEmailAddress",
+              groupEmailAddress,
+              "groupUpdateMode",
+              "REMOVE"),
+          MediaType.PLAIN_TEXT_UTF_8,
+          new byte[0]);
+    } else {
+      logger.atInfo().log("Removing IAP role from user %s", email);
+      iamClient.removeBinding(email, IAP_SECURED_WEB_APP_USER_ROLE);
+    }
     return String.format("Deleted user with email %s", email);
   }
 }

--- a/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
+++ b/core/src/main/java/google/registry/tools/server/ToolsServerModule.java
@@ -23,12 +23,11 @@ import static google.registry.request.RequestParameters.extractRequiredParameter
 import dagger.Module;
 import dagger.Provides;
 import google.registry.request.Parameter;
+import google.registry.tools.server.UpdateUserGroupAction.Mode;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
 
-/**
- * Dagger module for the tools package.
- */
+/** Dagger module for the tools package. */
 @Module
 public class ToolsServerModule {
 
@@ -74,5 +73,22 @@ public class ToolsServerModule {
   @Parameter("refreshQps")
   static Optional<Integer> provideRefreshQps(HttpServletRequest req) {
     return extractOptionalIntParameter(req, "refreshQps");
+  }
+
+  @Provides
+  static Mode provideGroupUpdateMode(HttpServletRequest req) {
+    return Mode.valueOf(extractRequiredParameter(req, "groupUpdateMode"));
+  }
+
+  @Provides
+  @Parameter("userEmailAddress")
+  static String provideUserEmailAddress(HttpServletRequest req) {
+    return extractRequiredParameter(req, "userEmailAddress");
+  }
+
+  @Provides
+  @Parameter("groupEmailAddress")
+  static String provideGroupEmailAddress(HttpServletRequest req) {
+    return extractRequiredParameter(req, "groupEmailAddress");
   }
 }

--- a/core/src/main/java/google/registry/tools/server/UpdateUserGroupAction.java
+++ b/core/src/main/java/google/registry/tools/server/UpdateUserGroupAction.java
@@ -1,0 +1,83 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.tools.server;
+
+import static google.registry.request.Action.Method.POST;
+
+import com.google.common.flogger.FluentLogger;
+import google.registry.groups.GroupsConnection;
+import google.registry.groups.GroupsConnection.Role;
+import google.registry.request.Action;
+import google.registry.request.Parameter;
+import google.registry.request.Response;
+import google.registry.request.auth.Auth;
+import javax.inject.Inject;
+
+/** Action that adds or deletes a console user to/from the group that has IAP permissions. */
+@Action(
+    service = Action.Service.TOOLS,
+    path = UpdateUserGroupAction.PATH,
+    method = POST,
+    auth = Auth.AUTH_API_ADMIN)
+public class UpdateUserGroupAction implements Runnable {
+
+  public static final String PATH = "/_dr/admin/updateUserGroup";
+
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
+  @Inject GroupsConnection groupsConnection;
+  @Inject Response response;
+
+  @Inject
+  @Parameter("userEmailAddress")
+  String userEmailAddress;
+
+  @Inject
+  @Parameter("groupEmailAddress")
+  String groupEmailAddress;
+
+  @Inject Mode mode;
+
+  @Inject
+  UpdateUserGroupAction() {}
+
+  enum Mode {
+    ADD,
+    REMOVE
+  }
+
+  @Override
+  public void run() {
+    logger.atInfo().log(
+        "Updating group %s: %s user %s",
+        groupEmailAddress, mode == Mode.ADD ? "adding" : "removing", userEmailAddress);
+    try {
+      if (mode == Mode.ADD) {
+        // The group will be created if it does not exist.
+        groupsConnection.addMemberToGroup(groupEmailAddress, userEmailAddress, Role.MEMBER);
+      } else {
+        if (groupsConnection.isMemberOfGroup(userEmailAddress, groupEmailAddress)) {
+          groupsConnection.removeMemberFromGroup(groupEmailAddress, userEmailAddress);
+        } else {
+          logger.atInfo().log(
+              "Ignoring request to remove non-member %s from group %s",
+              userEmailAddress, groupEmailAddress);
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Cannot update group", e);
+    }
+  }
+}

--- a/core/src/test/java/google/registry/tools/CreateUserCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateUserCommandTest.java
@@ -19,15 +19,18 @@ import static google.registry.tools.CreateUserCommand.IAP_SECURED_WEB_APP_USER_R
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import com.google.common.net.MediaType;
 import google.registry.model.console.GlobalRole;
 import google.registry.model.console.RegistrarRole;
 import google.registry.model.console.User;
 import google.registry.model.console.UserDao;
 import google.registry.testing.DatabaseHelper;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,10 +38,13 @@ import org.junit.jupiter.api.Test;
 public class CreateUserCommandTest extends CommandTestCase<CreateUserCommand> {
 
   private final IamClient iamClient = mock(IamClient.class);
+  private final ServiceConnection connection = mock(ServiceConnection.class);
 
   @BeforeEach
   void beforeEach() {
     command.iamClient = iamClient;
+    command.maybeGroupEmailAddress = Optional.empty();
+    command.setConnection(connection);
   }
 
   @Test
@@ -51,6 +57,32 @@ public class CreateUserCommandTest extends CommandTestCase<CreateUserCommand> {
     assertThat(onlyUser.getUserRoles().getRegistrarRoles()).isEmpty();
     verify(iamClient).addBinding("user@example.test", IAP_SECURED_WEB_APP_USER_ROLE);
     verifyNoMoreInteractions(iamClient);
+    verifyNoInteractions(connection);
+  }
+
+  @Test
+  void testSuccess_addToGroup() throws Exception {
+    command.maybeGroupEmailAddress = Optional.of("group@example.test");
+    runCommandForced("--email", "user@example.test");
+    User onlyUser = Iterables.getOnlyElement(DatabaseHelper.loadAllOf(User.class));
+    assertThat(onlyUser.getEmailAddress()).isEqualTo("user@example.test");
+    assertThat(onlyUser.getUserRoles().isAdmin()).isFalse();
+    assertThat(onlyUser.getUserRoles().getGlobalRole()).isEqualTo(GlobalRole.NONE);
+    assertThat(onlyUser.getUserRoles().getRegistrarRoles()).isEmpty();
+    verify(connection)
+        .sendPostRequest(
+            "/_dr/admin/updateUserGroup",
+            ImmutableMap.of(
+                "userEmailAddress",
+                "user@example.test",
+                "groupEmailAddress",
+                "group@example.test",
+                "groupUpdateMode",
+                "ADD"),
+            MediaType.PLAIN_TEXT_UTF_8,
+            new byte[0]);
+    verifyNoInteractions(iamClient);
+    verifyNoMoreInteractions(connection);
   }
 
   @Test
@@ -70,6 +102,7 @@ public class CreateUserCommandTest extends CommandTestCase<CreateUserCommand> {
     assertThat(UserDao.loadUser("user@example.test").get().getUserRoles().isAdmin()).isTrue();
     verify(iamClient).addBinding("user@example.test", IAP_SECURED_WEB_APP_USER_ROLE);
     verifyNoMoreInteractions(iamClient);
+    verifyNoInteractions(connection);
   }
 
   @Test
@@ -79,6 +112,7 @@ public class CreateUserCommandTest extends CommandTestCase<CreateUserCommand> {
         .isEqualTo(GlobalRole.FTE);
     verify(iamClient).addBinding("user@example.test", IAP_SECURED_WEB_APP_USER_ROLE);
     verifyNoMoreInteractions(iamClient);
+    verifyNoInteractions(connection);
   }
 
   @Test
@@ -97,6 +131,7 @@ public class CreateUserCommandTest extends CommandTestCase<CreateUserCommand> {
                 RegistrarRole.PRIMARY_CONTACT));
     verify(iamClient).addBinding("user@example.test", IAP_SECURED_WEB_APP_USER_ROLE);
     verifyNoMoreInteractions(iamClient);
+    verifyNoInteractions(connection);
   }
 
   @Test
@@ -111,6 +146,7 @@ public class CreateUserCommandTest extends CommandTestCase<CreateUserCommand> {
         .hasMessageThat()
         .isEqualTo("A user with email user@example.test already exists");
     verifyNoMoreInteractions(iamClient);
+    verifyNoInteractions(connection);
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/server/CreateGroupsActionTest.java
+++ b/core/src/test/java/google/registry/tools/server/CreateGroupsActionTest.java
@@ -28,7 +28,7 @@ import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationTestExtension;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.HttpException.InternalServerErrorException;
-import google.registry.request.Response;
+import google.registry.testing.FakeResponse;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -41,7 +41,7 @@ class CreateGroupsActionTest {
       new JpaTestExtensions.Builder().buildIntegrationTestExtension();
 
   private final DirectoryGroupsConnection connection = mock(DirectoryGroupsConnection.class);
-  private final Response response = mock(Response.class);
+  private final FakeResponse response = new FakeResponse();
 
   private void runAction(String registrarId) {
     CreateGroupsAction action = new CreateGroupsAction();
@@ -74,8 +74,8 @@ class CreateGroupsActionTest {
   @Test
   void test_createsAllGroupsSuccessfully() throws Exception {
     runAction("NewRegistrar");
-    verify(response).setStatus(SC_OK);
-    verify(response).setPayload("Success!");
+    assertThat(response.getStatus()).isEqualTo(SC_OK);
+    assertThat(response.getPayload()).isEqualTo("Success!");
     verifyGroupCreationCallsForNewRegistrar();
     verify(connection).addMemberToGroup("registrar-primary-contacts@domain-registry.example",
         "newregistrar-primary-contacts@domain-registry.example",

--- a/core/src/test/java/google/registry/tools/server/UpdateUserGroupActionTest.java
+++ b/core/src/test/java/google/registry/tools/server/UpdateUserGroupActionTest.java
@@ -1,0 +1,77 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.tools.server;
+
+import static com.google.common.truth.Truth.assertThat;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import google.registry.groups.DirectoryGroupsConnection;
+import google.registry.groups.GroupsConnection.Role;
+import google.registry.testing.FakeResponse;
+import google.registry.tools.server.UpdateUserGroupAction.Mode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link google.registry.tools.server.UpdateUserGroupAction}. */
+class UpdateUserGroupActionTest {
+
+  private final DirectoryGroupsConnection connection = mock(DirectoryGroupsConnection.class);
+  private final FakeResponse response = new FakeResponse();
+  private final UpdateUserGroupAction action = new UpdateUserGroupAction();
+  private final String userEmailAddress = "user@example.com";
+  private final String groupEmailAddress = "group@example.com";
+
+  @BeforeEach
+  void beforeEach() {
+    action.groupsConnection = connection;
+    action.response = response;
+    action.userEmailAddress = userEmailAddress;
+    action.groupEmailAddress = groupEmailAddress;
+    action.mode = Mode.ADD;
+  }
+
+  @Test
+  void testSuccess_addMember() throws Exception {
+    action.run();
+    assertThat(response.getStatus()).isEqualTo(SC_OK);
+    verify(connection).addMemberToGroup(groupEmailAddress, userEmailAddress, Role.MEMBER);
+    verifyNoMoreInteractions(connection);
+  }
+
+  @Test
+  void testSuccess_removeMember() throws Exception {
+    action.mode = Mode.REMOVE;
+    when(connection.isMemberOfGroup(userEmailAddress, groupEmailAddress)).thenReturn(true);
+    action.run();
+    assertThat(response.getStatus()).isEqualTo(SC_OK);
+    verify(connection).isMemberOfGroup(userEmailAddress, groupEmailAddress);
+    verify(connection).removeMemberFromGroup(groupEmailAddress, userEmailAddress);
+    verifyNoMoreInteractions(connection);
+  }
+
+  @Test
+  void testSuccess_removeMember_notAMember() throws Exception {
+    action.mode = Mode.REMOVE;
+    when(connection.isMemberOfGroup(userEmailAddress, groupEmailAddress)).thenReturn(false);
+    action.run();
+    assertThat(response.getStatus()).isEqualTo(SC_OK);
+    verify(connection).isMemberOfGroup(userEmailAddress, groupEmailAddress);
+    verifyNoMoreInteractions(connection);
+  }
+}

--- a/core/src/test/resources/google/registry/module/routing.txt
+++ b/core/src/test/resources/google/registry/module/routing.txt
@@ -6,6 +6,7 @@ PATH                                               CLASS                        
 /_dr/admin/list/registrars                         ListRegistrarsAction                           GET,POST n  API          APP  ADMIN
 /_dr/admin/list/reservedLists                      ListReservedListsAction                        GET,POST n  API          APP  ADMIN
 /_dr/admin/list/tlds                               ListTldsAction                                 GET,POST n  API          APP  ADMIN
+/_dr/admin/updateUserGroup                         UpdateUserGroupAction                          POST     n  API          APP  ADMIN
 /_dr/admin/verifyOte                               VerifyOteAction                                POST     n  API          APP  ADMIN
 /_dr/cron/fanout                                   TldFanoutAction                                GET      y  API          APP  ADMIN
 /_dr/dnsRefresh                                    RefreshDnsAction                               GET      y  API          APP  ADMIN

--- a/core/src/test/resources/google/registry/module/tools/tools_routing.txt
+++ b/core/src/test/resources/google/registry/module/tools/tools_routing.txt
@@ -6,6 +6,7 @@ PATH                              CLASS                         METHODS  OK AUTH
 /_dr/admin/list/registrars        ListRegistrarsAction          GET,POST n  API          APP ADMIN
 /_dr/admin/list/reservedLists     ListReservedListsAction       GET,POST n  API          APP ADMIN
 /_dr/admin/list/tlds              ListTldsAction                GET,POST n  API          APP ADMIN
+/_dr/admin/updateUserGroup        UpdateUserGroupAction         POST     n  API          APP ADMIN
 /_dr/admin/verifyOte              VerifyOteAction               POST     n  API          APP ADMIN
 /_dr/epptool                      EppToolAction                 POST     n  API          APP ADMIN
 /_dr/loadtest                     LoadTestAction                POST     y  API          APP ADMIN


### PR DESCRIPTION
If a console user group is defined in the config file, we will add/remove the user to/from the group during user creation/deletion, instead of granting/removing the necessary IAP roles to/from the user.

This makes it easy when IAM roles are managed externally (e. g. under latchkey) where individual changes made to IAM will be rolled back, if not also made to latchkey. This way we can simply grant the role to the group via an one-time config change to latchkey, and rely on a user's membership in the group to determine if IAP would all or deny the user's access.

Also forbid mocking of `Response` in tests. We should use the fake implementation instead.

TESTED=tested both individual and group IAP behavior on crash. Verified that email addresses are added/removed to/from the group.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2450)
<!-- Reviewable:end -->
