### PR TITLE
Don't show snackbar on rlock-load failure if 403

### DIFF
--- a/console-webapp/src/app/domains/domainList.component.ts
+++ b/console-webapp/src/app/domains/domainList.component.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { HttpErrorResponse } from '@angular/common/http';
+import { HttpErrorResponse, HttpStatusCode } from '@angular/common/http';
 import { Component, ViewChild, effect } from '@angular/core';
 import { MatPaginator, PageEvent } from '@angular/material/paginator';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -91,7 +91,10 @@ export class DomainListComponent {
   loadLocks() {
     this.registryLockService.retrieveLocks().subscribe({
       error: (err: HttpErrorResponse) => {
-        this._snackBar.open(err.message);
+        if (err.status !== HttpStatusCode.Forbidden) {
+          // Some users may not have registry lock permissions and that's OK
+          this._snackBar.open(err.message);
+        }
       },
     });
   }


### PR DESCRIPTION
ACCOUNT_MANAGER users don't have permission to see locks so it'll throw 403s. That's OK, we don't need/want to display that error to the client.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2574)
<!-- Reviewable:end -->
