### PR TITLE
Removing leading newline from GKE log messages

### DIFF
--- a/util/src/main/java/google/registry/util/GcpJsonFormatter.java
+++ b/util/src/main/java/google/registry/util/GcpJsonFormatter.java
@@ -101,11 +101,6 @@ public class GcpJsonFormatter extends Formatter {
 
   @Override
   public String format(LogRecord record) {
-    // Add an extra newline before the message for better displaying of multi-line logs. To see the
-    // correctly indented multi-line logs, expand the log and look for the textPayload field. This
-    // newline makes sure that the entire message starts on its own line, so that indentation within
-    // the message is correct.
-
     String severity = severityFor(record.getLevel());
 
     // The rest is mostly lifted from java.util.logging.SimpleFormatter.
@@ -119,7 +114,7 @@ public class GcpJsonFormatter extends Formatter {
       throwable = sw.toString();
     }
 
-    String message = '\n' + formatMessage(record);
+    String message = formatMessage(record);
 
     String function = "";
     if (record.getSourceClassName() != null) {

--- a/util/src/test/java/google/registry/util/GcpJsonFormatterTest.java
+++ b/util/src/test/java/google/registry/util/GcpJsonFormatterTest.java
@@ -44,7 +44,7 @@ class GcpJsonFormatterTest {
 
   private static final String LOG_TEMPLATE =
       """
-      {"severity":"@@SEVERITY@@","logging.googleapis.com/sourceLocation":{"file":"GcpJsonFormatterTest.java","line":"@@LINE@@","function":"google.registry.util.GcpJsonFormatterTest.@@FUNCTION@@"},"message":"\\n@@MESSAGE@@"}
+      {"severity":"@@SEVERITY@@","logging.googleapis.com/sourceLocation":{"file":"GcpJsonFormatterTest.java","line":"@@LINE@@","function":"google.registry.util.GcpJsonFormatterTest.@@FUNCTION@@"},"message":"@@MESSAGE@@"}
       """;
 
   private static String makeJson(String severity, int line, String function, String message) {


### PR DESCRIPTION
GKE now displays log messages correctly. There is no need for an extra
leading newline, which now results in a useless blank line for each log
entry in Log Explorer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2454)
<!-- Reviewable:end -->
