### PR TITLE
Make Nomulus work on GKE with external load balancer

### DIFF
--- a/jetty/kubernetes/nomulus-gateway.yaml
+++ b/jetty/kubernetes/nomulus-gateway.yaml
@@ -28,4 +28,19 @@ spec:
       kind: ServiceImport
       name: nomulus
       port: 80
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: nomulus
+spec:
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: /healthz/
+  targetRef:
+    group: net.gke.io
+    kind: ServiceImport
+    name: nomulus
 

--- a/jetty/kubernetes/nomulus-service.yaml
+++ b/jetty/kubernetes/nomulus-service.yaml
@@ -15,8 +15,8 @@ spec:
     - port: 700
       targetPort: epp
       name: epp
-#---
-#kind: ServiceExport
-#apiVersion: net.gke.io/v1
-#metadata:
-#  name: nomulus
+---
+kind: ServiceExport
+apiVersion: net.gke.io/v1
+metadata:
+  name: nomulus

--- a/jetty/src/main/jetty-base/webapps/healthz/index.html
+++ b/jetty/src/main/jetty-base/webapps/healthz/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<title>Health Check</title>
+<body>Health check successful.</body>
+</html>


### PR DESCRIPTION
This will create a multi-cluster external load balancer exposing HTTP
traffic to nomulus running in clusters in the fleet.

Note that this is only an intermediate step. The endpoints need to be split into services that can be independently scaled, and become IAP-protected HTTPS endpoints.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2527)
<!-- Reviewable:end -->
