### PR TITLE
Make registrant nullable on domains

### DIFF
--- a/core/src/main/java/google/registry/beam/rde/RdePipeline.java
+++ b/core/src/main/java/google/registry/beam/rde/RdePipeline.java
@@ -468,7 +468,7 @@ public class RdePipeline implements Serializable {
                                 HashSet<Serializable> contacts = new HashSet<>();
                                 contacts.add(domain.getAdminContact().getKey());
                                 contacts.add(domain.getTechContact().getKey());
-                                contacts.add(domain.getRegistrant().getKey());
+                                domain.getRegistrant().ifPresent(r -> contacts.add(r.getKey()));
                                 // Billing contact is not mandatory.
                                 if (domain.getBillingContact() != null) {
                                   contacts.add(domain.getBillingContact().getKey());

--- a/core/src/main/java/google/registry/flows/domain/DomainInfoFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainInfoFlow.java
@@ -119,8 +119,11 @@ public final class DomainInfoFlow implements TransactionalFlow {
             .setCreationTime(domain.getCreationTime())
             .setLastEppUpdateTime(domain.getLastEppUpdateTime())
             .setRegistrationExpirationTime(domain.getRegistrationExpirationTime())
-            .setLastTransferTime(domain.getLastTransferTime())
-            .setRegistrant(tm().loadByKey(domain.getRegistrant()).getContactId());
+            .setLastTransferTime(domain.getLastTransferTime());
+    domain
+        .getRegistrant()
+        .ifPresent(r -> infoBuilder.setRegistrant(tm().loadByKey(r).getContactId()));
+
     // If authInfo is non-null, then the caller is authorized to see the full information since we
     // will have already verified the authInfo is valid.
     if (registrarId.equals(domain.getCurrentSponsorRegistrarId()) || authInfo.isPresent()) {

--- a/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
@@ -278,7 +278,7 @@ public final class DomainUpdateFlow implements MutatingFlow {
             .removeStatusValues(remove.getStatusValues())
             .removeContacts(remove.getContacts())
             .addContacts(add.getContacts())
-            .setRegistrant(firstNonNull(change.getRegistrant(), domain.getRegistrant()))
+            .setRegistrant(change.getRegistrant().or(domain::getRegistrant))
             .setAuthInfo(firstNonNull(change.getAuthInfo(), domain.getAuthInfo()));
 
     if (!add.getNameservers().isEmpty()) {
@@ -301,7 +301,10 @@ public final class DomainUpdateFlow implements MutatingFlow {
   }
 
   private static void validateRegistrantIsntBeingRemoved(Change change) throws EppException {
-    if (change.getRegistrantContactId() != null && change.getRegistrantContactId().isEmpty()) {
+    // TODO(mcilwain): Make this check the minimum registration data set migration schedule
+    //                 and not require presence of a registrant in later stages.
+    if (change.getRegistrantContactId().isPresent()
+        && change.getRegistrantContactId().get().isEmpty()) {
       throw new MissingRegistrantException();
     }
   }

--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -135,7 +135,7 @@ public class DomainBase extends EppResource
 
   @Expose VKey<Contact> billingContact;
   @Expose VKey<Contact> techContact;
-  @Expose VKey<Contact> registrantContact;
+  @Expose @Nullable VKey<Contact> registrantContact;
 
   /** Authorization info (aka transfer secret) of the domain. */
   @Embedded
@@ -585,8 +585,8 @@ public class DomainBase extends EppResource
   }
 
   /** A key to the registrant who registered this domain. */
-  public VKey<Contact> getRegistrant() {
-    return registrantContact;
+  public Optional<VKey<Contact>> getRegistrant() {
+    return Optional.ofNullable(registrantContact);
   }
 
   public VKey<Contact> getAdminContact() {
@@ -604,6 +604,11 @@ public class DomainBase extends EppResource
   /** Associated contacts for the domain (other than registrant). */
   public ImmutableSet<DesignatedContact> getContacts() {
     return getAllContacts(false);
+  }
+
+  /** Gets all associated contacts for the domain, including the registrant. */
+  public ImmutableSet<DesignatedContact> getAllContacts() {
+    return getAllContacts(true);
   }
 
   public DomainAuthInfo getAuthInfo() {
@@ -717,7 +722,6 @@ public class DomainBase extends EppResource
       instance.autorenewEndTime = firstNonNull(getInstance().autorenewEndTime, END_OF_TIME);
 
       checkArgumentNotNull(emptyToNull(instance.domainName), "Missing domainName");
-      checkArgumentNotNull(instance.getRegistrant(), "Missing registrant");
       instance.tld = getTldFromDomainName(instance.domainName);
 
       T newDomain = super.build();
@@ -749,9 +753,9 @@ public class DomainBase extends EppResource
       return thisCastToDerived();
     }
 
-    public B setRegistrant(VKey<Contact> registrant) {
+    public B setRegistrant(Optional<VKey<Contact>> registrant) {
       // Set the registrant field specifically.
-      getInstance().registrantContact = registrant;
+      getInstance().registrantContact = registrant.orElse(null);
       return thisCastToDerived();
     }
 

--- a/core/src/main/java/google/registry/model/domain/DomainCommand.java
+++ b/core/src/main/java/google/registry/model/domain/DomainCommand.java
@@ -40,6 +40,7 @@ import google.registry.model.eppinput.ResourceCommand.ResourceUpdate;
 import google.registry.model.eppinput.ResourceCommand.SingleResourceCommand;
 import google.registry.model.host.Host;
 import google.registry.persistence.VKey;
+import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlAttribute;
@@ -76,21 +77,21 @@ public class DomainCommand {
 
     /** The contactId of the registrant who registered this domain. */
     @XmlElement(name = "registrant")
+    @Nullable
     String registrantContactId;
 
     /** A resolved key to the registrant who registered this domain. */
-    @XmlTransient VKey<Contact> registrant;
+    @Nullable @XmlTransient VKey<Contact> registrant;
 
     /** Authorization info (aka transfer secret) of the domain. */
     DomainAuthInfo authInfo;
 
-    public String getRegistrantContactId() {
-      return registrantContactId;
+    public Optional<String> getRegistrantContactId() {
+      return Optional.ofNullable(registrantContactId);
     }
 
-    @Nullable
-    public VKey<Contact> getRegistrant() {
-      return registrant;
+    public Optional<VKey<Contact>> getRegistrant() {
+      return Optional.ofNullable(registrant);
     }
 
     public DomainAuthInfo getAuthInfo() {

--- a/core/src/main/java/google/registry/model/domain/DomainInfoData.java
+++ b/core/src/main/java/google/registry/model/domain/DomainInfoData.java
@@ -63,6 +63,7 @@ public abstract class DomainInfoData implements ResponseData {
   abstract ImmutableSet<StatusValue> getStatusValues();
 
   @XmlElement(name = "registrant")
+  @Nullable
   abstract String getRegistrant();
 
   @XmlElement(name = "contact")

--- a/core/src/main/java/google/registry/rdap/RdapEntityAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapEntityAction.java
@@ -76,7 +76,7 @@ public class RdapEntityAction extends RdapActionBase {
       // they are global, and might have different roles for different domains.
       if (contact.isPresent() && isAuthorized(contact.get())) {
         return rdapJsonFormatter.createRdapContactEntity(
-            contact.get(), ImmutableSet.of(), OutputDataType.FULL);
+            contact, ImmutableSet.of(), OutputDataType.FULL);
       }
     }
 

--- a/core/src/main/java/google/registry/rdap/RdapEntitySearchAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapEntitySearchAction.java
@@ -461,7 +461,7 @@ public class RdapEntitySearchAction extends RdapSearchActionBase {
           .entitySearchResultsBuilder()
           .add(
               rdapJsonFormatter.createRdapContactEntity(
-                  contact, ImmutableSet.of(), outputDataType));
+                  Optional.of(contact), ImmutableSet.of(), outputDataType));
       newCursor =
           Optional.of(
               CONTACT_CURSOR_PREFIX

--- a/core/src/main/java/google/registry/rde/DomainToXjcConverter.java
+++ b/core/src/main/java/google/registry/rde/DomainToXjcConverter.java
@@ -20,7 +20,6 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import com.google.common.base.Ascii;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.flogger.FluentLogger;
 import google.registry.model.contact.Contact;
 import google.registry.model.domain.DesignatedContact;
 import google.registry.model.domain.Domain;
@@ -45,11 +44,10 @@ import google.registry.xjc.rgp.XjcRgpStatusType;
 import google.registry.xjc.rgp.XjcRgpStatusValueType;
 import google.registry.xjc.secdns.XjcSecdnsDsDataType;
 import google.registry.xjc.secdns.XjcSecdnsDsOrKeyType;
+import java.util.Optional;
 
 /** Utility class that turns {@link Domain} as {@link XjcRdeDomainElement}. */
 final class DomainToXjcConverter {
-
-  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   /** Converts {@link Domain} to {@link XjcRdeDomainElement}. */
   static XjcRdeDomainElement convert(Domain domain, RdeMode mode) {
@@ -168,11 +166,9 @@ final class DomainToXjcConverter {
         // o  An OPTIONAL <registrant> element that contain the identifier for
         //    the human or organizational social information object associated
         //    as the holder of the domain name object.
-        VKey<Contact> registrant = model.getRegistrant();
-        if (registrant == null) {
-          logger.atWarning().log("Domain %s has no registrant contact.", domainName);
-        } else {
-          Contact registrantContact = tm().transact(() -> tm().loadByKey(registrant));
+        Optional<VKey<Contact>> registrant = model.getRegistrant();
+        if (registrant.isPresent()) {
+          Contact registrantContact = tm().transact(() -> tm().loadByKey(registrant.get()));
           checkState(
               registrantContact != null,
               "Registrant contact %s on domain %s does not exist",

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleApiAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleApiAction.java
@@ -254,5 +254,4 @@ public abstract class ConsoleApiAction implements Runnable {
       super(message);
     }
   }
-
 }

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleUpdateRegistrarAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleUpdateRegistrarAction.java
@@ -47,8 +47,7 @@ public class ConsoleUpdateRegistrarAction extends ConsoleApiAction {
 
   @Inject
   ConsoleUpdateRegistrarAction(
-      ConsoleApiParams consoleApiParams,
-      @Parameter("registrar") Optional<Registrar> registrar) {
+      ConsoleApiParams consoleApiParams, @Parameter("registrar") Optional<Registrar> registrar) {
     super(consoleApiParams);
     this.registrar = registrar;
   }
@@ -108,5 +107,4 @@ public class ConsoleUpdateRegistrarAction extends ConsoleApiAction {
 
     consoleApiParams.response().setStatus(SC_OK);
   }
-
 }

--- a/core/src/main/java/google/registry/whois/DomainWhoisResponse.java
+++ b/core/src/main/java/google/registry/whois/DomainWhoisResponse.java
@@ -105,7 +105,9 @@ final class DomainWhoisResponse extends WhoisResponseImpl {
                 "Registrar Abuse Contact Phone",
                 abuseContact.map(RegistrarPoc::getPhoneNumber).orElse(""))
             .emitStatusValues(domain.getStatusValues(), domain.getGracePeriods())
-            .emitContact("Registrant", Optional.of(domain.getRegistrant()), preferUnicode)
+            // TODO(mcilwain): Investigate if the WHOIS spec requires us to always output REDACTED
+            //                 text in WHOIS even if the contact is not present, and if so, do so.
+            .emitContact("Registrant", domain.getRegistrant(), preferUnicode)
             .emitContact("Admin", getContactReference(Type.ADMIN), preferUnicode)
             .emitContact("Tech", getContactReference(Type.TECH), preferUnicode)
             .emitContact("Billing", getContactReference(Type.BILLING), preferUnicode)

--- a/core/src/test/java/google/registry/beam/common/RegistryJpaReadTest.java
+++ b/core/src/test/java/google/registry/beam/common/RegistryJpaReadTest.java
@@ -43,6 +43,7 @@ import google.registry.persistence.transaction.CriteriaQueryBuilder;
 import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationTestExtension;
 import google.registry.testing.FakeClock;
+import java.util.Optional;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.values.PCollection;
@@ -191,7 +192,7 @@ public class RegistryJpaReadTest {
                     StatusValue.SERVER_UPDATE_PROHIBITED,
                     StatusValue.SERVER_RENEW_PROHIBITED,
                     StatusValue.SERVER_HOLD))
-            .setRegistrant(contact.createVKey())
+            .setRegistrant(Optional.of(contact.createVKey()))
             .setContacts(ImmutableSet.of())
             .setSubordinateHosts(ImmutableSet.of("ns1.example.com"))
             .setPersistedCurrentSponsorRegistrarId(registrar.getRegistrarId())

--- a/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
+++ b/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
@@ -54,6 +54,7 @@ import google.registry.util.Retrier;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Optional;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -297,7 +298,7 @@ class Spec11PipelineTest {
         .setLastEppUpdateTime(fakeClock.nowUtc())
         .setLastEppUpdateRegistrarId(registrar.getRegistrarId())
         .setLastTransferTime(fakeClock.nowUtc())
-        .setRegistrant(contact.createVKey())
+        .setRegistrant(Optional.of(contact.createVKey()))
         .setPersistedCurrentSponsorRegistrarId(registrar.getRegistrarId())
         .setRegistrationExpirationTime(fakeClock.nowUtc().plusYears(1))
         .setAuthInfo(DomainAuthInfo.create(PasswordAuth.create("password")))

--- a/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
@@ -103,6 +103,7 @@ import google.registry.model.transfer.TransferStatus;
 import google.registry.testing.CloudTasksHelper.TaskMatcher;
 import google.registry.testing.DatabaseHelper;
 import java.util.Map;
+import java.util.Optional;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
@@ -162,7 +163,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             DatabaseHelper.newDomain(getUniqueIdFromCommand())
                 .asBuilder()
                 .setCreationTimeForTest(TIME_BEFORE_FLOW)
-                .setRegistrant(contact.createVKey())
+                .setRegistrant(Optional.of(contact.createVKey()))
                 .setRegistrationExpirationTime(expirationTime)
                 .build());
     earlierHistoryEntry =
@@ -738,7 +739,8 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         DatabaseHelper.newDomain("example1.tld")
             .asBuilder()
             .setRegistrant(
-                loadByForeignKey(Contact.class, "sh8013", clock.nowUtc()).get().createVKey())
+                Optional.of(
+                    loadByForeignKey(Contact.class, "sh8013", clock.nowUtc()).get().createVKey()))
             .setNameservers(ImmutableSet.of(host.createVKey()))
             .setDeletionTime(START_OF_TIME)
             .build());

--- a/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
@@ -78,6 +78,7 @@ import google.registry.persistence.VKey;
 import google.registry.persistence.transaction.JpaTransactionManagerExtension;
 import google.registry.testing.DatabaseHelper;
 import google.registry.xml.ValidationMode;
+import java.util.Optional;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.joda.money.Money;
@@ -139,7 +140,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 .setLastEppUpdateTime(DateTime.parse("1999-12-03T09:00:00.0Z"))
                 .setLastTransferTime(DateTime.parse("2000-04-08T09:00:00.0Z"))
                 .setRegistrationExpirationTime(DateTime.parse("2005-04-03T22:00:00.0Z"))
-                .setRegistrant(registrant.createVKey())
+                .setRegistrant(Optional.of(registrant.createVKey()))
                 .setContacts(
                     ImmutableSet.of(
                         DesignatedContact.create(Type.ADMIN, contact.createVKey()),
@@ -225,6 +226,13 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
   @Test
   void testSuccess_allHosts() throws Exception {
     doSuccessfulTest("domain_info_response.xml");
+  }
+
+  @Test
+  void testSuccess_noRegistrant() throws Exception {
+    persistTestEntities(false);
+    domain = persistResource(domain.asBuilder().setRegistrant(Optional.empty()).build());
+    doSuccessfulTest("domain_info_response_no_registrant.xml", false);
   }
 
   @Test

--- a/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
@@ -162,7 +162,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
                         DesignatedContact.create(Type.TECH, mak21Contact.createVKey()),
                         DesignatedContact.create(Type.ADMIN, mak21Contact.createVKey()),
                         DesignatedContact.create(Type.BILLING, mak21Contact.createVKey())))
-                .setRegistrant(mak21Contact.createVKey())
+                .setRegistrant(Optional.of(mak21Contact.createVKey()))
                 .setNameservers(ImmutableSet.of(host.createVKey()))
                 .build());
     persistResource(
@@ -338,7 +338,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .asBuilder()
             .setNameservers(nameservers.build())
             .setContacts(ImmutableSet.copyOf(contacts.subList(0, 3)))
-            .setRegistrant(contacts.get(3).getContactKey())
+            .setRegistrant(Optional.of(contacts.get(3).getContactKey()))
             .build());
     clock.advanceOneMilli();
     assertMutatingFlow(true);
@@ -348,7 +348,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     assertThat(domain.getNameservers()).hasSize(13);
     // getContacts does not return contacts of type REGISTRANT, so check these separately.
     assertThat(domain.getContacts()).hasSize(3);
-    assertThat(loadByKey(domain.getRegistrant()).getContactId()).isEqualTo("max_test_7");
+    assertThat(loadByKey(domain.getRegistrant().get()).getContactId()).isEqualTo("max_test_7");
     assertNoBillingEvents();
     assertDomainDnsRequests("example.tld");
   }
@@ -426,7 +426,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     persistResource(
         DatabaseHelper.newDomain(getUniqueIdFromCommand())
             .asBuilder()
-            .setRegistrant(sh8013.createVKey())
+            .setRegistrant(Optional.of(sh8013.createVKey()))
             .build());
     clock.advanceOneMilli();
     runFlowAssertResponse(loadFile("generic_success_response.xml"));
@@ -441,7 +441,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     persistResource(
         DatabaseHelper.newDomain(getUniqueIdFromCommand())
             .asBuilder()
-            .setRegistrant(sh8013Key)
+            .setRegistrant(Optional.of(sh8013Key))
             .setContacts(
                 ImmutableSet.of(
                     DesignatedContact.create(Type.ADMIN, sh8013Key),
@@ -1590,7 +1590,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .setAllowedFullyQualifiedHostNames(ImmutableSet.of("ns1.example.foo"))
             .build());
     runFlow();
-    assertThat(loadByKey(reloadResourceByForeignKey().getRegistrant()).getContactId())
+    assertThat(loadByKey(reloadResourceByForeignKey().getRegistrant().get()).getContactId())
         .isEqualTo("sh8013");
   }
 
@@ -1605,7 +1605,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
         .forEach(
             contact ->
                 assertThat(loadByKey(contact.getContactKey()).getContactId()).isEqualTo("mak21"));
-    assertThat(loadByKey(reloadResourceByForeignKey().getRegistrant()).getContactId())
+    assertThat(loadByKey(reloadResourceByForeignKey().getRegistrant().get()).getContactId())
         .isEqualTo("mak21");
 
     runFlow();
@@ -1615,7 +1615,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
         .forEach(
             contact ->
                 assertThat(loadByKey(contact.getContactKey()).getContactId()).isEqualTo("sh8013"));
-    assertThat(loadByKey(reloadResourceByForeignKey().getRegistrant()).getContactId())
+    assertThat(loadByKey(reloadResourceByForeignKey().getRegistrant().get()).getContactId())
         .isEqualTo("sh8013");
   }
 

--- a/core/src/test/java/google/registry/model/domain/DomainSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainSqlTest.java
@@ -54,6 +54,7 @@ import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationW
 import google.registry.testing.FakeClock;
 import google.registry.util.SerializeUtils;
 import java.util.Arrays;
+import java.util.Optional;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,7 +70,7 @@ public class DomainSqlTest {
       new JpaTestExtensions.Builder().withClock(fakeClock).buildIntegrationWithCoverageExtension();
 
   private Domain domain;
-  private VKey<Contact> contactKey;
+  private Optional<VKey<Contact>> contactKey;
   private VKey<Contact> contact2Key;
   private VKey<Host> host1VKey;
   private Host host;
@@ -82,7 +83,7 @@ public class DomainSqlTest {
     saveRegistrar("registrar1");
     saveRegistrar("registrar2");
     saveRegistrar("registrar3");
-    contactKey = createKey(Contact.class, "contact_id1");
+    contactKey = Optional.of(createKey(Contact.class, "contact_id1"));
     contact2Key = createKey(Contact.class, "contact_id2");
 
     host1VKey = createKey(Host.class, "host1");

--- a/core/src/test/java/google/registry/model/domain/DomainTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainTest.java
@@ -185,7 +185,7 @@ public class DomainTest {
                             StatusValue.SERVER_UPDATE_PROHIBITED,
                             StatusValue.SERVER_RENEW_PROHIBITED,
                             StatusValue.SERVER_HOLD))
-                    .setRegistrant(contact1Key)
+                    .setRegistrant(Optional.of(contact1Key))
                     .setNameservers(ImmutableSet.of(hostKey))
                     .setSubordinateHosts(ImmutableSet.of("ns1.example.com"))
                     .setPersistedCurrentSponsorRegistrarId("NewRegistrar")
@@ -240,6 +240,16 @@ public class DomainTest {
     // original domain object).
     assertThat(loadByForeignKey(Domain.class, domain.getForeignKey(), fakeClock.nowUtc()))
         .hasValue(domain);
+  }
+
+  @Test
+  void testRegistrantNotRequired() {
+    persistResource(domain.asBuilder().setRegistrant(Optional.empty()).build());
+    assertThat(
+            loadByForeignKey(Domain.class, domain.getForeignKey(), fakeClock.nowUtc())
+                .get()
+                .getRegistrant())
+        .isEmpty();
   }
 
   @Test
@@ -1012,14 +1022,14 @@ public class DomainTest {
             DesignatedContact.create(Type.BILLING, contact3Key),
             DesignatedContact.create(Type.TECH, contact4Key)),
         true);
-    assertThat(domain.getRegistrant()).isEqualTo(contact1Key);
+    assertThat(domain.getRegistrant()).hasValue(contact1Key);
     assertThat(domain.getAdminContact()).isEqualTo(contact2Key);
     assertThat(domain.getBillingContact()).isEqualTo(contact3Key);
     assertThat(domain.getTechContact()).isEqualTo(contact4Key);
 
     // Make sure everything gets nulled out.
     domain.setContactFields(ImmutableSet.of(), true);
-    assertThat(domain.getRegistrant()).isNull();
+    assertThat(domain.getRegistrant()).isEmpty();
     assertThat(domain.getAdminContact()).isNull();
     assertThat(domain.getBillingContact()).isNull();
     assertThat(domain.getTechContact()).isNull();
@@ -1032,13 +1042,13 @@ public class DomainTest {
             DesignatedContact.create(Type.BILLING, contact3Key),
             DesignatedContact.create(Type.TECH, contact4Key)),
         false);
-    assertThat(domain.getRegistrant()).isNull();
+    assertThat(domain.getRegistrant()).isEmpty();
     assertThat(domain.getAdminContact()).isEqualTo(contact2Key);
     assertThat(domain.getBillingContact()).isEqualTo(contact3Key);
     assertThat(domain.getTechContact()).isEqualTo(contact4Key);
-    domain = domain.asBuilder().setRegistrant(contact1Key).build();
+    domain = domain.asBuilder().setRegistrant(Optional.of(contact1Key)).build();
     domain.setContactFields(ImmutableSet.of(), false);
-    assertThat(domain.getRegistrant()).isEqualTo(contact1Key);
+    assertThat(domain.getRegistrant()).hasValue(contact1Key);
     assertThat(domain.getAdminContact()).isNull();
     assertThat(domain.getBillingContact()).isNull();
     assertThat(domain.getTechContact()).isNull();

--- a/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchTest.java
+++ b/core/src/test/java/google/registry/model/reporting/Spec11ThreatMatchTest.java
@@ -31,6 +31,7 @@ import google.registry.model.domain.Domain;
 import google.registry.model.host.Host;
 import google.registry.model.transfer.ContactTransferData;
 import google.registry.persistence.VKey;
+import java.util.Optional;
 import org.joda.time.LocalDate;
 import org.joda.time.format.ISODateTimeFormat;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,7 +69,7 @@ public final class Spec11ThreatMatchTest extends EntityTestCase {
             .setDomainName("foo.tld")
             .setRepoId(domainRepoId)
             .setNameservers(hostVKey)
-            .setRegistrant(registrantContactVKey)
+            .setRegistrant(Optional.of(registrantContactVKey))
             .setContacts(ImmutableSet.of())
             .build();
 

--- a/core/src/test/java/google/registry/rdap/RdapDomainActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapDomainActionTest.java
@@ -15,6 +15,7 @@
 package google.registry.rdap;
 
 import static com.google.common.truth.Truth.assertThat;
+import static google.registry.model.EppResourceUtils.loadByForeignKey;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DatabaseHelper.persistSimpleResources;
@@ -275,6 +276,19 @@ class RdapDomainActionTest extends RdapActionBaseTestCase<RdapDomainAction> {
 
   @Test
   void testValidDomain_notLoggedIn_noContacts() {
+    assertProperResponseForCatLol("cat.lol", "rdap_domain_no_contacts_with_remark.json");
+  }
+
+  @Test
+  void testValidDomain_notLoggedIn_contactsShowRedacted_evenWhenRegistrantDoesntExist() {
+    // Even though the registrant is empty on this domain, it still shows a full set of REDACTED
+    // fields through RDAP.
+    persistResource(
+        loadByForeignKey(Domain.class, "cat.lol", clock.nowUtc())
+            .get()
+            .asBuilder()
+            .setRegistrant(Optional.empty())
+            .build());
     assertProperResponseForCatLol("cat.lol", "rdap_domain_no_contacts_with_remark.json");
   }
 

--- a/core/src/test/java/google/registry/rdap/RdapJsonFormatterTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapJsonFormatterTest.java
@@ -52,6 +52,8 @@ import google.registry.rdap.RdapObjectClasses.ReplyPayloadBase;
 import google.registry.rdap.RdapObjectClasses.TopLevelReplyObject;
 import google.registry.testing.FakeClock;
 import google.registry.testing.FullFieldsTestEntityHelper;
+import java.util.Optional;
+import javax.annotation.Nullable;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -77,7 +79,7 @@ class RdapJsonFormatterTest {
   private Host hostNoAddresses;
   private Host hostNotLinked;
   private Host hostSuperordinatePendingTransfer;
-  private Contact contactRegistrant;
+  @Nullable private Contact contactRegistrant;
   private Contact contactAdmin;
   private Contact contactTech;
   private Contact contactNotLinked;
@@ -371,7 +373,7 @@ class RdapJsonFormatterTest {
         .that(
             rdapJsonFormatter
                 .createRdapContactEntity(
-                    contactRegistrant,
+                    Optional.of(contactRegistrant),
                     ImmutableSet.of(RdapEntity.Role.REGISTRANT),
                     OutputDataType.FULL)
                 .toJson())
@@ -384,7 +386,7 @@ class RdapJsonFormatterTest {
         .that(
             rdapJsonFormatter
                 .createRdapContactEntity(
-                    contactRegistrant,
+                    Optional.of(contactRegistrant),
                     ImmutableSet.of(RdapEntity.Role.REGISTRANT),
                     OutputDataType.SUMMARY)
                 .toJson())
@@ -398,7 +400,7 @@ class RdapJsonFormatterTest {
         .that(
             rdapJsonFormatter
                 .createRdapContactEntity(
-                    contactRegistrant,
+                    Optional.of(contactRegistrant),
                     ImmutableSet.of(RdapEntity.Role.REGISTRANT),
                     OutputDataType.FULL)
                 .toJson())
@@ -418,7 +420,7 @@ class RdapJsonFormatterTest {
         .that(
             rdapJsonFormatter
                 .createRdapContactEntity(
-                    contactRegistrant,
+                    Optional.of(contactRegistrant),
                     ImmutableSet.of(RdapEntity.Role.REGISTRANT),
                     OutputDataType.FULL)
                 .toJson())
@@ -431,7 +433,9 @@ class RdapJsonFormatterTest {
         .that(
             rdapJsonFormatter
                 .createRdapContactEntity(
-                    contactAdmin, ImmutableSet.of(RdapEntity.Role.ADMIN), OutputDataType.FULL)
+                    Optional.of(contactAdmin),
+                    ImmutableSet.of(RdapEntity.Role.ADMIN),
+                    OutputDataType.FULL)
                 .toJson())
         .isEqualTo(loadJson("rdapjson_admincontact.json"));
   }
@@ -442,7 +446,9 @@ class RdapJsonFormatterTest {
         .that(
             rdapJsonFormatter
                 .createRdapContactEntity(
-                    contactTech, ImmutableSet.of(RdapEntity.Role.TECH), OutputDataType.FULL)
+                    Optional.of(contactTech),
+                    ImmutableSet.of(RdapEntity.Role.TECH),
+                    OutputDataType.FULL)
                 .toJson())
         .isEqualTo(loadJson("rdapjson_techcontact.json"));
   }
@@ -452,7 +458,8 @@ class RdapJsonFormatterTest {
     assertAboutJson()
         .that(
             rdapJsonFormatter
-                .createRdapContactEntity(contactTech, ImmutableSet.of(), OutputDataType.FULL)
+                .createRdapContactEntity(
+                    Optional.of(contactTech), ImmutableSet.of(), OutputDataType.FULL)
                 .toJson())
         .isEqualTo(loadJson("rdapjson_rolelesscontact.json"));
   }
@@ -462,7 +469,8 @@ class RdapJsonFormatterTest {
     assertAboutJson()
         .that(
             rdapJsonFormatter
-                .createRdapContactEntity(contactNotLinked, ImmutableSet.of(), OutputDataType.FULL)
+                .createRdapContactEntity(
+                    Optional.of(contactNotLinked), ImmutableSet.of(), OutputDataType.FULL)
                 .toJson())
         .isEqualTo(loadJson("rdapjson_unlinkedcontact.json"));
   }

--- a/core/src/test/java/google/registry/rde/DomainToXjcConverterTest.java
+++ b/core/src/test/java/google/registry/rde/DomainToXjcConverterTest.java
@@ -70,6 +70,7 @@ import google.registry.xjc.rdedomain.XjcRdeDomainElement;
 import google.registry.xjc.rgp.XjcRgpStatusType;
 import google.registry.xjc.secdns.XjcSecdnsDsDataType;
 import java.io.ByteArrayOutputStream;
+import java.util.Optional;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -280,9 +281,14 @@ public class DomainToXjcConverterTest {
                     makeHost(clock, "4-Q9JYB4C", "ns2.cat.みんな", "bad:f00d:cafe::15:beef")
                         .createVKey()))
             .setRegistrant(
-                makeContact(
-                        clock, "12-Q9JYB4C", "5372808-ERL", "(◕‿◕) nevermore", "prophet@evil.みんな")
-                    .createVKey())
+                Optional.of(
+                    makeContact(
+                            clock,
+                            "12-Q9JYB4C",
+                            "5372808-ERL",
+                            "(◕‿◕) nevermore",
+                            "prophet@evil.みんな")
+                        .createVKey()))
             .setRegistrationExpirationTime(DateTime.parse("1930-01-01T00:00:00Z"))
             .setGracePeriods(
                 ImmutableSet.of(

--- a/core/src/test/java/google/registry/rde/RdeFixtures.java
+++ b/core/src/test/java/google/registry/rde/RdeFixtures.java
@@ -51,6 +51,7 @@ import google.registry.model.transfer.DomainTransferData;
 import google.registry.model.transfer.TransferStatus;
 import google.registry.testing.FakeClock;
 import google.registry.util.Idn;
+import java.util.Optional;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
 
@@ -63,8 +64,9 @@ final class RdeFixtures {
             .setDomainName("example." + tld)
             .setRepoId(generateNewDomainRoid(tld))
             .setRegistrant(
-                makeContact(clock, "5372808-ERL", "(◕‿◕) nevermore", "prophet@evil.みんな")
-                    .createVKey())
+                Optional.of(
+                    makeContact(clock, "5372808-ERL", "(◕‿◕) nevermore", "prophet@evil.みんな")
+                        .createVKey()))
             .build();
     DomainHistory historyEntry =
         persistResource(

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -190,7 +190,7 @@ public final class DatabaseHelper {
         .setPersistedCurrentSponsorRegistrarId("TheRegistrar")
         .setCreationTimeForTest(START_OF_TIME)
         .setAuthInfo(DomainAuthInfo.create(PasswordAuth.create("2fooBAR")))
-        .setRegistrant(contactKey)
+        .setRegistrant(Optional.of(contactKey))
         .setContacts(
             ImmutableSet.of(
                 DesignatedContact.create(Type.ADMIN, contactKey),
@@ -603,7 +603,7 @@ public final class DatabaseHelper {
                 .setCreationRegistrarId("TheRegistrar")
                 .setCreationTimeForTest(creationTime)
                 .setRegistrationExpirationTime(expirationTime)
-                .setRegistrant(contact.createVKey())
+                .setRegistrant(Optional.of(contact.createVKey()))
                 .setContacts(
                     ImmutableSet.of(
                         DesignatedContact.create(Type.ADMIN, contact.createVKey()),

--- a/core/src/test/java/google/registry/testing/FullFieldsTestEntityHelper.java
+++ b/core/src/test/java/google/registry/testing/FullFieldsTestEntityHelper.java
@@ -46,6 +46,7 @@ import google.registry.persistence.VKey;
 import google.registry.util.Idn;
 import java.net.InetAddress;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import org.joda.time.DateTime;
 
@@ -351,7 +352,7 @@ public final class FullFieldsTestEntityHelper {
                     StatusValue.SERVER_UPDATE_PROHIBITED))
             .setDsData(ImmutableSet.of(DomainDsData.create(1, 2, 3, "deadface")));
     if (registrant != null) {
-      builder.setRegistrant(registrant.createVKey());
+      builder.setRegistrant(Optional.of(registrant.createVKey()));
     }
     if ((admin != null) || (tech != null)) {
       ImmutableSet.Builder<DesignatedContact> contactsBuilder = new ImmutableSet.Builder<>();

--- a/core/src/test/java/google/registry/whois/DomainWhoisResponseTest.java
+++ b/core/src/test/java/google/registry/whois/DomainWhoisResponseTest.java
@@ -41,6 +41,7 @@ import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationTestExtension;
 import google.registry.testing.FakeClock;
 import google.registry.whois.WhoisResponse.WhoisResponseResults;
+import java.util.Optional;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -264,7 +265,7 @@ class DomainWhoisResponseTest {
                         StatusValue.CLIENT_RENEW_PROHIBITED,
                         StatusValue.CLIENT_TRANSFER_PROHIBITED,
                         StatusValue.SERVER_UPDATE_PROHIBITED))
-                .setRegistrant(registrantResourceKey)
+                .setRegistrant(Optional.of(registrantResourceKey))
                 .setContacts(
                     ImmutableSet.of(
                         DesignatedContact.create(DesignatedContact.Type.ADMIN, adminResourceKey),
@@ -289,6 +290,21 @@ class DomainWhoisResponseTest {
                 false,
                 "Doodle Disclaimer\nI exist so that carriage return\nin disclaimer can be tested."))
         .isEqualTo(WhoisResponseResults.create(loadFile("whois_domain.txt"), 1));
+  }
+
+  @Test
+  void getPlainTextOutputTest_noRegistrant() {
+    DomainWhoisResponse domainWhoisResponse =
+        new DomainWhoisResponse(
+            domain.asBuilder().setRegistrant(Optional.empty()).build(),
+            false,
+            "Please contact registrar",
+            clock.nowUtc());
+    assertThat(
+            domainWhoisResponse.getResponse(
+                false,
+                "Doodle Disclaimer\nI exist so that carriage return\nin disclaimer can be tested."))
+        .isEqualTo(WhoisResponseResults.create(loadFile("whois_domain_no_registrant.txt"), 1));
   }
 
   @Test

--- a/core/src/test/resources/google/registry/flows/domain/domain_info_response_no_registrant.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_info_response_no_registrant.xml
@@ -1,0 +1,37 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <response>
+    <result code="1000">
+      <msg>Command completed successfully</msg>
+    </result>
+    <resData>
+      <domain:infData
+       xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>example.tld</domain:name>
+        <domain:roid>%ROID%</domain:roid>
+        <domain:status s="ok"/>
+        <domain:contact type="admin">sh8013</domain:contact>
+        <domain:contact type="tech">sh8013</domain:contact>
+        <domain:ns>
+          <domain:hostObj>ns1.example.tld</domain:hostObj>
+          <domain:hostObj>ns1.example.net</domain:hostObj>
+        </domain:ns>
+        <domain:host>ns1.example.tld</domain:host>
+        <domain:host>ns2.example.tld</domain:host>
+        <domain:clID>NewRegistrar</domain:clID>
+        <domain:crID>TheRegistrar</domain:crID>
+        <domain:crDate>1999-04-03T22:00:00.0Z</domain:crDate>
+        <domain:upID>NewRegistrar</domain:upID>
+        <domain:upDate>1999-12-03T09:00:00.0Z</domain:upDate>
+        <domain:exDate>2005-04-03T22:00:00.0Z</domain:exDate>
+        <domain:trDate>2000-04-08T09:00:00.0Z</domain:trDate>
+        <domain:authInfo>
+          <domain:pw>2fooBAR</domain:pw>
+        </domain:authInfo>
+      </domain:infData>
+    </resData>
+    <trID>
+      <clTRID>ABC-12345</clTRID>
+      <svTRID>server-trid</svTRID>
+    </trID>
+  </response>
+</epp>

--- a/core/src/test/resources/google/registry/whois/whois_domain_no_registrant.txt
+++ b/core/src/test/resources/google/registry/whois/whois_domain_no_registrant.txt
@@ -1,0 +1,53 @@
+Domain Name: example.tld
+Registry Domain ID: 3-TLD
+Registrar WHOIS Server: whois.nic.fakewhois.example
+Registrar URL: http://my.fake.url
+Updated Date: 2009-05-29T20:13:00Z
+Creation Date: 2000-10-08T00:45:00Z
+Registry Expiry Date: 2010-10-08T00:44:59Z
+Registrar: New Registrar
+Registrar IANA ID: 5555555
+Registrar Abuse Contact Email: jakedoe@theregistrar.com
+Registrar Abuse Contact Phone: +1.2125551216
+Domain Status: addPeriod https://icann.org/epp#addPeriod
+Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
+Domain Status: clientRenewProhibited https://icann.org/epp#clientRenewProhibited
+Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+Domain Status: serverUpdateProhibited https://icann.org/epp#serverUpdateProhibited
+Domain Status: transferPeriod https://icann.org/epp#transferPeriod
+Registry Admin ID: REDACTED FOR PRIVACY
+Admin Name: REDACTED FOR PRIVACY
+Admin Organization: REDACTED FOR PRIVACY
+Admin Street: REDACTED FOR PRIVACY
+Admin City: REDACTED FOR PRIVACY
+Admin State/Province: REDACTED FOR PRIVACY
+Admin Postal Code: REDACTED FOR PRIVACY
+Admin Country: REDACTED FOR PRIVACY
+Admin Phone: REDACTED FOR PRIVACY
+Admin Phone Ext: REDACTED FOR PRIVACY
+Admin Fax: REDACTED FOR PRIVACY
+Admin Email: Please contact registrar
+Registry Tech ID: REDACTED FOR PRIVACY
+Tech Name: REDACTED FOR PRIVACY
+Tech Organization: REDACTED FOR PRIVACY
+Tech Street: REDACTED FOR PRIVACY
+Tech City: REDACTED FOR PRIVACY
+Tech State/Province: REDACTED FOR PRIVACY
+Tech Postal Code: REDACTED FOR PRIVACY
+Tech Country: REDACTED FOR PRIVACY
+Tech Phone: REDACTED FOR PRIVACY
+Tech Phone Ext: REDACTED FOR PRIVACY
+Tech Fax: REDACTED FOR PRIVACY
+Tech Fax Ext: REDACTED FOR PRIVACY
+Tech Email: Please contact registrar
+Name Server: ns01.exampleregistrar.tld
+Name Server: ns02.exampleregistrar.tld
+DNSSEC: signedDelegation
+URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2009-05-29T20:15:00Z <<<
+
+For more information on Whois status codes, please visit https://icann.org/epp
+
+Doodle Disclaimer
+I exist so that carriage return
+in disclaimer can be tested.


### PR DESCRIPTION
This is the first step in migrating to the minimum registration data set. Note that our database model already permits null domain registrants, so this just makes the code accept it as well. Note that I haven't changed any requirements in EPP flows yet; a later step will be to check the migration schedule and then not require the registrant to be present if in a suitable state.

This does potentially affect the output of WHOIS/RDAP, but that's a NOOP so long as EPP commands and other tools continue to enforce the requirement of a registrant.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2477)
<!-- Reviewable:end -->
