### PR TITLE
Use token's renewalPrice if renewalBehavior is SPECIFIED

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -366,7 +366,7 @@ public final class DomainCreateFlow implements MutatingFlow {
         createAutorenewBillingEvent(
             domainHistoryId,
             registrationExpirationTime,
-            getRenewalPriceInfo(isAnchorTenant, allocationToken, feesAndCredits));
+            getRenewalPriceInfo(isAnchorTenant, allocationToken));
     PollMessage.Autorenew autorenewPollMessage =
         createAutorenewPollMessage(domainHistoryId, registrationExpirationTime);
     ImmutableSet.Builder<ImmutableObject> entitiesToSave = new ImmutableSet.Builder<>();
@@ -689,9 +689,7 @@ public final class DomainCreateFlow implements MutatingFlow {
    * AllocationToken} is 'SPECIFIED'.
    */
   static RenewalPriceInfo getRenewalPriceInfo(
-      boolean isAnchorTenant,
-      Optional<AllocationToken> allocationToken,
-      FeesAndCredits feesAndCredits) {
+      boolean isAnchorTenant, Optional<AllocationToken> allocationToken) {
     if (isAnchorTenant) {
       allocationToken.ifPresent(
           token ->
@@ -702,7 +700,7 @@ public final class DomainCreateFlow implements MutatingFlow {
     } else if (allocationToken.isPresent()
         && allocationToken.get().getRenewalPriceBehavior() == RenewalPriceBehavior.SPECIFIED) {
       return RenewalPriceInfo.create(
-          RenewalPriceBehavior.SPECIFIED, feesAndCredits.getCreateCost());
+          RenewalPriceBehavior.SPECIFIED, allocationToken.get().getRenewalPrice().get());
     } else {
       return RenewalPriceInfo.create(RenewalPriceBehavior.DEFAULT, null);
     }

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -344,8 +344,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         .and()
         .hasPeriodYears(2);
     RenewalPriceInfo renewalPriceInfo =
-        DomainCreateFlow.getRenewalPriceInfo(
-            isAnchorTenant, Optional.ofNullable(allocationToken), feesAndCredits);
+        DomainCreateFlow.getRenewalPriceInfo(isAnchorTenant, Optional.ofNullable(allocationToken));
     // There should be one bill for the create and one for the recurrence autorenew event.
     BillingEvent createBillingEvent =
         new BillingEvent.Builder()
@@ -3189,53 +3188,25 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Test
   void testGetRenewalPriceInfo_isAnchorTenantWithoutToken_returnsNonPremiumAndNullPrice() {
-    assertThat(
-            DomainCreateFlow.getRenewalPriceInfo(
-                true,
-                Optional.empty(),
-                new FeesAndCredits.Builder()
-                    .setCurrency(USD)
-                    .addFeeOrCredit(Fee.create(BigDecimal.valueOf(0), FeeType.CREATE, false))
-                    .build()))
+    assertThat(DomainCreateFlow.getRenewalPriceInfo(true, Optional.empty()))
         .isEqualTo(RenewalPriceInfo.create(NONPREMIUM, null));
   }
 
   @Test
   void testGetRenewalPriceInfo_isAnchorTenantWithDefaultToken_returnsNonPremiumAndNullPrice() {
-    assertThat(
-            DomainCreateFlow.getRenewalPriceInfo(
-                true,
-                Optional.of(allocationToken),
-                new FeesAndCredits.Builder()
-                    .setCurrency(USD)
-                    .addFeeOrCredit(Fee.create(BigDecimal.valueOf(0), FeeType.CREATE, false))
-                    .build()))
+    assertThat(DomainCreateFlow.getRenewalPriceInfo(true, Optional.of(allocationToken)))
         .isEqualTo(RenewalPriceInfo.create(NONPREMIUM, null));
   }
 
   @Test
   void testGetRenewalPriceInfo_isNotAnchorTenantWithDefaultToken_returnsDefaultAndNullPrice() {
-    assertThat(
-            DomainCreateFlow.getRenewalPriceInfo(
-                false,
-                Optional.of(allocationToken),
-                new FeesAndCredits.Builder()
-                    .setCurrency(USD)
-                    .addFeeOrCredit(Fee.create(BigDecimal.valueOf(100), FeeType.CREATE, false))
-                    .build()))
+    assertThat(DomainCreateFlow.getRenewalPriceInfo(false, Optional.of(allocationToken)))
         .isEqualTo(RenewalPriceInfo.create(DEFAULT, null));
   }
 
   @Test
   void testGetRenewalPriceInfo_isNotAnchorTenantWithoutToken_returnsDefaultAndNullPrice() {
-    assertThat(
-            DomainCreateFlow.getRenewalPriceInfo(
-                false,
-                Optional.empty(),
-                new FeesAndCredits.Builder()
-                    .setCurrency(USD)
-                    .addFeeOrCredit(Fee.create(BigDecimal.valueOf(100), FeeType.CREATE, false))
-                    .build()))
+    assertThat(DomainCreateFlow.getRenewalPriceInfo(false, Optional.empty()))
         .isEqualTo(RenewalPriceInfo.create(DEFAULT, null));
   }
 
@@ -3248,17 +3219,10 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 .setToken("abc123")
                 .setTokenType(SINGLE_USE)
                 .setRenewalPriceBehavior(SPECIFIED)
-                .setRenewalPrice(Money.of(USD, 0))
+                .setRenewalPrice(Money.of(USD, 5))
                 .build());
-    assertThat(
-            DomainCreateFlow.getRenewalPriceInfo(
-                false,
-                Optional.of(token),
-                new FeesAndCredits.Builder()
-                    .setCurrency(USD)
-                    .addFeeOrCredit(Fee.create(BigDecimal.valueOf(100), FeeType.CREATE, false))
-                    .build()))
-        .isEqualTo(RenewalPriceInfo.create(SPECIFIED, Money.of(USD, 100)));
+    assertThat(DomainCreateFlow.getRenewalPriceInfo(false, Optional.of(token)))
+        .isEqualTo(RenewalPriceInfo.create(SPECIFIED, Money.of(USD, 5)));
   }
 
   @Test
@@ -3276,11 +3240,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                                 .setTokenType(SINGLE_USE)
                                 .setRenewalPriceBehavior(SPECIFIED)
                                 .setRenewalPrice(Money.of(USD, 0))
-                                .build())),
-                    new FeesAndCredits.Builder()
-                        .setCurrency(USD)
-                        .addFeeOrCredit(Fee.create(BigDecimal.valueOf(0), FeeType.CREATE, true))
-                        .build()));
+                                .build()))));
     assertThat(thrown)
         .hasMessageThat()
         .isEqualTo("Renewal price behavior cannot be SPECIFIED for anchor tenant");
@@ -3300,11 +3260,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                                 .setToken("abc123")
                                 .setTokenType(SINGLE_USE)
                                 .setRenewalPriceBehavior(RenewalPriceBehavior.valueOf("INVALID"))
-                                .build())),
-                    new FeesAndCredits.Builder()
-                        .setCurrency(USD)
-                        .addFeeOrCredit(Fee.create(BigDecimal.valueOf(0), FeeType.CREATE, true))
-                        .build()));
+                                .build()))));
     assertThat(thrown)
         .hasMessageThat()
         .isEqualTo(


### PR DESCRIPTION
Previous PRs and token changes (see b/332928676) have made it so that SPECIFIED renewalPriceBehavior tokens must have a renewal price. As such, we can now use that renewalPrice when creating domains with SPECIFIED tokens.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2502)
<!-- Reviewable:end -->
