### PR TITLE
Sometimes include deletion times in domain-list exports

### DIFF
--- a/core/src/main/java/google/registry/model/common/FeatureFlag.java
+++ b/core/src/main/java/google/registry/model/common/FeatureFlag.java
@@ -66,6 +66,7 @@ public class FeatureFlag extends ImmutableObject implements Buildable {
     TEST_FEATURE,
     MINIMUM_DATASET_CONTACTS_OPTIONAL,
     MINIMUM_DATASET_CONTACTS_PROHIBITED,
+    INCLUDE_PENDING_DELETE_DATE_FOR_DOMAINS
   }
 
   /** The name of the flag/feature. */
@@ -152,6 +153,15 @@ public class FeatureFlag extends ImmutableObject implements Buildable {
 
   public FeatureStatus getStatus(DateTime time) {
     return status.getValueAtTime(time);
+  }
+
+  /** Returns if the flag is active, or the default value if the flag does not exist. */
+  public static boolean isActiveNowOrElse(FeatureName featureName, boolean defaultValue) {
+    tm().assertInTransaction();
+    return CACHE
+        .get(featureName)
+        .map(flag -> flag.getStatus(tm().getTransactionTime()).equals(ACTIVE))
+        .orElse(defaultValue);
   }
 
   /** Returns if the FeatureFlag with the given FeatureName is active now. */

--- a/db/src/main/resources/sql/schema/db-schema.sql.generated
+++ b/db/src/main/resources/sql/schema/db-schema.sql.generated
@@ -470,7 +470,7 @@
     );
 
     create table "FeatureFlag" (
-        feature_name text not null check (feature_name in ('TEST_FEATURE','MINIMUM_DATASET_CONTACTS_OPTIONAL','MINIMUM_DATASET_CONTACTS_PROHIBITED')),
+        feature_name text not null check (feature_name in ('TEST_FEATURE','MINIMUM_DATASET_CONTACTS_OPTIONAL','MINIMUM_DATASET_CONTACTS_PROHIBITED','INCLUDE_PENDING_DELETE_DATE_FOR_DOMAINS')),
         status hstore not null,
         primary key (feature_name)
     );


### PR DESCRIPTION
We only include the deletion time if the domain is in the 5-day PENDING_DELETE period after the 30 day REDEMPTION period. For all other domains, we just have an empty string as that field.

This is behind a feature flag so that we can control when it is enabled

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2602)
<!-- Reviewable:end -->
