### PR TITLE
Reduce cardinality of reserved list processing time metric

### DIFF
--- a/core/src/test/java/google/registry/model/tld/label/ReservedListTest.java
+++ b/core/src/test/java/google/registry/model/tld/label/ReservedListTest.java
@@ -65,7 +65,7 @@ class ReservedListTest {
         .and()
         .hasNoOtherValues();
     assertThat(reservedListProcessingTime)
-        .hasAnyValueForLabels("tld", "0", "(none)", "(none)")
+        .hasAnyValueForLabels("tld", "0")
         .and()
         .hasNoOtherValues();
     assertThat(reservedListHits).hasNoOtherValues();
@@ -130,11 +130,11 @@ class ReservedListTest {
         .and()
         .hasNoOtherValues();
     assertThat(reservedListProcessingTime)
-        .hasAnyValueForLabels("tld", "0", "(none)", "(none)")
+        .hasAnyValueForLabels("tld", "0")
         .and()
-        .hasAnyValueForLabels("tld", "1", "reserved1", FULLY_BLOCKED.toString())
+        .hasAnyValueForLabels("tld", "1")
         .and()
-        .hasAnyValueForLabels("tld", "1", "reserved2", FULLY_BLOCKED.toString())
+        .hasAnyValueForLabels("tld", "1")
         .and()
         .hasNoOtherValues();
     assertThat(reservedListHits)
@@ -182,9 +182,9 @@ class ReservedListTest {
         .and()
         .hasNoOtherValues();
     assertThat(reservedListProcessingTime)
-        .hasAnyValueForLabels("tld", "1", "reserved2", FULLY_BLOCKED.toString())
+        .hasAnyValueForLabels("tld", "1")
         .and()
-        .hasAnyValueForLabels("tld", "0", "(none)", "(none)")
+        .hasAnyValueForLabels("tld", "0")
         .and()
         .hasNoOtherValues();
     assertThat(reservedListHits)
@@ -209,9 +209,9 @@ class ReservedListTest {
         .and()
         .hasNoOtherValues();
     assertThat(reservedListProcessingTime)
-        .hasAnyValueForLabels("tld", "1", "reserved1", ALLOWED_IN_SUNRISE.toString())
+        .hasAnyValueForLabels("tld", "1")
         .and()
-        .hasAnyValueForLabels("tld", "2", "reserved2", FULLY_BLOCKED.toString())
+        .hasAnyValueForLabels("tld", "2")
         .and()
         .hasNoOtherValues();
     assertThat(reservedListHits)

--- a/docs/operational-procedures.md
+++ b/docs/operational-procedures.md
@@ -20,7 +20,7 @@ metrics monitored are as follows:
     name, client id, and return status code.
 *   `/custom/epp/processing_time` -- A [Distribution][distribution] representing
     the processing time for EPP requests, described by command name, client id,
-    and retujrn status code.
+    and return status code.
 *   `/custom/whois/requests` -- A count of WHOIS requests, described by command
     name, number of returned results, and return status code.
 *   `/custom/whois/processing_time` -- A [Distribution][distribution]


### PR DESCRIPTION
This single metric currently accounts for 22.2% of our total metrics bill, almost double the size of our EPP requests metric, while also simultaneously being much less useful. This change reduces the cardinality by removing two parameters we don't care that much about, which should significantly reduce the size and thus the cost. If after this change the metric is still too large, I'll also then remove the matchCount parameter from this metric. We could possibly even consider deleting the metric in its entirety, as we hardly ever use it.

This PR also removes unused code for premium list metrics that have never actually been written out (and that we won't bother with at this point).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2542)
<!-- Reviewable:end -->
