### PR TITLE
Harmonize http status code usage

### DIFF
--- a/config/presubmits.py
+++ b/config/presubmits.py
@@ -202,7 +202,12 @@ PRESUBMITS = {
         {"/node_modules/", "JpaTransactionManagerImpl.java"},
     ):
         "Do not use java.util.Date. Use classes in java.time package instead.",
-
+    PresubmitCheck(
+        r".*com\.google\.api\.client\.http\.HttpStatusCodes.*",
+        "java",
+        {"/node_modules/"},
+    ):
+        "Use status code from jakarta.servlet.http.HttpServletResponse.",
 }
 
 # Note that this regex only works for one kind of Flyway file.  If we want to

--- a/core/src/main/java/google/registry/bsa/UploadBsaUnavailableDomainsAction.java
+++ b/core/src/main/java/google/registry/bsa/UploadBsaUnavailableDomainsAction.java
@@ -23,9 +23,9 @@ import static google.registry.model.tld.label.ReservedList.loadReservedLists;
 import static google.registry.persistence.transaction.TransactionManagerFactory.replicaTm;
 import static google.registry.request.Action.Method.GET;
 import static google.registry.request.Action.Method.POST;
+import static jakarta.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.cloud.storage.BlobId;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
@@ -190,7 +190,7 @@ public class UploadBsaUnavailableDomainsAction implements Runnable {
       return true;
     } catch (IOException e) {
       logger.atSevere().withCause(e).log("Error while attempting to upload to BSA, aborting.");
-      response.setStatus(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+      response.setStatus(SC_INTERNAL_SERVER_ERROR);
       response.setPayload("Error while attempting to upload to BSA: " + e.getMessage());
       return false;
     }

--- a/core/src/main/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsAction.java
+++ b/core/src/main/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsAction.java
@@ -14,11 +14,11 @@
 
 package google.registry.rdap;
 
-import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_OK;
 import static com.google.common.net.HttpHeaders.ACCEPT_ENCODING;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.UrlConnectionUtils.gUnzipBytes;
 import static google.registry.request.UrlConnectionUtils.isGZipped;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableMap;
@@ -114,7 +114,7 @@ public final class UpdateRegistrarRdapBaseUrlsAction implements Runnable {
     connection.setRequestProperty(ACCEPT_ENCODING, "gzip");
     String csvString;
     try {
-      if (connection.getResponseCode() != STATUS_CODE_OK) {
+      if (connection.getResponseCode() != SC_OK) {
         throw new UrlConnectionException("Failed to load RDAP base URLs from ICANN", connection);
       }
       // With GZIP encoding header in the request (see above) ICANN had still sent response in plain

--- a/core/src/main/java/google/registry/rde/RdeReporter.java
+++ b/core/src/main/java/google/registry/rde/RdeReporter.java
@@ -14,12 +14,12 @@
 
 package google.registry.rde;
 
-import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_BAD_REQUEST;
-import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_OK;
 import static google.registry.request.UrlConnectionUtils.getResponseBytes;
 import static google.registry.request.UrlConnectionUtils.setBasicAuth;
 import static google.registry.request.UrlConnectionUtils.setPayload;
 import static google.registry.util.DomainNameUtils.canonicalizeHostname;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.api.client.http.HttpMethods;
@@ -85,7 +85,7 @@ public class RdeReporter {
 
     try {
       responseCode = connection.getResponseCode();
-      if (responseCode != STATUS_CODE_OK && responseCode != STATUS_CODE_BAD_REQUEST) {
+      if (responseCode != SC_OK && responseCode != SC_BAD_REQUEST) {
         logger.atWarning().log("Connection to RDE report server failed: %d", responseCode);
         throw new UrlConnectionException("PUT failed", connection);
       }
@@ -96,7 +96,7 @@ public class RdeReporter {
 
     // We know that an HTTP 200 response can only contain a result code of
     // 1000 (i. e. success), there is no need to parse it.
-    if (responseCode != STATUS_CODE_OK) {
+    if (responseCode != SC_OK) {
       XjcIirdeaResult result = parseResult(responseBytes);
       logger.atWarning().log(
           "Rejected when trying to PUT RDE report to ICANN server: %d %s\n%s",

--- a/core/src/main/java/google/registry/reporting/icann/IcannHttpReporter.java
+++ b/core/src/main/java/google/registry/reporting/icann/IcannHttpReporter.java
@@ -14,10 +14,10 @@
 
 package google.registry.reporting.icann;
 
-import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_OK;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.net.MediaType.CSV_UTF_8;
 import static google.registry.model.tld.Tlds.assertTldExists;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 
 import com.google.api.client.http.HttpMethods;
 import com.google.common.base.Ascii;
@@ -95,7 +95,7 @@ public class IcannHttpReporter {
     try {
       responseCode = connection.getResponseCode();
       content = UrlConnectionUtils.getResponseBytes(connection);
-      if (responseCode != STATUS_CODE_OK) {
+      if (responseCode != SC_OK) {
         XjcIirdeaResult result = parseResult(content);
         logger.atWarning().log(
             "PUT rejected, status code %s:\n%s\n%s",

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleApiAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleApiAction.java
@@ -14,9 +14,12 @@
 
 package google.registry.ui.server.console;
 
+import static com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static google.registry.request.Action.Method.GET;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.base.Throwables;
 import com.google.common.flogger.FluentLogger;
 import google.registry.model.console.ConsolePermission;
@@ -50,7 +53,7 @@ public abstract class ConsoleApiAction implements Runnable {
     AuthResult authResult = consoleApiParams.authResult();
     if (authResult.userAuthInfo().isEmpty()
         || authResult.userAuthInfo().get().consoleUser().isEmpty()) {
-      consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
+      consoleApiParams.response().setStatus(SC_UNAUTHORIZED);
       return;
     }
     User user = consoleApiParams.authResult().userAuthInfo().get().consoleUser().get();
@@ -77,15 +80,13 @@ public abstract class ConsoleApiAction implements Runnable {
       }
     } catch (ConsolePermissionForbiddenException e) {
       logger.atWarning().withCause(e).log("Forbidden");
-      setFailedResponse("", HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+      setFailedResponse("", SC_FORBIDDEN);
     } catch (HttpException.BadRequestException | IllegalArgumentException e) {
       logger.atWarning().withCause(e).log("Error in request");
-      setFailedResponse(
-          Throwables.getRootCause(e).getMessage(), HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
+      setFailedResponse(Throwables.getRootCause(e).getMessage(), SC_BAD_REQUEST);
     } catch (Throwable t) {
       logger.atWarning().withCause(t).log("Internal server error");
-      setFailedResponse(
-          Throwables.getRootCause(t).getMessage(), HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+      setFailedResponse(Throwables.getRootCause(t).getMessage(), SC_INTERNAL_SERVER_ERROR);
     }
   }
 
@@ -118,7 +119,7 @@ public abstract class ConsoleApiAction implements Runnable {
             .findFirst();
     if (maybeCookie.isEmpty()
         || !consoleApiParams.xsrfTokenManager().validateToken(maybeCookie.get().getValue())) {
-      consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
+      consoleApiParams.response().setStatus(SC_UNAUTHORIZED);
       return false;
     }
     return true;

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleDomainGetAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleDomainGetAction.java
@@ -15,8 +15,9 @@
 package google.registry.ui.server.console;
 
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import google.registry.model.EppResourceUtils;
 import google.registry.model.console.ConsolePermission;
@@ -59,16 +60,16 @@ public class ConsoleDomainGetAction extends ConsoleApiAction {
                     EppResourceUtils.loadByForeignKeyCached(
                         Domain.class, paramDomain, tm().getTransactionTime()));
     if (possibleDomain.isEmpty()) {
-      consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
+      consoleApiParams.response().setStatus(SC_NOT_FOUND);
       return;
     }
     Domain domain = possibleDomain.get();
     if (!user.getUserRoles()
         .hasPermission(domain.getCurrentSponsorRegistrarId(), ConsolePermission.DOWNLOAD_DOMAINS)) {
-      consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
+      consoleApiParams.response().setStatus(SC_NOT_FOUND);
       return;
     }
-    consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_OK);
+    consoleApiParams.response().setStatus(SC_OK);
     consoleApiParams.response().setPayload(gson.toJson(domain));
   }
 }

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleDomainListAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleDomainListAction.java
@@ -17,8 +17,8 @@ package google.registry.ui.server.console;
 import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.model.console.ConsolePermission.DOWNLOAD_DOMAINS;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ascii;
 import com.google.gson.Gson;
@@ -118,7 +118,7 @@ public class ConsoleDomainListAction extends ConsoleApiAction {
     consoleApiParams
         .response()
         .setPayload(gson.toJson(new DomainListResult(domains, checkpoint, actualTotalResults)));
-    consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_OK);
+    consoleApiParams.response().setStatus(SC_OK);
   }
 
   /** Creates the query to get the total number of matching domains, interpolating as necessary. */

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleEppPasswordAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleEppPasswordAction.java
@@ -17,8 +17,10 @@ package google.registry.ui.server.console;
 import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.Action.Method.POST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.base.Strings;
 import com.google.gson.annotations.Expose;
 import google.registry.flows.EppException.AuthenticationErrorException;
@@ -92,14 +94,14 @@ public class ConsoleEppPasswordAction extends ConsoleApiAction {
     try {
       registrar = registrarAccessor.getRegistrar(eppRequestBody.registrarId());
     } catch (RegistrarAccessDeniedException e) {
-      setFailedResponse(e.getMessage(), HttpStatusCodes.STATUS_CODE_NOT_FOUND);
+      setFailedResponse(e.getMessage(), SC_NOT_FOUND);
       return;
     }
 
     try {
       credentials.validate(registrar, eppRequestBody.oldPassword());
     } catch (AuthenticationErrorException e) {
-      setFailedResponse(e.getMessage(), HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+      setFailedResponse(e.getMessage(), SC_FORBIDDEN);
       return;
     }
 
@@ -113,7 +115,7 @@ public class ConsoleEppPasswordAction extends ConsoleApiAction {
                       new InternetAddress(registrar.getEmailAddress(), true)));
             });
 
-    consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_OK);
+    consoleApiParams.response().setStatus(SC_OK);
   }
 
   public record EppPasswordData(

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleRegistryLockAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleRegistryLockAction.java
@@ -24,8 +24,9 @@ import static google.registry.request.RequestParameters.extractOptionalLongParam
 import static google.registry.request.RequestParameters.extractOptionalParameter;
 import static google.registry.request.RequestParameters.extractRequiredParameter;
 import static google.registry.ui.server.registrar.RegistryLockPostAction.VERIFICATION_EMAIL_TEMPLATE;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import google.registry.flows.EppException;
@@ -90,7 +91,7 @@ public class ConsoleRegistryLockAction extends ConsoleApiAction {
   protected void getHandler(User user) {
     checkPermission(user, registrarId, ConsolePermission.REGISTRY_LOCK);
     consoleApiParams.response().setPayload(gson.toJson(getLockedDomains()));
-    consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_OK);
+    consoleApiParams.response().setStatus(SC_OK);
   }
 
   @Override
@@ -124,8 +125,7 @@ public class ConsoleRegistryLockAction extends ConsoleApiAction {
     if (!isAdmin) {
       checkArgument(maybePassword.isPresent(), "No password provided");
       if (!user.verifyRegistryLockPassword(maybePassword.get())) {
-        setFailedResponse(
-            "Incorrect registry lock password", HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
+        setFailedResponse("Incorrect registry lock password", SC_UNAUTHORIZED);
         return;
       }
     }
@@ -147,7 +147,7 @@ public class ConsoleRegistryLockAction extends ConsoleApiAction {
                           relockDurationMillis.map(Duration::new));
               sendVerificationEmail(registryLock, registryLockEmail, isLock);
             });
-    response.setStatus(HttpStatusCodes.STATUS_CODE_OK);
+    response.setStatus(SC_OK);
   }
 
   private void sendVerificationEmail(RegistryLock lock, String userEmail, boolean isLock) {

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleUserDataAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleUserDataAction.java
@@ -15,8 +15,8 @@
 package google.registry.ui.server.console;
 
 import static google.registry.request.Action.Method.GET;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.collect.ImmutableMap;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.model.console.User;
@@ -88,6 +88,6 @@ public class ConsoleUserDataAction extends ConsoleApiAction {
                 "technicalDocsUrl", technicalDocsUrl));
 
     consoleApiParams.response().setPayload(json.toString());
-    consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_OK);
+    consoleApiParams.response().setStatus(SC_OK);
   }
 }

--- a/core/src/main/java/google/registry/ui/server/console/RegistrarsAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/RegistrarsAction.java
@@ -19,8 +19,9 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.Action.Method.GET;
 import static google.registry.request.Action.Method.POST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import com.google.gson.Gson;
@@ -72,7 +73,7 @@ public class RegistrarsAction extends ConsoleApiAction {
   @Override
   protected void getHandler(User user) {
     if (!user.getUserRoles().hasGlobalPermission(ConsolePermission.VIEW_REGISTRARS)) {
-      consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+      consoleApiParams.response().setStatus(SC_FORBIDDEN);
       return;
     }
 
@@ -82,13 +83,13 @@ public class RegistrarsAction extends ConsoleApiAction {
             .collect(ImmutableList.toImmutableList());
 
     consoleApiParams.response().setPayload(gson.toJson(registrars));
-    consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_OK);
+    consoleApiParams.response().setStatus(SC_OK);
   }
 
   @Override
   protected void postHandler(User user) {
     if (!user.getUserRoles().isAdmin()) {
-      consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+      consoleApiParams.response().setStatus(SC_FORBIDDEN);
       return;
     }
 

--- a/core/src/main/java/google/registry/ui/server/console/settings/ContactAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/settings/ContactAction.java
@@ -19,8 +19,8 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.Action.Method.GET;
 import static google.registry.request.Action.Method.POST;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.FluentLogger;
@@ -78,7 +78,7 @@ public class ContactAction extends ConsoleApiAction {
                         .filter(r -> !r.getTypes().isEmpty())
                         .collect(toImmutableList()));
 
-    consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_OK);
+    consoleApiParams.response().setStatus(SC_OK);
     consoleApiParams.response().setPayload(gson.toJson(am));
   }
 
@@ -112,6 +112,6 @@ public class ContactAction extends ConsoleApiAction {
     }
 
     RegistrarPoc.updateContacts(registrar, updatedContacts);
-    consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_OK);
+    consoleApiParams.response().setStatus(SC_OK);
   }
 }

--- a/core/src/main/java/google/registry/ui/server/console/settings/SecurityAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/settings/SecurityAction.java
@@ -17,8 +17,10 @@ package google.registry.ui.server.console.settings;
 import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.Action.Method.POST;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 
-import com.google.api.client.http.HttpStatusCodes;
 import google.registry.flows.certs.CertificateChecker;
 import google.registry.flows.certs.CertificateChecker.InsecureCertificateException;
 import google.registry.model.console.ConsolePermission;
@@ -70,7 +72,7 @@ public class SecurityAction extends ConsoleApiAction {
     try {
       savedRegistrar = registrarAccessor.getRegistrar(registrarId);
     } catch (RegistrarAccessDeniedException e) {
-      setFailedResponse(e.getMessage(), HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+      setFailedResponse(e.getMessage(), SC_FORBIDDEN);
       return;
     }
 
@@ -104,12 +106,11 @@ public class SecurityAction extends ConsoleApiAction {
         }
       }
     } catch (InsecureCertificateException e) {
-      setFailedResponse(
-          "Invalid certificate in parameter", HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
+      setFailedResponse("Invalid certificate in parameter", SC_BAD_REQUEST);
       return;
     }
 
     tm().put(updatedRegistrar.build());
-    consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_OK);
+    consoleApiParams.response().setStatus(SC_OK);
   }
 }

--- a/core/src/main/java/google/registry/ui/server/console/settings/WhoisRegistrarFieldsAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/settings/WhoisRegistrarFieldsAction.java
@@ -17,8 +17,9 @@ package google.registry.ui.server.console.settings;
 import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.Action.Method.POST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 
-import com.google.api.client.http.HttpStatusCodes;
 import google.registry.model.console.ConsolePermission;
 import google.registry.model.console.User;
 import google.registry.model.registrar.Registrar;
@@ -73,7 +74,7 @@ public class WhoisRegistrarFieldsAction extends ConsoleApiAction {
       // reload to make sure the object has all the correct fields
       savedRegistrar = registrarAccessor.getRegistrar(providedRegistrar.getRegistrarId());
     } catch (RegistrarAccessDeniedException e) {
-      setFailedResponse(e.getMessage(), HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+      setFailedResponse(e.getMessage(), SC_FORBIDDEN);
       return;
     }
 
@@ -84,6 +85,6 @@ public class WhoisRegistrarFieldsAction extends ConsoleApiAction {
     newRegistrar.setPhoneNumber(providedRegistrar.getPhoneNumber());
     newRegistrar.setFaxNumber(providedRegistrar.getFaxNumber());
     tm().put(newRegistrar.build());
-    consoleApiParams.response().setStatus(HttpStatusCodes.STATUS_CODE_OK);
+    consoleApiParams.response().setStatus(SC_OK);
   }
 }

--- a/core/src/test/java/google/registry/rde/RdeReportActionTest.java
+++ b/core/src/test/java/google/registry/rde/RdeReportActionTest.java
@@ -14,9 +14,6 @@
 
 package google.registry.rde;
 
-import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_BAD_REQUEST;
-import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_OK;
-import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_UNAUTHORIZED;
 import static com.google.common.net.MediaType.PLAIN_TEXT_UTF_8;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.common.Cursor.CursorType.RDE_REPORT;
@@ -26,6 +23,9 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.loadByKey;
 import static google.registry.testing.DatabaseHelper.persistResource;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 import static org.joda.time.Duration.standardDays;
 import static org.joda.time.Duration.standardSeconds;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -121,7 +121,7 @@ public class RdeReportActionTest {
     gcsUtils.createFromBytes(reportFile, Ghostryde.encode(REPORT_XML.read(), encryptKey));
     tm().transact(() -> RdeRevision.saveRevision("test", DateTime.parse("2006-06-06TZ"), FULL, 0));
     when(httpUrlConnection.getOutputStream()).thenReturn(connectionOutputStream);
-    when(httpUrlConnection.getResponseCode()).thenReturn(STATUS_CODE_OK);
+    when(httpUrlConnection.getResponseCode()).thenReturn(SC_OK);
     when(httpUrlConnection.getInputStream()).thenReturn(IIRDEA_GOOD_XML.openBufferedStream());
   }
 
@@ -263,7 +263,7 @@ public class RdeReportActionTest {
 
   @Test
   void testRunWithLock_badRequest_throws500WithErrorInfo() throws Exception {
-    when(httpUrlConnection.getResponseCode()).thenReturn(STATUS_CODE_BAD_REQUEST);
+    when(httpUrlConnection.getResponseCode()).thenReturn(SC_BAD_REQUEST);
     when(httpUrlConnection.getErrorStream()).thenReturn(IIRDEA_BAD_XML.openBufferedStream());
     InternalServerErrorException thrown =
         assertThrows(
@@ -274,7 +274,7 @@ public class RdeReportActionTest {
 
   @Test
   void testRunWithLock_notAuthorized() throws Exception {
-    when(httpUrlConnection.getResponseCode()).thenReturn(STATUS_CODE_UNAUTHORIZED);
+    when(httpUrlConnection.getResponseCode()).thenReturn(SC_UNAUTHORIZED);
     UrlConnectionException thrown =
         assertThrows(
             UrlConnectionException.class, () -> createAction().runWithLock(loadRdeReportCursor()));

--- a/core/src/test/java/google/registry/reporting/icann/IcannHttpReporterTest.java
+++ b/core/src/test/java/google/registry/reporting/icann/IcannHttpReporterTest.java
@@ -14,11 +14,11 @@
 
 package google.registry.reporting.icann;
 
-import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_BAD_REQUEST;
-import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_OK;
-import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_SERVER_ERROR;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.testing.DatabaseHelper.createTld;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
@@ -61,7 +61,7 @@ class IcannHttpReporterTest {
     createTld("test");
     createTld("xn--abc123");
     when(connection.getOutputStream()).thenReturn(outputStream);
-    when(connection.getResponseCode()).thenReturn(STATUS_CODE_OK);
+    when(connection.getResponseCode()).thenReturn(SC_OK);
     when(connection.getInputStream()).thenReturn(IIRDEA_GOOD_XML.openBufferedStream());
     reporter.urlConnectionService = urlConnectionService;
     reporter.password = "fakePass";
@@ -99,7 +99,7 @@ class IcannHttpReporterTest {
 
   @Test
   void testFail_BadIirdeaResponse() throws Exception {
-    when(connection.getResponseCode()).thenReturn(STATUS_CODE_BAD_REQUEST);
+    when(connection.getResponseCode()).thenReturn(SC_BAD_REQUEST);
     when(connection.getErrorStream()).thenReturn(IIRDEA_BAD_XML.openBufferedStream());
     assertThat(reporter.send(FAKE_PAYLOAD, "test-transactions-201706.csv")).isFalse();
     verify(connection).getErrorStream();
@@ -107,7 +107,7 @@ class IcannHttpReporterTest {
 
   @Test
   void testFail_OtherBadHttpResponse() throws Exception {
-    when(connection.getResponseCode()).thenReturn(STATUS_CODE_SERVER_ERROR);
+    when(connection.getResponseCode()).thenReturn(SC_INTERNAL_SERVER_ERROR);
     assertThat(reporter.send(FAKE_PAYLOAD, "test-transactions-201706.csv")).isFalse();
     verify(connection, times(0)).getInputStream();
   }

--- a/core/src/test/java/google/registry/ui/server/console/ConsoleDomainGetActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/ConsoleDomainGetActionTest.java
@@ -16,10 +16,12 @@ package google.registry.ui.server.console;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.testing.DatabaseHelper.createTld;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import google.registry.model.console.RegistrarRole;
@@ -68,8 +70,7 @@ public class ConsoleDomainGetActionTest {
                             .build()))),
             "exists.tld");
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_OK);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_OK);
     assertThat(((FakeResponse) consoleApiParams.response()).getPayload())
         .isEqualTo(
             "{\"domainName\":\"exists.tld\",\"adminContact\":{\"key\":\"3-ROID\",\"kind\":"
@@ -88,8 +89,7 @@ public class ConsoleDomainGetActionTest {
   void testFailure_emptyAuth() {
     ConsoleDomainGetAction action = createAction(AuthResult.NOT_AUTHENTICATED, "exists.tld");
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_UNAUTHORIZED);
   }
 
   @Test
@@ -97,8 +97,7 @@ public class ConsoleDomainGetActionTest {
     ConsoleDomainGetAction action =
         createAction(AuthResult.createApp("service@registry.example"), "exists.tld");
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_UNAUTHORIZED);
   }
 
   @Test
@@ -109,8 +108,7 @@ public class ConsoleDomainGetActionTest {
                 UserAuthInfo.create(mock(com.google.appengine.api.users.User.class), false)),
             "exists.tld");
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_UNAUTHORIZED);
   }
 
   @Test
@@ -120,8 +118,7 @@ public class ConsoleDomainGetActionTest {
             AuthResult.createUser(UserAuthInfo.create(createUser(new UserRoles.Builder().build()))),
             "exists.tld");
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_NOT_FOUND);
   }
 
   @Test
@@ -132,8 +129,7 @@ public class ConsoleDomainGetActionTest {
                 UserAuthInfo.create(createUser(new UserRoles.Builder().setIsAdmin(true).build()))),
             "nonexistent.tld");
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_NOT_FOUND);
   }
 
   private User createUser(UserRoles userRoles) {

--- a/core/src/test/java/google/registry/ui/server/console/ConsoleDomainListActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/ConsoleDomainListActionTest.java
@@ -20,9 +20,9 @@ import static google.registry.testing.DatabaseHelper.createAdminUser;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistDomainAsDeleted;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static org.mockito.Mockito.when;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.collect.Iterables;
 import com.google.gson.Gson;
 import google.registry.model.EppResourceUtils;
@@ -230,15 +230,13 @@ public class ConsoleDomainListActionTest {
   void testFailure_invalidResultsPerPage() {
     ConsoleDomainListAction action = createAction("TheRegistrar", null, 0, 0, null, null);
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_BAD_REQUEST);
     assertThat(((FakeResponse) consoleApiParams.response()).getPayload())
         .isEqualTo("Results per page must be between 1 and 500 inclusive");
 
     action = createAction("TheRegistrar", null, 0, 501, null, null);
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_BAD_REQUEST);
     assertThat(((FakeResponse) consoleApiParams.response()).getPayload())
         .isEqualTo("Results per page must be between 1 and 500 inclusive");
   }
@@ -247,8 +245,7 @@ public class ConsoleDomainListActionTest {
   void testFailure_invalidPageNumber() {
     ConsoleDomainListAction action = createAction("TheRegistrar", null, -1, 10, null, null);
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_BAD_REQUEST);
     assertThat(((FakeResponse) consoleApiParams.response()).getPayload())
         .isEqualTo("Page number must be non-negative");
   }

--- a/core/src/test/java/google/registry/ui/server/console/ConsoleDumDownloadActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/ConsoleDumDownloadActionTest.java
@@ -16,9 +16,10 @@ package google.registry.ui.server.console;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.testing.DatabaseHelper.createTld;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static org.mockito.Mockito.when;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import google.registry.model.console.GlobalRole;
@@ -82,7 +83,7 @@ class ConsoleDumDownloadActionTest {
             "1exists.tld,2024-04-15 00:00:00.001+00,2025-02-09 00:00:00.001+00,{INACTIVE}",
             "0exists.tld,2024-04-15 00:00:00+00,2025-02-09 00:00:00+00,{INACTIVE}");
     FakeResponse response = (FakeResponse) consoleApiParams.response();
-    assertThat(response.getStatus()).isEqualTo(HttpStatusCodes.STATUS_CODE_OK);
+    assertThat(response.getStatus()).isEqualTo(SC_OK);
     ImmutableList<String> actual =
         ImmutableList.copyOf(response.getStringWriter().toString().split("\r\n"));
     assertThat(actual).containsExactlyElementsIn(expected);
@@ -99,8 +100,7 @@ class ConsoleDumDownloadActionTest {
     AuthResult authResult = AuthResult.createUser(UserAuthInfo.create(user));
     ConsoleDumDownloadAction action = createAction(Optional.of(authResult));
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_FORBIDDEN);
   }
 
   private ConsoleDumDownloadAction createAction(Optional<AuthResult> maybeAuthResult) {

--- a/core/src/test/java/google/registry/ui/server/console/ConsoleEppPasswordActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/ConsoleEppPasswordActionTest.java
@@ -19,6 +19,9 @@ import static google.registry.request.auth.AuthenticatedRegistrarAccessor.Role.O
 import static google.registry.testing.DatabaseHelper.loadRegistrar;
 import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -26,7 +29,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.gson.Gson;
 import google.registry.flows.PasswordOnlyTransportCredentials;
@@ -90,8 +92,7 @@ class ConsoleEppPasswordActionTest {
   void testFailure_emptyParams() throws IOException {
     ConsoleEppPasswordAction action = createAction("", "", "", "");
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_BAD_REQUEST);
     assertThat(((FakeResponse) consoleApiParams.response()).getPayload())
         .isEqualTo("Missing param(s): registrarId");
   }
@@ -101,8 +102,7 @@ class ConsoleEppPasswordActionTest {
     ConsoleEppPasswordAction action =
         createAction("registrarId", "oldPassword", "newPassword", "newPasswordRepeat");
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_BAD_REQUEST);
     assertThat(((FakeResponse) consoleApiParams.response()).getPayload())
         .contains("New password fields don't match");
   }
@@ -112,8 +112,7 @@ class ConsoleEppPasswordActionTest {
     ConsoleEppPasswordAction action =
         createAction("registrarId", "oldPassword", "randomPasword", "randomPasword");
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_FORBIDDEN);
     assertThat(((FakeResponse) consoleApiParams.response()).getPayload())
         .contains("Registrar password is incorrect");
   }
@@ -130,8 +129,7 @@ class ConsoleEppPasswordActionTest {
                 "Dear registrarId name,\n"
                     + "This is to confirm that your account password has been changed.",
                 new InternetAddress("testEmail@google.com")));
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_OK);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_OK);
   }
 
   @Test
@@ -139,8 +137,7 @@ class ConsoleEppPasswordActionTest {
     ConsoleEppPasswordAction action =
         createAction("registrarId", "foobar", "randomPassword", "randomPassword");
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_OK);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_OK);
     assertDoesNotThrow(
         () -> {
           credentials.validate(loadRegistrar("registrarId"), "randomPassword");

--- a/core/src/test/java/google/registry/ui/server/console/ConsoleUserDataActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/ConsoleUserDataActionTest.java
@@ -16,9 +16,10 @@ package google.registry.ui.server.console;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 import static org.mockito.Mockito.when;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.gson.Gson;
 import google.registry.model.console.User;
 import google.registry.persistence.transaction.JpaTestExtensions;
@@ -67,8 +68,7 @@ class ConsoleUserDataActionTest {
     ConsoleUserDataAction action =
         createAction(Optional.of(FakeConsoleApiParams.get(Optional.of(authResult))));
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_OK);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_OK);
     Map jsonObject =
         GSON.fromJson(((FakeResponse) consoleApiParams.response()).getPayload(), Map.class);
     assertThat(jsonObject)
@@ -91,8 +91,7 @@ class ConsoleUserDataActionTest {
   void testFailure_notAConsoleUser() throws IOException {
     ConsoleUserDataAction action = createAction(Optional.empty());
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_UNAUTHORIZED);
   }
 
   private ConsoleUserDataAction createAction(Optional<ConsoleApiParams> maybeConsoleApiParams)

--- a/core/src/test/java/google/registry/ui/server/console/RegistrarsActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/RegistrarsActionTest.java
@@ -20,10 +20,12 @@ import static google.registry.testing.DatabaseHelper.loadRegistrar;
 import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.SqlHelper.saveRegistrar;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
@@ -116,8 +118,7 @@ class RegistrarsActionTest {
                     createUser(
                         new UserRoles.Builder().setGlobalRole(GlobalRole.SUPPORT_LEAD).build()))));
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_OK);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_OK);
     String payload = ((FakeResponse) consoleApiParams.response()).getPayload();
 
     var actualRegistrarIds =
@@ -138,8 +139,7 @@ class RegistrarsActionTest {
                 UserAuthInfo.create(
                     createUser(new UserRoles.Builder().setGlobalRole(GlobalRole.FTE).build()))));
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_OK);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_OK);
     String payload = ((FakeResponse) consoleApiParams.response()).getPayload();
     assertThat(
             ImmutableList.of(
@@ -159,8 +159,7 @@ class RegistrarsActionTest {
             AuthResult.createUser(
                 UserAuthInfo.create(createUser(new UserRoles.Builder().setIsAdmin(true).build()))));
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_OK);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_OK);
     Registrar r = loadRegistrar("regIdTest");
     assertThat(r).isNotNull();
     assertThat(
@@ -190,7 +189,7 @@ class RegistrarsActionTest {
                               createUser(new UserRoles.Builder().setIsAdmin(true).build()))));
               action.run();
               assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-                  .isEqualTo(HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
+                  .isEqualTo(SC_BAD_REQUEST);
               assertThat(((FakeResponse) consoleApiParams.response()).getPayload())
                   .isEqualTo(
                       String.format(
@@ -207,8 +206,7 @@ class RegistrarsActionTest {
             AuthResult.createUser(
                 UserAuthInfo.create(createUser(new UserRoles.Builder().setIsAdmin(true).build()))));
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_BAD_REQUEST);
     assertThat(((FakeResponse) consoleApiParams.response()).getPayload())
         .isEqualTo("Registrar with registrarId regIdTest already exists");
   }
@@ -229,8 +227,7 @@ class RegistrarsActionTest {
                                     RegistrarRole.ACCOUNT_MANAGER_WITH_REGISTRY_LOCK))
                             .build()))));
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_FORBIDDEN);
   }
 
   private User createUser(UserRoles userRoles) {

--- a/core/src/test/java/google/registry/ui/server/console/settings/ContactActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/settings/ContactActionTest.java
@@ -21,10 +21,11 @@ import static google.registry.testing.DatabaseHelper.createAdminUser;
 import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.loadAllOf;
 import static google.registry.testing.SqlHelper.saveRegistrar;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
@@ -105,8 +106,7 @@ class ContactActionTest {
             testRegistrar.getRegistrarId(),
             null);
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_OK);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_OK);
     assertThat(((FakeResponse) consoleApiParams.response()).getPayload())
         .isEqualTo("[" + jsonRegistrar1 + "]");
   }
@@ -122,8 +122,7 @@ class ContactActionTest {
             testRegistrar.getRegistrarId(),
             null);
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_OK);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_OK);
     assertThat(((FakeResponse) consoleApiParams.response()).getPayload()).isEqualTo("[]");
   }
 
@@ -136,8 +135,7 @@ class ContactActionTest {
             testRegistrar.getRegistrarId(),
             "[" + jsonRegistrar1 + "," + jsonRegistrar2 + "]");
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_OK);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_OK);
     assertThat(
             loadAllOf(RegistrarPoc.class).stream()
                 .filter(r -> r.registrarId.equals(testRegistrar.getRegistrarId()))
@@ -157,8 +155,7 @@ class ContactActionTest {
             testRegistrar.getRegistrarId(),
             "[" + jsonRegistrar1 + "," + jsonRegistrar2 + "]");
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_OK);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_OK);
     HashMap<String, String> testResult = new HashMap<>();
     loadAllOf(RegistrarPoc.class).stream()
         .filter(r -> r.registrarId.equals(testRegistrar.getRegistrarId()))
@@ -181,8 +178,7 @@ class ContactActionTest {
             testRegistrar.getRegistrarId(),
             "[" + jsonRegistrar2 + "]");
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_OK);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_OK);
     assertThat(
             loadAllOf(RegistrarPoc.class).stream()
                 .filter(r -> r.registrarId.equals(testRegistrar.getRegistrarId()))
@@ -212,8 +208,7 @@ class ContactActionTest {
             testRegistrar.getRegistrarId(),
             "[" + jsonRegistrar2 + "]");
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_FORBIDDEN);
   }
 
   private ContactAction createAction(

--- a/core/src/test/java/google/registry/ui/server/console/settings/SecurityActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/settings/SecurityActionTest.java
@@ -19,10 +19,10 @@ import static google.registry.testing.CertificateSamples.SAMPLE_CERT2;
 import static google.registry.testing.DatabaseHelper.loadRegistrar;
 import static google.registry.testing.SqlHelper.saveRegistrar;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.ImmutableSortedMap;
@@ -94,8 +94,7 @@ class SecurityActionTest {
                 UserAuthInfo.create(DatabaseHelper.createAdminUser("email@email.com"))),
             testRegistrar.getRegistrarId());
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_OK);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_OK);
     Registrar r = loadRegistrar(testRegistrar.getRegistrarId());
     assertThat(r.getClientCertificateHash().get())
         .isEqualTo("GNd6ZP8/n91t9UTnpxR8aH7aAW4+CpvufYx9ViGbcMY");

--- a/core/src/test/java/google/registry/ui/server/console/settings/WhoisRegistrarFieldsActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/settings/WhoisRegistrarFieldsActionTest.java
@@ -16,10 +16,11 @@ package google.registry.ui.server.console.settings;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
@@ -116,8 +117,7 @@ public class WhoisRegistrarFieldsActionTest {
                 + " \"NL\", \"zip\": \"10011\", \"countryCode\": \"CA\"}"));
     WhoisRegistrarFieldsAction action = createAction();
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_OK);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_OK);
     Registrar newRegistrar = Registrar.loadByRegistrarId("TheRegistrar").get(); // skip cache
     assertThat(newRegistrar.getWhoisServer()).isEqualTo("whois.nic.google");
     assertThat(newRegistrar.getUrl()).isEqualTo("https://newurl.example");
@@ -148,8 +148,7 @@ public class WhoisRegistrarFieldsActionTest {
     uiRegistrarMap.put("registrarId", "NewRegistrar");
     WhoisRegistrarFieldsAction action = createAction(onlyTheRegistrar);
     action.run();
-    assertThat(((FakeResponse) consoleApiParams.response()).getStatus())
-        .isEqualTo(HttpStatusCodes.STATUS_CODE_FORBIDDEN);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_FORBIDDEN);
     // should be no change
     assertThat(DatabaseHelper.loadByEntity(newRegistrar)).isEqualTo(newRegistrar);
   }

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistryLockGetActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistryLockGetActionTest.java
@@ -24,9 +24,9 @@ import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.SqlHelper.saveRegistryLock;
 import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
 import static jakarta.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.appengine.api.users.User;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -110,7 +110,7 @@ final class RegistryLockGetActionTest {
 
     action.authResult = AuthResult.createUser(UserAuthInfo.create(consoleUser));
     action.run();
-    assertThat(response.getStatus()).isEqualTo(HttpStatusCodes.STATUS_CODE_OK);
+    assertThat(response.getStatus()).isEqualTo(SC_OK);
     assertThat(GSON.fromJson(response.getPayload(), Map.class))
         .containsExactly(
             "status",
@@ -220,7 +220,7 @@ final class RegistryLockGetActionTest {
     saveRegistryLock(unlockedLock);
 
     action.run();
-    assertThat(response.getStatus()).isEqualTo(HttpStatusCodes.STATUS_CODE_OK);
+    assertThat(response.getStatus()).isEqualTo(SC_OK);
     assertThat(GSON.fromJson(response.getPayload(), Map.class))
         .containsExactly(
             "status", "SUCCESS",


### PR DESCRIPTION
Given that we run servlets, it makes sense to always use the status
code contants from the servlet class.
