### PR TITLE
Fully reset domain-list page on registrar change

### DIFF
--- a/console-webapp/src/app/domains/domainList.component.ts
+++ b/console-webapp/src/app/domains/domainList.component.ts
@@ -59,6 +59,8 @@ export class DomainListComponent {
   ) {
     effect(() => {
       if (this.registrarService.registrarId()) {
+        this.pageNumber = 0;
+        this.totalResults = 0;
         this.reloadData();
       }
     });

--- a/core/src/test/java/google/registry/server/Fixture.java
+++ b/core/src/test/java/google/registry/server/Fixture.java
@@ -155,6 +155,13 @@ public enum Fixture {
               .build());
 
       persistResource(
+          DatabaseHelper.newDomain("newregistrar.example")
+              .asBuilder()
+              .setPersistedCurrentSponsorRegistrarId("NewRegistrar")
+              .setCreationRegistrarId("NewRegistrar")
+              .build());
+
+      persistResource(
           loadRegistrar("TheRegistrar")
               .asBuilder()
               .setAllowedTlds(ImmutableSet.of("example", "xn--q9jyb4c"))


### PR DESCRIPTION
When the registrar changes we should reset the page and the total results to 0 (since we haven't loaded them yet)

https://b.corp.google.com/issues/343193698

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2456)
<!-- Reviewable:end -->
