### PR TITLE
Add an action to export pending-delete domains

### DIFF
--- a/core/src/main/java/google/registry/export/ExportPendingDeleteDomainsAction.java
+++ b/core/src/main/java/google/registry/export/ExportPendingDeleteDomainsAction.java
@@ -1,0 +1,111 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.export;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static google.registry.model.tld.Tlds.getTldsOfType;
+import static google.registry.persistence.transaction.TransactionManagerFactory.replicaTm;
+import static google.registry.request.Action.Method.POST;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.flogger.FluentLogger;
+import com.google.common.net.MediaType;
+import google.registry.model.domain.Domain;
+import google.registry.model.tld.Tld;
+import google.registry.request.Action;
+import google.registry.request.auth.Auth;
+import google.registry.storage.drive.DriveConnection;
+import jakarta.persistence.Query;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javax.inject.Inject;
+
+/**
+ * Exports to Drive lists of domains that are in the PENDING_DELETE stage but not deleted.
+ *
+ * <p>This includes domains that are in the regular 35-day redemption + pending-delete period plus
+ * any not-yet-expired domains for which an explicit DOMAIN_DELETE action has been issued.
+ *
+ * <p>We provide these lists in an effort to reduce spam requests intended for drop-catching.
+ */
+@Action(
+    service = Action.GaeService.BACKEND,
+    path = "/_dr/task/exportPendingDeleteDomains",
+    method = POST,
+    auth = Auth.AUTH_ADMIN)
+public class ExportPendingDeleteDomainsAction implements Runnable {
+
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+  private static final String FIND_PENDING_DELETE_DOMAINS_QUERY =
+      "SELECT * FROM \"Domain\" WHERE tld = :tld AND 'PENDING_DELETE' = any(statuses) AND"
+          + " deletion_time > CAST(:now AS timestamptz) ORDER BY deletion_time";
+
+  static final String PENDING_DELETE_DOMAINS_FILENAME = "pending_delete_domains.csv";
+
+  private final DriveConnection driveConnection;
+
+  @Inject
+  public ExportPendingDeleteDomainsAction(DriveConnection driveConnection) {
+    this.driveConnection = driveConnection;
+  }
+
+  @Override
+  public void run() {
+    ImmutableSet<String> realTlds = getTldsOfType(Tld.TldType.REAL);
+    logger.atInfo().log("Exporting pending-delete domains for TLDs %s.", realTlds);
+    realTlds.forEach(this::runForTld);
+  }
+
+  private void runForTld(String tldStr) {
+    replicaTm().transact(() -> runInReplicaTransaction(tldStr));
+  }
+
+  private void runInReplicaTransaction(String tldStr) {
+    Tld tld = Tld.get(tldStr);
+    String driveFolderId = Tld.get(tldStr).getDriveFolderId();
+    if (isNullOrEmpty(driveFolderId)) {
+      logger.atInfo().log(
+          "Skipping pending-delete domains export for TLD %s because Drive folder isn't specified.",
+          tldStr);
+      return;
+    }
+    Query query =
+        replicaTm()
+            .getEntityManager()
+            .createNativeQuery(FIND_PENDING_DELETE_DOMAINS_QUERY, Domain.class)
+            .setParameter("now", replicaTm().getTransactionTime().toString())
+            .setParameter("tld", tldStr);
+    Stream<Domain> resultsStream = (Stream<Domain>) query.getResultStream();
+    String outputString =
+        resultsStream
+            .map(d -> String.format("%s,%s", d.getDomainName(), d.getDeletionTime()))
+            .collect(Collectors.joining("\n"));
+    try {
+      String resultMsg =
+          driveConnection.createOrUpdateFile(
+              PENDING_DELETE_DOMAINS_FILENAME,
+              MediaType.CSV_UTF_8,
+              tld.getDriveFolderId(),
+              outputString.getBytes(UTF_8));
+      logger.atInfo().log(
+          "Exporting pending-delete domains succeeded for TLD %s, response was: %s",
+          tldStr, resultMsg);
+    } catch (Throwable t) {
+      logger.atSevere().withCause(t).log(
+          "Error exporting pending-delete domains for TLD %s to Drive. Skipping...", tldStr);
+    }
+  }
+}

--- a/core/src/main/java/google/registry/module/backend/BackendRequestComponent.java
+++ b/core/src/main/java/google/registry/module/backend/BackendRequestComponent.java
@@ -39,6 +39,7 @@ import google.registry.dns.writer.clouddns.CloudDnsWriterModule;
 import google.registry.dns.writer.dnsupdate.DnsUpdateConfigModule;
 import google.registry.dns.writer.dnsupdate.DnsUpdateWriterModule;
 import google.registry.export.ExportDomainListsAction;
+import google.registry.export.ExportPendingDeleteDomainsAction;
 import google.registry.export.ExportPremiumTermsAction;
 import google.registry.export.ExportReservedTermsAction;
 import google.registry.export.SyncGroupMembersAction;
@@ -116,6 +117,8 @@ public interface BackendRequestComponent {
   ExpandBillingRecurrencesAction expandBillingRecurrencesAction();
 
   ExportDomainListsAction exportDomainListsAction();
+
+  ExportPendingDeleteDomainsAction exportPendingDeleteDomainsAction();
 
   ExportPremiumTermsAction exportPremiumTermsAction();
 

--- a/core/src/test/java/google/registry/export/ExportPendingDeleteDomainsActionTest.java
+++ b/core/src/test/java/google/registry/export/ExportPendingDeleteDomainsActionTest.java
@@ -1,0 +1,105 @@
+// Copyright 2024 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.export;
+
+import static com.google.common.truth.Truth.assertThat;
+import static google.registry.export.ExportPendingDeleteDomainsAction.PENDING_DELETE_DOMAINS_FILENAME;
+import static google.registry.testing.DatabaseHelper.createTld;
+import static google.registry.testing.DatabaseHelper.persistActiveDomain;
+import static google.registry.testing.DatabaseHelper.persistResource;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.net.MediaType;
+import google.registry.model.eppcommon.StatusValue;
+import google.registry.model.tld.Tld;
+import google.registry.persistence.transaction.JpaTestExtensions;
+import google.registry.storage.drive.DriveConnection;
+import google.registry.testing.FakeClock;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentCaptor;
+
+/** Tests for {@link ExportPendingDeleteDomainsAction}. */
+public class ExportPendingDeleteDomainsActionTest {
+
+  private final DriveConnection driveConnection = mock(DriveConnection.class);
+  private final ArgumentCaptor<byte[]> bytesExportedToDrive = ArgumentCaptor.forClass(byte[].class);
+  private ExportPendingDeleteDomainsAction action;
+
+  private final FakeClock clock = new FakeClock(DateTime.parse("2024-05-13T13:13:13Z"));
+
+  @RegisterExtension
+  final JpaTestExtensions.JpaIntegrationTestExtension jpa =
+      new JpaTestExtensions.Builder().withClock(clock).buildIntegrationTestExtension();
+
+  @BeforeEach
+  void beforeEach() {
+    createTld("tld");
+    createTld("testtld");
+    persistResource(Tld.get("tld").asBuilder().setDriveFolderId("brouhaha").build());
+    persistResource(Tld.get("testtld").asBuilder().setTldType(Tld.TldType.TEST).build());
+    action = new ExportPendingDeleteDomainsAction(driveConnection);
+  }
+
+  @Test
+  void testPendingDeleteDomainsInRealTlds() throws Exception {
+    persistActiveDomain("active.tld");
+    persistDomainWithPendingDelete("pendingdelete.tld");
+    clock.advanceOneMilli();
+    persistDomainWithPendingDelete("pendingdelete2.tld");
+    persistDomainWithPendingDelete("pendingdelete.testtld");
+
+    action.run();
+
+    verifyExportedToDrive(
+        "brouhaha",
+        "pendingdelete.tld,2024-06-07T13:13:13.000Z\npendingdelete2.tld,2024-06-07T13:13:13.001Z");
+  }
+
+  @Test
+  void testNoDriveFolder_noExport() throws Exception {
+    persistDomainWithPendingDelete("pendingdelete.tld");
+    persistResource(Tld.get("tld").asBuilder().setDriveFolderId(null).build());
+    action.run();
+    verifyNoMoreInteractions(driveConnection);
+  }
+
+  private void persistDomainWithPendingDelete(String domainName) {
+    persistResource(
+        persistActiveDomain(domainName)
+            .asBuilder()
+            .setDeletionTime(clock.nowUtc().plusDays(25))
+            .setRegistrationExpirationTime(clock.nowUtc().minusDays(1))
+            .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
+            .build());
+  }
+
+  private void verifyExportedToDrive(String folderId, String content) throws Exception {
+    verify(driveConnection)
+        .createOrUpdateFile(
+            eq(PENDING_DELETE_DOMAINS_FILENAME),
+            eq(MediaType.CSV_UTF_8),
+            eq(folderId),
+            bytesExportedToDrive.capture());
+    assertThat(new String(bytesExportedToDrive.getValue(), UTF_8)).isEqualTo(content);
+  }
+}

--- a/core/src/test/resources/google/registry/module/backend/backend_routing.txt
+++ b/core/src/test/resources/google/registry/module/backend/backend_routing.txt
@@ -9,6 +9,7 @@ BACKEND /_dr/task/dnsRefresh                               RefreshDnsAction     
 BACKEND /_dr/task/executeCannedScript                      CannedScriptExecutionAction                    POST,GET y  APP ADMIN
 BACKEND /_dr/task/expandBillingRecurrences                 ExpandBillingRecurrencesAction                 GET      n  APP ADMIN
 BACKEND /_dr/task/exportDomainLists                        ExportDomainListsAction                        POST     n  APP ADMIN
+BACKEND /_dr/task/exportPendingDeleteDomains               ExportPendingDeleteDomainsAction               POST     n  APP ADMIN
 BACKEND /_dr/task/exportPremiumTerms                       ExportPremiumTermsAction                       POST     n  APP ADMIN
 BACKEND /_dr/task/exportReservedTerms                      ExportReservedTermsAction                      POST     n  APP ADMIN
 BACKEND /_dr/task/generateInvoices                         GenerateInvoicesAction                         POST     n  APP ADMIN


### PR DESCRIPTION
This will allow our partners to know when domains will expire, versus having to constantly request various domains to see when they'll drop. Hopefully this reduces load on us.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2595)
<!-- Reviewable:end -->
