### PR TITLE
Suppress misleading error-level logs by hibernate

### DIFF
--- a/core/src/main/java/google/registry/env/common/backend/WEB-INF/logging.properties
+++ b/core/src/main/java/google/registry/env/common/backend/WEB-INF/logging.properties
@@ -13,5 +13,5 @@
 .level = INFO
 
 # Turn off logging in Hibernate classes for misleading ERROR-level logs
-org.hibernate.engine.jdbc.batch.internal.BatchingBatch.level=OFF
+org.hibernate.orm.jdbc.batch.level=OFF
 org.hibernate.engine.jdbc.spi.SqlExceptionHelper.level=OFF

--- a/core/src/main/java/google/registry/env/common/bsa/WEB-INF/logging.properties
+++ b/core/src/main/java/google/registry/env/common/bsa/WEB-INF/logging.properties
@@ -13,5 +13,5 @@
 .level = INFO
 
 # Turn off logging in Hibernate classes for misleading ERROR-level logs
-org.hibernate.engine.jdbc.batch.internal.BatchingBatch.level=OFF
+org.hibernate.orm.jdbc.batch.level=OFF
 org.hibernate.engine.jdbc.spi.SqlExceptionHelper.level=OFF

--- a/core/src/main/java/google/registry/env/common/default/WEB-INF/logging.properties
+++ b/core/src/main/java/google/registry/env/common/default/WEB-INF/logging.properties
@@ -13,5 +13,5 @@
 .level = INFO
 
 # Turn off logging in Hibernate classes for misleading ERROR-level logs
-org.hibernate.engine.jdbc.batch.internal.BatchingBatch.level=OFF
+org.hibernate.orm.jdbc.batch.level=OFF
 org.hibernate.engine.jdbc.spi.SqlExceptionHelper.level=OFF

--- a/core/src/main/java/google/registry/env/common/pubapi/WEB-INF/logging.properties
+++ b/core/src/main/java/google/registry/env/common/pubapi/WEB-INF/logging.properties
@@ -13,5 +13,5 @@
 .level = INFO
 
 # Turn off logging in Hibernate classes for misleading ERROR-level logs
-org.hibernate.engine.jdbc.batch.internal.BatchingBatch.level=OFF
+org.hibernate.orm.jdbc.batch.level=OFF
 org.hibernate.engine.jdbc.spi.SqlExceptionHelper.level=OFF

--- a/core/src/main/java/google/registry/env/common/tools/WEB-INF/logging.properties
+++ b/core/src/main/java/google/registry/env/common/tools/WEB-INF/logging.properties
@@ -13,5 +13,5 @@
 .level = INFO
 
 # Turn off logging in Hibernate classes for misleading ERROR-level logs
-org.hibernate.engine.jdbc.batch.internal.BatchingBatch.level=OFF
+org.hibernate.orm.jdbc.batch.level=OFF
 org.hibernate.engine.jdbc.spi.SqlExceptionHelper.level=OFF


### PR DESCRIPTION
Update logging configs after Hibernate 6 migration.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2546)
<!-- Reviewable:end -->
