### PR TITLE
Disable legacy registrar console

### DIFF
--- a/core/src/main/java/google/registry/ui/html/index.html
+++ b/core/src/main/java/google/registry/ui/html/index.html
@@ -3,4 +3,4 @@
 <title>Nomulus</title>
 <body lang="en-US">
 If this page doesn't change automatically, please go
-to <a href="/registrar">https://www.registry.google/registrar</a>
+to <a href="/console">https://www.registry.google/console</a>

--- a/core/src/test/java/google/registry/ui/server/registrar/ConsoleUiActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/registrar/ConsoleUiActionTest.java
@@ -20,6 +20,7 @@ import static google.registry.request.auth.AuthenticatedRegistrarAccessor.Role.A
 import static google.registry.request.auth.AuthenticatedRegistrarAccessor.Role.OWNER;
 import static jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSetMultimap;
@@ -84,6 +85,7 @@ class ConsoleUiActionTest {
                 "NewRegistrar", ADMIN,
                 "AdminRegistrar", ADMIN));
     RegistrarConsoleMetrics.consoleRequestMetric.reset();
+    when(request.getParameter("noredirect")).thenReturn("true");
   }
 
   @AfterEach
@@ -96,6 +98,14 @@ class ConsoleUiActionTest {
         .hasValueForLabels(1, registrarId, explicitClientId, roles, status);
     RegistrarConsoleMetrics.consoleRequestMetric.reset(
         registrarId, explicitClientId, roles, status);
+  }
+
+  @Test
+  void testWebPage_redirect() {
+    when(request.getParameter("noredirect")).thenReturn(null);
+    action.run();
+    assertThat(response.getStatus()).isEqualTo(302);
+    assertThat(response.getPayload()).isEqualTo("Redirected to /console");
   }
 
   @Test

--- a/core/src/test/java/google/registry/webdriver/RegistrarConsoleScreenshotTest.java
+++ b/core/src/test/java/google/registry/webdriver/RegistrarConsoleScreenshotTest.java
@@ -43,12 +43,14 @@ import google.registry.testing.DatabaseHelper;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junitpioneer.jupiter.RetryingTest;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 
 /** Registrar Console Screenshot Differ tests. */
+@Disabled
 class RegistrarConsoleScreenshotTest extends WebDriverTestCase {
 
   @RegisterExtension

--- a/core/src/test/java/google/registry/webdriver/RegistrarConsoleWebTest.java
+++ b/core/src/test/java/google/registry/webdriver/RegistrarConsoleWebTest.java
@@ -28,12 +28,14 @@ import google.registry.model.registrar.RegistrarPoc;
 import google.registry.module.frontend.FrontendServlet;
 import google.registry.server.RegistryTestServer;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junitpioneer.jupiter.RetryingTest;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 /** WebDriver tests for Registrar Console UI. */
+@Disabled
 public class RegistrarConsoleWebTest extends WebDriverTestCase {
 
   @RegisterExtension


### PR DESCRIPTION
The only way to access it now is by adding a non-null URL parameter `noredirect`, for example `https://registry.example/registrar?noredirect=true`.

TESTED=Deployed on alpha, tested both `/registrar` and `/`, and that the `noredirect` override works.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2575)
<!-- Reviewable:end -->
