### PR TITLE
Make nomulus update_recurrence command only fail on pending transfers

### DIFF
--- a/core/src/main/java/google/registry/tools/UpdateRecurrenceCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdateRecurrenceCommand.java
@@ -30,6 +30,7 @@ import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.reporting.HistoryEntry.HistoryEntryId;
+import google.registry.model.transfer.TransferStatus;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -174,7 +175,8 @@ public class UpdateRecurrenceCommand extends ConfirmingCommand {
           "Domain %s has already had a deletion time set",
           domainName);
       checkArgument(
-          domain.getTransferData().isEmpty(),
+          domain.getTransferData().isEmpty()
+              || domain.getTransferData().getTransferStatus() != TransferStatus.PENDING,
           "Domain %s has a pending transfer: %s",
           domainName,
           domain.getTransferData());


### PR DESCRIPTION
It was failing when any kind of transfer data was present, even completed transfer data. Note that completed transfer data persists on a domain indefinitely until/unless a new transfer is requested.

BUG= http://b/377328244

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2605)
<!-- Reviewable:end -->
