### PR TITLE
Move domain-list search+download outside of loading bar

### DIFF
--- a/console-webapp/src/app/domains/domainList.component.html
+++ b/console-webapp/src/app/domains/domainList.component.html
@@ -1,18 +1,6 @@
 <app-selected-registrar-wrapper>
   <div class="console-domains">
     <h1 class="mat-headline-4">Domains</h1>
-    @if (totalResults === 0) {
-    <div class="console-app__empty-domains">
-      <h1>
-        <mat-icon class="console-app__empty-domains-icon secondary-text"
-          >apps_outage</mat-icon
-        >
-      </h1>
-      <h1>No domains found</h1>
-    </div>
-    } @else if(isLoading) {
-    <mat-progress-bar mode="indeterminate"></mat-progress-bar>
-    } @else {
     <a
       mat-stroked-button
       color="primary"
@@ -31,55 +19,75 @@
         matInput
         [(ngModel)]="searchTerm"
         (ngModelChange)="sendInput()"
+        [disabled]="isLoading"
         #input
       />
     </mat-form-field>
-    <mat-table
-      [dataSource]="dataSource"
-      class="mat-elevation-z0"
-      class="console-app__domains-table"
-    >
-      <ng-container matColumnDef="domainName">
-        <mat-header-cell *matHeaderCellDef>Domain Name</mat-header-cell>
-        <mat-cell *matCellDef="let element">{{ element.domainName }}</mat-cell>
-      </ng-container>
+    @if (!isLoading && totalResults == 0) {
+    <div class="console-app__empty-domains">
+      <h1>
+        <mat-icon class="console-app__empty-domains-icon secondary-text"
+          >apps_outage</mat-icon
+        >
+      </h1>
+      <h1>No domains found</h1>
+    </div>
+    } @else {
+    <div class="console-app__domains-table-parent">
+      @if (isLoading) {
+      <div class="console-app__domains-spinner">
+        <mat-spinner />
+      </div>
+      }
+      <mat-table
+        [dataSource]="dataSource"
+        class="mat-elevation-z0"
+        class="console-app__domains-table"
+      >
+        <ng-container matColumnDef="domainName">
+          <mat-header-cell *matHeaderCellDef>Domain Name</mat-header-cell>
+          <mat-cell *matCellDef="let element">{{
+            element.domainName
+          }}</mat-cell>
+        </ng-container>
 
-      <ng-container matColumnDef="creationTime">
-        <mat-header-cell *matHeaderCellDef>Creation Time</mat-header-cell>
-        <mat-cell *matCellDef="let element">
-          {{ element.creationTime.creationTime }}
-        </mat-cell>
-      </ng-container>
+        <ng-container matColumnDef="creationTime">
+          <mat-header-cell *matHeaderCellDef>Creation Time</mat-header-cell>
+          <mat-cell *matCellDef="let element">
+            {{ element.creationTime.creationTime }}
+          </mat-cell>
+        </ng-container>
 
-      <ng-container matColumnDef="registrationExpirationTime">
-        <mat-header-cell *matHeaderCellDef>Expiration Time</mat-header-cell>
-        <mat-cell *matCellDef="let element">
-          {{ element.registrationExpirationTime }}
-        </mat-cell>
-      </ng-container>
+        <ng-container matColumnDef="registrationExpirationTime">
+          <mat-header-cell *matHeaderCellDef>Expiration Time</mat-header-cell>
+          <mat-cell *matCellDef="let element">
+            {{ element.registrationExpirationTime }}
+          </mat-cell>
+        </ng-container>
 
-      <ng-container matColumnDef="statuses">
-        <mat-header-cell *matHeaderCellDef>Statuses</mat-header-cell>
-        <mat-cell *matCellDef="let element">{{ element.statuses }}</mat-cell>
-      </ng-container>
+        <ng-container matColumnDef="statuses">
+          <mat-header-cell *matHeaderCellDef>Statuses</mat-header-cell>
+          <mat-cell *matCellDef="let element">{{ element.statuses }}</mat-cell>
+        </ng-container>
 
-      <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-      <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
+        <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+        <mat-row *matRowDef="let row; columns: displayedColumns"></mat-row>
 
-      <!-- Row shown when there is no matching data. -->
-      <mat-row *matNoDataRow>
-        <mat-cell colspan="4">No domains found</mat-cell>
-      </mat-row>
-    </mat-table>
-    <mat-paginator
-      [length]="totalResults"
-      [pageIndex]="pageNumber"
-      [pageSize]="resultsPerPage"
-      [pageSizeOptions]="[10, 25, 50, 100, 500]"
-      (page)="onPageChange($event)"
-      aria-label="Select page of domain results"
-      showFirstLastButtons
-    ></mat-paginator>
+        <!-- Row shown when there is no matching data. -->
+        <mat-row *matNoDataRow>
+          <mat-cell colspan="4">No domains found</mat-cell>
+        </mat-row>
+      </mat-table>
+      <mat-paginator
+        [length]="totalResults"
+        [pageIndex]="pageNumber"
+        [pageSize]="resultsPerPage"
+        [pageSizeOptions]="[10, 25, 50, 100, 500]"
+        (page)="onPageChange($event)"
+        aria-label="Select page of domain results"
+        showFirstLastButtons
+      ></mat-paginator>
+    </div>
     }
   </div>
 </app-selected-registrar-wrapper>

--- a/console-webapp/src/app/domains/domainList.component.scss
+++ b/console-webapp/src/app/domains/domainList.component.scss
@@ -31,8 +31,22 @@
     width: 100%;
   }
 
+  &__domains-table-parent {
+    position: relative;
+  }
+
   &__domains-table {
     min-width: $min-width !important;
+  }
+
+  &__domains-spinner {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+    position: absolute;
+    height: 100%;
+    width: 100%;
+    background: rgba(255, 255, 255, 0.6);
   }
 
   .mat-mdc-paginator {

--- a/console-webapp/src/app/domains/domainList.component.ts
+++ b/console-webapp/src/app/domains/domainList.component.ts
@@ -58,11 +58,10 @@ export class DomainListComponent {
     private _snackBar: MatSnackBar
   ) {
     effect(() => {
-      if (this.registrarService.registrarId()) {
-        this.pageNumber = 0;
-        this.totalResults = 0;
-        this.reloadData();
-      }
+      this.pageNumber = 0;
+      this.totalResults = 0;
+      this.reloadData();
+      this.registrarService.registrarId();
     });
   }
 


### PR DESCRIPTION
This means that they'll stick around even while we're loading domains from the server.

This also adds a loading spinner.

https://b.corp.google.com/issues/343213150
https://b.corp.google.com/issues/343211773

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2457)
<!-- Reviewable:end -->
