### PR TITLE
Fix releases

### DIFF
--- a/release/cloudbuild-release.yaml
+++ b/release/cloudbuild-release.yaml
@@ -18,6 +18,7 @@ steps:
   - |
     set -e
     git clone https://gerrit.googlesource.com/gcompute-tools
+    sed -i s@/usr/bin/python@/usr/bin/python3@g ./gcompute-tools/git-cookie-authdaemon
     ./gcompute-tools/git-cookie-authdaemon
     git clone ${_INTERNAL_REPO_URL} nomulus-internal
 # Tag and push the internal repo.


### PR DESCRIPTION
It seems like `/usr/bin/python` is no longer symlinked to the `python3`
binary in the `gcr.io/cloud-builders/git` image.

I've sent out a separate fix to upstream to change the shebang.

https://gerrit-review.git.corp.google.com/c/gcompute-tools/+/439501

But in the meantime, we need this temporary fix for the release to
build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2591)
<!-- Reviewable:end -->
