### PR TITLE
Create Users when setting up OT&E and Production registrars

### DIFF
--- a/core/src/main/java/google/registry/env/common/default/WEB-INF/cloud-tasks-queue.xml
+++ b/core/src/main/java/google/registry/env/common/default/WEB-INF/cloud-tasks-queue.xml
@@ -96,6 +96,14 @@
     <max-retry-duration>3600s</max-retry-duration>
   </queue>
 
+  <!-- Queue for tasks that update membership in the console user group. -->
+  <queue>
+    <name>console-user-group-update</name>
+    <max-dispatches-per-second>1</max-dispatches-per-second>
+    <max-concurrent-dispatches>1</max-concurrent-dispatches>
+    <max-retry-duration>3600s</max-retry-duration>
+  </queue>
+
   <!-- Queue for infrequent cron tasks (i.e. hourly or less often) that should retry three times on failure. -->
   <queue>
     <name>retryable-cron-tasks</name>

--- a/core/src/main/java/google/registry/tools/IamClient.java
+++ b/core/src/main/java/google/registry/tools/IamClient.java
@@ -20,7 +20,7 @@ import com.google.api.services.cloudresourcemanager.model.GetIamPolicyRequest;
 import com.google.api.services.cloudresourcemanager.model.Policy;
 import com.google.api.services.cloudresourcemanager.model.SetIamPolicyRequest;
 import com.google.common.base.Ascii;
-import google.registry.config.CredentialModule.LocalCredential;
+import google.registry.config.CredentialModule.ApplicationDefaultCredential;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.util.GoogleCredentialsBundle;
 import java.io.IOException;
@@ -38,7 +38,7 @@ public class IamClient {
 
   @Inject
   public IamClient(
-      @LocalCredential GoogleCredentialsBundle credentialsBundle,
+      @ApplicationDefaultCredential GoogleCredentialsBundle credentialsBundle,
       @Config("projectId") String projectId) {
     this(
         new CloudResourceManager.Builder(

--- a/core/src/main/java/google/registry/tools/RegistryToolDataflowModule.java
+++ b/core/src/main/java/google/registry/tools/RegistryToolDataflowModule.java
@@ -17,7 +17,7 @@ package google.registry.tools;
 import com.google.api.services.dataflow.Dataflow;
 import dagger.Module;
 import dagger.Provides;
-import google.registry.config.CredentialModule.LocalCredential;
+import google.registry.config.CredentialModule.ApplicationDefaultCredential;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.util.GoogleCredentialsBundle;
 
@@ -27,7 +27,7 @@ public class RegistryToolDataflowModule {
 
   @Provides
   static Dataflow provideDataflow(
-      @LocalCredential GoogleCredentialsBundle credentialsBundle,
+      @ApplicationDefaultCredential GoogleCredentialsBundle credentialsBundle,
       @Config("projectId") String projectId) {
     return new Dataflow.Builder(
             credentialsBundle.getHttpTransport(),

--- a/core/src/main/java/google/registry/tools/server/UpdateUserGroupAction.java
+++ b/core/src/main/java/google/registry/tools/server/UpdateUserGroupAction.java
@@ -34,6 +34,7 @@ import javax.inject.Inject;
 public class UpdateUserGroupAction implements Runnable {
 
   public static final String PATH = "/_dr/admin/updateUserGroup";
+  public static final String GROUP_UPDATE_QUEUE = "console-user-group-update";
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
@@ -53,7 +54,7 @@ public class UpdateUserGroupAction implements Runnable {
   @Inject
   UpdateUserGroupAction() {}
 
-  enum Mode {
+  public enum Mode {
     ADD,
     REMOVE
   }

--- a/core/src/test/java/google/registry/model/OteStatsTestHelper.java
+++ b/core/src/test/java/google/registry/model/OteStatsTestHelper.java
@@ -79,9 +79,7 @@ public final class OteStatsTestHelper {
   public static void setupIncompleteOte(String baseClientId) throws IOException {
     createTld("tld");
     persistPremiumList("default_sandbox_list", USD, "sandbox,USD 1000");
-    OteAccountBuilder.forRegistrarId(baseClientId)
-        .addContact("email@example.com")
-        .buildAndPersist();
+    OteAccountBuilder.forRegistrarId(baseClientId).buildAndPersist();
     String oteAccount1 = String.format("%s-1", baseClientId);
     DateTime now = DateTime.now(DateTimeZone.UTC);
     persistResource(

--- a/core/src/test/java/google/registry/server/RegistryTestServerMain.java
+++ b/core/src/test/java/google/registry/server/RegistryTestServerMain.java
@@ -135,7 +135,7 @@ public final class RegistryTestServerMain {
 
     final RegistryTestServer server = new RegistryTestServer(address);
 
-    System.out.printf("%sLoading SQL fixtures and User service...%s\n", BLUE, RESET);
+    System.out.printf("%sLoading SQL fixtures setting User for authentication...%s\n", BLUE, RESET);
     UserRoles userRoles =
         new UserRoles.Builder().setIsAdmin(loginIsAdmin).setGlobalRole(GlobalRole.FTE).build();
     User user =
@@ -151,7 +151,7 @@ public final class RegistryTestServerMain {
     for (Fixture fixture : fixtures) {
       fixture.load();
     }
-    System.out.printf("%sStarting Jetty6 HTTP Server...%s\n", BLUE, RESET);
+    System.out.printf("%sStarting Jetty HTTP Server...%s\n", BLUE, RESET);
     server.start();
     System.out.printf("%sListening on: %s%s\n", PURPLE, server.getUrl("/"), RESET);
     try {

--- a/core/src/test/java/google/registry/server/TestServer.java
+++ b/core/src/test/java/google/registry/server/TestServer.java
@@ -24,7 +24,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
 import com.google.common.util.concurrent.SimpleTimeLimiter;
-import google.registry.ui.server.registrar.RegistrarSettingsAction;
+import google.registry.util.RegistryEnvironment;
 import google.registry.util.UrlChecker;
 import jakarta.servlet.http.HttpServlet;
 import java.net.MalformedURLException;
@@ -91,7 +91,7 @@ public final class TestServer {
   /** Starts the HTTP server in a new thread and returns once it's online. */
   public void start() {
     try {
-      RegistrarSettingsAction.setIsInTestDriverToTrue();
+      RegistryEnvironment.setIsInTestDriver(true);
       server.start();
     } catch (Exception e) {
       throwIfUnchecked(e);
@@ -129,7 +129,7 @@ public final class TestServer {
               .callWithTimeout(
                   () -> {
                     server.stop();
-                    RegistrarSettingsAction.setIsInTestDriverToFalse();
+                    RegistryEnvironment.setIsInTestDriver(false);
                     return null;
                   },
                   SHUTDOWN_TIMEOUT_MS,

--- a/core/src/test/java/google/registry/testing/CloudTasksHelper.java
+++ b/core/src/test/java/google/registry/testing/CloudTasksHelper.java
@@ -80,12 +80,12 @@ import org.joda.time.DateTime;
  * to the same test task container that the original instance pushes to, so that we can make
  * assertions on them by accessing the original instance. We cannot make the test task container
  * itself static because we do not want tasks enqueued in previous tests to interfere with latter
- * tests, when they run on the same JVM (and therefore share the same static class members). To
- * solve this we put the test container in a static map whose keys are the instance IDs. An
- * explicitly created new {@link CloudTasksHelper} (as would be created for a new test method) would
- * have a new ID allocated to it, and therefore stores its tasks in a distinct container. A
- * deserialized {@link CloudTasksHelper}, on the other hand, will have the same instance ID and
- * share the same test class container with its progenitor.
+ * tests when they run on the same JVM (and therefore share the same static class members). To solve
+ * this, we put the test container in a static map whose keys are the instance IDs. An explicitly
+ * created new {@link CloudTasksHelper} (as would be created for a new test method) would have a new
+ * ID allocated to it, and therefore stores its tasks in a distinct container. A deserialized {@link
+ * CloudTasksHelper}, on the other hand, will have the same instance ID and share the same test
+ * class container with its progenitor.
  */
 public class CloudTasksHelper implements Serializable {
 
@@ -131,7 +131,7 @@ public class CloudTasksHelper implements Serializable {
    */
   public void assertTasksEnqueuedWithProperty(
       String queueName, Function<Task, String> propertyGetter, String... expectedTaskProperties) {
-    // Ordering is irrelevant but duplicates should be considered independently.
+    // Ordering is irrelevant, but duplicates should be considered independently.
     assertThat(getTestTasksFor(queueName).stream().map(propertyGetter))
         .containsExactly((Object[]) expectedTaskProperties);
   }
@@ -285,7 +285,7 @@ public class CloudTasksHelper implements Serializable {
               });
       headers = headerBuilder.build();
       ImmutableMultimap.Builder<String, String> paramBuilder = new ImmutableMultimap.Builder<>();
-      // Note that UriParameters.parse() does not throw an IAE on a bad query string (e.g. one
+      // Note that UriParameters.parse() does not throw an IAE on a bad query string (e.g., one
       // where parameters are not properly URL-encoded); it always does a best-effort parse.
       if (method == HttpMethod.GET && uri.getQuery() != null) {
         paramBuilder.putAll(UriParameters.parse(uri.getQuery()));
@@ -382,7 +382,7 @@ public class CloudTasksHelper implements Serializable {
      * the same contract as {@link #equals}, since it will ignore null fields.
      *
      * <p>Match fails if any headers or params expected on the TaskMatcher are not found on the
-     * Task. Note that the inverse is not true (i.e. there may be extra headers on the Task).
+     * Task. Note that the inverse is not true (i.e., there may be extra headers on the Task).
      *
      * <p>Schedule time by default is Timestamp.getDefaultInstance() or null.
      */


### PR DESCRIPTION
We no longer use `RegistrarPoc` to login to the registrar console (old or new). Therefore, we need to create `User` objects when creating OT&E and production registrars.

Since there are now a couple of places where we need to grant IAP credentials to the newly created `User` objects, it makes sense to put the same logic in an auxiliary function to avoid code duplication.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2488)
<!-- Reviewable:end -->
