### PR TITLE
Add canary service to GKE

### DIFF
--- a/core/src/main/java/google/registry/tools/CurlCommand.java
+++ b/core/src/main/java/google/registry/tools/CurlCommand.java
@@ -21,6 +21,7 @@ import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.beust.jcommander.converters.IParameterSplitter;
+import com.google.common.base.Ascii;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -103,7 +104,10 @@ class CurlCommand implements CommandWithConnection {
       throw new IllegalArgumentException("You may not specify a body for a get method.");
     }
 
-    Service service = useGke ? GkeService.valueOf(serviceName) : GaeService.valueOf(serviceName);
+    Service service =
+        useGke
+            ? GkeService.valueOf(Ascii.toUpperCase(serviceName))
+            : GaeService.valueOf(Ascii.toUpperCase(serviceName));
 
     ServiceConnection connectionToService = connection.withService(service, canary);
     String response =

--- a/core/src/test/java/google/registry/tools/ServiceConnectionTest.java
+++ b/core/src/test/java/google/registry/tools/ServiceConnectionTest.java
@@ -16,23 +16,65 @@ package google.registry.tools;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.request.Action.GaeService.DEFAULT;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpRequest;
+import com.google.api.client.http.HttpRequestFactory;
+import com.google.api.client.http.HttpResponse;
+import com.google.common.collect.ImmutableMap;
+import google.registry.request.Action.GkeService;
+import java.io.ByteArrayInputStream;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link google.registry.tools.ServiceConnection}. */
 public class ServiceConnectionTest {
 
   @Test
-  void testServerUrl_notCanary() {
+  void testSuccess_serverUrl_notCanary() {
     ServiceConnection connection = new ServiceConnection(false, null).withService(DEFAULT, false);
     String serverUrl = connection.getServer().toString();
     assertThat(serverUrl).isEqualTo("https://default.example.com"); // See default-config.yaml
   }
 
   @Test
-  void testServerUrl_canary() {
+  void testFailure_mixedService() throws Exception {
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> {
+              new ServiceConnection(true, null).withService(DEFAULT, true);
+            });
+    assertThat(thrown).hasMessageThat().contains("Cannot switch from GkeService to GaeService");
+  }
+
+  @Test
+  void testSuccess_serverUrl_gae_canary() {
     ServiceConnection connection = new ServiceConnection(false, null).withService(DEFAULT, true);
     String serverUrl = connection.getServer().toString();
     assertThat(serverUrl).isEqualTo("https://nomulus-dot-default.example.com");
+  }
+
+  @Test
+  void testSuccess_serverUrl_gke_canary() throws Exception {
+    HttpRequestFactory factory = mock(HttpRequestFactory.class);
+    HttpRequest request = mock(HttpRequest.class);
+    HttpHeaders headers = mock(HttpHeaders.class);
+    HttpResponse response = mock(HttpResponse.class);
+    when(request.getHeaders()).thenReturn(headers);
+    when(factory.buildGetRequest(any(GenericUrl.class))).thenReturn(request);
+    when(request.execute()).thenReturn(response);
+    when(response.getContent()).thenReturn(ByteArrayInputStream.nullInputStream());
+    ServiceConnection connection =
+        new ServiceConnection(true, factory).withService(GkeService.PUBAPI, true);
+    String serverUrl = connection.getServer().toString();
+    assertThat(serverUrl).isEqualTo("https://pubapi.registry.test");
+    connection.sendGetRequest("/path", ImmutableMap.of());
+    verify(headers).set("canary", "true");
   }
 }

--- a/jetty/deploy-nomulus-for-env.sh
+++ b/jetty/deploy-nomulus-for-env.sh
@@ -37,6 +37,11 @@ do
     sed s/GCP_PROJECT/"${project}"/g "./kubernetes/nomulus-${service}.yaml" | \
     sed s/ENVIRONMENT/"${environment}"/g | \
     kubectl apply -f -
+    # canary
+    sed s/GCP_PROJECT/"${project}"/g "./kubernetes/nomulus-${service}.yaml" | \
+    sed s/ENVIRONMENT/"${environment}"/g | \
+    sed s/"${service}"/"${service}-canary"/g | \
+    kubectl apply -f -
   done
   # Kills all running pods, new pods created will be pulling the new image.
   kubectl delete pods --all

--- a/jetty/kubernetes/gateway/nomulus-route-backend.yaml
+++ b/jetty/kubernetes/gateway/nomulus-route-backend.yaml
@@ -30,6 +30,42 @@ spec:
       kind: ServiceImport
       name: backend
       port: 80
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /_dr/task
+      headers:
+      - name: "canary"
+        value: "true"
+    - path:
+        type: PathPrefix
+        value: /_dr/cron
+      headers:
+      - name: "canary"
+        value: "true"
+    - path:
+        type: PathPrefix
+        value: /_dr/admin
+      headers:
+      - name: "canary"
+        value: "true"
+    - path:
+        type: PathPrefix
+        value: /_dr/epptool
+      headers:
+      - name: "canary"
+        value: "true"
+    - path:
+        type: PathPrefix
+        value: /loadtest
+      headers:
+      - name: "canary"
+        value: "true"
+    backendRefs:
+    - group: net.gke.io
+      kind: ServiceImport
+      name: backend-canary
+      port: 80
 ---
 apiVersion: networking.gke.io/v1
 kind: HealthCheckPolicy
@@ -45,3 +81,18 @@ spec:
     group: net.gke.io
     kind: ServiceImport
     name: backend
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: backend-canary
+spec:
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: /healthz/
+  targetRef:
+    group: net.gke.io
+    kind: ServiceImport
+    name: backend-canary

--- a/jetty/kubernetes/gateway/nomulus-route-console.yaml
+++ b/jetty/kubernetes/gateway/nomulus-route-console.yaml
@@ -21,6 +21,24 @@ spec:
       kind: ServiceImport
       name: console
       port: 80
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /console-api
+      headers:
+      - name: "canary"
+        value: "true"
+    - path:
+        type: PathPrefix
+        value: /console
+      headers:
+      - name: "canary"
+        value: "true"
+    backendRefs:
+    - group: net.gke.io
+      kind: ServiceImport
+      name: console-canary
+      port: 80
 ---
 apiVersion: networking.gke.io/v1
 kind: HealthCheckPolicy
@@ -36,3 +54,18 @@ spec:
     group: net.gke.io
     kind: ServiceImport
     name: console
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: console-canary
+spec:
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: /healthz/
+  targetRef:
+    group: net.gke.io
+    kind: ServiceImport
+    name: console-canary

--- a/jetty/kubernetes/gateway/nomulus-route-frontend.yaml
+++ b/jetty/kubernetes/gateway/nomulus-route-frontend.yaml
@@ -18,6 +18,18 @@ spec:
       kind: ServiceImport
       name: frontend
       port: 80
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /_dr/epp
+      headers:
+      - name: "canary"
+        value: "true"
+    backendRefs:
+    - group: net.gke.io
+      kind: ServiceImport
+      name: frontend-canary
+      port: 80
 ---
 apiVersion: networking.gke.io/v1
 kind: HealthCheckPolicy
@@ -33,3 +45,18 @@ spec:
     group: net.gke.io
     kind: ServiceImport
     name: frontend
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: frontend-canary
+spec:
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: /healthz/
+  targetRef:
+    group: net.gke.io
+    kind: ServiceImport
+    name: frontend-canary

--- a/jetty/kubernetes/gateway/nomulus-route-pubapi.yaml
+++ b/jetty/kubernetes/gateway/nomulus-route-pubapi.yaml
@@ -27,6 +27,36 @@ spec:
       kind: ServiceImport
       name: pubapi
       port: 80
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /_dr/whois
+      headers:
+      - name: "canary"
+        value: "true"
+    - path:
+        type: PathPrefix
+        value: /check
+      headers:
+      - name: "canary"
+        value: "true"
+    - path:
+        type: PathPrefix
+        value: /whois
+      headers:
+      - name: "canary"
+        value: "true"
+    - path:
+        type: PathPrefix
+        value: /rdap
+      headers:
+      - name: "canary"
+        value: "true"
+    backendRefs:
+    - group: net.gke.io
+      kind: ServiceImport
+      name: pubapi-canary
+      port: 80
 ---
 apiVersion: networking.gke.io/v1
 kind: HealthCheckPolicy
@@ -42,3 +72,18 @@ spec:
     group: net.gke.io
     kind: ServiceImport
     name: pubapi
+---
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: pubapi-canary
+spec:
+  default:
+    config:
+      type: HTTP
+      httpHealthCheck:
+        requestPath: /healthz/
+  targetRef:
+    group: net.gke.io
+    kind: ServiceImport
+    name: pubapi-canary

--- a/proxy/src/main/java/google/registry/proxy/EppProtocolModule.java
+++ b/proxy/src/main/java/google/registry/proxy/EppProtocolModule.java
@@ -151,12 +151,14 @@ public final class EppProtocolModule {
   static EppServiceHandler provideEppServiceHandler(
       @Named("idToken") Supplier<String> idTokenSupplier,
       @Named("hello") byte[] helloBytes,
+      @Named("canary") boolean canary,
       FrontendMetrics metrics,
       ProxyConfig config,
       @HttpsRelayProtocol boolean localRelay) {
     return new EppServiceHandler(
         localRelay ? "localhost" : config.epp.relayHost,
         config.epp.relayPath,
+        canary,
         idTokenSupplier,
         helloBytes,
         metrics);

--- a/proxy/src/main/java/google/registry/proxy/ProxyConfig.java
+++ b/proxy/src/main/java/google/registry/proxy/ProxyConfig.java
@@ -41,6 +41,7 @@ public class ProxyConfig {
 
   public String projectId;
   public String oauthClientId;
+  public boolean canary;
   public List<String> gcpScopes;
   public int serverCertificateCacheSeconds;
   public Gcs gcs;

--- a/proxy/src/main/java/google/registry/proxy/ProxyModule.java
+++ b/proxy/src/main/java/google/registry/proxy/ProxyModule.java
@@ -280,6 +280,13 @@ public class ProxyModule {
 
   @Singleton
   @Provides
+  @Named("canary")
+  static boolean provideIsCanary(ProxyConfig config) {
+    return config.canary;
+  }
+
+  @Singleton
+  @Provides
   static CloudKMS provideCloudKms(GoogleCredentialsBundle credentialsBundle, ProxyConfig config) {
     return new CloudKMS.Builder(
             credentialsBundle.getHttpTransport(),

--- a/proxy/src/main/java/google/registry/proxy/WhoisProtocolModule.java
+++ b/proxy/src/main/java/google/registry/proxy/WhoisProtocolModule.java
@@ -96,11 +96,13 @@ public final class WhoisProtocolModule {
   static WhoisServiceHandler provideWhoisServiceHandler(
       ProxyConfig config,
       @Named("idToken") Supplier<String> idTokenSupplier,
+      @Named("canary") boolean canary,
       FrontendMetrics metrics,
       @HttpsRelayProtocol boolean localRelay) {
     return new WhoisServiceHandler(
         localRelay ? "localhost" : config.whois.relayHost,
         config.whois.relayPath,
+        canary,
         idTokenSupplier,
         metrics);
   }

--- a/proxy/src/main/java/google/registry/proxy/config/default-config.yaml
+++ b/proxy/src/main/java/google/registry/proxy/config/default-config.yaml
@@ -8,6 +8,9 @@
 # GCP project ID
 projectId: your-gcp-project-id
 
+# Whether to connect to the canary (instead of regular) service.
+canary: false
+
 # OAuth client ID set as the audience of the OIDC token. This value must be the
 # same as the auth.oauthClientId value in Nomulus config file, which usually is
 # the IAP client ID, to allow the request to access IAP protected endpoints.

--- a/proxy/src/main/java/google/registry/proxy/handler/EppServiceHandler.java
+++ b/proxy/src/main/java/google/registry/proxy/handler/EppServiceHandler.java
@@ -60,10 +60,11 @@ public class EppServiceHandler extends HttpsRelayServiceHandler {
   public EppServiceHandler(
       String relayHost,
       String relayPath,
+      boolean canary,
       Supplier<String> idTokenSupplier,
       byte[] helloBytes,
       FrontendMetrics metrics) {
-    super(relayHost, relayPath, idTokenSupplier, metrics);
+    super(relayHost, relayPath, canary, idTokenSupplier, metrics);
     this.helloBytes = helloBytes.clone();
   }
 

--- a/proxy/src/main/java/google/registry/proxy/handler/WhoisServiceHandler.java
+++ b/proxy/src/main/java/google/registry/proxy/handler/WhoisServiceHandler.java
@@ -33,9 +33,10 @@ public final class WhoisServiceHandler extends HttpsRelayServiceHandler {
   public WhoisServiceHandler(
       String relayHost,
       String relayPath,
+      boolean canary,
       Supplier<String> idTokenSupplier,
       FrontendMetrics metrics) {
-    super(relayHost, relayPath, idTokenSupplier, metrics);
+    super(relayHost, relayPath, canary, idTokenSupplier, metrics);
   }
 
   @Override

--- a/proxy/src/test/java/google/registry/proxy/ProtocolModuleTest.java
+++ b/proxy/src/test/java/google/registry/proxy/ProtocolModuleTest.java
@@ -263,6 +263,13 @@ public abstract class ProtocolModuleTest {
 
     @Singleton
     @Provides
+    @Named("canary")
+    static boolean provideIsCanary() {
+      return false;
+    }
+
+    @Singleton
+    @Provides
     static LoggingHandler provideLoggingHandler() {
       return new LoggingHandler();
     }


### PR DESCRIPTION
This PR adds the ability to deploy canary service in GKE. It includes the following:

1. New deployments and services are added for the canary version of the existing ones.
2. New HTTP routes are created to route requests with `canary: true` header to the canary service.
3. The proxy is configured to add the header when necessary.
4. The Nomulus curl tool now respects the `--canary` flag and will add the header when necessary.
5. Not related: The curl command now displays the content when the response is not OK, as the content may contain error information.

TESTED=1. Deployed to alpha GKE and verified the pubapi service respects the header based routing when using curl to access the endpoint.
2. Verified that Nomulus curl sends the request to canary service when the flag is used.
3. Deployed proxy to alpha and verified that the requests are routed to canary when configured so. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2594)
<!-- Reviewable:end -->
