### PR TITLE
Mark console state field on new registrar form as required

### DIFF
--- a/console-webapp/src/app/registrar/newRegistrar.component.html
+++ b/console-webapp/src/app/registrar/newRegistrar.component.html
@@ -142,7 +142,7 @@ JPY=billing-id-for-yen"
         <mat-label>State/Region: </mat-label>
         <input
           matInput
-          [required]="false"
+          [required]="true"
           [(ngModel)]="newRegistrar.localizedAddress.state"
           [ngModelOptions]="{ standalone: true }"
         />


### PR DESCRIPTION
I was creating new registrars in sandbox for support team testing and noticed that state field is not marked as required, although being required for submission to succeed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2509)
<!-- Reviewable:end -->
