### PR TITLE
Make the db object sync job more reliable

### DIFF
--- a/release/cloudbuild-sync-db-objects.yaml
+++ b/release/cloudbuild-sync-db-objects.yaml
@@ -22,6 +22,9 @@ steps:
   - |
     set -e
     git clone https://gerrit.googlesource.com/gcompute-tools
+    if [ ! -f /usr/bin/python ]; then
+      ln -s /usr/bin/python3 /usr/bin/python
+    fi
     ./gcompute-tools/git-cookie-authdaemon
     git clone ${_INTERNAL_REPO_URL} nomulus-internal
 # Download and decrypt the nomulus tool credential


### PR DESCRIPTION
It looks like /usr/bin/python *may* no longer exists in the latest cloud
builder git image. I ran the latest image and logged into it to verify
that /usr/bin/python3 does exist on 9/25, and again on 9/26 where it
re-appeared.

I think it is generally a good idea to not rely on it being there going
forward.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2567)
<!-- Reviewable:end -->
