### PR TITLE
Change domain-check fee responses for registrars in tiered promos

### DIFF
--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -1781,6 +1781,19 @@ public final class RegistryConfig {
   }
 
   /**
+   * List of registrars for which we include a promotional price on domain checks if configured.
+   *
+   * <p>In these cases, when a default promotion is running for the domain+registrar combination in
+   * question (a DEFAULT_PROMO token is set on the TLD), the standard non-promotional price will be
+   * returned for that domain as the standard create price. We will then add an additional fee check
+   * response with the actual promotional price and a "STANDARD PROMOTION" class.
+   */
+  public static ImmutableSet<String> getTieredPricingPromotionRegistrarIds() {
+    return ImmutableSet.copyOf(
+        CONFIG_SETTINGS.get().registryPolicy.tieredPricingPromotionRegistrarIds);
+  }
+
+  /**
    * Memoizes loading of the {@link RegistryConfigSettings} POJO.
    *
    * <p>Memoizing without cache expiration is used because the app must be re-deployed in order to
@@ -1789,8 +1802,6 @@ public final class RegistryConfig {
   @VisibleForTesting
   public static final Supplier<RegistryConfigSettings> CONFIG_SETTINGS =
       memoize(RegistryConfig::getConfigSettings);
-
-
 
   private static InternetAddress parseEmailAddress(String email) {
     try {

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -113,6 +113,7 @@ public class RegistryConfigSettings {
     public List<String> spec11WebResources;
     public boolean requireSslCertificates;
     public double sunriseDomainCreateDiscount;
+    public Set<String> tieredPricingPromotionRegistrarIds;
   }
 
   /** Configuration for Hibernate. */

--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -201,6 +201,15 @@ registryPolicy:
   # will be free.
   sunriseDomainCreateDiscount: 0.15
 
+  # List of registrars participating in tiered pricing promotions that require
+  # non-standard responses to EPP domain:check and domain:create commands.
+  # When a promotion is active, we will set an additional STANDARD PROMOTION
+  # fee check response on any domain checks that corresponds to the actual
+  # promotional price (the regular response will be the non-promotional price).
+  # In addition, we will return the non-promotional (i.e. incorrect) price on
+  # domain create requests.
+  tieredPricingPromotionRegistrarIds: []
+
 hibernate:
   # If set to false, calls to tm().transact() cannot be nested. If set to true,
   # nested calls to tm().transact() are allowed, as long as they do not specify

--- a/core/src/main/java/google/registry/config/files/nomulus-config-unittest.yaml
+++ b/core/src/main/java/google/registry/config/files/nomulus-config-unittest.yaml
@@ -9,6 +9,8 @@ registryPolicy:
   reservedTermsExportDisclaimer: |
     Disclaimer line 1.
     Line 2 is this 1.
+  tieredPricingPromotionRegistrarIds:
+    - NewRegistrar
 
 caching:
   singletonCacheRefreshSeconds: 0

--- a/core/src/main/java/google/registry/model/domain/fee/FeeQueryCommandExtensionItem.java
+++ b/core/src/main/java/google/registry/model/domain/fee/FeeQueryCommandExtensionItem.java
@@ -34,19 +34,26 @@ public abstract class FeeQueryCommandExtensionItem extends ImmutableObject {
 
   /** The name of a command that might have an associated fee. */
   public enum CommandName {
-    UNKNOWN(false),
-    CREATE(false),
-    RENEW(true),
-    TRANSFER(true),
-    RESTORE(true),
-    UPDATE(false);
+    UNKNOWN(false, false),
+    CREATE(false, true),
+    RENEW(true, true),
+    TRANSFER(true, true),
+    RESTORE(true, true),
+    UPDATE(false, true),
+    /**
+     * We don't accept CUSTOM commands in requests but may issue them in responses. A CUSTOM command
+     * name is permitted in general per RFC 8748 section 3.1.
+     */
+    CUSTOM(false, false);
 
     private final boolean loadDomainForCheck;
+    private final boolean acceptableInputAction;
 
     public static CommandName parseKnownCommand(String string) {
       try {
         CommandName command = valueOf(string);
-        checkArgument(!command.equals(UNKNOWN));
+        checkArgument(
+            command.acceptableInputAction, "Command %s is not an acceptable input action", string);
         return command;
       } catch (IllegalArgumentException e) {
         throw new IllegalArgumentException(
@@ -55,8 +62,9 @@ public abstract class FeeQueryCommandExtensionItem extends ImmutableObject {
       }
     }
 
-    CommandName(boolean loadDomainForCheck) {
+    CommandName(boolean loadDomainForCheck, boolean acceptableInputAction) {
       this.loadDomainForCheck = loadDomainForCheck;
+      this.acceptableInputAction = acceptableInputAction;
     }
 
     public boolean shouldLoadDomainForCheck() {

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_tiered_promotion_fee_response_v12.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_tiered_promotion_fee_response_v12.xml
@@ -1,0 +1,91 @@
+<epp xmlns:domain="urn:ietf:params:xml:ns:domain-1.0" xmlns:contact="urn:ietf:params:xml:ns:contact-1.0" xmlns:fee="urn:ietf:params:xml:ns:fee-0.6" xmlns="urn:ietf:params:xml:ns:epp-1.0" xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0" xmlns:bulkToken="urn:google:params:xml:ns:bulkToken-1.0" xmlns:fee11="urn:ietf:params:xml:ns:fee-0.11" xmlns:fee="urn:ietf:params:xml:ns:fee-0.12" xmlns:launch="urn:ietf:params:xml:ns:launch-1.0" xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1" xmlns:host="urn:ietf:params:xml:ns:host-1.0">
+    <response>
+        <result code="1000">
+            <msg>Command completed successfully</msg>
+        </result>
+        <resData>
+            <domain:chkData>
+                <domain:cd>
+                    <domain:name avail="false">example1.tld</domain:name>
+                    <domain:reason>In use</domain:reason>
+                </domain:cd>
+                <domain:cd>
+                    <domain:name avail="true">example2.tld</domain:name>
+                </domain:cd>
+                <domain:cd>
+                    <domain:name avail="true">example3.tld</domain:name>
+                </domain:cd>
+            </domain:chkData>
+        </resData>
+        <extension>
+            <fee:chkData xmlns:fee="urn:ietf:params:xml:ns:fee-0.12"
+                         xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+            <fee:currency>USD</fee:currency>
+                <fee:cd>
+                    <fee:object>
+                        <domain:name>example1.tld</domain:name>
+                    </fee:object>
+                    <fee:command name="create">
+                        <fee:period unit="y">1</fee:period>
+                        <fee:fee description="create">13.00</fee:fee>
+                        <fee:class>STANDARD</fee:class>
+                    </fee:command>
+                </fee:cd>
+                <fee:cd>
+                    <fee:object>
+                        <domain:name>example1.tld</domain:name>
+                    </fee:object>
+                    <fee:command name="custom">
+                        <fee:period unit="y">1</fee:period>
+                        <fee:fee description="create">6.50</fee:fee>
+                        <fee:class>STANDARD PROMOTION</fee:class>
+                    </fee:command>
+                </fee:cd>
+                <fee:cd>
+                    <fee:object>
+                        <domain:name>example2.tld</domain:name>
+                    </fee:object>
+                    <fee:command name="create">
+                        <fee:period unit="y">1</fee:period>
+                        <fee:fee description="create">13.00</fee:fee>
+                        <fee:class>STANDARD</fee:class>
+                    </fee:command>
+                </fee:cd>
+                <fee:cd>
+                    <fee:object>
+                        <domain:name>example2.tld</domain:name>
+                    </fee:object>
+                    <fee:command name="custom">
+                        <fee:period unit="y">1</fee:period>
+                        <fee:fee description="create">6.50</fee:fee>
+                        <fee:class>STANDARD PROMOTION</fee:class>
+                    </fee:command>
+                </fee:cd>
+                <fee:cd>
+                    <fee:object>
+                        <domain:name>example3.tld</domain:name>
+                    </fee:object>
+                    <fee:command name="create">
+                        <fee:period unit="y">1</fee:period>
+                        <fee:fee description="create">13.00</fee:fee>
+                        <fee:class>STANDARD</fee:class>
+                    </fee:command>
+                </fee:cd>
+                <fee:cd>
+                    <fee:object>
+                        <domain:name>example3.tld</domain:name>
+                    </fee:object>
+                    <fee:command name="custom">
+                        <fee:period unit="y">1</fee:period>
+                        <fee:fee description="create">6.50</fee:fee>
+                        <fee:class>STANDARD PROMOTION</fee:class>
+                    </fee:command>
+                </fee:cd>
+            </fee:chkData>
+        </extension>
+        <trID>
+            <clTRID>ABC-12345</clTRID>
+            <svTRID>server-trid</svTRID>
+        </trID>
+    </response>
+</epp>


### PR DESCRIPTION
As requested, for registrars participaing in these tiered pricing promos that wish to receive this type of response, we make the following changes:

1. The pre-promotional (i.e. base tier) price is returned as the standard domain-create fee when running a domain check.
2. The promotional (i.e. correct) price is returned as a special custom command class with a name of "STANDARD PROMO" when running a domain check.
3. Domain creates will return the non-promotional (i.e. incorrect) price rather than the actual promotional price. This is not implemented in this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2489)
<!-- Reviewable:end -->
