### PR TITLE
Remove schedule CodeQL run

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,8 +6,6 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ 'master' ]
-  schedule:
-    - cron: '24 4 * * *'
 
 jobs:
   analyze:


### PR DESCRIPTION
This fails for me every day for some reason (starting about a month
ago). The same commit went through the workflow fine when the action was
triggered by a push.

I think there's no reason for us to have a cron run as the changes to the
master branch can only come from commit pushes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2581)
<!-- Reviewable:end -->
