### PR TITLE
Connect to the correct endpoints based on runtime

### DIFF
--- a/core/src/main/java/google/registry/batch/AsyncTaskEnqueuer.java
+++ b/core/src/main/java/google/registry/batch/AsyncTaskEnqueuer.java
@@ -24,7 +24,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.flogger.FluentLogger;
 import google.registry.model.EppResource;
 import google.registry.persistence.VKey;
-import google.registry.request.Action.Service;
+import google.registry.request.Action;
 import javax.inject.Inject;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
@@ -78,7 +78,7 @@ public final class AsyncTaskEnqueuer {
     logger.atInfo().log("Enqueuing async re-save of %s to run at %s.", entityKey, whenToResave);
     cloudTasksUtils.enqueue(
         QUEUE_ASYNC_ACTIONS,
-        cloudTasksUtils.createPostTaskWithDelay(
-            ResaveEntityAction.PATH, Service.BACKEND, params, etaDuration));
+        cloudTasksUtils.createTaskWithDelay(
+            ResaveEntityAction.class, Action.Method.POST, params, etaDuration));
   }
 }

--- a/core/src/main/java/google/registry/batch/CannedScriptExecutionAction.java
+++ b/core/src/main/java/google/registry/batch/CannedScriptExecutionAction.java
@@ -20,6 +20,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.flogger.FluentLogger;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.UrlConnectionService;
@@ -42,7 +43,7 @@ import javax.net.ssl.HttpsURLConnection;
  * --service BACKEND -X POST -u '/_dr/task/executeCannedScript}'}
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = "/_dr/task/executeCannedScript",
     method = {POST, GET},
     automaticallyPrintOk = true,

--- a/core/src/main/java/google/registry/batch/CheckBulkComplianceAction.java
+++ b/core/src/main/java/google/registry/batch/CheckBulkComplianceAction.java
@@ -27,7 +27,7 @@ import google.registry.model.domain.token.AllocationToken;
 import google.registry.model.domain.token.BulkPricingPackage;
 import google.registry.model.registrar.Registrar;
 import google.registry.request.Action;
-import google.registry.request.Action.Service;
+import google.registry.request.Action.GaeService;
 import google.registry.request.auth.Auth;
 import google.registry.ui.server.SendEmailUtils;
 import google.registry.util.Clock;
@@ -39,7 +39,7 @@ import org.joda.time.Days;
  * An action that checks all {@link BulkPricingPackage} objects for compliance with their max create
  * limit.
  */
-@Action(service = Service.BACKEND, path = CheckBulkComplianceAction.PATH, auth = Auth.AUTH_ADMIN)
+@Action(service = GaeService.BACKEND, path = CheckBulkComplianceAction.PATH, auth = Auth.AUTH_ADMIN)
 public class CheckBulkComplianceAction implements Runnable {
 
   public static final String PATH = "/_dr/task/checkBulkCompliance";

--- a/core/src/main/java/google/registry/batch/CloudTasksUtils.java
+++ b/core/src/main/java/google/registry/batch/CloudTasksUtils.java
@@ -28,6 +28,7 @@ import com.google.cloud.tasks.v2.QueueName;
 import com.google.cloud.tasks.v2.Task;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Streams;
 import com.google.common.escape.Escaper;
@@ -219,6 +220,13 @@ public class CloudTasksUtils implements Serializable {
         "Action class %s is not annotated with @Action",
         actionClazz.getSimpleName());
     String path = action.path();
+    ImmutableSet<Method> allowedMethods = ImmutableSet.copyOf(action.method());
+    checkArgument(
+        allowedMethods.contains(method),
+        "Method %s is not allowed for action %s. Allowed methods are %s",
+        method,
+        actionClazz.getSimpleName(),
+        allowedMethods);
     Service service =
         RegistryEnvironment.isOnJetty() ? Action.ServiceGetter.get(action) : action.service();
     return createTask(path, method, service, params);

--- a/core/src/main/java/google/registry/batch/CloudTasksUtils.java
+++ b/core/src/main/java/google/registry/batch/CloudTasksUtils.java
@@ -15,8 +15,8 @@
 package google.registry.batch;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static google.registry.tools.ServiceConnection.getServer;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.google.api.gax.rpc.ApiException;
@@ -39,11 +39,15 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.util.Timestamps;
 import google.registry.config.CredentialModule.ApplicationDefaultCredential;
 import google.registry.config.RegistryConfig.Config;
+import google.registry.request.Action;
+import google.registry.request.Action.Method;
 import google.registry.request.Action.Service;
 import google.registry.util.Clock;
 import google.registry.util.CollectionUtils;
 import google.registry.util.GoogleCredentialsBundle;
+import google.registry.util.RegistryEnvironment;
 import google.registry.util.Retrier;
+import java.io.Serial;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -58,7 +62,7 @@ import org.joda.time.Duration;
 /** Utilities for dealing with Cloud Tasks. */
 public class CloudTasksUtils implements Serializable {
 
-  private static final long serialVersionUID = -7605156291755534069L;
+  @Serial private static final long serialVersionUID = -7605156291755534069L;
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
   private static final Random random = new Random();
 
@@ -122,7 +126,7 @@ public class CloudTasksUtils implements Serializable {
    */
   private static String processRequestParameters(
       String path,
-      HttpMethod method,
+      Method method,
       Multimap<String, String> params,
       BiConsumer<String, String> putHeadersFunction,
       Consumer<ByteString> setBodyFunction) {
@@ -140,7 +144,7 @@ public class CloudTasksUtils implements Serializable {
                                 "%s=%s",
                                 escaper.escape(entry.getKey()), escaper.escape(entry.getValue())))
                     .collect(toImmutableList()));
-    if (method.equals(HttpMethod.GET)) {
+    if (method.equals(Method.GET)) {
       return String.format("%s?%s", path, encodedParams);
     }
     putHeadersFunction.accept(HttpHeaders.CONTENT_TYPE, MediaType.FORM_DATA.toString());
@@ -155,9 +159,12 @@ public class CloudTasksUtils implements Serializable {
    * default service account as the principal. That account must have permission to submit tasks to
    * Cloud Tasks.
    *
+   * <p>The caller of this method is responsible for passing in the appropriate service based on the
+   * runtime (GAE/GKE). Use the overload that takes an action class if possible.
+   *
    * @param path the relative URI (staring with a slash and ending without one).
-   * @param method the HTTP method to be used for the request, only GET and POST are supported.
-   * @param service the App Engine service to route the request to.
+   * @param method the HTTP method to be used for the request.
+   * @param service the GAE/GKE service to route the request to.
    * @param params a multimap of URL query parameters. Duplicate keys are saved as is, and it is up
    *     to the server to process the duplicate keys.
    * @return the enqueued task.
@@ -165,16 +172,13 @@ public class CloudTasksUtils implements Serializable {
    *     href=ttps://cloud.google.com/appengine/docs/standard/java/taskqueue/push/creating-tasks#target>Specifyinig
    *     the worker service</a>
    */
-  private Task createTask(
-      String path, HttpMethod method, Service service, Multimap<String, String> params) {
+  protected Task createTask(
+      String path, Method method, Service service, Multimap<String, String> params) {
     checkArgument(
         path != null && !path.isEmpty() && path.charAt(0) == '/',
         "The path must start with a '/'.");
-    checkArgument(
-        method.equals(HttpMethod.GET) || method.equals(HttpMethod.POST),
-        "HTTP method %s is used. Only GET and POST are allowed.",
-        method);
-    HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().setHttpMethod(method);
+    HttpRequest.Builder requestBuilder =
+        HttpRequest.newBuilder().setHttpMethod(HttpMethod.valueOf(method.name()));
     path =
         processRequestParameters(
             path, method, params, requestBuilder::putHeaders, requestBuilder::setBody);
@@ -183,17 +187,52 @@ public class CloudTasksUtils implements Serializable {
             .setServiceAccountEmail(credential.serviceAccount())
             .setAudience(oauthClientId);
     requestBuilder.setOidcToken(oidcTokenBuilder.build());
-    String totalPath = String.format("%s%s", getServer(service), path);
+    String totalPath = String.format("%s%s", service.getServiceUrl(), path);
     requestBuilder.setUrl(totalPath);
     return Task.newBuilder().setHttpRequest(requestBuilder.build()).build();
   }
 
   /**
+   * Create a {@link Task} to be enqueued.
+   *
+   * <p>This uses the standard Cloud Tasks auth format to create and send an OIDC ID token with the
+   * default service account as the principal. That account must have permission to submit tasks to
+   * Cloud Tasks.
+   *
+   * <p>Prefer this overload over the one where the path and service are explicit defined, as this
+   * class will automatically determine the service to use based on the action and the runtime.
+   *
+   * @param actionClazz the action class to run, must be annotated with {@link Action}.
+   * @param method the HTTP method to be used for the request.
+   * @param params a multimap of URL query parameters. Duplicate keys are saved as is, and it is up
+   *     to the server to process the duplicate keys.
+   * @return the enqueued task.
+   * @see <a
+   *     href=ttps://cloud.google.com/appengine/docs/standard/java/taskqueue/push/creating-tasks#target>Specifyinig
+   *     the worker service</a>
+   */
+  public Task createTask(
+      Class<? extends Runnable> actionClazz, Method method, Multimap<String, String> params) {
+    Action action = actionClazz.getAnnotation(Action.class);
+    checkArgument(
+        action != null,
+        "Action class %s is not annotated with @Action",
+        actionClazz.getSimpleName());
+    String path = action.path();
+    Service service =
+        RegistryEnvironment.isOnJetty() ? Action.ServiceGetter.get(action) : action.service();
+    return createTask(path, method, service, params);
+  }
+
+  /**
    * Create a {@link Task} to be enqueued with a random delay up to {@code jitterSeconds}.
    *
+   * <p>The caller of this method is responsible for passing in the appropriate service based on the
+   * runtime (GAE/GKE). Use the overload that takes an action class if possible.
+   *
    * @param path the relative URI (staring with a slash and ending without one).
-   * @param method the HTTP method to be used for the request, only GET and POST are supported.
-   * @param service the App Engine service to route the request to.
+   * @param method the HTTP method to be used for the request.
+   * @param service the GAE/GKE service to route the request to.
    * @param params a multimap of URL query parameters. Duplicate keys are saved as is, and it is up
    *     to the server to process the duplicate keys.
    * @param jitterSeconds the number of seconds that a task is randomly delayed up to.
@@ -202,9 +241,9 @@ public class CloudTasksUtils implements Serializable {
    *     href=ttps://cloud.google.com/appengine/docs/standard/java/taskqueue/push/creating-tasks#target>Specifyinig
    *     the worker service</a>
    */
-  private Task createTaskWithJitter(
+  public Task createTaskWithJitter(
       String path,
-      HttpMethod method,
+      Method method,
       Service service,
       Multimap<String, String> params,
       Optional<Integer> jitterSeconds) {
@@ -220,11 +259,43 @@ public class CloudTasksUtils implements Serializable {
   }
 
   /**
+   * Create a {@link Task} to be enqueued with a random delay up to {@code jitterSeconds}.
+   *
+   * <p>Prefer this overload over the one where the path and service are explicit defined, as this
+   * class will automatically determine the service to use based on the action and the runtime.
+   *
+   * @param actionClazz the action class to run, must be annotated with {@link Action}.
+   * @param method the HTTP method to be used for the request.
+   * @param params a multimap of URL query parameters. Duplicate keys are saved as is, and it is up
+   *     to the server to process the duplicate keys.
+   * @param jitterSeconds the number of seconds that a task is randomly delayed up to.
+   * @return the enqueued task.
+   * @see <a
+   *     href=ttps://cloud.google.com/appengine/docs/standard/java/taskqueue/push/creating-tasks#target>Specifyinig
+   *     the worker service</a>
+   */
+  public Task createTaskWithJitter(
+      Class<? extends Runnable> actionClazz,
+      Method method,
+      Multimap<String, String> params,
+      Optional<Integer> jitterSeconds) {
+    Action action = getAction(actionClazz);
+    checkState(
+        action != null,
+        "Action class %s is not annotated with @Action",
+        actionClazz.getSimpleName());
+    String path = action.path();
+    Service service =
+        RegistryEnvironment.isOnJetty() ? Action.ServiceGetter.get(action) : action.service();
+    return createTaskWithJitter(path, method, service, params, jitterSeconds);
+  }
+
+  /**
    * Create a {@link Task} to be enqueued with delay of {@code duration}.
    *
    * @param path the relative URI (staring with a slash and ending without one).
-   * @param method the HTTP method to be used for the request, only GET and POST are supported.
-   * @param service the App Engine service to route the request to.
+   * @param method the HTTP method to be used for the request.
+   * @param service the GAE/GKE service to route the request to.
    * @param params a multimap of URL query parameters. Duplicate keys are saved as is, and it is up
    *     to the server to process the duplicate keys.
    * @param delay the amount of time that a task needs to delayed for.
@@ -235,7 +306,7 @@ public class CloudTasksUtils implements Serializable {
    */
   private Task createTaskWithDelay(
       String path,
-      HttpMethod method,
+      Method method,
       Service service,
       Multimap<String, String> params,
       Duration delay) {
@@ -248,58 +319,53 @@ public class CloudTasksUtils implements Serializable {
         .build();
   }
 
-  public Task createPostTask(String path, Service service, Multimap<String, String> params) {
-    return createTask(path, HttpMethod.POST, service, params);
-  }
-
-  public Task createGetTask(String path, Service service, Multimap<String, String> params) {
-    return createTask(path, HttpMethod.GET, service, params);
-  }
-
   /**
-   * Create a {@link Task} via HTTP.POST that will be randomly delayed up to {@code jitterSeconds}.
+   * Create a {@link Task} to be enqueued with delay of {@code duration}.
+   *
+   * <p>Prefer this overload over the one where the path and service are explicit defined, as this
+   * class will automatically determine the service to use based on the action and the runtime.
+   *
+   * @param actionClazz the action class to run, must be annotated with {@link Action}.
+   * @param method the HTTP method to be used for the request.
+   * @param params a multimap of URL query parameters. Duplicate keys are saved as is, and it is up
+   *     to the server to process the duplicate keys.
+   * @param delay the amount of time that a task needs to delayed for.
+   * @return the enqueued task.
+   * @see <a
+   *     href=ttps://cloud.google.com/appengine/docs/standard/java/taskqueue/push/creating-tasks#target>Specifyinig
+   *     the worker service</a>
    */
-  public Task createPostTaskWithJitter(
-      String path,
-      Service service,
+  public Task createTaskWithDelay(
+      Class<? extends Runnable> actionClazz,
+      Method method,
       Multimap<String, String> params,
-      Optional<Integer> jitterSeconds) {
-    return createTaskWithJitter(path, HttpMethod.POST, service, params, jitterSeconds);
+      Duration delay) {
+    Action action = getAction(actionClazz);
+    String path = action.path();
+    Service service =
+        RegistryEnvironment.isOnJetty() ? Action.ServiceGetter.get(action) : action.service();
+    return createTaskWithDelay(path, method, service, params, delay);
   }
 
-  /**
-   * Create a {@link Task} via HTTP.GET that will be randomly delayed up to {@code jitterSeconds}.
-   */
-  public Task createGetTaskWithJitter(
-      String path,
-      Service service,
-      Multimap<String, String> params,
-      Optional<Integer> jitterSeconds) {
-    return createTaskWithJitter(path, HttpMethod.GET, service, params, jitterSeconds);
-  }
-
-  /** Create a {@link Task} via HTTP.POST that will be delayed for {@code delay}. */
-  public Task createPostTaskWithDelay(
-      String path, Service service, Multimap<String, String> params, Duration delay) {
-    return createTaskWithDelay(path, HttpMethod.POST, service, params, delay);
-  }
-
-  /** Create a {@link Task} via HTTP.GET that will be delayed for {@code delay}. */
-  public Task createGetTaskWithDelay(
-      String path, Service service, Multimap<String, String> params, Duration delay) {
-    return createTaskWithDelay(path, HttpMethod.GET, service, params, delay);
+  private static Action getAction(Class<? extends Runnable> actionClazz) {
+    Action action = actionClazz.getAnnotation(Action.class);
+    checkState(
+        action != null,
+        "Action class %s is not annotated with @Action",
+        actionClazz.getSimpleName());
+    return action;
   }
 
   public abstract static class SerializableCloudTasksClient implements Serializable {
 
-    private static final long serialVersionUID = 7872861868968535498L;
+    @Serial private static final long serialVersionUID = 7872861868968535498L;
 
     public abstract Task enqueue(String projectId, String locationId, String queueName, Task task);
   }
 
   public static class GcpCloudTasksClient extends SerializableCloudTasksClient {
 
-    private static final long serialVersionUID = -5959253033129154037L;
+    @Serial private static final long serialVersionUID = -5959253033129154037L;
 
     // Use a supplier so that we can use try-with-resources with the client, which implements
     // Autocloseable.

--- a/core/src/main/java/google/registry/batch/DeleteExpiredDomainsAction.java
+++ b/core/src/main/java/google/registry/batch/DeleteExpiredDomainsAction.java
@@ -37,6 +37,7 @@ import google.registry.model.eppcommon.ProtocolDefinition;
 import google.registry.model.eppoutput.EppOutput;
 import google.registry.persistence.transaction.QueryComposer.Comparator;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
 import google.registry.request.lock.LockHandler;
@@ -67,7 +68,7 @@ import org.joda.time.Duration;
  * this action runs, thus alerting us that human action is needed to correctly process the delete.
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = DeleteExpiredDomainsAction.PATH,
     auth = Auth.AUTH_ADMIN)
 public class DeleteExpiredDomainsAction implements Runnable {

--- a/core/src/main/java/google/registry/batch/DeleteLoadTestDataAction.java
+++ b/core/src/main/java/google/registry/batch/DeleteLoadTestDataAction.java
@@ -37,6 +37,7 @@ import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.reporting.HistoryEntryDao;
 import google.registry.persistence.VKey;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
 import google.registry.util.Clock;
@@ -54,7 +55,7 @@ import javax.inject.Inject;
  * production.
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = "/_dr/task/deleteLoadTestData",
     method = POST,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/batch/DeleteProberDataAction.java
+++ b/core/src/main/java/google/registry/batch/DeleteProberDataAction.java
@@ -42,6 +42,7 @@ import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.tld.Tld.TldType;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
 import google.registry.util.RegistryEnvironment;
@@ -58,7 +59,7 @@ import org.joda.time.Duration;
  * billing events, along with their ForeignKeyDomainIndex entities.
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = "/_dr/task/deleteProberData",
     method = POST,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/batch/ExpandBillingRecurrencesAction.java
+++ b/core/src/main/java/google/registry/batch/ExpandBillingRecurrencesAction.java
@@ -35,6 +35,7 @@ import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingRecurrence;
 import google.registry.model.common.Cursor;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -50,7 +51,7 @@ import org.joda.time.DateTime;
  * BillingRecurrence} billing events into synthetic {@link BillingEvent} events.
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = "/_dr/task/expandBillingRecurrences",
     auth = Auth.AUTH_ADMIN)
 public class ExpandBillingRecurrencesAction implements Runnable {

--- a/core/src/main/java/google/registry/batch/RelockDomainAction.java
+++ b/core/src/main/java/google/registry/batch/RelockDomainAction.java
@@ -35,6 +35,7 @@ import google.registry.model.registrar.RegistrarPoc;
 import google.registry.model.tld.RegistryLockDao;
 import google.registry.persistence.VKey;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -49,7 +50,7 @@ import org.joda.time.Duration;
 
 /** Task that re-locks a previously-Registry-Locked domain after a predetermined period of time. */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = RelockDomainAction.PATH,
     method = POST,
     automaticallyPrintOk = true,

--- a/core/src/main/java/google/registry/batch/ResaveAllEppResourcesPipelineAction.java
+++ b/core/src/main/java/google/registry/batch/ResaveAllEppResourcesPipelineAction.java
@@ -28,6 +28,7 @@ import com.google.common.flogger.FluentLogger;
 import com.google.common.net.MediaType;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -53,7 +54,7 @@ import javax.inject.Inject;
  * <p>This runs the {@link google.registry.beam.resave.ResaveAllEppResourcesPipeline}.
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = ResaveAllEppResourcesPipelineAction.PATH,
     auth = Auth.AUTH_ADMIN)
 public class ResaveAllEppResourcesPipelineAction implements Runnable {

--- a/core/src/main/java/google/registry/batch/ResaveEntityAction.java
+++ b/core/src/main/java/google/registry/batch/ResaveEntityAction.java
@@ -25,6 +25,7 @@ import com.google.common.flogger.FluentLogger;
 import google.registry.model.EppResource;
 import google.registry.persistence.VKey;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.Method;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
@@ -39,7 +40,7 @@ import org.joda.time.DateTime;
  * <p>{@link EppResource}s will be projected forward to the current time.
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = ResaveEntityAction.PATH,
     auth = Auth.AUTH_ADMIN,
     method = Method.POST)

--- a/core/src/main/java/google/registry/batch/SendExpiringCertificateNotificationEmailAction.java
+++ b/core/src/main/java/google/registry/batch/SendExpiringCertificateNotificationEmailAction.java
@@ -35,6 +35,7 @@ import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.RegistrarPoc;
 import google.registry.model.registrar.RegistrarPocBase.Type;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
 import google.registry.util.EmailMessage;
@@ -49,7 +50,7 @@ import org.joda.time.format.DateTimeFormatter;
 
 /** An action that sends notification emails to registrars whose certificates are expiring soon. */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = SendExpiringCertificateNotificationEmailAction.PATH,
     auth = Auth.AUTH_ADMIN)
 public class SendExpiringCertificateNotificationEmailAction implements Runnable {

--- a/core/src/main/java/google/registry/batch/WipeOutContactHistoryPiiAction.java
+++ b/core/src/main/java/google/registry/batch/WipeOutContactHistoryPiiAction.java
@@ -30,7 +30,7 @@ import google.registry.beam.wipeout.WipeOutContactHistoryPiiPipeline;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.model.contact.ContactHistory;
 import google.registry.request.Action;
-import google.registry.request.Action.Service;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -49,7 +49,7 @@ import org.joda.time.DateTime;
  * time.
  */
 @Action(
-    service = Service.BACKEND,
+    service = GaeService.BACKEND,
     path = WipeOutContactHistoryPiiAction.PATH,
     auth = Auth.AUTH_ADMIN)
 public class WipeOutContactHistoryPiiAction implements Runnable {

--- a/core/src/main/java/google/registry/beam/rde/RdeIO.java
+++ b/core/src/main/java/google/registry/beam/rde/RdeIO.java
@@ -44,7 +44,7 @@ import google.registry.rde.RdeModule;
 import google.registry.rde.RdeResourceType;
 import google.registry.rde.RdeUploadAction;
 import google.registry.rde.RdeUtils;
-import google.registry.request.Action.Service;
+import google.registry.request.Action;
 import google.registry.request.RequestParameters;
 import google.registry.tldconfig.idn.IdnTableEnum;
 import google.registry.xjc.rdeheader.XjcRdeHeader;
@@ -302,9 +302,9 @@ public class RdeIO {
                 if (key.mode() == RdeMode.FULL) {
                   cloudTasksUtils.enqueue(
                       RDE_UPLOAD_QUEUE,
-                      cloudTasksUtils.createPostTaskWithDelay(
-                          RdeUploadAction.PATH,
-                          Service.BACKEND,
+                      cloudTasksUtils.createTaskWithDelay(
+                          RdeUploadAction.class,
+                          Action.Method.POST,
                           ImmutableMultimap.of(
                               RequestParameters.PARAM_TLD,
                               key.tld(),
@@ -314,9 +314,9 @@ public class RdeIO {
                 } else {
                   cloudTasksUtils.enqueue(
                       BRDA_QUEUE,
-                      cloudTasksUtils.createPostTaskWithDelay(
-                          BrdaCopyAction.PATH,
-                          Service.BACKEND,
+                      cloudTasksUtils.createTaskWithDelay(
+                          BrdaCopyAction.class,
+                          Action.Method.POST,
                           ImmutableMultimap.of(
                               RequestParameters.PARAM_TLD,
                               key.tld(),

--- a/core/src/main/java/google/registry/bsa/BsaDownloadAction.java
+++ b/core/src/main/java/google/registry/bsa/BsaDownloadAction.java
@@ -41,6 +41,7 @@ import google.registry.bsa.persistence.DownloadScheduler;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.model.tld.Tlds;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
 import google.registry.util.Clock;
@@ -50,7 +51,7 @@ import java.util.stream.Stream;
 import javax.inject.Inject;
 
 @Action(
-    service = Action.Service.BSA,
+    service = GaeService.BSA,
     path = BsaDownloadAction.PATH,
     method = {GET, POST},
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/bsa/BsaRefreshAction.java
+++ b/core/src/main/java/google/registry/bsa/BsaRefreshAction.java
@@ -31,6 +31,7 @@ import google.registry.bsa.persistence.RefreshScheduler;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.model.tld.Tlds;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
 import google.registry.util.BatchedStreams;
@@ -41,7 +42,7 @@ import javax.inject.Inject;
 import org.joda.time.Duration;
 
 @Action(
-    service = Action.Service.BSA,
+    service = GaeService.BSA,
     path = BsaRefreshAction.PATH,
     method = {GET, POST},
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/bsa/BsaValidateAction.java
+++ b/core/src/main/java/google/registry/bsa/BsaValidateAction.java
@@ -55,6 +55,7 @@ import google.registry.model.tld.Tld;
 import google.registry.model.tld.Tld.TldType;
 import google.registry.persistence.VKey;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
 import google.registry.util.Clock;
@@ -67,7 +68,7 @@ import org.joda.time.Duration;
 
 /** Validates the BSA data in the database against the most recent block lists. */
 @Action(
-    service = Action.Service.BSA,
+    service = GaeService.BSA,
     path = BsaValidateAction.PATH,
     method = {GET, POST},
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/bsa/UploadBsaUnavailableDomainsAction.java
+++ b/core/src/main/java/google/registry/bsa/UploadBsaUnavailableDomainsAction.java
@@ -42,7 +42,7 @@ import google.registry.model.tld.Tld;
 import google.registry.model.tld.Tld.TldType;
 import google.registry.model.tld.label.ReservedList;
 import google.registry.request.Action;
-import google.registry.request.Action.Service;
+import google.registry.request.Action.GaeService;
 import google.registry.request.auth.Auth;
 import google.registry.util.Clock;
 import jakarta.persistence.TypedQuery;
@@ -72,7 +72,7 @@ import org.joda.time.DateTime;
  * <p>The file is also uploaded to GCS to preserve it as a record for ourselves.
  */
 @Action(
-    service = Service.BSA,
+    service = GaeService.BSA,
     path = "/_dr/task/uploadBsaUnavailableNames",
     method = {GET, POST},
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/config/ConfigUtils.java
+++ b/core/src/main/java/google/registry/config/ConfigUtils.java
@@ -15,6 +15,8 @@
 package google.registry.config;
 
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 /** Helper methods for configuration classes. */
@@ -23,12 +25,12 @@ public final class ConfigUtils {
   /**
    * Creates a URL instance.
    *
-   * @throws RuntimeException to rethrow {@link MalformedURLException}
+   * @throws RuntimeException to rethrow {@link URISyntaxException} or {@link MalformedURLException}
    */
   public static URL makeUrl(String url) {
     try {
-      return new URL(url);
-    } catch (MalformedURLException e) {
+      return new URI(url).toURL();
+    } catch (URISyntaxException | MalformedURLException e) {
       throw new RuntimeException(e);
     }
   }

--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -37,6 +37,7 @@ import google.registry.bsa.UploadBsaUnavailableDomainsAction;
 import google.registry.dns.ReadDnsRefreshRequestsAction;
 import google.registry.model.common.DnsRefreshRequest;
 import google.registry.persistence.transaction.JpaTransactionManager;
+import google.registry.request.Action.GkeService;
 import google.registry.util.RegistryEnvironment;
 import google.registry.util.YamlUtils;
 import jakarta.mail.internet.AddressException;
@@ -1591,6 +1592,14 @@ public final class RegistryConfig {
 
   public static boolean areServersLocal() {
     return CONFIG_SETTINGS.get().gcpProject.isLocal;
+  }
+
+  public static String getBaseDomain() {
+    return CONFIG_SETTINGS.get().gcpProject.baseDomain;
+  }
+
+  public static URL getServiceUrl(GkeService service) {
+    return makeUrl(String.format("https://%s.%s", service.getServiceId(), getBaseDomain()));
   }
 
   /**

--- a/core/src/main/java/google/registry/cron/TldFanoutAction.java
+++ b/core/src/main/java/google/registry/cron/TldFanoutAction.java
@@ -40,12 +40,14 @@ import com.google.common.collect.Streams;
 import com.google.common.flogger.FluentLogger;
 import google.registry.batch.CloudTasksUtils;
 import google.registry.request.Action;
-import google.registry.request.Action.Service;
+import google.registry.request.Action.GaeService;
+import google.registry.request.Action.GkeService;
 import google.registry.request.Parameter;
 import google.registry.request.ParameterMap;
 import google.registry.request.RequestParameters;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
+import google.registry.util.RegistryEnvironment;
 import java.util.Optional;
 import java.util.stream.Stream;
 import javax.inject.Inject;
@@ -78,7 +80,7 @@ import javax.inject.Inject;
  * </ul>
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = "/_dr/cron/fanout",
     automaticallyPrintOk = true,
     auth = Auth.AUTH_ADMIN)
@@ -157,7 +159,11 @@ public final class TldFanoutAction implements Runnable {
       params = ArrayListMultimap.create(params);
       params.put(RequestParameters.PARAM_TLD, tld);
     }
-    return cloudTasksUtils.createPostTaskWithJitter(
-        endpoint, Service.BACKEND, params, jitterSeconds);
+    return cloudTasksUtils.createTaskWithJitter(
+        endpoint,
+        Action.Method.POST,
+        RegistryEnvironment.isOnJetty() ? GkeService.BACKEND : GaeService.BACKEND,
+        params,
+        jitterSeconds);
   }
 }

--- a/core/src/main/java/google/registry/dns/PublishDnsUpdatesAction.java
+++ b/core/src/main/java/google/registry/dns/PublishDnsUpdatesAction.java
@@ -53,7 +53,7 @@ import google.registry.model.registrar.RegistrarPoc;
 import google.registry.model.registrar.RegistrarPocBase;
 import google.registry.model.tld.Tld;
 import google.registry.request.Action;
-import google.registry.request.Action.Service;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Header;
 import google.registry.request.HttpException.ServiceUnavailableException;
 import google.registry.request.Parameter;
@@ -73,7 +73,7 @@ import org.joda.time.Duration;
 
 /** Task that sends domain and host updates to the DNS server. */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = PublishDnsUpdatesAction.PATH,
     method = POST,
     automaticallyPrintOk = true,
@@ -328,9 +328,9 @@ public final class PublishDnsUpdatesAction implements Runnable, Callable<Void> {
   private void enqueue(ImmutableList<String> domains, ImmutableList<String> hosts) {
     cloudTasksUtils.enqueue(
         DNS_PUBLISH_PUSH_QUEUE_NAME,
-        cloudTasksUtils.createPostTask(
-            PATH,
-            Service.BACKEND,
+        cloudTasksUtils.createTask(
+            this.getClass(),
+            POST,
             ImmutableMultimap.<String, String>builder()
                 .put(PARAM_TLD, tld)
                 .put(PARAM_DNS_WRITER, dnsWriter)

--- a/core/src/main/java/google/registry/dns/ReadDnsRefreshRequestsAction.java
+++ b/core/src/main/java/google/registry/dns/ReadDnsRefreshRequestsAction.java
@@ -45,7 +45,7 @@ import google.registry.dns.DnsUtils.TargetType;
 import google.registry.model.common.DnsRefreshRequest;
 import google.registry.model.tld.Tld;
 import google.registry.request.Action;
-import google.registry.request.Action.Service;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
 import google.registry.util.Clock;
@@ -60,7 +60,7 @@ import org.joda.time.Duration;
  * table.
  */
 @Action(
-    service = Service.BACKEND,
+    service = GaeService.BACKEND,
     path = "/_dr/task/readDnsRefreshRequests",
     automaticallyPrintOk = true,
     method = POST,
@@ -182,9 +182,9 @@ public final class ReadDnsRefreshRequestsAction implements Runnable {
     ImmutableList<String> hosts = hostsBuilder.build();
     for (String dnsWriter : Tld.get(tld).getDnsWriters()) {
       Task task =
-          cloudTasksUtils.createPostTaskWithJitter(
-              PublishDnsUpdatesAction.PATH,
-              Service.BACKEND,
+          cloudTasksUtils.createTaskWithJitter(
+              PublishDnsUpdatesAction.class,
+              POST,
               ImmutableMultimap.<String, String>builder()
                   .put(PARAM_TLD, tld)
                   .put(PARAM_DNS_WRITER, dnsWriter)

--- a/core/src/main/java/google/registry/dns/RefreshDnsAction.java
+++ b/core/src/main/java/google/registry/dns/RefreshDnsAction.java
@@ -26,6 +26,7 @@ import google.registry.model.annotations.ExternalMessagingName;
 import google.registry.model.domain.Domain;
 import google.registry.model.host.Host;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.HttpException.NotFoundException;
 import google.registry.request.Parameter;
@@ -35,7 +36,7 @@ import javax.inject.Inject;
 
 /** Action that manually triggers refresh of DNS information. */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = "/_dr/task/dnsRefresh",
     automaticallyPrintOk = true,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/dns/RefreshDnsOnHostRenameAction.java
+++ b/core/src/main/java/google/registry/dns/RefreshDnsOnHostRenameAction.java
@@ -26,14 +26,18 @@ import google.registry.model.domain.Domain;
 import google.registry.model.host.Host;
 import google.registry.persistence.VKey;
 import google.registry.request.Action;
-import google.registry.request.Action.Service;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
 import javax.inject.Inject;
 import org.joda.time.DateTime;
 
-@Action(service = Service.BACKEND, path = PATH, method = Action.Method.POST, auth = Auth.AUTH_ADMIN)
+@Action(
+    service = GaeService.BACKEND,
+    path = PATH,
+    method = Action.Method.POST,
+    auth = Auth.AUTH_ADMIN)
 public class RefreshDnsOnHostRenameAction implements Runnable {
 
   public static final String QUEUE_HOST_RENAME = "async-host-rename";

--- a/core/src/main/java/google/registry/export/ExportDomainListsAction.java
+++ b/core/src/main/java/google/registry/export/ExportDomainListsAction.java
@@ -31,6 +31,7 @@ import google.registry.gcs.GcsUtils;
 import google.registry.model.tld.Tld;
 import google.registry.model.tld.Tld.TldType;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.auth.Auth;
 import google.registry.storage.drive.DriveConnection;
 import google.registry.util.Clock;
@@ -47,7 +48,7 @@ import javax.inject.Inject;
  * name TLD.txt into the domain-lists bucket. Note that this overwrites the files in place.
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = "/_dr/task/exportDomainLists",
     method = POST,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/export/ExportPremiumTermsAction.java
+++ b/core/src/main/java/google/registry/export/ExportPremiumTermsAction.java
@@ -33,6 +33,7 @@ import google.registry.model.tld.Tld;
 import google.registry.model.tld.label.PremiumList.PremiumEntry;
 import google.registry.model.tld.label.PremiumListDao;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.RequestParameters;
 import google.registry.request.Response;
@@ -45,7 +46,7 @@ import javax.inject.Inject;
 
 /** Action that exports the premium terms list for a TLD to Google Drive. */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = "/_dr/task/exportPremiumTerms",
     method = POST,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/export/ExportReservedTermsAction.java
+++ b/core/src/main/java/google/registry/export/ExportReservedTermsAction.java
@@ -25,6 +25,7 @@ import com.google.common.flogger.FluentLogger;
 import com.google.common.net.MediaType;
 import google.registry.model.tld.Tld;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.RequestParameters;
 import google.registry.request.Response;
@@ -34,7 +35,7 @@ import javax.inject.Inject;
 
 /** Action that exports the publicly viewable reserved terms list for a TLD to Google Drive. */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = "/_dr/task/exportReservedTerms",
     method = POST,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/export/SyncGroupMembersAction.java
+++ b/core/src/main/java/google/registry/export/SyncGroupMembersAction.java
@@ -35,6 +35,7 @@ import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.RegistrarPoc;
 import google.registry.model.registrar.RegistrarPocBase;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
 import google.registry.util.Retrier;
@@ -53,7 +54,7 @@ import javax.inject.Inject;
  * <p>This uses the <a href="https://developers.google.com/admin-sdk/directory/">Directory API</a>.
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = "/_dr/task/syncGroupMembers",
     method = POST,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/export/sheet/SyncRegistrarsSheetAction.java
+++ b/core/src/main/java/google/registry/export/sheet/SyncRegistrarsSheetAction.java
@@ -24,6 +24,7 @@ import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import com.google.common.flogger.FluentLogger;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -54,7 +55,7 @@ import org.joda.time.Duration;
  * @see SyncRegistrarsSheet
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = SyncRegistrarsSheetAction.PATH,
     method = POST,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/flows/CheckApiAction.java
+++ b/core/src/main/java/google/registry/flows/CheckApiAction.java
@@ -55,6 +55,7 @@ import google.registry.model.tld.label.ReservationType;
 import google.registry.monitoring.whitebox.CheckApiMetric;
 import google.registry.monitoring.whitebox.CheckApiMetric.Availability;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.RequestParameters;
 import google.registry.request.Response;
@@ -72,7 +73,7 @@ import org.joda.time.DateTime;
  * user controlled, lest it open an XSS vector. Do not modify this to return the domain name in the
  * response.
  */
-@Action(service = Action.Service.PUBAPI, path = "/check", auth = Auth.AUTH_PUBLIC)
+@Action(service = GaeService.PUBAPI, path = "/check", auth = Auth.AUTH_PUBLIC)
 public class CheckApiAction implements Runnable {
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();

--- a/core/src/main/java/google/registry/flows/EppTlsAction.java
+++ b/core/src/main/java/google/registry/flows/EppTlsAction.java
@@ -15,6 +15,7 @@
 package google.registry.flows;
 
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.Method;
 import google.registry.request.Payload;
 import google.registry.request.auth.Auth;
@@ -26,7 +27,7 @@ import javax.inject.Inject;
  * to RFC 5730. Commands must be requested via POST.
  */
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     path = "/_dr/epp",
     method = Method.POST,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/flows/EppToolAction.java
+++ b/core/src/main/java/google/registry/flows/EppToolAction.java
@@ -22,6 +22,7 @@ import dagger.Module;
 import dagger.Provides;
 import google.registry.model.eppcommon.ProtocolDefinition;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.Method;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
@@ -30,7 +31,7 @@ import javax.inject.Inject;
 
 /** Runs EPP commands directly without logging in, verifying an XSRF token from the tool. */
 @Action(
-    service = Action.Service.TOOLS,
+    service = GaeService.TOOLS,
     path = EppToolAction.PATH,
     method = Method.POST,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/flows/ExtensionManager.java
+++ b/core/src/main/java/google/registry/flows/ExtensionManager.java
@@ -164,8 +164,10 @@ public final class ExtensionManager {
   /** Service extension(s) must be declared at login. */
   public static class UndeclaredServiceExtensionException extends CommandUseErrorException {
     public UndeclaredServiceExtensionException(Set<String> undeclaredUris) {
-      super(String.format("Service extension(s) must be declared at login: %s",
-            Joiner.on(", ").join(undeclaredUris)));
+      super(
+          String.format(
+              "Service extension(s) must be declared at login: %s",
+              Joiner.on(", ").join(undeclaredUris)));
     }
   }
 

--- a/core/src/main/java/google/registry/flows/host/HostUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostUpdateFlow.java
@@ -65,7 +65,7 @@ import google.registry.model.host.HostCommand.Update.Change;
 import google.registry.model.host.HostHistory;
 import google.registry.model.reporting.IcannReportingTypes.ActivityReportField;
 import google.registry.persistence.VKey;
-import google.registry.request.Action.Service;
+import google.registry.request.Action;
 import java.util.Objects;
 import java.util.Optional;
 import javax.inject.Inject;
@@ -277,9 +277,9 @@ public final class HostUpdateFlow implements MutatingFlow {
       // We must also enqueue updates for all domains that use this host as their nameserver so
       // that their NS records can be updated to point at the new name.
       Task task =
-          cloudTasksUtils.createPostTask(
-              RefreshDnsOnHostRenameAction.PATH,
-              Service.BACKEND,
+          cloudTasksUtils.createTask(
+              RefreshDnsOnHostRenameAction.class,
+              Action.Method.POST,
               ImmutableMultimap.of(PARAM_HOST_KEY, existingHost.createVKey().stringify()));
       cloudTasksUtils.enqueue(QUEUE_HOST_RENAME, task);
     }

--- a/core/src/main/java/google/registry/loadtest/LoadTestAction.java
+++ b/core/src/main/java/google/registry/loadtest/LoadTestAction.java
@@ -29,8 +29,9 @@ import com.google.common.collect.Iterators;
 import com.google.common.flogger.FluentLogger;
 import com.google.protobuf.Timestamp;
 import google.registry.batch.CloudTasksUtils;
+import google.registry.flows.EppToolAction;
 import google.registry.request.Action;
-import google.registry.request.Action.Service;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
 import google.registry.security.XsrfTokenManager;
@@ -54,7 +55,7 @@ import org.joda.time.DateTime;
  * least one must be specified in order for load testing to do anything.
  */
 @Action(
-    service = Action.Service.TOOLS,
+    service = GaeService.TOOLS,
     path = LoadTestAction.PATH,
     method = Action.Method.POST,
     automaticallyPrintOk = true,
@@ -335,9 +336,9 @@ public class LoadTestAction implements Runnable {
           Task.newBuilder()
               .setAppEngineHttpRequest(
                   cloudTasksUtils
-                      .createPostTask(
-                          "/_dr/epptool",
-                          Service.TOOLS,
+                      .createTask(
+                          EppToolAction.class,
+                          Action.Method.POST,
                           ImmutableMultimap.of(
                               "clientId",
                               registrarId,

--- a/core/src/main/java/google/registry/model/console/User.java
+++ b/core/src/main/java/google/registry/model/console/User.java
@@ -24,7 +24,7 @@ import com.google.common.flogger.FluentLogger;
 import com.google.common.net.MediaType;
 import google.registry.batch.CloudTasksUtils;
 import google.registry.persistence.VKey;
-import google.registry.request.Action.Service;
+import google.registry.request.Action;
 import google.registry.tools.IamClient;
 import google.registry.tools.ServiceConnection;
 import google.registry.tools.server.UpdateUserGroupAction;
@@ -126,9 +126,9 @@ public class User extends UserBase {
       CloudTasksUtils cloudTasksUtils,
       Mode mode) {
     Task task =
-        cloudTasksUtils.createPostTask(
-            UpdateUserGroupAction.PATH,
-            Service.TOOLS,
+        cloudTasksUtils.createTask(
+            UpdateUserGroupAction.class,
+            Action.Method.POST,
             ImmutableMultimap.of(
                 "userEmailAddress",
                 userEmailAddress,

--- a/core/src/main/java/google/registry/module/RegistryComponent.java
+++ b/core/src/main/java/google/registry/module/RegistryComponent.java
@@ -102,11 +102,9 @@ interface RegistryComponent {
   class RegistryModule {
     @Provides
     static RequestHandler<RequestComponent> provideRequestHandler(
-        @Config("baseDomain") String baseDomain,
         Provider<RequestComponent.Builder> componentProvider,
         RequestAuthenticator requestAuthenticator) {
-      return RequestHandler.create(
-          RequestComponent.class, baseDomain, componentProvider, requestAuthenticator);
+      return RequestHandler.create(RequestComponent.class, componentProvider, requestAuthenticator);
     }
   }
 }

--- a/core/src/main/java/google/registry/rdap/RdapAutnumAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapAutnumAction.java
@@ -20,6 +20,7 @@ import static google.registry.request.Action.Method.HEAD;
 import google.registry.rdap.RdapMetrics.EndpointType;
 import google.registry.rdap.RdapObjectClasses.ReplyPayloadBase;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.NotImplementedException;
 import google.registry.request.auth.Auth;
 import javax.inject.Inject;
@@ -31,7 +32,7 @@ import javax.inject.Inject;
  * ARIN, not domain registries.
  */
 @Action(
-    service = Action.Service.PUBAPI,
+    service = GaeService.PUBAPI,
     path = "/rdap/autnum/",
     method = {GET, HEAD},
     isPrefix = true,

--- a/core/src/main/java/google/registry/rdap/RdapDomainAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapDomainAction.java
@@ -26,6 +26,7 @@ import google.registry.rdap.RdapJsonFormatter.OutputDataType;
 import google.registry.rdap.RdapMetrics.EndpointType;
 import google.registry.rdap.RdapObjectClasses.RdapDomain;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.HttpException.NotFoundException;
 import google.registry.request.auth.Auth;
@@ -34,7 +35,7 @@ import javax.inject.Inject;
 
 /** RDAP (new WHOIS) action for domain requests. */
 @Action(
-    service = Action.Service.PUBAPI,
+    service = GaeService.PUBAPI,
     path = "/rdap/domain/",
     method = {GET, HEAD},
     isPrefix = true,

--- a/core/src/main/java/google/registry/rdap/RdapDomainSearchAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapDomainSearchAction.java
@@ -43,6 +43,7 @@ import google.registry.rdap.RdapMetrics.WildcardType;
 import google.registry.rdap.RdapSearchResults.DomainSearchResponse;
 import google.registry.rdap.RdapSearchResults.IncompletenessWarningType;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.HttpException.NotFoundException;
 import google.registry.request.HttpException.UnprocessableEntityException;
@@ -71,7 +72,7 @@ import org.hibernate.Hibernate;
 // TODO: This isn't required by the RDAP Technical Implementation Guide, and hence should be
 // deleted, at least until it's actually required.
 @Action(
-    service = Action.Service.PUBAPI,
+    service = GaeService.PUBAPI,
     path = "/rdap/domains",
     method = {GET, HEAD},
     auth = Auth.AUTH_PUBLIC)

--- a/core/src/main/java/google/registry/rdap/RdapEntityAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapEntityAction.java
@@ -30,6 +30,7 @@ import google.registry.rdap.RdapJsonFormatter.OutputDataType;
 import google.registry.rdap.RdapMetrics.EndpointType;
 import google.registry.rdap.RdapObjectClasses.RdapEntity;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.NotFoundException;
 import google.registry.request.auth.Auth;
 import java.util.Optional;
@@ -46,7 +47,7 @@ import javax.inject.Inject;
  * Registrar ID registry. The type value of the publicID object MUST be equal to IANA Registrar ID.
  */
 @Action(
-    service = Action.Service.PUBAPI,
+    service = GaeService.PUBAPI,
     path = "/rdap/entity/",
     method = {GET, HEAD},
     isPrefix = true,

--- a/core/src/main/java/google/registry/rdap/RdapEntitySearchAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapEntitySearchAction.java
@@ -37,6 +37,7 @@ import google.registry.rdap.RdapMetrics.SearchType;
 import google.registry.rdap.RdapSearchResults.EntitySearchResponse;
 import google.registry.rdap.RdapSearchResults.IncompletenessWarningType;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.HttpException.NotFoundException;
 import google.registry.request.HttpException.UnprocessableEntityException;
@@ -78,7 +79,7 @@ import javax.inject.Inject;
 // TODO: This isn't required by the RDAP Technical Implementation Guide, and hence should be
 // deleted, at least until it's actually required.
 @Action(
-    service = Action.Service.PUBAPI,
+    service = GaeService.PUBAPI,
     path = "/rdap/entities",
     method = {GET, HEAD},
     auth = Auth.AUTH_PUBLIC)

--- a/core/src/main/java/google/registry/rdap/RdapHelpAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapHelpAction.java
@@ -22,6 +22,7 @@ import google.registry.rdap.RdapDataStructures.Notice;
 import google.registry.rdap.RdapMetrics.EndpointType;
 import google.registry.rdap.RdapObjectClasses.HelpResponse;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.NotFoundException;
 import google.registry.request.auth.Auth;
 import java.util.Optional;
@@ -29,7 +30,7 @@ import javax.inject.Inject;
 
 /** RDAP (new WHOIS) action for help requests. */
 @Action(
-    service = Action.Service.PUBAPI,
+    service = GaeService.PUBAPI,
     path = "/rdap/help",
     method = {GET, HEAD},
     isPrefix = true,

--- a/core/src/main/java/google/registry/rdap/RdapIpAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapIpAction.java
@@ -20,6 +20,7 @@ import static google.registry.request.Action.Method.HEAD;
 import google.registry.rdap.RdapMetrics.EndpointType;
 import google.registry.rdap.RdapObjectClasses.ReplyPayloadBase;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.NotImplementedException;
 import google.registry.request.auth.Auth;
 import javax.inject.Inject;
@@ -31,7 +32,7 @@ import javax.inject.Inject;
  * ARIN, not domain registries.
  */
 @Action(
-    service = Action.Service.PUBAPI,
+    service = GaeService.PUBAPI,
     path = "/rdap/ip/",
     method = {GET, HEAD},
     isPrefix = true,

--- a/core/src/main/java/google/registry/rdap/RdapNameserverAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapNameserverAction.java
@@ -26,6 +26,7 @@ import google.registry.rdap.RdapJsonFormatter.OutputDataType;
 import google.registry.rdap.RdapMetrics.EndpointType;
 import google.registry.rdap.RdapObjectClasses.RdapNameserver;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.HttpException.NotFoundException;
 import google.registry.request.auth.Auth;
@@ -34,7 +35,7 @@ import javax.inject.Inject;
 
 /** RDAP (new WHOIS) action for nameserver requests. */
 @Action(
-    service = Action.Service.PUBAPI,
+    service = GaeService.PUBAPI,
     path = "/rdap/nameserver/",
     method = {GET, HEAD},
     isPrefix = true,

--- a/core/src/main/java/google/registry/rdap/RdapNameserverSearchAction.java
+++ b/core/src/main/java/google/registry/rdap/RdapNameserverSearchAction.java
@@ -34,6 +34,7 @@ import google.registry.rdap.RdapMetrics.SearchType;
 import google.registry.rdap.RdapSearchResults.IncompletenessWarningType;
 import google.registry.rdap.RdapSearchResults.NameserverSearchResponse;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.HttpException.NotFoundException;
 import google.registry.request.HttpException.UnprocessableEntityException;
@@ -56,7 +57,7 @@ import javax.inject.Inject;
  *     Data Access Protocol (RDAP)</a>
  */
 @Action(
-    service = Action.Service.PUBAPI,
+    service = GaeService.PUBAPI,
     path = "/rdap/nameservers",
     method = {GET, HEAD},
     auth = Auth.AUTH_PUBLIC)

--- a/core/src/main/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsAction.java
+++ b/core/src/main/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsAction.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.FluentLogger;
 import google.registry.model.registrar.Registrar;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.InternalServerErrorException;
 import google.registry.request.UrlConnectionService;
 import google.registry.request.UrlConnectionUtils;
@@ -52,7 +53,7 @@ import org.apache.commons.csv.CSVRecord;
  * CSV endpoint requires no authentication.
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = "/_dr/task/updateRegistrarRdapBaseUrls",
     automaticallyPrintOk = true,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/rde/BrdaCopyAction.java
+++ b/core/src/main/java/google/registry/rde/BrdaCopyAction.java
@@ -32,6 +32,7 @@ import google.registry.model.rde.RdeNamingUtils;
 import google.registry.model.rde.RdeRevision;
 import google.registry.model.tld.Tld;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.NoContentException;
 import google.registry.request.Parameter;
 import google.registry.request.RequestParameters;
@@ -62,7 +63,7 @@ import org.joda.time.DateTime;
  *     Agreement</a>
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = BrdaCopyAction.PATH,
     method = POST,
     automaticallyPrintOk = true,

--- a/core/src/main/java/google/registry/rde/RdeReportAction.java
+++ b/core/src/main/java/google/registry/rde/RdeReportAction.java
@@ -36,6 +36,7 @@ import google.registry.model.rde.RdeRevision;
 import google.registry.model.tld.Tld;
 import google.registry.rde.EscrowTaskRunner.EscrowTask;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.NoContentException;
 import google.registry.request.Parameter;
 import google.registry.request.RequestParameters;
@@ -53,7 +54,7 @@ import org.joda.time.Duration;
  * Action that uploads a small XML RDE report to ICANN after {@link RdeUploadAction} has finished.
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = RdeReportAction.PATH,
     method = POST,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/rde/RdeStagingAction.java
+++ b/core/src/main/java/google/registry/rde/RdeStagingAction.java
@@ -50,6 +50,7 @@ import google.registry.model.host.Host;
 import google.registry.model.rde.RdeMode;
 import google.registry.model.registrar.Registrar;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.Parameter;
 import google.registry.request.RequestParameters;
@@ -204,7 +205,7 @@ import org.joda.time.Duration;
  *     Name Registration Data Objects Mapping</a>
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = RdeStagingAction.PATH,
     method = {GET, POST},
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/rde/RdeUploadAction.java
+++ b/core/src/main/java/google/registry/rde/RdeUploadAction.java
@@ -50,7 +50,7 @@ import google.registry.model.tld.Tld;
 import google.registry.rde.EscrowTaskRunner.EscrowTask;
 import google.registry.rde.JSchSshSession.JSchSshSessionFactory;
 import google.registry.request.Action;
-import google.registry.request.Action.Service;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.NoContentException;
 import google.registry.request.Parameter;
 import google.registry.request.RequestParameters;
@@ -84,7 +84,7 @@ import org.joda.time.Duration;
  * RdeReportAction}.
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = RdeUploadAction.PATH,
     method = POST,
     auth = Auth.AUTH_ADMIN)
@@ -130,8 +130,7 @@ public final class RdeUploadAction implements Runnable, EscrowTask {
     params.put(RequestParameters.PARAM_TLD, tld);
     prefix.ifPresent(s -> params.put(RdeModule.PARAM_PREFIX, s));
     cloudTasksUtils.enqueue(
-        RDE_REPORT_QUEUE,
-        cloudTasksUtils.createPostTask(RdeReportAction.PATH, Service.BACKEND, params));
+        RDE_REPORT_QUEUE, cloudTasksUtils.createTask(RdeReportAction.class, POST, params));
   }
 
   @Override

--- a/core/src/main/java/google/registry/reporting/billing/CopyDetailReportsAction.java
+++ b/core/src/main/java/google/registry/reporting/billing/CopyDetailReportsAction.java
@@ -32,6 +32,7 @@ import google.registry.gcs.GcsUtils;
 import google.registry.model.registrar.Registrar;
 import google.registry.reporting.billing.BillingModule.InvoiceDirectoryPrefix;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
 import google.registry.storage.drive.DriveConnection;
@@ -44,7 +45,7 @@ import javax.inject.Inject;
 
 /** Copy all registrar detail reports in a given bucket's subdirectory from GCS to Drive. */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = CopyDetailReportsAction.PATH,
     method = POST,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/reporting/billing/GenerateInvoicesAction.java
+++ b/core/src/main/java/google/registry/reporting/billing/GenerateInvoicesAction.java
@@ -32,7 +32,7 @@ import google.registry.config.RegistryConfig.Config;
 import google.registry.persistence.PersistenceModule;
 import google.registry.reporting.ReportingModule;
 import google.registry.request.Action;
-import google.registry.request.Action.Service;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -51,7 +51,7 @@ import org.joda.time.YearMonth;
  * template. The pipeline then generates invoices for the month and stores them on GCS.
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = GenerateInvoicesAction.PATH,
     method = POST,
     auth = Auth.AUTH_ADMIN)
@@ -138,9 +138,9 @@ public class GenerateInvoicesAction implements Runnable {
       if (shouldPublish) {
         cloudTasksUtils.enqueue(
             ReportingModule.BEAM_QUEUE,
-            cloudTasksUtils.createPostTaskWithDelay(
-                PublishInvoicesAction.PATH,
-                Service.BACKEND,
+            cloudTasksUtils.createTaskWithDelay(
+                PublishInvoicesAction.class,
+                POST,
                 ImmutableMultimap.of(
                     ReportingModule.PARAM_JOB_ID,
                     jobId,

--- a/core/src/main/java/google/registry/reporting/billing/PublishInvoicesAction.java
+++ b/core/src/main/java/google/registry/reporting/billing/PublishInvoicesAction.java
@@ -30,7 +30,7 @@ import google.registry.batch.CloudTasksUtils;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.reporting.ReportingModule;
 import google.registry.request.Action;
-import google.registry.request.Action.Service;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -49,7 +49,7 @@ import org.joda.time.YearMonth;
  *     Job States</a>
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = PublishInvoicesAction.PATH,
     method = POST,
     auth = Auth.AUTH_ADMIN)
@@ -125,9 +125,9 @@ public class PublishInvoicesAction implements Runnable {
   private void enqueueCopyDetailReportsTask() {
     cloudTasksUtils.enqueue(
         BillingModule.CRON_QUEUE,
-        cloudTasksUtils.createPostTask(
-            CopyDetailReportsAction.PATH,
-            Service.BACKEND,
+        cloudTasksUtils.createTask(
+            CopyDetailReportsAction.class,
+            POST,
             ImmutableMultimap.of(PARAM_YEAR_MONTH, yearMonth.toString())));
   }
 }

--- a/core/src/main/java/google/registry/reporting/icann/IcannReportingStagingAction.java
+++ b/core/src/main/java/google/registry/reporting/icann/IcannReportingStagingAction.java
@@ -34,7 +34,7 @@ import google.registry.groups.GmailClient;
 import google.registry.reporting.ReportingModule;
 import google.registry.reporting.icann.IcannReportingModule.ReportType;
 import google.registry.request.Action;
-import google.registry.request.Action.Service;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -66,7 +66,7 @@ import org.joda.time.format.DateTimeFormat;
  * 'transactions'. If none specified - defaults to generating both.
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = IcannReportingStagingAction.PATH,
     method = POST,
     auth = Auth.AUTH_ADMIN)
@@ -138,11 +138,8 @@ public final class IcannReportingStagingAction implements Runnable {
               logger.atInfo().log("Enqueueing report upload.");
               cloudTasksUtils.enqueue(
                   CRON_QUEUE,
-                  cloudTasksUtils.createPostTaskWithDelay(
-                      IcannReportingUploadAction.PATH,
-                      Service.BACKEND,
-                      null,
-                      Duration.standardMinutes(2)));
+                  cloudTasksUtils.createTaskWithDelay(
+                      IcannReportingUploadAction.class, POST, null, Duration.standardMinutes(2)));
             } else {
               logger.atInfo().log("Would have enqueued report upload");
             }

--- a/core/src/main/java/google/registry/reporting/icann/IcannReportingUploadAction.java
+++ b/core/src/main/java/google/registry/reporting/icann/IcannReportingUploadAction.java
@@ -35,6 +35,7 @@ import google.registry.model.tld.Tld.TldType;
 import google.registry.model.tld.Tlds;
 import google.registry.persistence.VKey;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.ServiceUnavailableException;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -67,7 +68,7 @@ import org.joda.time.Duration;
  * Defaults to "icann/monthly/[last month in yyyy-MM format]".
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = IcannReportingUploadAction.PATH,
     method = POST,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/reporting/spec11/GenerateSpec11ReportAction.java
+++ b/core/src/main/java/google/registry/reporting/spec11/GenerateSpec11ReportAction.java
@@ -32,7 +32,7 @@ import google.registry.config.RegistryConfig.Config;
 import google.registry.keyring.api.KeyModule.Key;
 import google.registry.reporting.ReportingModule;
 import google.registry.request.Action;
-import google.registry.request.Action.Service;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -50,7 +50,7 @@ import org.joda.time.LocalDate;
  * generates the specified month's Spec11 report and stores it on GCS.
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = GenerateSpec11ReportAction.PATH,
     method = POST,
     auth = Auth.AUTH_ADMIN)
@@ -133,9 +133,9 @@ public class GenerateSpec11ReportAction implements Runnable {
       if (sendEmail) {
         cloudTasksUtils.enqueue(
             ReportingModule.BEAM_QUEUE,
-            cloudTasksUtils.createPostTaskWithDelay(
-                PublishSpec11ReportAction.PATH,
-                Service.BACKEND,
+            cloudTasksUtils.createTaskWithDelay(
+                PublishSpec11ReportAction.class,
+                POST,
                 ImmutableMultimap.of(
                     ReportingModule.PARAM_JOB_ID,
                     jobId,

--- a/core/src/main/java/google/registry/reporting/spec11/PublishSpec11ReportAction.java
+++ b/core/src/main/java/google/registry/reporting/spec11/PublishSpec11ReportAction.java
@@ -38,6 +38,7 @@ import google.registry.config.RegistryConfig.Config;
 import google.registry.reporting.ReportingModule;
 import google.registry.reporting.spec11.soy.Spec11EmailSoyInfo;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -56,7 +57,7 @@ import org.json.JSONException;
  * ImmutableSet)} on success or {@link Spec11EmailUtils#sendAlertEmail(String, String)} on failure.
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = PublishSpec11ReportAction.PATH,
     method = POST,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/tmch/NordnUploadAction.java
+++ b/core/src/main/java/google/registry/tmch/NordnUploadAction.java
@@ -37,7 +37,7 @@ import google.registry.batch.CloudTasksUtils;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.model.domain.Domain;
 import google.registry.request.Action;
-import google.registry.request.Action.Service;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.RequestParameters;
 import google.registry.request.UrlConnectionService;
@@ -66,7 +66,7 @@ import org.joda.time.Duration;
  * @see NordnVerifyAction
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = NordnUploadAction.PATH,
     method = Action.Method.POST,
     automaticallyPrintOk = true,
@@ -240,9 +240,9 @@ public final class NordnUploadAction implements Runnable {
 
   private Task makeVerifyTask(URL url) {
     // The actionLogId is used to uniquely associate the verify task back to the upload task.
-    return cloudTasksUtils.createPostTaskWithDelay(
-        NordnVerifyAction.PATH,
-        Service.BACKEND,
+    return cloudTasksUtils.createTaskWithDelay(
+        NordnVerifyAction.class,
+        Action.Method.POST,
         ImmutableMultimap.<String, String>builder()
             .put(NordnVerifyAction.NORDN_URL_PARAM, url.toString())
             .put(NordnVerifyAction.NORDN_LOG_ID_PARAM, actionLogId)

--- a/core/src/main/java/google/registry/tmch/NordnVerifyAction.java
+++ b/core/src/main/java/google/registry/tmch/NordnVerifyAction.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.flogger.FluentLogger;
 import com.google.common.io.ByteSource;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.ConflictException;
 import google.registry.request.Parameter;
 import google.registry.request.RequestParameters;
@@ -50,7 +51,7 @@ import javax.inject.Inject;
  *     http://tools.ietf.org/html/draft-lozano-tmch-func-spec-08#section-5.2.3.3</a>
  */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = NordnVerifyAction.PATH,
     method = Action.Method.POST,
     automaticallyPrintOk = true,

--- a/core/src/main/java/google/registry/tmch/TmchCrlAction.java
+++ b/core/src/main/java/google/registry/tmch/TmchCrlAction.java
@@ -19,6 +19,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import google.registry.config.RegistryConfig.Config;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.auth.Auth;
 import java.io.IOException;
 import java.net.URL;
@@ -28,7 +29,7 @@ import javax.inject.Inject;
 
 /** Action to download the latest ICANN TMCH CRL from MarksDB. */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = "/_dr/task/tmchCrl",
     method = POST,
     automaticallyPrintOk = true,

--- a/core/src/main/java/google/registry/tmch/TmchDnlAction.java
+++ b/core/src/main/java/google/registry/tmch/TmchDnlAction.java
@@ -22,6 +22,7 @@ import google.registry.keyring.api.KeyModule.Key;
 import google.registry.model.tmch.ClaimsList;
 import google.registry.model.tmch.ClaimsListDao;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.auth.Auth;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -31,7 +32,7 @@ import org.bouncycastle.openpgp.PGPException;
 
 /** Action to download the latest domain name list (aka claims list) from MarksDB. */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = "/_dr/task/tmchDnl",
     method = POST,
     automaticallyPrintOk = true,

--- a/core/src/main/java/google/registry/tmch/TmchSmdrlAction.java
+++ b/core/src/main/java/google/registry/tmch/TmchSmdrlAction.java
@@ -21,6 +21,7 @@ import com.google.common.flogger.FluentLogger;
 import google.registry.keyring.api.KeyModule.Key;
 import google.registry.model.smd.SignedMarkRevocationList;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.auth.Auth;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -30,7 +31,7 @@ import org.bouncycastle.openpgp.PGPException;
 
 /** Action to download the latest signed mark revocation list from MarksDB. */
 @Action(
-    service = Action.Service.BACKEND,
+    service = GaeService.BACKEND,
     path = "/_dr/task/tmchSmdrl",
     method = POST,
     automaticallyPrintOk = true,

--- a/core/src/main/java/google/registry/tools/DomainLockUtils.java
+++ b/core/src/main/java/google/registry/tools/DomainLockUtils.java
@@ -34,7 +34,7 @@ import google.registry.model.domain.RegistryLock;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.tld.RegistryLockDao;
 import google.registry.model.tld.Tld;
-import google.registry.request.Action.Service;
+import google.registry.request.Action;
 import google.registry.util.StringGenerator;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -191,9 +191,9 @@ public final class DomainLockUtils {
   public void enqueueDomainRelock(Duration countdown, long lockRevisionId, int previousAttempts) {
     cloudTasksUtils.enqueue(
         QUEUE_ASYNC_ACTIONS,
-        cloudTasksUtils.createPostTaskWithDelay(
-            RelockDomainAction.PATH,
-            Service.BACKEND,
+        cloudTasksUtils.createTaskWithDelay(
+            RelockDomainAction.class,
+            Action.Method.POST,
             ImmutableMultimap.of(
                 RelockDomainAction.OLD_UNLOCK_REVISION_ID_PARAM,
                 String.valueOf(lockRevisionId),

--- a/core/src/main/java/google/registry/tools/GenerateEscrowDepositCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateEscrowDepositCommand.java
@@ -22,6 +22,7 @@ import static google.registry.rde.RdeModule.PARAM_MODE;
 import static google.registry.rde.RdeModule.PARAM_REVISION;
 import static google.registry.rde.RdeModule.PARAM_WATERMARKS;
 import static google.registry.rde.RdeModule.RDE_REPORT_QUEUE;
+import static google.registry.request.Action.Method.POST;
 import static google.registry.request.RequestParameters.PARAM_TLDS;
 
 import com.beust.jcommander.Parameter;
@@ -31,7 +32,6 @@ import com.google.common.collect.ImmutableMultimap;
 import google.registry.batch.CloudTasksUtils;
 import google.registry.model.rde.RdeMode;
 import google.registry.rde.RdeStagingAction;
-import google.registry.request.Action.Service;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -124,8 +124,7 @@ final class GenerateEscrowDepositCommand implements Command {
     }
     cloudTasksUtils.enqueue(
         RDE_REPORT_QUEUE,
-        cloudTasksUtils.createPostTask(
-            RdeStagingAction.PATH, Service.BACKEND, paramsBuilder.build()));
+        cloudTasksUtils.createTask(RdeStagingAction.class, POST, paramsBuilder.build()));
   }
 
 }

--- a/core/src/main/java/google/registry/tools/RegistryCli.java
+++ b/core/src/main/java/google/registry/tools/RegistryCli.java
@@ -70,6 +70,9 @@ final class RegistryCli implements CommandRunner {
               + "Beam pipelines")
   private String sqlAccessInfoFile = null;
 
+  @Parameter(names = "--gke", description = "Whether to use GKE runtime, instead of GAE")
+  private boolean useGke = false;
+
   // Do not make this final - compile-time constant inlining may interfere with JCommander.
   @ParametersDelegate private LoggingParameters loggingParams = new LoggingParameters();
 
@@ -93,10 +96,10 @@ final class RegistryCli implements CommandRunner {
     Security.addProvider(new BouncyCastleProvider());
   }
 
-  // The <? extends Class<? extends Command>> wildcard looks a little funny, but is needed so that
-  // we can accept maps with value types that are subtypes of Class<? extends Command> rather than
-  // literally that type.  For more explanation, see:
-  //   http://www.angelikalanger.com/GenericsFAQ/FAQSections/TypeArguments.html#FAQ104
+  // The <? extends Class<? extends Command>> wildcard looks a little funny, but is necessary so
+  // that we can accept maps with value types that are subtypes of Class<? extends Command> rather
+  // than literally that type.  For more explanation, see:
+  // http://www.angelikalanger.com/GenericsFAQ/FAQSections/TypeArguments.html#FAQ104
   @Override
   public void run(String[] args) throws Exception {
 
@@ -105,7 +108,7 @@ final class RegistryCli implements CommandRunner {
     jcommander.addConverterFactory(new ParameterFactory());
     jcommander.setProgramName(programName);
 
-    // Create all command instances. It would be preferrable to do this in the constructor, but
+    // Create all command instances. It would be preferable to do this in the constructor, but
     // JCommander mutates the command instances and doesn't reset them, so we have to do it for
     // every run.
     try {
@@ -162,6 +165,7 @@ final class RegistryCli implements CommandRunner {
         DaggerRegistryToolComponent.builder()
             .credentialFilePath(credentialJson)
             .sqlAccessInfoFile(sqlAccessInfoFile)
+            .useGke(useGke)
             .build();
 
     // JCommander stores sub-commands as nested JCommander objects containing a list of user objects
@@ -204,7 +208,7 @@ final class RegistryCli implements CommandRunner {
   }
 
   private ServiceConnection getConnection() {
-    // Get the App Engine connection, advise the user if they are not currently logged in..
+    // Get the App Engine connection, advise the user if they are not currently logged in.
     if (connection == null) {
       connection = component.serviceConnection();
     }

--- a/core/src/main/java/google/registry/tools/RegistryToolComponent.java
+++ b/core/src/main/java/google/registry/tools/RegistryToolComponent.java
@@ -101,6 +101,8 @@ interface RegistryToolComponent {
 
   void inject(CreateUserCommand command);
 
+  void inject(CurlCommand command);
+
   void inject(DeleteUserCommand command);
 
   void inject(EncryptEscrowDepositCommand command);
@@ -189,6 +191,9 @@ interface RegistryToolComponent {
 
     @BindsInstance
     Builder sqlAccessInfoFile(@Nullable @Config("sqlAccessInfoFile") String sqlAccessInfoFile);
+
+    @BindsInstance
+    Builder useGke(@Config("useGke") boolean useGke);
 
     RegistryToolComponent build();
   }

--- a/core/src/main/java/google/registry/tools/ServiceConnection.java
+++ b/core/src/main/java/google/registry/tools/ServiceConnection.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.net.HttpHeaders.X_REQUESTED_WITH;
 import static com.google.common.net.MediaType.JSON_UTF_8;
+import static google.registry.config.ConfigUtils.makeUrl;
 import static google.registry.security.JsonHttp.JSON_SAFETY_PREFIX;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -35,11 +36,12 @@ import com.google.common.io.CharStreams;
 import com.google.common.net.MediaType;
 import com.google.re2j.Matcher;
 import com.google.re2j.Pattern;
-import google.registry.config.RegistryConfig;
+import google.registry.config.RegistryConfig.Config;
+import google.registry.request.Action.GaeService;
+import google.registry.request.Action.GkeService;
 import google.registry.request.Action.Service;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -49,33 +51,33 @@ import org.json.simple.JSONValue;
 /**
  * An HTTP connection to a service.
  *
- * <p>By default - connects to the TOOLS service. To create a Connection to another service, call
- * the {@link #withService} function.
+ * <p>By default - connects to the TOOLS service in GAE and the BACKEND service in GKE. To create a
+ * Connection to another service, call the {@link #withService} function.
  */
 public class ServiceConnection {
 
   /** Pattern to heuristically extract title tag contents in HTML responses. */
-  private static final Pattern HTML_TITLE_TAG_PATTERN = Pattern.compile("<title>(.*?)</title>");
+  protected static final Pattern HTML_TITLE_TAG_PATTERN = Pattern.compile("<title>(.*?)</title>");
 
-  @Inject HttpRequestFactory requestFactory;
-  private final Service service;
-  private final boolean useCanary;
+  protected final Service service;
+  protected final boolean useCanary;
+  protected final HttpRequestFactory requestFactory;
 
   @Inject
-  ServiceConnection() {
-    service = Service.TOOLS;
-    useCanary = false;
+  ServiceConnection(@Config("useGke") boolean useGke, HttpRequestFactory requestFactory) {
+    this(useGke ? GkeService.BACKEND : GaeService.TOOLS, requestFactory, false);
   }
 
-  private ServiceConnection(Service service, HttpRequestFactory requestFactory, boolean useCanary) {
+  protected ServiceConnection(
+      Service service, HttpRequestFactory requestFactory, boolean useCanary) {
     this.service = service;
     this.requestFactory = requestFactory;
     this.useCanary = useCanary;
   }
 
   /** Returns a copy of this connection that talks to a different service endpoint. */
-  public ServiceConnection withService(Service service, boolean isCanary) {
-    return new ServiceConnection(service, requestFactory, isCanary);
+  public ServiceConnection withService(Service service, boolean useCanary) {
+    return new ServiceConnection(service, requestFactory, useCanary);
   }
 
   /** Returns the contents of the title tag in the given HTML, or null if not found. */
@@ -129,14 +131,14 @@ public class ServiceConnection {
 
   @VisibleForTesting
   URL getServer() {
-    URL url = getServer(service);
-    if (useCanary) {
+    URL url = service.getServiceUrl();
+    // Currently only GAE supports connecting to canary.
+    if (service instanceof GaeService && useCanary) {
       verify(!isNullOrEmpty(url.getHost()), "Null host in url");
-      try {
-        return new URL(url.getProtocol(), "nomulus-dot-" + url.getHost(), url.getFile());
-      } catch (MalformedURLException e) {
-        throw new RuntimeException(e);
-      }
+      url =
+          makeUrl(
+              String.format(
+                  "%s://nomulus-dot-%s%s", url.getProtocol(), url.getHost(), url.getFile()));
     }
     return url;
   }
@@ -160,15 +162,5 @@ public class ServiceConnection {
             JSON_UTF_8,
             JSONValue.toJSONString(object).getBytes(UTF_8));
     return (Map<String, Object>) JSONValue.parse(response.substring(JSON_SAFETY_PREFIX.length()));
-  }
-
-  public static URL getServer(Service service) {
-    return switch (service) {
-      case DEFAULT -> RegistryConfig.getDefaultServer();
-      case TOOLS -> RegistryConfig.getToolsServer();
-      case BACKEND -> RegistryConfig.getBackendServer();
-      case BSA -> RegistryConfig.getBsaServer();
-      case PUBAPI -> RegistryConfig.getPubapiServer();
-    };
   }
 }

--- a/core/src/main/java/google/registry/tools/server/CreateGroupsAction.java
+++ b/core/src/main/java/google/registry/tools/server/CreateGroupsAction.java
@@ -26,6 +26,7 @@ import google.registry.groups.GroupsConnection.Role;
 import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.RegistrarPocBase;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.HttpException.InternalServerErrorException;
 import google.registry.request.Parameter;
@@ -40,7 +41,7 @@ import javax.inject.Inject;
 
 /** Action that creates Google Groups for a registrar's mailing lists. */
 @Action(
-    service = Action.Service.TOOLS,
+    service = GaeService.TOOLS,
     path = CreateGroupsAction.PATH,
     method = POST,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/tools/server/GenerateZoneFilesAction.java
+++ b/core/src/main/java/google/registry/tools/server/GenerateZoneFilesAction.java
@@ -33,6 +33,7 @@ import google.registry.model.domain.secdns.DomainDsData;
 import google.registry.model.host.Host;
 import google.registry.model.tld.Tld;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.JsonActionRunner;
 import google.registry.request.auth.Auth;
@@ -62,7 +63,7 @@ import org.joda.time.Duration;
  * days in the past, and must be at midnight UTC.
  */
 @Action(
-    service = Action.Service.TOOLS,
+    service = GaeService.TOOLS,
     path = GenerateZoneFilesAction.PATH,
     method = POST,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/tools/server/ListDomainsAction.java
+++ b/core/src/main/java/google/registry/tools/server/ListDomainsAction.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableSet;
 import google.registry.model.EppResourceUtils;
 import google.registry.model.domain.Domain;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
 import google.registry.util.Clock;
@@ -36,7 +37,7 @@ import javax.inject.Inject;
 
 /** An action that lists domains, for use by the {@code nomulus list_domains} command. */
 @Action(
-    service = Action.Service.TOOLS,
+    service = GaeService.TOOLS,
     path = ListDomainsAction.PATH,
     method = {GET, POST},
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/tools/server/ListHostsAction.java
+++ b/core/src/main/java/google/registry/tools/server/ListHostsAction.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSet;
 import google.registry.model.EppResourceUtils;
 import google.registry.model.host.Host;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.auth.Auth;
 import google.registry.util.Clock;
 import javax.inject.Inject;
@@ -31,7 +32,7 @@ import org.joda.time.DateTime;
 
 /** An action that lists hosts, for use by the {@code nomulus list_hosts} command. */
 @Action(
-    service = Action.Service.TOOLS,
+    service = GaeService.TOOLS,
     path = ListHostsAction.PATH,
     method = {GET, POST},
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/tools/server/ListPremiumListsAction.java
+++ b/core/src/main/java/google/registry/tools/server/ListPremiumListsAction.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import google.registry.model.tld.label.PremiumList;
 import google.registry.model.tld.label.PremiumListDao;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.auth.Auth;
 import java.util.Comparator;
 import java.util.Optional;
@@ -32,7 +33,7 @@ import javax.inject.Inject;
  * An action that lists premium lists, for use by the {@code nomulus list_premium_lists} command.
  */
 @Action(
-    service = Action.Service.TOOLS,
+    service = GaeService.TOOLS,
     path = ListPremiumListsAction.PATH,
     method = {GET, POST},
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/tools/server/ListRegistrarsAction.java
+++ b/core/src/main/java/google/registry/tools/server/ListRegistrarsAction.java
@@ -22,12 +22,13 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import google.registry.model.registrar.Registrar;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.auth.Auth;
 import javax.inject.Inject;
 
 /** An action that lists registrars, for use by the {@code nomulus list_registrars} command. */
 @Action(
-    service = Action.Service.TOOLS,
+    service = GaeService.TOOLS,
     path = ListRegistrarsAction.PATH,
     method = {GET, POST},
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/tools/server/ListReservedListsAction.java
+++ b/core/src/main/java/google/registry/tools/server/ListReservedListsAction.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableSet;
 import google.registry.model.tld.label.ReservedList;
 import google.registry.model.tld.label.ReservedListDao;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.auth.Auth;
 import java.util.Comparator;
 import java.util.Optional;
@@ -30,7 +31,7 @@ import javax.inject.Inject;
 
 /** A that lists reserved lists, for use by the {@code nomulus list_reserved_lists} command. */
 @Action(
-    service = Action.Service.TOOLS,
+    service = GaeService.TOOLS,
     path = ListReservedListsAction.PATH,
     method = {GET, POST},
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/tools/server/ListTldsAction.java
+++ b/core/src/main/java/google/registry/tools/server/ListTldsAction.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import google.registry.model.tld.Tld;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.auth.Auth;
 import google.registry.util.Clock;
 import javax.inject.Inject;
@@ -31,7 +32,7 @@ import org.joda.time.DateTime;
 
 /** An action that lists top-level domains, for use by the {@code nomulus list_tlds} command. */
 @Action(
-    service = Action.Service.TOOLS,
+    service = GaeService.TOOLS,
     path = ListTldsAction.PATH,
     method = {GET, POST},
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
+++ b/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.FluentLogger;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -57,7 +58,7 @@ import org.joda.time.Duration;
  * domains that have since been deleted.
  */
 @Action(
-    service = Action.Service.TOOLS,
+    service = GaeService.TOOLS,
     path = "/_dr/task/refreshDnsForAllDomains",
     auth = Auth.AUTH_ADMIN)
 public class RefreshDnsForAllDomainsAction implements Runnable {

--- a/core/src/main/java/google/registry/tools/server/UpdateUserGroupAction.java
+++ b/core/src/main/java/google/registry/tools/server/UpdateUserGroupAction.java
@@ -20,6 +20,7 @@ import com.google.common.flogger.FluentLogger;
 import google.registry.groups.GroupsConnection;
 import google.registry.groups.GroupsConnection.Role;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -27,7 +28,7 @@ import javax.inject.Inject;
 
 /** Action that adds or deletes a console user to/from the group that has IAP permissions. */
 @Action(
-    service = Action.Service.TOOLS,
+    service = GaeService.TOOLS,
     path = UpdateUserGroupAction.PATH,
     method = POST,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/tools/server/VerifyOteAction.java
+++ b/core/src/main/java/google/registry/tools/server/VerifyOteAction.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Maps;
 import google.registry.model.OteStats;
 import google.registry.model.OteStats.StatType;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.JsonActionRunner;
 import google.registry.request.JsonActionRunner.JsonAction;
 import google.registry.request.auth.Auth;
@@ -34,7 +35,7 @@ import javax.inject.Inject;
  * OT&amp;E commands that have been run just previously to verification may not be picked up yet.
  */
 @Action(
-    service = Action.Service.TOOLS,
+    service = GaeService.TOOLS,
     path = VerifyOteAction.PATH,
     method = Action.Method.POST,
     auth = Auth.AUTH_ADMIN)

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleApiAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleApiAction.java
@@ -41,7 +41,6 @@ import google.registry.model.console.UserRoles;
 import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.RegistrarPoc;
 import google.registry.model.registrar.RegistrarPocBase;
-import google.registry.request.Action.Service;
 import google.registry.request.HttpException;
 import google.registry.security.XsrfTokenManager;
 import google.registry.ui.server.registrar.ConsoleUiAction;
@@ -197,8 +196,7 @@ public abstract class ConsoleApiAction implements Runnable {
       // there's an update besides the lastUpdateTime
       cloudTasksUtils.enqueue(
           SyncRegistrarsSheetAction.QUEUE,
-          cloudTasksUtils.createGetTask(
-              SyncRegistrarsSheetAction.PATH, Service.BACKEND, ImmutableMultimap.of()));
+          cloudTasksUtils.createTask(SyncRegistrarsSheetAction.class, GET, ImmutableMultimap.of()));
     }
 
     String environment = Ascii.toLowerCase(String.valueOf(RegistryEnvironment.get()));

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleDomainGetAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleDomainGetAction.java
@@ -24,6 +24,7 @@ import google.registry.model.console.ConsolePermission;
 import google.registry.model.console.User;
 import google.registry.model.domain.Domain;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.GkeService;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
@@ -32,7 +33,7 @@ import javax.inject.Inject;
 
 /** Returns a JSON representation of a domain to the registrar console. */
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     gkeService = GkeService.CONSOLE,
     path = ConsoleDomainGetAction.PATH,
     auth = Auth.AUTH_PUBLIC_LOGGED_IN)

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleDomainListAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleDomainListAction.java
@@ -27,6 +27,7 @@ import google.registry.model.CreateAutoTimestamp;
 import google.registry.model.console.User;
 import google.registry.model.domain.Domain;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.GkeService;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
@@ -38,7 +39,7 @@ import org.joda.time.DateTime;
 
 /** Returns a (paginated) list of domains for a particular registrar. */
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     gkeService = GkeService.CONSOLE,
     path = ConsoleDomainListAction.PATH,
     method = Action.Method.GET,

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleDumDownloadAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleDumDownloadAction.java
@@ -26,6 +26,7 @@ import google.registry.config.RegistryConfig.Config;
 import google.registry.model.console.ConsolePermission;
 import google.registry.model.console.User;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.GkeService;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
@@ -39,7 +40,7 @@ import org.apache.commons.csv.CSVPrinter;
 import org.joda.time.DateTime;
 
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     gkeService = GkeService.CONSOLE,
     path = ConsoleDumDownloadAction.PATH,
     method = {GET},

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleEppPasswordAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleEppPasswordAction.java
@@ -30,6 +30,7 @@ import google.registry.flows.PasswordOnlyTransportCredentials;
 import google.registry.model.console.User;
 import google.registry.model.registrar.Registrar;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.GkeService;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
@@ -40,7 +41,7 @@ import java.util.Optional;
 import javax.inject.Inject;
 
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     gkeService = GkeService.CONSOLE,
     path = ConsoleEppPasswordAction.PATH,
     method = {POST},

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleOteAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleOteAction.java
@@ -50,7 +50,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 @Action(
-    service = Action.Service.DEFAULT,
+    service = Action.GaeService.DEFAULT,
     gkeService = GkeService.CONSOLE,
     path = ConsoleOteAction.PATH,
     method = {GET, POST},

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleRegistryLockAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleRegistryLockAction.java
@@ -35,6 +35,7 @@ import google.registry.model.domain.RegistryLock;
 import google.registry.model.registrar.Registrar;
 import google.registry.model.tld.RegistryLockDao;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.GkeService;
 import google.registry.request.Parameter;
 import google.registry.request.Response;
@@ -55,7 +56,7 @@ import org.joda.time.Duration;
  * action).
  */
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     gkeService = GkeService.CONSOLE,
     path = ConsoleRegistryLockAction.PATH,
     method = {GET, POST},

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleRegistryLockVerifyAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleRegistryLockVerifyAction.java
@@ -22,6 +22,7 @@ import com.google.gson.annotations.Expose;
 import google.registry.model.console.User;
 import google.registry.model.domain.RegistryLock;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.GkeService;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
@@ -31,7 +32,7 @@ import javax.inject.Inject;
 
 /** Handler for verifying registry lock requests, a form of 2FA. */
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     gkeService = GkeService.CONSOLE,
     path = ConsoleRegistryLockVerifyAction.PATH,
     method = {GET},

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleUpdateRegistrarAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleUpdateRegistrarAction.java
@@ -26,6 +26,7 @@ import google.registry.model.console.ConsolePermission;
 import google.registry.model.console.User;
 import google.registry.model.registrar.Registrar;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.GkeService;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.Parameter;
@@ -37,7 +38,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     gkeService = GkeService.CONSOLE,
     path = ConsoleUpdateRegistrarAction.PATH,
     method = {POST},

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleUserDataAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleUserDataAction.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.model.console.User;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.GkeService;
 import google.registry.request.auth.Auth;
 import google.registry.security.XsrfTokenManager;
@@ -29,7 +30,7 @@ import javax.inject.Inject;
 import org.json.JSONObject;
 
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     gkeService = GkeService.CONSOLE,
     path = ConsoleUserDataAction.PATH,
     method = {GET},

--- a/core/src/main/java/google/registry/ui/server/console/RegistrarsAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/RegistrarsAction.java
@@ -34,6 +34,7 @@ import google.registry.model.registrar.RegistrarBase;
 import google.registry.model.registrar.RegistrarBase.State;
 import google.registry.model.registrar.RegistrarPoc;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.GkeService;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
@@ -45,7 +46,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     gkeService = GkeService.CONSOLE,
     path = RegistrarsAction.PATH,
     method = {GET, POST},

--- a/core/src/main/java/google/registry/ui/server/console/settings/ContactAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/settings/ContactAction.java
@@ -31,6 +31,7 @@ import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.RegistrarPoc;
 import google.registry.persistence.transaction.QueryComposer.Comparator;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.GkeService;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
@@ -43,7 +44,7 @@ import java.util.Optional;
 import javax.inject.Inject;
 
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     gkeService = GkeService.CONSOLE,
     path = ContactAction.PATH,
     method = {GET, POST},

--- a/core/src/main/java/google/registry/ui/server/console/settings/SecurityAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/settings/SecurityAction.java
@@ -28,6 +28,7 @@ import google.registry.model.console.ConsolePermission;
 import google.registry.model.console.User;
 import google.registry.model.registrar.Registrar;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.GkeService;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
@@ -39,7 +40,7 @@ import java.util.Optional;
 import javax.inject.Inject;
 
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     gkeService = GkeService.CONSOLE,
     path = SecurityAction.PATH,
     method = {POST},

--- a/core/src/main/java/google/registry/ui/server/console/settings/WhoisRegistrarFieldsAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/settings/WhoisRegistrarFieldsAction.java
@@ -25,6 +25,7 @@ import google.registry.model.console.ConsolePermission;
 import google.registry.model.console.User;
 import google.registry.model.registrar.Registrar;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.GkeService;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
@@ -43,7 +44,7 @@ import javax.inject.Inject;
  * WHOIS/RDAP and don't have any other obvious means of edit.
  */
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     gkeService = GkeService.CONSOLE,
     path = WhoisRegistrarFieldsAction.PATH,
     method = {POST},

--- a/core/src/main/java/google/registry/ui/server/registrar/ConsoleOteSetupAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/ConsoleOteSetupAction.java
@@ -28,6 +28,7 @@ import google.registry.batch.CloudTasksUtils;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.model.OteAccountBuilder;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.Method;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.Parameter;
@@ -54,7 +55,7 @@ import javax.inject.Named;
  * Methods), separate this class to 2 Actions.
  */
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     path = ConsoleOteSetupAction.PATH,
     method = {Method.POST, Method.GET},
     auth = Auth.AUTH_PUBLIC_LOGGED_IN)

--- a/core/src/main/java/google/registry/ui/server/registrar/ConsoleRegistrarCreatorAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/ConsoleRegistrarCreatorAction.java
@@ -35,8 +35,8 @@ import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.RegistrarAddress;
 import google.registry.model.registrar.RegistrarBase.State;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.Method;
-import google.registry.request.Action.Service;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
@@ -66,7 +66,7 @@ import org.joda.money.CurrencyUnit;
  * information. - for POST, receives the information and creates the Registrar.
  */
 @Action(
-    service = Service.DEFAULT,
+    service = GaeService.DEFAULT,
     path = ConsoleRegistrarCreatorAction.PATH,
     method = {Method.POST, Method.GET},
     auth = Auth.AUTH_PUBLIC_LOGGED_IN)

--- a/core/src/main/java/google/registry/ui/server/registrar/ConsoleUiAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/ConsoleUiAction.java
@@ -32,6 +32,7 @@ import google.registry.config.RegistryConfig.Config;
 import google.registry.model.common.FeatureFlag;
 import google.registry.model.console.GlobalRole;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
 import google.registry.request.auth.AuthenticatedRegistrarAccessor;
@@ -48,7 +49,7 @@ import javax.inject.Inject;
 
 /** Action that serves Registrar Console single HTML page (SPA). */
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     path = ConsoleUiAction.PATH,
     auth = Auth.AUTH_PUBLIC_LOGGED_IN)
 public final class ConsoleUiAction extends HtmlAction {

--- a/core/src/main/java/google/registry/ui/server/registrar/OteStatusAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/OteStatusAction.java
@@ -28,6 +28,7 @@ import google.registry.model.OteStats.StatType;
 import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.RegistrarBase.Type;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.JsonActionRunner;
 import google.registry.request.auth.Auth;
 import google.registry.request.auth.AuthenticatedRegistrarAccessor;
@@ -42,7 +43,7 @@ import javax.inject.Inject;
  * preserve history.
  */
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     path = OteStatusAction.PATH,
     method = Action.Method.POST,
     auth = Auth.AUTH_PUBLIC_LOGGED_IN)

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
@@ -43,7 +43,7 @@ import google.registry.model.registrar.Registrar;
 import google.registry.model.registrar.RegistrarPoc;
 import google.registry.model.registrar.RegistrarPocBase.Type;
 import google.registry.request.Action;
-import google.registry.request.Action.Service;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.HttpException.ForbiddenException;
 import google.registry.request.JsonActionRunner;
@@ -74,7 +74,7 @@ import org.joda.time.DateTime;
  * preserve history.
  */
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     path = RegistrarSettingsAction.PATH,
     method = Action.Method.POST,
     auth = Auth.AUTH_PUBLIC_LOGGED_IN)
@@ -604,8 +604,8 @@ public class RegistrarSettingsAction implements Runnable, JsonActionRunner.JsonA
       // there's an update besides the lastUpdateTime
       cloudTasksUtils.enqueue(
           SyncRegistrarsSheetAction.QUEUE,
-          cloudTasksUtils.createGetTask(
-              SyncRegistrarsSheetAction.PATH, Service.BACKEND, ImmutableMultimap.of()));
+          cloudTasksUtils.createTask(
+              SyncRegistrarsSheetAction.class, Action.Method.GET, ImmutableMultimap.of()));
     }
     String environment = Ascii.toLowerCase(String.valueOf(RegistryEnvironment.get()));
     sendEmailUtils.sendEmail(

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistrarSettingsAction.java
@@ -605,7 +605,7 @@ public class RegistrarSettingsAction implements Runnable, JsonActionRunner.JsonA
       cloudTasksUtils.enqueue(
           SyncRegistrarsSheetAction.QUEUE,
           cloudTasksUtils.createTask(
-              SyncRegistrarsSheetAction.class, Action.Method.GET, ImmutableMultimap.of()));
+              SyncRegistrarsSheetAction.class, Action.Method.POST, ImmutableMultimap.of()));
     }
     String environment = Ascii.toLowerCase(String.valueOf(RegistryEnvironment.get()));
     sendEmailUtils.sendEmail(

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistryLockGetAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistryLockGetAction.java
@@ -34,6 +34,7 @@ import google.registry.model.domain.RegistryLock;
 import google.registry.model.registrar.Registrar;
 import google.registry.model.tld.RegistryLockDao;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.Method;
 import google.registry.request.Parameter;
 import google.registry.request.RequestMethod;
@@ -54,7 +55,7 @@ import org.joda.time.DateTime;
  * URL, which is why this is distinct from the {@link RegistryLockPostAction}.
  */
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     path = RegistryLockGetAction.PATH,
     auth = Auth.AUTH_PUBLIC_LOGGED_IN)
 public final class RegistryLockGetAction implements JsonGetAction {

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistryLockPostAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistryLockPostAction.java
@@ -32,6 +32,7 @@ import google.registry.groups.GmailClient;
 import google.registry.model.console.User;
 import google.registry.model.domain.RegistryLock;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Action.Method;
 import google.registry.request.HttpException.ForbiddenException;
 import google.registry.request.JsonActionRunner;
@@ -60,7 +61,7 @@ import org.joda.time.Duration;
  * URL, which is why this is distinct from the {@link RegistryLockGetAction}.
  */
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     path = RegistryLockPostAction.PATH,
     method = Method.POST,
     auth = Auth.AUTH_PUBLIC_LOGGED_IN)

--- a/core/src/main/java/google/registry/ui/server/registrar/RegistryLockVerifyAction.java
+++ b/core/src/main/java/google/registry/ui/server/registrar/RegistryLockVerifyAction.java
@@ -22,6 +22,7 @@ import com.google.common.flogger.FluentLogger;
 import com.google.template.soy.tofu.SoyTofu;
 import google.registry.model.domain.RegistryLock;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Parameter;
 import google.registry.request.auth.Auth;
 import google.registry.tools.DomainLockUtils;
@@ -32,7 +33,7 @@ import javax.inject.Inject;
 
 /** Action that allows for verification of registry lock / unlock requests */
 @Action(
-    service = Action.Service.DEFAULT,
+    service = GaeService.DEFAULT,
     path = RegistryLockVerifyAction.PATH,
     auth = Auth.AUTH_PUBLIC_LOGGED_IN)
 public final class RegistryLockVerifyAction extends HtmlAction {

--- a/core/src/main/java/google/registry/whois/WhoisAction.java
+++ b/core/src/main/java/google/registry/whois/WhoisAction.java
@@ -22,6 +22,7 @@ import com.google.common.flogger.FluentLogger;
 import com.google.common.net.MediaType;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
 import google.registry.util.Clock;
@@ -47,7 +48,7 @@ import org.joda.time.DateTime;
  * @see WhoisHttpAction
  * @see <a href="http://www.ietf.org/rfc/rfc3912.txt">RFC 3912: WHOIS Protocol Specification</a>
  */
-@Action(service = Action.Service.PUBAPI, path = "/_dr/whois", method = POST, auth = Auth.AUTH_ADMIN)
+@Action(service = GaeService.PUBAPI, path = "/_dr/whois", method = POST, auth = Auth.AUTH_ADMIN)
 public class WhoisAction implements Runnable {
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();

--- a/core/src/main/java/google/registry/whois/WhoisHttpAction.java
+++ b/core/src/main/java/google/registry/whois/WhoisHttpAction.java
@@ -32,6 +32,7 @@ import com.google.common.base.Throwables;
 import com.google.common.flogger.FluentLogger;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.RequestPath;
 import google.registry.request.Response;
 import google.registry.request.auth.Auth;
@@ -94,7 +95,7 @@ import org.joda.time.Duration;
  * @see WhoisAction
  */
 @Action(
-    service = Action.Service.PUBAPI,
+    service = GaeService.PUBAPI,
     path = WhoisHttpAction.PATH,
     isPrefix = true,
     auth = Auth.AUTH_PUBLIC)

--- a/core/src/test/java/google/registry/batch/CloudTasksUtilsTest.java
+++ b/core/src/test/java/google/registry/batch/CloudTasksUtilsTest.java
@@ -15,6 +15,8 @@
 package google.registry.batch;
 
 import static com.google.common.truth.Truth.assertThat;
+import static google.registry.request.Action.Method.GET;
+import static google.registry.request.Action.Method.POST;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -29,7 +31,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.LinkedListMultimap;
 import google.registry.batch.CloudTasksUtils.SerializableCloudTasksClient;
-import google.registry.request.Action.Service;
+import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
+import google.registry.request.Action.GkeService;
+import google.registry.request.auth.Auth;
 import google.registry.testing.CloudTasksHelper.FakeGoogleCredentialsBundle;
 import google.registry.testing.FakeClock;
 import google.registry.testing.FakeSleeper;
@@ -68,24 +73,13 @@ public class CloudTasksUtilsTest {
   }
 
   @Test
-  void testFailure_createGetTasks_withNegativeDelay() {
+  void testFailure_createTasks_withNegativeDelay() {
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,
             () ->
-                cloudTasksUtils.createGetTaskWithDelay(
-                    "/the/path", Service.BACKEND, params, Duration.standardMinutes(-10)));
-    assertThat(thrown).hasMessageThat().isEqualTo("Negative duration is not supported.");
-  }
-
-  @Test
-  void testFailure_createPostTasks_withNegativeDelay() {
-    IllegalArgumentException thrown =
-        assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                cloudTasksUtils.createGetTaskWithDelay(
-                    "/the/path", Service.BACKEND, params, Duration.standardMinutes(-10)));
+                cloudTasksUtils.createTaskWithDelay(
+                    TheAction.class, GET, params, Duration.standardMinutes(-10)));
     assertThat(thrown).hasMessageThat().isEqualTo("Negative duration is not supported.");
   }
 
@@ -93,26 +87,26 @@ public class CloudTasksUtilsTest {
   void testFailure_illegalPath() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> cloudTasksUtils.createPostTask("the/path", Service.BACKEND, params));
+        () -> cloudTasksUtils.createTask("the/path", GET, GkeService.BACKEND, params));
     assertThrows(
         IllegalArgumentException.class,
-        () -> cloudTasksUtils.createPostTask(null, Service.BACKEND, params));
+        () -> cloudTasksUtils.createTask(null, GET, GkeService.BACKEND, params));
     assertThrows(
         IllegalArgumentException.class,
-        () -> cloudTasksUtils.createPostTask("", Service.BACKEND, params));
+        () -> cloudTasksUtils.createTask("", GET, GkeService.BACKEND, params));
   }
 
   @Test
   void testSuccess_enqueueTask() {
-    Task task = cloudTasksUtils.createGetTask("/the/path", Service.BACKEND, params);
+    Task task = cloudTasksUtils.createTask(TheAction.class, GET, params);
     cloudTasksUtils.enqueue("test-queue", task);
     verify(mockClient).enqueue("project", "location", "test-queue", task);
   }
 
   @Test
   void testSuccess_enqueueTasks_varargs() {
-    Task task1 = cloudTasksUtils.createGetTask("/the/path", Service.BACKEND, params);
-    Task task2 = cloudTasksUtils.createGetTask("/other/path", Service.TOOLS, params);
+    Task task1 = cloudTasksUtils.createTask(TheAction.class, GET, params);
+    Task task2 = cloudTasksUtils.createTask(OtherAction.class, GET, params);
     cloudTasksUtils.enqueue("test-queue", task1, task2);
     verify(mockClient).enqueue("project", "location", "test-queue", task1);
     verify(mockClient).enqueue("project", "location", "test-queue", task2);
@@ -120,8 +114,8 @@ public class CloudTasksUtilsTest {
 
   @Test
   void testSuccess_enqueueTasks_iterable() {
-    Task task1 = cloudTasksUtils.createGetTask("/the/path", Service.BACKEND, params);
-    Task task2 = cloudTasksUtils.createGetTask("/other/path", Service.TOOLS, params);
+    Task task1 = cloudTasksUtils.createTask(TheAction.class, GET, params);
+    Task task2 = cloudTasksUtils.createTask(OtherAction.class, GET, params);
     cloudTasksUtils.enqueue("test-queue", ImmutableList.of(task1, task2));
     verify(mockClient).enqueue("project", "location", "test-queue", task1);
     verify(mockClient).enqueue("project", "location", "test-queue", task2);
@@ -129,7 +123,7 @@ public class CloudTasksUtilsTest {
 
   @Test
   void testSuccess_createGetTasks() {
-    Task task = cloudTasksUtils.createGetTask("/the/path", Service.BACKEND, params);
+    Task task = cloudTasksUtils.createTask(TheAction.class, GET, params);
     assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.GET);
     assertThat(task.getHttpRequest().getUrl())
         .isEqualTo("https://backend.example.com/the/path?key1=val1&key2=val2&key1=val3");
@@ -138,8 +132,35 @@ public class CloudTasksUtilsTest {
   }
 
   @Test
+  void testSuccess_createTasks_WithPathAndService_GAE() {
+    Task task = cloudTasksUtils.createTask("/the/path", GET, GaeService.BACKEND, params);
+    assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.GET);
+    assertThat(task.getHttpRequest().getUrl())
+        .isEqualTo("https://backend.example.com/the/path?key1=val1&key2=val2&key1=val3");
+    verifyOidcToken(task);
+    assertThat(task.getScheduleTime().getSeconds()).isEqualTo(0);
+  }
+
+  @Test
+  void testSuccess_createTasks_WithPathAndService_GKE() {
+    Task task = cloudTasksUtils.createTask("/the/path", GET, GkeService.BACKEND, params);
+    assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.GET);
+    assertThat(task.getHttpRequest().getUrl())
+        .isEqualTo("https://backend.registry.test/the/path?key1=val1&key2=val2&key1=val3");
+    verifyOidcToken(task);
+    assertThat(task.getScheduleTime().getSeconds()).isEqualTo(0);
+  }
+
+  @Test
+  void testFailure_createTasks_notAnAction() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> cloudTasksUtils.createTask(NotAnAction.class, GET, params));
+  }
+
+  @Test
   void testSuccess_createPostTasks() {
-    Task task = cloudTasksUtils.createPostTask("/the/path", Service.BACKEND, params);
+    Task task = cloudTasksUtils.createTask(TheAction.class, POST, params);
     assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.POST);
     assertThat(task.getHttpRequest().getUrl()).isEqualTo("https://backend.example.com/the/path");
     assertThat(task.getHttpRequest().getHeadersMap().get("Content-Type"))
@@ -152,7 +173,7 @@ public class CloudTasksUtilsTest {
 
   @Test
   void testSuccess_createGetTasks_withNullParams() {
-    Task task = cloudTasksUtils.createGetTask("/the/path", Service.BACKEND, null);
+    Task task = cloudTasksUtils.createTask(TheAction.class, GET, null);
     assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.GET);
     assertThat(task.getHttpRequest().getUrl()).isEqualTo("https://backend.example.com/the/path");
     verifyOidcToken(task);
@@ -161,7 +182,7 @@ public class CloudTasksUtilsTest {
 
   @Test
   void testSuccess_createPostTasks_withNullParams() {
-    Task task = cloudTasksUtils.createPostTask("/the/path", Service.BACKEND, null);
+    Task task = cloudTasksUtils.createTask(TheAction.class, POST, null);
     assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.POST);
     assertThat(task.getHttpRequest().getUrl()).isEqualTo("https://backend.example.com/the/path");
     assertThat(task.getHttpRequest().getBody().toString(StandardCharsets.UTF_8)).isEmpty();
@@ -171,7 +192,7 @@ public class CloudTasksUtilsTest {
 
   @Test
   void testSuccess_createGetTasks_withEmptyParams() {
-    Task task = cloudTasksUtils.createGetTask("/the/path", Service.BACKEND, ImmutableMultimap.of());
+    Task task = cloudTasksUtils.createTask(TheAction.class, GET, ImmutableMultimap.of());
     assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.GET);
     assertThat(task.getHttpRequest().getUrl()).isEqualTo("https://backend.example.com/the/path");
     verifyOidcToken(task);
@@ -180,8 +201,7 @@ public class CloudTasksUtilsTest {
 
   @Test
   void testSuccess_createPostTasks_withEmptyParams() {
-    Task task =
-        cloudTasksUtils.createPostTask("/the/path", Service.BACKEND, ImmutableMultimap.of());
+    Task task = cloudTasksUtils.createTask(TheAction.class, POST, ImmutableMultimap.of());
     assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.POST);
     assertThat(task.getHttpRequest().getUrl()).isEqualTo("https://backend.example.com/the/path");
     assertThat(task.getHttpRequest().getBody().toString(StandardCharsets.UTF_8)).isEmpty();
@@ -191,15 +211,15 @@ public class CloudTasksUtilsTest {
 
   @SuppressWarnings("ProtoTimestampGetSecondsGetNano")
   @Test
-  void testSuccess_createGetTasks_withJitterSeconds() {
+  void testSuccess_createTasks_withJitterSeconds() {
     Task task =
-        cloudTasksUtils.createGetTaskWithJitter(
-            "/the/path", Service.BACKEND, params, Optional.of(100));
+        cloudTasksUtils.createTaskWithJitter(TheAction.class, GET, params, Optional.of(100));
     assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.GET);
     assertThat(task.getHttpRequest().getUrl())
         .isEqualTo("https://backend.example.com/the/path?key1=val1&key2=val2&key1=val3");
     verifyOidcToken(task);
 
+    assertThat(task.getScheduleTime().getSeconds()).isNotEqualTo(0);
     Instant scheduleTime = Instant.ofEpochSecond(task.getScheduleTime().getSeconds());
     Instant lowerBoundTime = Instant.ofEpochMilli(clock.nowUtc().getMillis());
     Instant upperBound = Instant.ofEpochMilli(clock.nowUtc().plusSeconds(100).getMillis());
@@ -208,49 +228,10 @@ public class CloudTasksUtilsTest {
     assertThat(upperBound.isBefore(scheduleTime)).isFalse();
   }
 
-  @SuppressWarnings("ProtoTimestampGetSecondsGetNano")
   @Test
-  void testSuccess_createPostTasks_withJitterSeconds() {
+  void testSuccess_createTasks_withEmptyJitterSeconds() {
     Task task =
-        cloudTasksUtils.createPostTaskWithJitter(
-            "/the/path", Service.BACKEND, params, Optional.of(1));
-    assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.POST);
-    assertThat(task.getHttpRequest().getUrl()).isEqualTo("https://backend.example.com/the/path");
-    assertThat(task.getHttpRequest().getHeadersMap().get("Content-Type"))
-        .isEqualTo("application/x-www-form-urlencoded");
-    assertThat(task.getHttpRequest().getBody().toString(StandardCharsets.UTF_8))
-        .isEqualTo("key1=val1&key2=val2&key1=val3");
-    verifyOidcToken(task);
-    assertThat(task.getScheduleTime().getSeconds()).isNotEqualTo(0);
-
-    Instant scheduleTime = Instant.ofEpochSecond(task.getScheduleTime().getSeconds());
-    Instant lowerBoundTime = Instant.ofEpochMilli(clock.nowUtc().getMillis());
-    Instant upperBound = Instant.ofEpochMilli(clock.nowUtc().plusSeconds(1).getMillis());
-
-    assertThat(scheduleTime.isBefore(lowerBoundTime)).isFalse();
-    assertThat(upperBound.isBefore(scheduleTime)).isFalse();
-  }
-
-  @Test
-  void testSuccess_createPostTasks_withEmptyJitterSeconds() {
-    Task task =
-        cloudTasksUtils.createPostTaskWithJitter(
-            "/the/path", Service.BACKEND, params, Optional.empty());
-    assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.POST);
-    assertThat(task.getHttpRequest().getUrl()).isEqualTo("https://backend.example.com/the/path");
-    assertThat(task.getHttpRequest().getHeadersMap().get("Content-Type"))
-        .isEqualTo("application/x-www-form-urlencoded");
-    assertThat(task.getHttpRequest().getBody().toString(StandardCharsets.UTF_8))
-        .isEqualTo("key1=val1&key2=val2&key1=val3");
-    verifyOidcToken(task);
-    assertThat(task.getScheduleTime().getSeconds()).isEqualTo(0);
-  }
-
-  @Test
-  void testSuccess_createGetTasks_withEmptyJitterSeconds() {
-    Task task =
-        cloudTasksUtils.createGetTaskWithJitter(
-            "/the/path", Service.BACKEND, params, Optional.empty());
+        cloudTasksUtils.createTaskWithJitter(TheAction.class, GET, params, Optional.empty());
     assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.GET);
     assertThat(task.getHttpRequest().getUrl())
         .isEqualTo("https://backend.example.com/the/path?key1=val1&key2=val2&key1=val3");
@@ -259,25 +240,8 @@ public class CloudTasksUtilsTest {
   }
 
   @Test
-  void testSuccess_createPostTasks_withZeroJitterSeconds() {
-    Task task =
-        cloudTasksUtils.createPostTaskWithJitter(
-            "/the/path", Service.BACKEND, params, Optional.of(0));
-    assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.POST);
-    assertThat(task.getHttpRequest().getUrl()).isEqualTo("https://backend.example.com/the/path");
-    assertThat(task.getHttpRequest().getHeadersMap().get("Content-Type"))
-        .isEqualTo("application/x-www-form-urlencoded");
-    assertThat(task.getHttpRequest().getBody().toString(StandardCharsets.UTF_8))
-        .isEqualTo("key1=val1&key2=val2&key1=val3");
-    verifyOidcToken(task);
-    assertThat(task.getScheduleTime().getSeconds()).isEqualTo(0);
-  }
-
-  @Test
-  void testSuccess_createGetTasks_withZeroJitterSeconds() {
-    Task task =
-        cloudTasksUtils.createGetTaskWithJitter(
-            "/the/path", Service.BACKEND, params, Optional.of(0));
+  void testSuccess_createTasks_withZeroJitterSeconds() {
+    Task task = cloudTasksUtils.createTaskWithJitter(TheAction.class, GET, params, Optional.of(0));
     assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.GET);
     assertThat(task.getHttpRequest().getUrl())
         .isEqualTo("https://backend.example.com/the/path?key1=val1&key2=val2&key1=val3");
@@ -286,10 +250,10 @@ public class CloudTasksUtilsTest {
   }
 
   @Test
-  void testSuccess_createGetTasks_withDelay() {
+  void testSuccess_createTasks_withDelay() {
     Task task =
-        cloudTasksUtils.createGetTaskWithDelay(
-            "/the/path", Service.BACKEND, params, Duration.standardMinutes(10));
+        cloudTasksUtils.createTaskWithDelay(
+            TheAction.class, GET, params, Duration.standardMinutes(10));
     assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.GET);
     assertThat(task.getHttpRequest().getUrl())
         .isEqualTo("https://backend.example.com/the/path?key1=val1&key2=val2&key1=val3");
@@ -299,46 +263,43 @@ public class CloudTasksUtilsTest {
   }
 
   @Test
-  void testSuccess_createPostTasks_withDelay() {
-    Task task =
-        cloudTasksUtils.createPostTaskWithDelay(
-            "/the/path", Service.BACKEND, params, Duration.standardMinutes(10));
-    assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.POST);
-    assertThat(task.getHttpRequest().getUrl()).isEqualTo("https://backend.example.com/the/path");
-    assertThat(task.getHttpRequest().getHeadersMap().get("Content-Type"))
-        .isEqualTo("application/x-www-form-urlencoded");
-    assertThat(task.getHttpRequest().getBody().toString(StandardCharsets.UTF_8))
-        .isEqualTo("key1=val1&key2=val2&key1=val3");
-    verifyOidcToken(task);
-    assertThat(task.getScheduleTime().getSeconds()).isNotEqualTo(0);
-    assertThat(Instant.ofEpochSecond(task.getScheduleTime().getSeconds()))
-        .isEqualTo(Instant.ofEpochMilli(clock.nowUtc().plusMinutes(10).getMillis()));
-  }
-
-  @Test
-  void testSuccess_createPostTasks_withZeroDelay() {
-    Task task =
-        cloudTasksUtils.createPostTaskWithDelay(
-            "/the/path", Service.BACKEND, params, Duration.ZERO);
-    assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.POST);
-    assertThat(task.getHttpRequest().getUrl()).isEqualTo("https://backend.example.com/the/path");
-    assertThat(task.getHttpRequest().getHeadersMap().get("Content-Type"))
-        .isEqualTo("application/x-www-form-urlencoded");
-    assertThat(task.getHttpRequest().getBody().toString(StandardCharsets.UTF_8))
-        .isEqualTo("key1=val1&key2=val2&key1=val3");
-    verifyOidcToken(task);
-    assertThat(task.getScheduleTime().getSeconds()).isEqualTo(0);
-  }
-
-  @Test
-  void testSuccess_createGetTasks_withZeroDelay() {
-    Task task =
-        cloudTasksUtils.createGetTaskWithDelay("/the/path", Service.BACKEND, params, Duration.ZERO);
+  void testSuccess_createTasks_withZeroDelay() {
+    Task task = cloudTasksUtils.createTaskWithDelay(TheAction.class, GET, params, Duration.ZERO);
     assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.GET);
     assertThat(task.getHttpRequest().getUrl())
         .isEqualTo("https://backend.example.com/the/path?key1=val1&key2=val2&key1=val3");
     verifyOidcToken(task);
     assertThat(task.getScheduleTime().getSeconds()).isEqualTo(0);
+  }
+
+  @Action(
+      service = GaeService.BACKEND,
+      gkeService = GkeService.BACKEND,
+      path = "/the/path",
+      method = {GET},
+      auth = Auth.AUTH_ADMIN)
+  private static class TheAction implements Runnable {
+
+    @Override
+    public void run() {}
+  }
+
+  @Action(
+      service = GaeService.TOOLS,
+      gkeService = GkeService.BACKEND,
+      path = "/other/path",
+      method = {GET},
+      auth = Auth.AUTH_ADMIN)
+  private static class OtherAction implements Runnable {
+
+    @Override
+    public void run() {}
+  }
+
+  private static class NotAnAction implements Runnable {
+
+    @Override
+    public void run() {}
   }
 
   private static void verifyOidcToken(Task task) {

--- a/core/src/test/java/google/registry/batch/CloudTasksUtilsTest.java
+++ b/core/src/test/java/google/registry/batch/CloudTasksUtilsTest.java
@@ -159,6 +159,13 @@ public class CloudTasksUtilsTest {
   }
 
   @Test
+  void testFailure_methodNotAllowed() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> cloudTasksUtils.createTask(OtherAction.class, POST, params));
+  }
+
+  @Test
   void testSuccess_createPostTasks() {
     Task task = cloudTasksUtils.createTask(TheAction.class, POST, params);
     assertThat(task.getHttpRequest().getHttpMethod()).isEqualTo(HttpMethod.POST);
@@ -276,7 +283,7 @@ public class CloudTasksUtilsTest {
       service = GaeService.BACKEND,
       gkeService = GkeService.BACKEND,
       path = "/the/path",
-      method = {GET},
+      method = {GET, POST},
       auth = Auth.AUTH_ADMIN)
   private static class TheAction implements Runnable {
 

--- a/core/src/test/java/google/registry/module/backend/BackendRequestComponentTest.java
+++ b/core/src/test/java/google/registry/module/backend/BackendRequestComponentTest.java
@@ -16,7 +16,7 @@ package google.registry.module.backend;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.RouterDisplayHelper;
 import google.registry.testing.GoldenFileTestHelper;
 import org.junit.jupiter.api.Test;
@@ -35,7 +35,7 @@ class BackendRequestComponentTest {
   void testRoutingService() {
     assertThat(
             RouterDisplayHelper.extractHumanReadableRoutesWithWrongService(
-                BackendRequestComponent.class, Action.Service.BACKEND))
+                BackendRequestComponent.class, GaeService.BACKEND))
         .isEmpty();
   }
 }

--- a/core/src/test/java/google/registry/module/bsa/BsaRequestComponentTest.java
+++ b/core/src/test/java/google/registry/module/bsa/BsaRequestComponentTest.java
@@ -16,7 +16,7 @@ package google.registry.module.bsa;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import google.registry.request.Action.Service;
+import google.registry.request.Action.GaeService;
 import google.registry.request.RouterDisplayHelper;
 import google.registry.testing.GoldenFileTestHelper;
 import org.junit.jupiter.api.Test;
@@ -35,7 +35,7 @@ public class BsaRequestComponentTest {
   void testRoutingService() {
     assertThat(
             RouterDisplayHelper.extractHumanReadableRoutesWithWrongService(
-                BsaRequestComponent.class, Service.BSA))
+                BsaRequestComponent.class, GaeService.BSA))
         .isEmpty();
   }
 }

--- a/core/src/test/java/google/registry/module/frontend/FrontendRequestComponentTest.java
+++ b/core/src/test/java/google/registry/module/frontend/FrontendRequestComponentTest.java
@@ -16,7 +16,7 @@ package google.registry.module.frontend;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.RouterDisplayHelper;
 import google.registry.testing.GoldenFileTestHelper;
 import org.junit.jupiter.api.Test;
@@ -35,7 +35,7 @@ class FrontendRequestComponentTest {
   void testRoutingService() {
     assertThat(
             RouterDisplayHelper.extractHumanReadableRoutesWithWrongService(
-                FrontendRequestComponent.class, Action.Service.DEFAULT))
+                FrontendRequestComponent.class, GaeService.DEFAULT))
         .isEmpty();
   }
 }

--- a/core/src/test/java/google/registry/module/pubapi/PubApiRequestComponentTest.java
+++ b/core/src/test/java/google/registry/module/pubapi/PubApiRequestComponentTest.java
@@ -16,7 +16,7 @@ package google.registry.module.pubapi;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.RouterDisplayHelper;
 import google.registry.testing.GoldenFileTestHelper;
 import org.junit.jupiter.api.Test;
@@ -35,7 +35,7 @@ class PubApiRequestComponentTest {
   void testRoutingService() {
     assertThat(
             RouterDisplayHelper.extractHumanReadableRoutesWithWrongService(
-                PubApiRequestComponent.class, Action.Service.PUBAPI))
+                PubApiRequestComponent.class, GaeService.PUBAPI))
         .isEmpty();
   }
 }

--- a/core/src/test/java/google/registry/module/tools/ToolsRequestComponentTest.java
+++ b/core/src/test/java/google/registry/module/tools/ToolsRequestComponentTest.java
@@ -16,7 +16,7 @@ package google.registry.module.tools;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.RouterDisplayHelper;
 import google.registry.testing.GoldenFileTestHelper;
 import org.junit.jupiter.api.Test;
@@ -35,7 +35,7 @@ class ToolsRequestComponentTest {
   void testRoutingService() {
     assertThat(
             RouterDisplayHelper.extractHumanReadableRoutesWithWrongService(
-                ToolsRequestComponent.class, Action.Service.TOOLS))
+                ToolsRequestComponent.class, GaeService.TOOLS))
         .isEmpty();
   }
 }

--- a/core/src/test/java/google/registry/rdap/RdapActionBaseTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapActionBaseTest.java
@@ -30,6 +30,7 @@ import google.registry.rdap.RdapObjectClasses.BoilerplateType;
 import google.registry.rdap.RdapObjectClasses.ReplyPayloadBase;
 import google.registry.rdap.RdapSearchResults.IncompletenessWarningType;
 import google.registry.request.Action;
+import google.registry.request.Action.GaeService;
 import google.registry.request.auth.Auth;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,7 +45,7 @@ class RdapActionBaseTest extends RdapActionBaseTestCase<RdapActionBaseTest.RdapT
 
   /** Dummy RdapActionBase subclass used for testing. */
   @Action(
-      service = Action.Service.PUBAPI,
+      service = GaeService.PUBAPI,
       path = "/rdap/test/",
       method = {GET, HEAD},
       auth = Auth.AUTH_PUBLIC)

--- a/core/src/test/java/google/registry/rdap/RdapTestHelper.java
+++ b/core/src/test/java/google/registry/rdap/RdapTestHelper.java
@@ -48,41 +48,42 @@ class RdapTestHelper {
 
   private static JsonObject createTosNotice(String linkBase) {
     return GSON.toJsonTree(
-        ImmutableMap.of(
-            "title", "RDAP Terms of Service",
-            "description",
-                ImmutableList.of(
-                    "By querying our Domain Database, you are agreeing to comply with these terms"
-                        + " so please read them carefully.",
-                    "Any information provided is 'as is' without any guarantee of accuracy.",
-                    "Please do not misuse the Domain Database. It is intended solely for"
-                        + " query-based access.",
-                    "Don't use the Domain Database to allow, enable, or otherwise support the"
-                        + " transmission of mass unsolicited, commercial advertising or"
-                        + " solicitations.",
-                    "Don't access our Domain Database through the use of high volume, automated"
-                        + " electronic processes that send queries or data to the systems of any"
-                        + " ICANN-accredited registrar.",
-                    "You may only use the information contained in the Domain Database for lawful"
-                        + " purposes.",
-                    "Do not compile, repackage, disseminate, or otherwise use the information"
-                        + " contained in the Domain Database in its entirety, or in any substantial"
-                        + " portion, without our prior written permission.",
-                    "We may retain certain details about queries to our Domain Database for the"
-                        + " purposes of detecting and preventing misuse.",
-                    "We reserve the right to restrict or deny your access to the database if we"
-                        + " suspect that you have failed to comply with these terms.",
-                    "We reserve the right to modify this agreement at any time."),
-            "links",
-                ImmutableList.of(
-                    ImmutableMap.of(
-                        "rel", "self",
-                        "href", linkBase + "help/tos",
-                        "type", "application/rdap+json"),
-                    ImmutableMap.of(
-                        "rel", "alternate",
-                        "href", "https://www.registry.tld/about/rdap/tos.html",
-                        "type", "text/html")))).getAsJsonObject();
+            ImmutableMap.of(
+                "title", "RDAP Terms of Service",
+                "description",
+                    ImmutableList.of(
+                        "By querying our Domain Database, you are agreeing to comply with these"
+                            + " terms so please read them carefully.",
+                        "Any information provided is 'as is' without any guarantee of accuracy.",
+                        "Please do not misuse the Domain Database. It is intended solely for"
+                            + " query-based access.",
+                        "Don't use the Domain Database to allow, enable, or otherwise support the"
+                            + " transmission of mass unsolicited, commercial advertising or"
+                            + " solicitations.",
+                        "Don't access our Domain Database through the use of high volume, automated"
+                            + " electronic processes that send queries or data to the systems of"
+                            + " any ICANN-accredited registrar.",
+                        "You may only use the information contained in the Domain Database for"
+                            + " lawful purposes.",
+                        "Do not compile, repackage, disseminate, or otherwise use the information"
+                            + " contained in the Domain Database in its entirety, or in any"
+                            + " substantial portion, without our prior written permission.",
+                        "We may retain certain details about queries to our Domain Database for the"
+                            + " purposes of detecting and preventing misuse.",
+                        "We reserve the right to restrict or deny your access to the database if we"
+                            + " suspect that you have failed to comply with these terms.",
+                        "We reserve the right to modify this agreement at any time."),
+                "links",
+                    ImmutableList.of(
+                        ImmutableMap.of(
+                            "rel", "self",
+                            "href", linkBase + "help/tos",
+                            "type", "application/rdap+json"),
+                        ImmutableMap.of(
+                            "rel", "alternate",
+                            "href", "https://www.registry.tld/about/rdap/tos.html",
+                            "type", "text/html"))))
+        .getAsJsonObject();
   }
 
   static void addNonDomainBoilerplateNotices(JsonObject jsonObject, String linkBase) {

--- a/core/src/test/java/google/registry/request/RequestHandlerTest.java
+++ b/core/src/test/java/google/registry/request/RequestHandlerTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.testing.NullPointerTester;
 import google.registry.model.console.User;
 import google.registry.model.console.UserRoles;
+import google.registry.request.Action.GaeService;
 import google.registry.request.HttpException.ServiceUnavailableException;
 import google.registry.request.auth.AuthResult;
 import google.registry.request.auth.AuthSettings.AuthLevel;
@@ -48,7 +49,7 @@ import org.junit.jupiter.api.Test;
 public final class RequestHandlerTest {
 
   @Action(
-      service = Action.Service.DEFAULT,
+      service = GaeService.DEFAULT,
       path = "/bumblebee",
       method = {GET, POST},
       isPrefix = true,
@@ -59,7 +60,7 @@ public final class RequestHandlerTest {
   }
 
   @Action(
-      service = Action.Service.DEFAULT,
+      service = GaeService.DEFAULT,
       path = "/sloth",
       method = POST,
       automaticallyPrintOk = true,
@@ -70,7 +71,7 @@ public final class RequestHandlerTest {
   }
 
   @Action(
-      service = Action.Service.DEFAULT,
+      service = GaeService.DEFAULT,
       path = "/safe-sloth",
       method = {GET, POST},
       auth = AUTH_PUBLIC)
@@ -79,7 +80,7 @@ public final class RequestHandlerTest {
     public void run() {}
   }
 
-  @Action(service = Action.Service.DEFAULT, path = "/fail", auth = AUTH_PUBLIC)
+  @Action(service = GaeService.DEFAULT, path = "/fail", auth = AUTH_PUBLIC)
   public static final class FailTask implements Runnable {
     @Override
     public void run() {
@@ -87,7 +88,7 @@ public final class RequestHandlerTest {
     }
   }
 
-  @Action(service = Action.Service.DEFAULT, path = "/failAtConstruction", auth = AUTH_PUBLIC)
+  @Action(service = GaeService.DEFAULT, path = "/failAtConstruction", auth = AUTH_PUBLIC)
   public static final class FailAtConstructionTask implements Runnable {
     FailAtConstructionTask() {
       throw new ServiceUnavailableException("Fail at construction");
@@ -112,18 +113,14 @@ public final class RequestHandlerTest {
     }
   }
 
-  @Action(service = Action.Service.DEFAULT, path = "/auth/none", auth = AUTH_PUBLIC, method = GET)
+  @Action(service = GaeService.DEFAULT, path = "/auth/none", auth = AUTH_PUBLIC, method = GET)
   public class AuthNoneAction extends AuthBase {
     AuthNoneAction(AuthResult authResult) {
       super(authResult);
     }
   }
 
-  @Action(
-      service = Action.Service.DEFAULT,
-      path = "/auth/adminUser",
-      auth = AUTH_ADMIN,
-      method = GET)
+  @Action(service = GaeService.DEFAULT, path = "/auth/adminUser", auth = AUTH_ADMIN, method = GET)
   public class AuthAdminUserAction extends AuthBase {
     AuthAdminUserAction(AuthResult authResult) {
       super(authResult);
@@ -204,7 +201,6 @@ public final class RequestHandlerTest {
     handler =
         RequestHandler.create(
             Component.class,
-            "registry.test",
             () ->
                 new Builder() {
                   @Override

--- a/core/src/test/java/google/registry/request/RouterTest.java
+++ b/core/src/test/java/google/registry/request/RouterTest.java
@@ -18,6 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static google.registry.request.auth.Auth.AUTH_ADMIN;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import google.registry.request.Action.GaeService;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
@@ -41,7 +42,7 @@ public final class RouterTest {
 
   ////////////////////////////////////////////////////////////////////////////////////////////////
 
-  @Action(service = Action.Service.DEFAULT, path = "/sloth", auth = AUTH_ADMIN)
+  @Action(service = GaeService.DEFAULT, path = "/sloth", auth = AUTH_ADMIN)
   public static final class SlothTask implements Runnable {
     @Override
     public void run() {}
@@ -71,7 +72,7 @@ public final class RouterTest {
 
   ////////////////////////////////////////////////////////////////////////////////////////////////
 
-  @Action(service = Action.Service.DEFAULT, path = "/prefix", isPrefix = true, auth = AUTH_ADMIN)
+  @Action(service = GaeService.DEFAULT, path = "/prefix", isPrefix = true, auth = AUTH_ADMIN)
   public static final class PrefixTask implements Runnable {
     @Override
     public void run() {}
@@ -97,11 +98,7 @@ public final class RouterTest {
 
   ////////////////////////////////////////////////////////////////////////////////////////////////
 
-  @Action(
-      service = Action.Service.DEFAULT,
-      path = "/prefix/long",
-      isPrefix = true,
-      auth = AUTH_ADMIN)
+  @Action(service = GaeService.DEFAULT, path = "/prefix/long", isPrefix = true, auth = AUTH_ADMIN)
   public static final class LongTask implements Runnable {
     @Override
     public void run() {}
@@ -153,13 +150,13 @@ public final class RouterTest {
 
   ////////////////////////////////////////////////////////////////////////////////////////////////
 
-  @Action(service = Action.Service.DEFAULT, path = "/samePathAsOtherTask", auth = AUTH_ADMIN)
+  @Action(service = GaeService.DEFAULT, path = "/samePathAsOtherTask", auth = AUTH_ADMIN)
   public static final class DuplicateTask1 implements Runnable {
     @Override
     public void run() {}
   }
 
-  @Action(service = Action.Service.DEFAULT, path = "/samePathAsOtherTask", auth = AUTH_ADMIN)
+  @Action(service = GaeService.DEFAULT, path = "/samePathAsOtherTask", auth = AUTH_ADMIN)
   public static final class DuplicateTask2 implements Runnable {
     @Override
     public void run() {}

--- a/core/src/test/java/google/registry/tools/CurlCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CurlCommandTest.java
@@ -15,10 +15,10 @@
 package google.registry.tools;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.request.Action.Service.BACKEND;
-import static google.registry.request.Action.Service.DEFAULT;
-import static google.registry.request.Action.Service.PUBAPI;
-import static google.registry.request.Action.Service.TOOLS;
+import static google.registry.request.Action.GaeService.BACKEND;
+import static google.registry.request.Action.GaeService.DEFAULT;
+import static google.registry.request.Action.GaeService.PUBAPI;
+import static google.registry.request.Action.GaeService.TOOLS;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;

--- a/core/src/test/java/google/registry/tools/GcpProjectConnectionTest.java
+++ b/core/src/test/java/google/registry/tools/GcpProjectConnectionTest.java
@@ -84,9 +84,8 @@ final class GcpProjectConnectionTest {
         .thenReturn(new ByteArrayInputStream("MyContent".getBytes(UTF_8)));
     when(lowLevelHttpResponse.getStatusCode()).thenReturn(200);
 
-    connection = new ServiceConnection();
     httpTransport = new TestHttpTransport();
-    connection.requestFactory = httpTransport.createRequestFactory();
+    connection = new ServiceConnection(false, httpTransport.createRequestFactory());
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/ServiceConnectionTest.java
+++ b/core/src/test/java/google/registry/tools/ServiceConnectionTest.java
@@ -15,7 +15,7 @@
 package google.registry.tools;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.request.Action.Service.DEFAULT;
+import static google.registry.request.Action.GaeService.DEFAULT;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,14 +24,14 @@ public class ServiceConnectionTest {
 
   @Test
   void testServerUrl_notCanary() {
-    ServiceConnection connection = new ServiceConnection().withService(DEFAULT, false);
+    ServiceConnection connection = new ServiceConnection(false, null).withService(DEFAULT, false);
     String serverUrl = connection.getServer().toString();
     assertThat(serverUrl).isEqualTo("https://default.example.com"); // See default-config.yaml
   }
 
   @Test
   void testServerUrl_canary() {
-    ServiceConnection connection = new ServiceConnection().withService(DEFAULT, true);
+    ServiceConnection connection = new ServiceConnection(false, null).withService(DEFAULT, true);
     String serverUrl = connection.getServer().toString();
     assertThat(serverUrl).isEqualTo("https://nomulus-dot-default.example.com");
   }

--- a/core/src/test/java/google/registry/ui/server/registrar/RegistrarSettingsActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/RegistrarSettingsActionTest.java
@@ -72,7 +72,7 @@ class RegistrarSettingsActionTest extends RegistrarSettingsActionTestCase {
         new TaskMatcher()
             .path(SyncRegistrarsSheetAction.PATH)
             .service("Backend")
-            .method(HttpMethod.GET));
+            .method(HttpMethod.POST));
     assertMetric(CLIENT_ID, "update", "[OWNER]", "SUCCESS");
   }
 


### PR DESCRIPTION
This PR makes the following to functionality changes:

1. For the nomulus tool, a `--gke` flag can be passed to make it connect to the GKE endpoints, instead of the default GAE ones.

2. For Cloud Tasks, the correct endpoints will be inferred based on the runtime of the caller, i. e. Nomulus running on GAE will schedule tasks to run against GAE endpoints, and vice versa.

`CloudTasksUtils` is refactored for simplicity. We no longer provide `createGetTask*` and `createPostTask*` variants, in order to avoid combinatorial explosions. The allowed methods are instead checked against the `Method` enum defined in `Action`.
 
TESTED=Deployed to alpha and ran the following test:

1. Ran `nomulus -e alpha list_tlds` and `nomulus --gke -e alpha list_tlds` and confirmed that the corresponding GAE/GKE endpoints are called.

2. Ran `nomulus -e alpha curl --service TOOLS -u /_dr/admin/list/tlds` and `nomulus --gke -e alpha curl --service BACKEND -u /_dr/admin/list/tlds` and confirmed that the corresponding GAE/GKE endpoints are called.

3. Ran `nomulus -e alpha curl -u /_dr/cron/fanout?queue=retryable-cron-tasks&endpoint=/_dr/task/relockDomain&runInEmpty` and `nomulus --gke -e alpha curl -u /_dr/cron/fanout?queue=retryable-cron-tasks&endpoint=/_dr/task/relockDomain&runInEmpty` and confirmed that the corresponding GAE/GKE endpoints are called and Cloud Tasks tasks are enqueued for the appropriate endpoints for the respective runtime, and that these endpoints are in turn called by tasks.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2540)
<!-- Reviewable:end -->
