### PR TITLE
Call Workspace Groups API directly from nomulus tool

### DIFF
--- a/core/src/main/java/google/registry/batch/CloudTasksUtils.java
+++ b/core/src/main/java/google/registry/batch/CloudTasksUtils.java
@@ -77,6 +77,7 @@ public class CloudTasksUtils implements Serializable {
       @Config("projectId") String projectId,
       @Config("locationId") String locationId,
       @Config("oauthClientId") String oauthClientId,
+      // Note that this has to be a service account, due to limitations of the Cloud Tasks API.
       @ApplicationDefaultCredential GoogleCredentialsBundle credential,
       SerializableCloudTasksClient client) {
     this.retrier = retrier;

--- a/core/src/main/java/google/registry/model/OteAccountBuilder.java
+++ b/core/src/main/java/google/registry/model/OteAccountBuilder.java
@@ -271,7 +271,7 @@ public final class OteAccountBuilder {
       Optional<String> groupEmailAddress, CloudTasksUtils cloudTasksUtils, IamClient iamClient) {
     for (User user : users) {
       User.grantIapPermission(
-          user.getEmailAddress(), groupEmailAddress, cloudTasksUtils, iamClient);
+          user.getEmailAddress(), groupEmailAddress, cloudTasksUtils, null, iamClient);
     }
   }
 

--- a/core/src/main/java/google/registry/tools/CreateUserCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateUserCommand.java
@@ -18,7 +18,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.model.console.User.grantIapPermission;
 
 import com.beust.jcommander.Parameters;
-import google.registry.batch.CloudTasksUtils;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.model.console.User;
 import google.registry.model.console.UserDao;
@@ -28,11 +27,11 @@ import javax.inject.Inject;
 
 /** Command to create a new User. */
 @Parameters(separators = " =", commandDescription = "Update a user account")
-public class CreateUserCommand extends CreateOrUpdateUserCommand {
+public class CreateUserCommand extends CreateOrUpdateUserCommand implements CommandWithConnection {
+
+  private ServiceConnection connection;
 
   @Inject IamClient iamClient;
-
-  @Inject CloudTasksUtils cloudTasksUtils;
 
   @Inject
   @Config("gSuiteConsoleUserGroupEmailAddress")
@@ -48,7 +47,12 @@ public class CreateUserCommand extends CreateOrUpdateUserCommand {
   @Override
   protected String execute() throws Exception {
     String ret = super.execute();
-    grantIapPermission(email, maybeGroupEmailAddress, cloudTasksUtils, iamClient);
+    grantIapPermission(email, maybeGroupEmailAddress, null, connection, iamClient);
     return ret;
+  }
+
+  @Override
+  public void setConnection(ServiceConnection connection) {
+    this.connection = connection;
   }
 }

--- a/core/src/main/java/google/registry/tools/DeleteUserCommand.java
+++ b/core/src/main/java/google/registry/tools/DeleteUserCommand.java
@@ -20,7 +20,6 @@ import static google.registry.util.PreconditionsUtils.checkArgumentPresent;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import google.registry.batch.CloudTasksUtils;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.model.console.User;
 import google.registry.model.console.UserDao;
@@ -30,11 +29,11 @@ import javax.inject.Inject;
 
 /** Deletes a {@link User}. */
 @Parameters(separators = " =", commandDescription = "Delete a user account")
-public class DeleteUserCommand extends ConfirmingCommand {
+public class DeleteUserCommand extends ConfirmingCommand implements CommandWithConnection {
+
+  private ServiceConnection connection;
 
   @Inject IamClient iamClient;
-
-  @Inject CloudTasksUtils cloudTasksUtils;
 
   @Inject
   @Config("gSuiteConsoleUserGroupEmailAddress")
@@ -59,7 +58,12 @@ public class DeleteUserCommand extends ConfirmingCommand {
               checkArgumentPresent(optionalUser, "Email no longer corresponds to a valid user");
               tm().delete(optionalUser.get());
             });
-    User.revokeIapPermission(email, maybeGroupEmailAddress, cloudTasksUtils, iamClient);
+    User.revokeIapPermission(email, maybeGroupEmailAddress, null, connection, iamClient);
     return String.format("Deleted user with email %s", email);
+  }
+
+  @Override
+  public void setConnection(ServiceConnection connection) {
+    this.connection = connection;
   }
 }

--- a/core/src/main/java/google/registry/ui/server/registrar/ConsoleRegistrarCreatorAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/ConsoleRegistrarCreatorAction.java
@@ -263,7 +263,7 @@ public final class ConsoleRegistrarCreatorAction extends HtmlAction {
               });
       UserDao.saveUser(user);
       User.grantIapPermission(
-          user.getEmailAddress(), maybeGroupEmailAddress, cloudTasksUtils, iamClient);
+          user.getEmailAddress(), maybeGroupEmailAddress, cloudTasksUtils, null, iamClient);
       data.put("password", password);
       data.put("passcode", phonePasscode);
 


### PR DESCRIPTION
When creating/deleting users, we need to add/remove the emails in
question to/from the console email group (if it exists). This used to be
done synchronously by calling the Groups API directly from the nomulus
tool. However #2488 made it so that in all cases where group membership
is modified, a Cloud Tasks task is created to execute the change on
the server side asynchronously (because there are multiple places where
this change needs to be done, and it is easier to make it all happen on the
server side).

Alas, as it turns out, Cloud Tasks tasks need to be created with a
service account's credential (which is trivially done on the server side
because the ADC is a service account). Nomulus command runs with a user
credential, and we need to grant the relevant user permission to
masquerade as a service account, in order to enqueue tasks from the
nomulus tool. It is therefore easier to just revert to the old behavior.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2515)
<!-- Reviewable:end -->
