### PR TITLE
Wait to load domain list until a registrar is selected

### DIFF
--- a/console-webapp/src/app/domains/domainList.component.ts
+++ b/console-webapp/src/app/domains/domainList.component.ts
@@ -60,8 +60,9 @@ export class DomainListComponent {
     effect(() => {
       this.pageNumber = 0;
       this.totalResults = 0;
-      this.reloadData();
-      this.registrarService.registrarId();
+      if (this.registrarService.registrarId()) {
+        this.reloadData();
+      }
     });
   }
 


### PR DESCRIPTION
This isn't the worst thing in the world but it does result in a bad request to the server otherwise, and log/error spam. So, only load the domains list if we have a registrar selected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2485)
<!-- Reviewable:end -->
