### PR TITLE
Set POST method to SyncRegistrarSheetAction invocation

### DIFF
--- a/core/src/main/java/google/registry/ui/server/console/ConsoleApiAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleApiAction.java
@@ -20,6 +20,7 @@ import static google.registry.model.common.FeatureFlag.FeatureName.NEW_CONSOLE;
 import static google.registry.model.common.FeatureFlag.isActiveNow;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.Action.Method.GET;
+import static google.registry.request.Action.Method.POST;
 import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
 import static jakarta.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
@@ -196,7 +197,8 @@ public abstract class ConsoleApiAction implements Runnable {
       // there's an update besides the lastUpdateTime
       cloudTasksUtils.enqueue(
           SyncRegistrarsSheetAction.QUEUE,
-          cloudTasksUtils.createTask(SyncRegistrarsSheetAction.class, GET, ImmutableMultimap.of()));
+          cloudTasksUtils.createTask(
+              SyncRegistrarsSheetAction.class, POST, ImmutableMultimap.of()));
     }
 
     String environment = Ascii.toLowerCase(String.valueOf(RegistryEnvironment.get()));
@@ -208,10 +210,10 @@ public abstract class ConsoleApiAction implements Runnable {
                 registrar.getRegistrarName(), registrar.getRegistrarId(), environment),
             String.format(
                 """
-                  The following changes were made in registry %s environment to the registrar %s by\
-                   %s:
+                The following changes were made in registry %s environment to the registrar %s by\
+                 %s:
 
-                  %s""",
+                %s""",
                 environment,
                 registrar.getRegistrarId(),
                 consoleApiParams.authResult().userIdForLogging(),


### PR DESCRIPTION
This fixes b/370927852

Context - Recent change https://github.com/google/nomulus/pull/2540 has made task creation synchronous, which surfaced the fact that method used for enqueuing a SyncRegistrarSheetAction has been incorrect (basically forever), but  it didn't matter much because updated fields are not reflected in the sheet anyway. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2580)
<!-- Reviewable:end -->
