### PR TITLE
Add OT&E create and status to the new console

### DIFF
--- a/core/src/main/java/google/registry/model/registrar/RegistrarBase.java
+++ b/core/src/main/java/google/registry/model/registrar/RegistrarBase.java
@@ -233,6 +233,7 @@ public class RegistrarBase extends UpdateAutoTimestampEntity implements Buildabl
   String registrarName;
 
   /** The type of this registrar. */
+  @Expose
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
   Type type;

--- a/core/src/main/java/google/registry/module/RequestComponent.java
+++ b/core/src/main/java/google/registry/module/RequestComponent.java
@@ -114,6 +114,7 @@ import google.registry.ui.server.console.ConsoleDomainListAction;
 import google.registry.ui.server.console.ConsoleDumDownloadAction;
 import google.registry.ui.server.console.ConsoleEppPasswordAction;
 import google.registry.ui.server.console.ConsoleModule;
+import google.registry.ui.server.console.ConsoleOteAction;
 import google.registry.ui.server.console.ConsoleRegistryLockAction;
 import google.registry.ui.server.console.ConsoleRegistryLockVerifyAction;
 import google.registry.ui.server.console.ConsoleUpdateRegistrarAction;
@@ -177,6 +178,8 @@ interface RequestComponent {
   ConsoleDomainListAction consoleDomainListAction();
 
   ConsoleEppPasswordAction consoleEppPasswordAction();
+
+  ConsoleOteAction consoleOteAction();
 
   ConsoleRegistryLockAction consoleRegistryLockAction();
 

--- a/core/src/main/java/google/registry/module/frontend/FrontendRequestComponent.java
+++ b/core/src/main/java/google/registry/module/frontend/FrontendRequestComponent.java
@@ -30,6 +30,7 @@ import google.registry.ui.server.console.ConsoleDomainListAction;
 import google.registry.ui.server.console.ConsoleDumDownloadAction;
 import google.registry.ui.server.console.ConsoleEppPasswordAction;
 import google.registry.ui.server.console.ConsoleModule;
+import google.registry.ui.server.console.ConsoleOteAction;
 import google.registry.ui.server.console.ConsoleRegistryLockAction;
 import google.registry.ui.server.console.ConsoleRegistryLockVerifyAction;
 import google.registry.ui.server.console.ConsoleUpdateRegistrarAction;
@@ -64,6 +65,8 @@ public interface FrontendRequestComponent {
   ConsoleDomainListAction consoleDomainListAction();
 
   ConsoleEppPasswordAction consoleEppPasswordAction();
+
+  ConsoleOteAction consoleOteAction();
 
   ConsoleOteSetupAction consoleOteSetupAction();
   ConsoleRegistrarCreatorAction consoleRegistrarCreatorAction();

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleModule.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleModule.java
@@ -34,6 +34,7 @@ import google.registry.request.auth.AuthResult;
 import google.registry.security.XsrfTokenManager;
 import google.registry.ui.server.SendEmailUtils;
 import google.registry.ui.server.console.ConsoleEppPasswordAction.EppPasswordData;
+import google.registry.ui.server.console.ConsoleOteAction.OteCreateData;
 import google.registry.ui.server.console.ConsoleRegistryLockAction.ConsoleRegistryLockPostInput;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
@@ -242,6 +243,13 @@ public final class ConsoleModule {
   public static Optional<EppPasswordData> provideEppPasswordChangeRequest(
       Gson gson, @OptionalJsonPayload Optional<JsonElement> payload) {
     return payload.map(s -> gson.fromJson(s, EppPasswordData.class));
+  }
+
+  @Provides
+  @Parameter("oteCreateData")
+  public static Optional<OteCreateData> provideOteCreateData(
+      Gson gson, @OptionalJsonPayload Optional<JsonElement> payload) {
+    return payload.map(s -> gson.fromJson(s, OteCreateData.class));
   }
 
   @Provides

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleOteAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleOteAction.java
@@ -1,0 +1,174 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ui.server.console;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.request.Action.Method.GET;
+import static google.registry.request.Action.Method.POST;
+import static google.registry.util.RegistryEnvironment.PRODUCTION;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.annotations.Expose;
+import google.registry.config.RegistryConfig.Config;
+import google.registry.model.OteAccountBuilder;
+import google.registry.model.OteStats;
+import google.registry.model.OteStats.StatType;
+import google.registry.model.console.ConsolePermission;
+import google.registry.model.console.User;
+import google.registry.model.registrar.Registrar;
+import google.registry.model.registrar.RegistrarBase;
+import google.registry.request.Action;
+import google.registry.request.Action.GkeService;
+import google.registry.request.Parameter;
+import google.registry.request.auth.Auth;
+import google.registry.tools.IamClient;
+import google.registry.util.RegistryEnvironment;
+import google.registry.util.StringGenerator;
+import java.util.Map;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+@Action(
+    service = Action.Service.DEFAULT,
+    gkeService = GkeService.CONSOLE,
+    path = ConsoleOteAction.PATH,
+    method = {GET, POST},
+    auth = Auth.AUTH_PUBLIC_LOGGED_IN)
+public class ConsoleOteAction extends ConsoleApiAction {
+  static final String PATH = "/console-api/ote";
+  private static final int PASSWORD_LENGTH = 16;
+  private static final String COMPLETED_PARAM = "completed";
+  private static final String STAT_TYPE_DESCRIPTION_PARAM = "description";
+  private static final String STAT_TYPE_REQUIREMENT_PARAM = "requirement";
+  private static final String STAT_TYPE_TIMES_PERFORMED_PARAM = "timesPerformed";
+  private final Gson gson;
+  private final StringGenerator passwordGenerator;
+  private final Optional<OteCreateData> oteCreateData;
+  private final Optional<String> maybeGroupEmailAddress;
+  private final IamClient iamClient;
+  private final String registrarId;
+
+  @Inject
+  public ConsoleOteAction(
+      ConsoleApiParams consoleApiParams,
+      Gson gson,
+      IamClient iamClient,
+      @Parameter("registrarId") String registrarId, // Get request param
+      @Config("gSuiteConsoleUserGroupEmailAddress") Optional<String> maybeGroupEmailAddress,
+      @Named("base58StringGenerator") StringGenerator passwordGenerator,
+      @Parameter("oteCreateData") Optional<OteCreateData> oteCreateData) {
+    super(consoleApiParams);
+    this.gson = gson;
+    this.passwordGenerator = passwordGenerator;
+    this.oteCreateData = oteCreateData;
+    this.maybeGroupEmailAddress = maybeGroupEmailAddress;
+    this.iamClient = iamClient;
+    this.registrarId = registrarId;
+  }
+
+  @Override
+  protected void postHandler(User user) {
+    checkState(!RegistryEnvironment.get().equals(PRODUCTION), "Can't create OT&E in prod");
+
+    if (!user.getUserRoles().hasGlobalPermission(ConsolePermission.EDIT_REGISTRAR_DETAILS)) {
+      setFailedResponse("User doesn't have a permission to create OT&E accounts", SC_FORBIDDEN);
+      return;
+    }
+
+    boolean isBodyValid =
+        this.oteCreateData.isPresent()
+            && !this.oteCreateData.get().registrarId.isEmpty()
+            && !this.oteCreateData.get().registrarEmail.isEmpty();
+
+    checkArgument(isBodyValid, "OT&E create body is invalid");
+
+    String password = passwordGenerator.createString(PASSWORD_LENGTH);
+
+    OteAccountBuilder oteAccountBuilder =
+        OteAccountBuilder.forRegistrarId(this.oteCreateData.get().registrarId)
+            .addUser(this.oteCreateData.get().registrarEmail)
+            .setPassword(password);
+
+    ImmutableMap<String, String> registrarIdToTld = oteAccountBuilder.buildAndPersist();
+    oteAccountBuilder.grantIapPermission(maybeGroupEmailAddress, cloudTasksUtils, iamClient);
+    consoleApiParams.response().setStatus(SC_OK);
+    consoleApiParams
+        .response()
+        .setPayload(
+            gson.toJson(
+                ImmutableMap.builder().putAll(registrarIdToTld).put("password", password).build()));
+  }
+
+  @Override
+  protected void getHandler(User user) {
+    checkArgument(!Strings.isNullOrEmpty(registrarId), "Missing registrarId parameter");
+
+    if (!user.getUserRoles().hasGlobalPermission(ConsolePermission.EDIT_REGISTRAR_DETAILS)) {
+      setFailedResponse("User doesn't have a permission to check OT&E status", SC_BAD_REQUEST);
+      return;
+    }
+
+    String baseRegistrarId = OteAccountBuilder.getBaseRegistrarId(registrarId);
+    tm().transact(
+            () -> {
+              Optional<Registrar> registrar = Registrar.loadByRegistrarId(registrarId);
+              if (registrar.isEmpty()) {
+                setFailedResponse(
+                    String.format("Registrar with ID %s is not present", registrarId),
+                    SC_BAD_REQUEST);
+                return;
+              }
+              if (!RegistrarBase.Type.OTE.equals(registrar.get().getType())) {
+                setFailedResponse(
+                    String.format("Registrar with ID %s is not an OT&E registrar", registrarId),
+                    SC_BAD_REQUEST);
+                return;
+              }
+              OteStats oteStats = OteStats.getFromRegistrar(baseRegistrarId);
+              var stats =
+                  StatType.REQUIRED_STAT_TYPES.stream()
+                      .map(
+                          statType ->
+                              convertSingleRequirement(statType, oteStats.getCount(statType)))
+                      .collect(toImmutableList());
+              consoleApiParams.response().setStatus(SC_OK);
+              consoleApiParams.response().setPayload(gson.toJson(stats));
+            });
+  }
+
+  private Map<String, Object> convertSingleRequirement(StatType statType, int count) {
+    int requirement = statType.getRequirement();
+    return ImmutableMap.of(
+        STAT_TYPE_DESCRIPTION_PARAM,
+        statType.getDescription(),
+        STAT_TYPE_REQUIREMENT_PARAM,
+        requirement,
+        STAT_TYPE_TIMES_PERFORMED_PARAM,
+        count,
+        COMPLETED_PARAM,
+        count >= requirement);
+  }
+
+  public record OteCreateData(@Expose String registrarId, @Expose String registrarEmail) {}
+}

--- a/core/src/test/java/google/registry/ui/server/console/ConsoleOteActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/ConsoleOteActionTest.java
@@ -1,0 +1,255 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.ui.server.console;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.model.OteAccountBuilderTest.verifyIapPermission;
+import static google.registry.testing.DatabaseHelper.persistPremiumList;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static jakarta.servlet.http.HttpServletResponse.SC_OK;
+import static org.joda.money.CurrencyUnit.USD;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import google.registry.model.OteStatsTestHelper;
+import google.registry.model.console.GlobalRole;
+import google.registry.model.console.User;
+import google.registry.model.console.UserRoles;
+import google.registry.persistence.transaction.JpaTestExtensions;
+import google.registry.request.Action;
+import google.registry.request.auth.AuthResult;
+import google.registry.testing.CloudTasksHelper;
+import google.registry.testing.ConsoleApiParamsUtils;
+import google.registry.testing.DeterministicStringGenerator;
+import google.registry.testing.FakeResponse;
+import google.registry.tools.GsonUtils;
+import google.registry.tools.IamClient;
+import google.registry.ui.server.console.ConsoleOteAction.OteCreateData;
+import google.registry.util.StringGenerator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.json.simple.JSONArray;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class ConsoleOteActionTest {
+
+  @RegisterExtension
+  final JpaTestExtensions.JpaIntegrationTestExtension jpa =
+      new JpaTestExtensions.Builder().buildIntegrationTestExtension();
+
+  private static final Gson GSON = GsonUtils.provideGson();
+  private final IamClient iamClient = mock(IamClient.class);
+  private final CloudTasksHelper cloudTasksHelper = new CloudTasksHelper();
+  private FakeResponse response;
+  private ConsoleApiParams consoleApiParams;
+
+  private StringGenerator passwordGenerator =
+      new DeterministicStringGenerator("abcdefghijklmnopqrstuvwxyz");
+
+  private User user =
+      new User.Builder()
+          .setEmailAddress("marla.singer@example.com")
+          .setUserRoles(new UserRoles())
+          .build();
+
+  @BeforeEach
+  void beforeEach() throws Exception {
+    persistPremiumList("default_sandbox_list", USD, "sandbox,USD 1000");
+  }
+
+  @Test
+  void testFailure_missingGlobalPermission() {
+    AuthResult authResult = AuthResult.createUser(user);
+    consoleApiParams = ConsoleApiParamsUtils.createFake(authResult);
+    ConsoleOteAction action =
+        createAction(
+            Action.Method.POST,
+            authResult,
+            "testRegistrarId",
+            Optional.of("someRandomString"),
+            Optional.of(new OteCreateData("testRegistrarId", "tescontact@registry.example")));
+    action.run();
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_FORBIDDEN);
+  }
+
+  @Test
+  void testFailure_invalidParamsNoRegistrarId() {
+    user =
+        user.asBuilder()
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.FTE).build())
+            .build();
+    AuthResult authResult = AuthResult.createUser(user);
+    consoleApiParams = ConsoleApiParamsUtils.createFake(authResult);
+    ConsoleOteAction action =
+        createAction(
+            Action.Method.POST,
+            authResult,
+            "testRegistrarId",
+            Optional.of("someRandomString"),
+            Optional.of(new OteCreateData("", "test@email.com")));
+    action.run();
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_BAD_REQUEST);
+    assertThat(((FakeResponse) consoleApiParams.response()).getPayload())
+        .isEqualTo("OT&E create body is invalid");
+  }
+
+  @Test
+  void testFailure_invalidParamsNoEmail() {
+    user =
+        user.asBuilder()
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.FTE).build())
+            .build();
+    AuthResult authResult = AuthResult.createUser(user);
+    consoleApiParams = ConsoleApiParamsUtils.createFake(authResult);
+    ConsoleOteAction action =
+        createAction(
+            Action.Method.POST,
+            authResult,
+            "testRegistrarId",
+            Optional.of("someRandomString"),
+            Optional.of(new OteCreateData("testRegistrarId", "")));
+    action.run();
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_BAD_REQUEST);
+    assertThat(((FakeResponse) consoleApiParams.response()).getPayload())
+        .isEqualTo("OT&E create body is invalid");
+  }
+
+  @Test
+  void testSuccess_oteCreated() {
+    user =
+        user.asBuilder()
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.FTE).build())
+            .build();
+    AuthResult authResult = AuthResult.createUser(user);
+    consoleApiParams = ConsoleApiParamsUtils.createFake(authResult);
+    ConsoleOteAction action =
+        createAction(
+            Action.Method.POST,
+            authResult,
+            "theregistrar",
+            Optional.of("someRandomString@email.test"),
+            Optional.of(new OteCreateData("theregistrar", "contact@registry.example")));
+    action.cloudTasksUtils = cloudTasksHelper.getTestCloudTasksUtils();
+    action.run();
+    String response = ((FakeResponse) consoleApiParams.response()).getPayload();
+    var obsResponse = GSON.fromJson(response, Map.class);
+    assertThat(
+            ImmutableMap.of(
+                "theregistrar-1", "theregistrar-sunrise",
+                "theregistrar-3", "theregistrar-ga",
+                "theregistrar-4", "theregistrar-ga",
+                "theregistrar-5", "theregistrar-eap",
+                "password", "abcdefghijklmnop"))
+        .containsExactlyEntriesIn(obsResponse);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_OK);
+    verifyIapPermission(
+        "contact@registry.example",
+        Optional.of("someRandomString@email.test"),
+        cloudTasksHelper,
+        iamClient);
+  }
+
+  @Test
+  void testFail_statusMissingParam() {
+    AuthResult authResult = AuthResult.createUser(user);
+    consoleApiParams = ConsoleApiParamsUtils.createFake(authResult);
+    ConsoleOteAction action =
+        createAction(
+            Action.Method.GET,
+            authResult,
+            "",
+            Optional.of("someRandomString@email.test"),
+            Optional.of(new OteCreateData("theregistrar", "contact@registry.example")));
+    action.cloudTasksUtils = cloudTasksHelper.getTestCloudTasksUtils();
+    action.run();
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_BAD_REQUEST);
+    assertThat(((FakeResponse) consoleApiParams.response()).getPayload())
+        .isEqualTo("Missing registrarId parameter");
+  }
+
+  @Test
+  void testSuccess_finishedOte() throws Exception {
+    OteStatsTestHelper.setupCompleteOte("theregistrar");
+    user =
+        user.asBuilder()
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.FTE).build())
+            .build();
+    AuthResult authResult = AuthResult.createUser(user);
+    consoleApiParams = ConsoleApiParamsUtils.createFake(authResult);
+    ConsoleOteAction action =
+        createAction(
+            Action.Method.GET, authResult, "theregistrar-1", Optional.empty(), Optional.empty());
+    action.run();
+
+    List<Map<String, ?>> response =
+        GSON.fromJson(((FakeResponse) consoleApiParams.response()).getPayload(), JSONArray.class);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_OK);
+    assertTrue(response.stream().allMatch(status -> Boolean.TRUE.equals(status.get("completed"))));
+  }
+
+  @Test
+  void testSuccess_unfinishedOte() throws Exception {
+    OteStatsTestHelper.setupIncompleteOte("theregistrar");
+    user =
+        user.asBuilder()
+            .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.FTE).build())
+            .build();
+    AuthResult authResult = AuthResult.createUser(user);
+    consoleApiParams = ConsoleApiParamsUtils.createFake(authResult);
+    ConsoleOteAction action =
+        createAction(
+            Action.Method.GET, authResult, "theregistrar-1", Optional.empty(), Optional.empty());
+    action.run();
+
+    List<Map<String, ?>> response =
+        GSON.fromJson(((FakeResponse) consoleApiParams.response()).getPayload(), JSONArray.class);
+    assertThat(((FakeResponse) consoleApiParams.response()).getStatus()).isEqualTo(SC_OK);
+    assertThat(
+            response.stream()
+                .filter(status -> Boolean.FALSE.equals(status.get("completed")))
+                .map(status -> status.get("description"))
+                .collect(Collectors.toList()))
+        .containsExactlyElementsIn(
+            ImmutableList.of("domain creates idn", "domain restores", "host deletes"));
+  }
+
+  private ConsoleOteAction createAction(
+      Action.Method method,
+      AuthResult authResult,
+      String registrarId,
+      Optional<String> maybeGroupEmailAddress,
+      Optional<OteCreateData> oteCreateData) {
+    response = new FakeResponse();
+    consoleApiParams = ConsoleApiParamsUtils.createFake(authResult);
+    when(consoleApiParams.request().getMethod()).thenReturn(method.toString());
+    return new ConsoleOteAction(
+        consoleApiParams,
+        GSON,
+        iamClient,
+        registrarId,
+        maybeGroupEmailAddress,
+        passwordGenerator,
+        oteCreateData);
+  }
+}

--- a/core/src/test/resources/google/registry/module/frontend/frontend_routing.txt
+++ b/core/src/test/resources/google/registry/module/frontend/frontend_routing.txt
@@ -12,6 +12,7 @@ CONSOLE  /console-api/domain                ConsoleDomainGetAction          GET 
 CONSOLE  /console-api/domain-list           ConsoleDomainListAction         GET      n  USER PUBLIC
 CONSOLE  /console-api/dum-download          ConsoleDumDownloadAction        GET      n  USER PUBLIC
 CONSOLE  /console-api/eppPassword           ConsoleEppPasswordAction        POST     n  USER PUBLIC
+CONSOLE  /console-api/ote                   ConsoleOteAction                GET,POST n  USER PUBLIC
 CONSOLE  /console-api/registrar             ConsoleUpdateRegistrarAction    POST     n  USER PUBLIC
 CONSOLE  /console-api/registrars            RegistrarsAction                GET,POST n  USER PUBLIC
 CONSOLE  /console-api/registry-lock         ConsoleRegistryLockAction       GET,POST n  USER PUBLIC

--- a/core/src/test/resources/google/registry/module/routing.txt
+++ b/core/src/test/resources/google/registry/module/routing.txt
@@ -70,6 +70,7 @@ CONSOLE  /console-api/domain                                ConsoleDomainGetActi
 CONSOLE  /console-api/domain-list                           ConsoleDomainListAction                        GET      n  USER PUBLIC
 CONSOLE  /console-api/dum-download                          ConsoleDumDownloadAction                       GET      n  USER PUBLIC
 CONSOLE  /console-api/eppPassword                           ConsoleEppPasswordAction                       POST     n  USER PUBLIC
+CONSOLE  /console-api/ote                                   ConsoleOteAction                               GET,POST n  USER PUBLIC
 CONSOLE  /console-api/registrar                             ConsoleUpdateRegistrarAction                   POST     n  USER PUBLIC
 CONSOLE  /console-api/registrars                            RegistrarsAction                               GET,POST n  USER PUBLIC
 CONSOLE  /console-api/registry-lock                         ConsoleRegistryLockAction                      GET,POST n  USER PUBLIC


### PR DESCRIPTION
This change allows us to safely delete the following from the old console:

[ConsoleOteSetupAction](https://cs.opensource.google/nomulus/nomulus/+/master:core/src/main/java/google/registry/ui/server/registrar/ConsoleOteSetupAction.java;bpv=1;bpt=1;l=61?q=ConsoleOte&ss=nomulus%2Fnomulus&gsn=ConsoleOteSetupAction&gs=KYTHE%3A%2F%2Fkythe%3A%2F%2Fgithub.com%2Fgoogle%2Fnomulus%3Flang%3Djava%3Fpath%3Dgoogle.registry.ui.server.registrar.ConsoleOteSetupAction%23ec203b4d693fdd53d26709f78a800106909d6115ada375cf0caffa6a3982692b) and [OteStatusAction](https://cs.opensource.google/nomulus/nomulus/+/master:core/src/main/java/google/registry/ui/server/registrar/OteStatusAction.java;bpv=1;bpt=1;l=49?gsn=OteStatusAction&gs=KYTHE%3A%2F%2Fkythe%3A%2F%2Fgithub.com%2Fgoogle%2Fnomulus%3Flang%3Djava%3Fpath%3Dgoogle.registry.ui.server.registrar.OteStatusAction%233a35b651d6187eb7963081caf1442b8b44a5900cef1db7eb8cf4f1240dd4d7bb) and tests obviously [OteStatusActionTest](https://cs.opensource.google/nomulus/nomulus/+/master:core/src/test/java/google/registry/ui/server/registrar/OteStatusActionTest.java;bpv=1;bpt=1;l=42?q=otestatusac&ss=nomulus%2Fnomulus&gsn=OteStatusActionTest&gs=KYTHE%3A%2F%2Fkythe%3A%2F%2Fgithub.com%2Fgoogle%2Fnomulus%3Flang%3Djava%3Fpath%3Dgoogle.registry.ui.server.registrar.OteStatusActionTest%23ab5ce755f125527cfd6fbd6a4c2a0e359d25797a38d9f6dde67ef1bfad857978) and [ConsoleOteSetupActionTest](https://cs.opensource.google/nomulus/nomulus/+/master:core/src/test/java/google/registry/ui/server/registrar/ConsoleOteSetupActionTest.java;bpv=1;bpt=1;l=63?gsn=ConsoleOteSetupActionTest&gs=KYTHE%3A%2F%2Fkythe%3A%2F%2Fgithub.com%2Fgoogle%2Fnomulus%3Flang%3Djava%3Fpath%3Dgoogle.registry.ui.server.registrar.ConsoleOteSetupActionTest%235d1300554a25709ef384bdd862da29c3c802229f84530fa3147b3865a74de3b3)

I merged both actions into 1 as I don't really see why they should be separete as they have a large overlap in logic. I've reviewed the guides used by Tech support to conduct said operations and simplified the logic, eg removed password field from the request.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2534)
<!-- Reviewable:end -->
