### PR TITLE
Include GracePeriod statuses in RDAP results

### DIFF
--- a/core/src/main/java/google/registry/rdap/RdapObjectClasses.java
+++ b/core/src/main/java/google/registry/rdap/RdapObjectClasses.java
@@ -51,7 +51,7 @@ final class RdapObjectClasses {
    */
   @RestrictJsonNames({})
   @AutoValue
-  abstract static class Vcard implements Jsonable {
+  public abstract static class Vcard implements Jsonable {
     abstract String property();
     abstract ImmutableMap<String, ImmutableList<String>> parameters();
     abstract String valueType();
@@ -94,7 +94,7 @@ final class RdapObjectClasses {
 
   @RestrictJsonNames("vcardArray")
   @AutoValue
-  abstract static class VcardArray implements Jsonable {
+  public abstract static class VcardArray implements Jsonable {
 
     private static final String VCARD_VERSION_NUMBER = "4.0";
     private static final Vcard VCARD_ENTRY_VERSION =
@@ -148,7 +148,7 @@ final class RdapObjectClasses {
    *
    * <p>All Actions need to return an object of this type.
    */
-  abstract static class ReplyPayloadBase extends AbstractJsonableObject {
+  public abstract static class ReplyPayloadBase extends AbstractJsonableObject {
     final BoilerplateType boilerplateType;
 
     ReplyPayloadBase(BoilerplateType boilerplateType) {
@@ -165,7 +165,7 @@ final class RdapObjectClasses {
    */
   @AutoValue
   @RestrictJsonNames({})
-  abstract static class TopLevelReplyObject extends AbstractJsonableObject {
+  public abstract static class TopLevelReplyObject extends AbstractJsonableObject {
     @JsonableElement("rdapConformance")
     static final RdapConformance RDAP_CONFORMANCE = RdapConformance.INSTANCE;
 
@@ -257,7 +257,7 @@ final class RdapObjectClasses {
    * <p>We're missing the "autnums" and "networks" fields
    */
   @RestrictJsonNames({"entities[]", "entitySearchResults[]"})
-  abstract static class RdapEntity extends RdapObjectBase {
+  public abstract static class RdapEntity extends RdapObjectBase {
 
     /** Role values specified in RFC 9083 § 10.2.4. */
     @RestrictJsonNames("roles[]")
@@ -311,7 +311,7 @@ final class RdapObjectClasses {
    * for each one for type safety.
    */
   @AutoValue
-  abstract static class RdapRegistrarEntity extends RdapEntity {
+  public abstract static class RdapRegistrarEntity extends RdapEntity {
 
     static Builder builder() {
       return new AutoValue_RdapObjectClasses_RdapRegistrarEntity.Builder();
@@ -330,7 +330,7 @@ final class RdapObjectClasses {
    * for each one for type safety.
    */
   @AutoValue
-  abstract static class RdapContactEntity extends RdapEntity {
+  public abstract static class RdapContactEntity extends RdapEntity {
 
     static Builder builder() {
       return new AutoValue_RdapObjectClasses_RdapContactEntity.Builder();
@@ -387,7 +387,7 @@ final class RdapObjectClasses {
   /** The Nameserver Object Class defined in 5.2 of RFC 9083. */
   @RestrictJsonNames({"nameservers[]", "nameserverSearchResults[]"})
   @AutoValue
-  abstract static class RdapNameserver extends RdapNamedObjectBase {
+  public abstract static class RdapNameserver extends RdapNamedObjectBase {
 
     @JsonableElement Optional<IpAddresses> ipAddresses() {
       if (ipv6().isEmpty() && ipv4().isEmpty()) {
@@ -429,7 +429,7 @@ final class RdapObjectClasses {
   /** Object defined in RFC 9083 section 5.3, only used for RdapDomain. */
   @RestrictJsonNames("secureDNS")
   @AutoValue
-  abstract static class SecureDns extends AbstractJsonableObject {
+  public abstract static class SecureDns extends AbstractJsonableObject {
     @RestrictJsonNames("dsData[]")
     @AutoValue
     abstract static class DsData extends AbstractJsonableObject {
@@ -507,7 +507,7 @@ final class RdapObjectClasses {
    */
   @RestrictJsonNames("domainSearchResults[]")
   @AutoValue
-  abstract static class RdapDomain extends RdapNamedObjectBase {
+  public abstract static class RdapDomain extends RdapNamedObjectBase {
 
     @JsonableElement abstract ImmutableList<RdapNameserver> nameservers();
 
@@ -535,7 +535,7 @@ final class RdapObjectClasses {
   /** Error Response Body defined in 6 of RFC 9083. */
   @RestrictJsonNames({})
   @AutoValue
-  abstract static class ErrorResponse extends ReplyPayloadBase {
+  public abstract static class ErrorResponse extends ReplyPayloadBase {
 
     @JsonableElement final LanguageIdentifier lang = LanguageIdentifier.EN;
 
@@ -561,7 +561,7 @@ final class RdapObjectClasses {
    */
   @RestrictJsonNames({})
   @AutoValue
-  abstract static class HelpResponse extends ReplyPayloadBase {
+  public abstract static class HelpResponse extends ReplyPayloadBase {
     @JsonableElement("notices[]") abstract Optional<Notice> helpNotice();
 
     HelpResponse() {

--- a/core/src/test/java/google/registry/rdap/RdapActionBaseTestCase.java
+++ b/core/src/test/java/google/registry/rdap/RdapActionBaseTestCase.java
@@ -42,9 +42,11 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 /** Common unit test code for actions inheriting {@link RdapActionBase}. */
 abstract class RdapActionBaseTestCase<A extends RdapActionBase> {
 
+  protected final FakeClock clock = new FakeClock(DateTime.parse("2000-01-01TZ"));
+
   @RegisterExtension
   final JpaIntegrationTestExtension jpa =
-      new JpaTestExtensions.Builder().buildIntegrationTestExtension();
+      new JpaTestExtensions.Builder().withClock(clock).buildIntegrationTestExtension();
 
   protected static final AuthResult AUTH_RESULT =
       AuthResult.createUser(
@@ -61,7 +63,6 @@ abstract class RdapActionBaseTestCase<A extends RdapActionBase> {
               .build());
 
   protected FakeResponse response = new FakeResponse();
-  protected final FakeClock clock = new FakeClock(DateTime.parse("2000-01-01TZ"));
   final RdapMetrics rdapMetrics = mock(RdapMetrics.class);
 
   RdapAuthorization.Role metricRole = PUBLIC;

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -124,6 +124,7 @@ import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.Duration;
 
 /** Static utils for setting up test resources. */
 public final class DatabaseHelper {
@@ -593,30 +594,36 @@ public final class DatabaseHelper {
       DateTime expirationTime) {
     String domainName = String.format("%s.%s", label, tld);
     String repoId = generateNewDomainRoid(tld);
-    Domain domain =
-        persistResource(
-            new Domain.Builder()
-                .setRepoId(repoId)
-                .setDomainName(domainName)
-                .setPersistedCurrentSponsorRegistrarId("TheRegistrar")
-                .setCreationRegistrarId("TheRegistrar")
-                .setCreationTimeForTest(creationTime)
-                .setRegistrationExpirationTime(expirationTime)
-                .setRegistrant(Optional.of(contact.createVKey()))
-                .setContacts(
-                    ImmutableSet.of(
-                        DesignatedContact.create(Type.ADMIN, contact.createVKey()),
-                        DesignatedContact.create(Type.TECH, contact.createVKey())))
-                .setAuthInfo(DomainAuthInfo.create(PasswordAuth.create("fooBAR")))
-                .addGracePeriod(
-                    GracePeriod.create(
-                        GracePeriodStatus.ADD, repoId, now.plusDays(10), "TheRegistrar", null))
-                .build());
+    Domain.Builder domainBuilder =
+        new Domain.Builder()
+            .setRepoId(repoId)
+            .setDomainName(domainName)
+            .setPersistedCurrentSponsorRegistrarId("TheRegistrar")
+            .setCreationRegistrarId("TheRegistrar")
+            .setCreationTimeForTest(creationTime)
+            .setRegistrationExpirationTime(expirationTime)
+            .setRegistrant(Optional.of(contact.createVKey()))
+            .setContacts(
+                ImmutableSet.of(
+                    DesignatedContact.create(Type.ADMIN, contact.createVKey()),
+                    DesignatedContact.create(Type.TECH, contact.createVKey())))
+            .setAuthInfo(DomainAuthInfo.create(PasswordAuth.create("fooBAR")));
+    Duration addGracePeriodLength = Tld.get(tld).getAddGracePeriodLength();
+    if (creationTime.plus(addGracePeriodLength).isAfter(now)) {
+      domainBuilder.addGracePeriod(
+          GracePeriod.create(
+              GracePeriodStatus.ADD,
+              repoId,
+              creationTime.plus(addGracePeriodLength),
+              "TheRegistrar",
+              null));
+    }
+    Domain domain = persistResource(domainBuilder.build());
     DomainHistory historyEntryDomainCreate =
         persistResource(
             new DomainHistory.Builder()
                 .setType(HistoryEntry.Type.DOMAIN_CREATE)
-                .setModificationTime(now)
+                .setModificationTime(creationTime)
                 .setDomain(domain)
                 .setRegistrarId(domain.getCreationRegistrarId())
                 .build());

--- a/core/src/test/java/google/registry/ui/server/console/ConsoleBulkDomainActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/ConsoleBulkDomainActionTest.java
@@ -108,9 +108,10 @@ public class ConsoleBulkDomainActionTest {
     assertThat(fakeResponse.getStatus()).isEqualTo(SC_OK);
     assertThat(fakeResponse.getPayload())
         .isEqualTo(
-            "{\"example.tld\":{\"message\":\"Command completed"
-                + " successfully\",\"responseCode\":1000}}");
-    assertThat(loadByEntity(domain).getDeletionTime()).isEqualTo(clock.nowUtc());
+            """
+{"example.tld":{"message":"Command completed successfully; action pending",\
+"responseCode":1001}}""");
+    assertThat(loadByEntity(domain).getDeletionTime()).isEqualTo(clock.nowUtc().plusDays(35));
   }
 
   @Test
@@ -132,8 +133,8 @@ public class ConsoleBulkDomainActionTest {
     assertThat(fakeResponse.getStatus()).isEqualTo(SC_OK);
     assertThat(fakeResponse.getPayload())
         .isEqualTo(
-            "{\"example.tld\":{\"message\":\"Command completed"
-                + " successfully\",\"responseCode\":1000}}");
+            """
+            {"example.tld":{"message":"Command completed successfully","responseCode":1000}}""");
     assertThat(loadByEntity(domain).getStatusValues())
         .containsAtLeast(
             StatusValue.SERVER_RENEW_PROHIBITED,
@@ -158,11 +159,11 @@ public class ConsoleBulkDomainActionTest {
     assertThat(fakeResponse.getStatus()).isEqualTo(SC_OK);
     assertThat(fakeResponse.getPayload())
         .isEqualTo(
-            "{\"example.tld\":{\"message\":\"Command completed"
-                + " successfully\",\"responseCode\":1000},\"nonexistent.tld\":{\"message\":\"The"
-                + " domain with given ID (nonexistent.tld) doesn\\u0027t"
-                + " exist.\",\"responseCode\":2303}}");
-    assertThat(loadByEntity(domain).getDeletionTime()).isEqualTo(clock.nowUtc());
+            """
+{"example.tld":{"message":"Command completed successfully; action pending","responseCode":1001},\
+"nonexistent.tld":{"message":"The domain with given ID (nonexistent.tld) doesn\\u0027t exist.",\
+"responseCode":2303}}""");
+    assertThat(loadByEntity(domain).getDeletionTime()).isEqualTo(clock.nowUtc().plusDays(35));
   }
 
   @Test

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_add_grace_period.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_add_grace_period.json
@@ -1,0 +1,161 @@
+{
+  "rdapConformance": [
+    "rdap_level_0",
+    "icann_rdap_response_profile_0",
+    "icann_rdap_technical_implementation_guide_0"
+  ],
+  "objectClassName": "domain",
+  "entities": [
+    {
+      "objectClassName": "entity",
+      "handle": "1",
+      "links": [
+        {
+          "href": "https://example.tld/rdap/entity/1",
+          "rel": "self",
+          "type": "application/rdap+json"
+        }
+      ],
+      "publicIds": [
+        {
+          "identifier": "1",
+          "type": "IANA Registrar ID"
+        }
+      ],
+      "remarks": [
+        {
+          "description": [
+            "Summary data only. For complete data, send a specific query for the object."
+          ],
+          "title": "Incomplete Data",
+          "type": "object truncated due to unexplainable reasons"
+        }
+      ],
+      "roles": [
+        "registrar"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "The Registrar"
+          ]
+        ]
+      ]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "",
+      "remarks": [
+        {
+          "description": [
+            "Some of the data in this object has been removed.",
+            "Contact personal data is visible only to the owning registrar."
+          ],
+          "links": [
+            {
+              "href": "https://github.com/google/nomulus/blob/master/docs/rdap.md#authentication",
+              "rel": "alternate",
+              "type": "text/html"
+            }
+          ],
+          "title": "REDACTED FOR PRIVACY",
+          "type": "object redacted due to authorization"
+        },
+        {
+          "description": [
+            "Please query the RDDS service of the Registrar of Record identifies in this output for information on how to contact the Registrant of the queried domain name."
+          ],
+          "title": "EMAIL REDACTED FOR PRIVACY",
+          "type": "object redacted due to authorization"
+        }
+      ],
+      "roles": [
+        "administrative",
+        "technical",
+        "registrant"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            ""
+          ]
+        ]
+      ]
+    }
+  ],
+  "events": [
+    {
+      "eventAction": "registration",
+      "eventActor": "TheRegistrar",
+      "eventDate": "2000-01-01T00:00:00.000Z"
+    },
+    {
+      "eventAction": "expiration",
+      "eventDate": "2001-01-01T00:00:00.000Z"
+    },
+    {
+      "eventAction": "last update of RDAP database",
+      "eventDate": "2000-01-01T00:00:00.000Z"
+    }
+  ],
+  "handle": "28-LOL",
+  "ldhName": "addgraceperiod.lol",
+  "links": [
+    {
+      "href": "https://example.tld/rdap/domain/addgraceperiod.lol",
+      "rel": "self",
+      "type": "application/rdap+json"
+    }
+  ],
+  "nameservers": [
+    {
+      "objectClassName": "nameserver",
+      "handle": "8-ROID",
+      "ldhName": "ns1.cat.lol",
+      "links": [
+        {
+          "href": "https://example.tld/rdap/nameserver/ns1.cat.lol",
+          "rel": "self",
+          "type": "application/rdap+json"
+        }
+      ],
+      "remarks": [
+        {
+          "description": [
+            "Summary data only. For complete data, send a specific query for the object."
+          ],
+          "title": "Incomplete Data",
+          "type": "object truncated due to unexplainable reasons"
+        }
+      ]
+    }
+  ],
+  "secureDNS": {
+    "delegationSigned": false,
+    "zoneSigned": true
+  },
+  "status": [
+    "active",
+    "add period"
+  ]
+}

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_auto_renew_grace_period.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_auto_renew_grace_period.json
@@ -1,0 +1,165 @@
+{
+  "rdapConformance": [
+    "rdap_level_0",
+    "icann_rdap_response_profile_0",
+    "icann_rdap_technical_implementation_guide_0"
+  ],
+  "objectClassName": "domain",
+  "entities": [
+    {
+      "objectClassName": "entity",
+      "handle": "1",
+      "links": [
+        {
+          "href": "https://example.tld/rdap/entity/1",
+          "rel": "self",
+          "type": "application/rdap+json"
+        }
+      ],
+      "publicIds": [
+        {
+          "identifier": "1",
+          "type": "IANA Registrar ID"
+        }
+      ],
+      "remarks": [
+        {
+          "description": [
+            "Summary data only. For complete data, send a specific query for the object."
+          ],
+          "title": "Incomplete Data",
+          "type": "object truncated due to unexplainable reasons"
+        }
+      ],
+      "roles": [
+        "registrar"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "The Registrar"
+          ]
+        ]
+      ]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "",
+      "remarks": [
+        {
+          "description": [
+            "Some of the data in this object has been removed.",
+            "Contact personal data is visible only to the owning registrar."
+          ],
+          "links": [
+            {
+              "href": "https://github.com/google/nomulus/blob/master/docs/rdap.md#authentication",
+              "rel": "alternate",
+              "type": "text/html"
+            }
+          ],
+          "title": "REDACTED FOR PRIVACY",
+          "type": "object redacted due to authorization"
+        },
+        {
+          "description": [
+            "Please query the RDDS service of the Registrar of Record identifies in this output for information on how to contact the Registrant of the queried domain name."
+          ],
+          "title": "EMAIL REDACTED FOR PRIVACY",
+          "type": "object redacted due to authorization"
+        }
+      ],
+      "roles": [
+        "administrative",
+        "technical",
+        "registrant"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            ""
+          ]
+        ]
+      ]
+    }
+  ],
+  "events": [
+    {
+      "eventAction": "registration",
+      "eventActor": "TheRegistrar",
+      "eventDate": "1998-12-31T00:00:00.000Z"
+    },
+    {
+      "eventAction": "expiration",
+      "eventDate": "2000-12-31T00:00:00.000Z"
+    },
+    {
+      "eventAction": "last update of RDAP database",
+      "eventDate": "2000-01-01T00:00:00.000Z"
+    },
+    {
+      "eventAction": "last changed",
+      "eventDate": "1999-12-31T00:00:00.000Z"
+    }
+  ],
+  "handle": "28-LOL",
+  "ldhName": "autorenew.lol",
+  "links": [
+    {
+      "href": "https://example.tld/rdap/domain/autorenew.lol",
+      "rel": "self",
+      "type": "application/rdap+json"
+    }
+  ],
+  "nameservers": [
+    {
+      "objectClassName": "nameserver",
+      "handle": "8-ROID",
+      "ldhName": "ns1.cat.lol",
+      "links": [
+        {
+          "href": "https://example.tld/rdap/nameserver/ns1.cat.lol",
+          "rel": "self",
+          "type": "application/rdap+json"
+        }
+      ],
+      "remarks": [
+        {
+          "description": [
+            "Summary data only. For complete data, send a specific query for the object."
+          ],
+          "title": "Incomplete Data",
+          "type": "object truncated due to unexplainable reasons"
+        }
+      ]
+    }
+  ],
+  "secureDNS": {
+    "delegationSigned": false,
+    "zoneSigned": true
+  },
+  "status": [
+    "active",
+    "auto renew period"
+  ]
+}

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_explicit_renew_grace_period.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_explicit_renew_grace_period.json
@@ -1,0 +1,161 @@
+{
+  "rdapConformance": [
+    "rdap_level_0",
+    "icann_rdap_response_profile_0",
+    "icann_rdap_technical_implementation_guide_0"
+  ],
+  "objectClassName": "domain",
+  "entities": [
+    {
+      "objectClassName": "entity",
+      "handle": "1",
+      "links": [
+        {
+          "href": "https://example.tld/rdap/entity/1",
+          "rel": "self",
+          "type": "application/rdap+json"
+        }
+      ],
+      "publicIds": [
+        {
+          "identifier": "1",
+          "type": "IANA Registrar ID"
+        }
+      ],
+      "remarks": [
+        {
+          "description": [
+            "Summary data only. For complete data, send a specific query for the object."
+          ],
+          "title": "Incomplete Data",
+          "type": "object truncated due to unexplainable reasons"
+        }
+      ],
+      "roles": [
+        "registrar"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "The Registrar"
+          ]
+        ]
+      ]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "",
+      "remarks": [
+        {
+          "description": [
+            "Some of the data in this object has been removed.",
+            "Contact personal data is visible only to the owning registrar."
+          ],
+          "links": [
+            {
+              "href": "https://github.com/google/nomulus/blob/master/docs/rdap.md#authentication",
+              "rel": "alternate",
+              "type": "text/html"
+            }
+          ],
+          "title": "REDACTED FOR PRIVACY",
+          "type": "object redacted due to authorization"
+        },
+        {
+          "description": [
+            "Please query the RDDS service of the Registrar of Record identifies in this output for information on how to contact the Registrant of the queried domain name."
+          ],
+          "title": "EMAIL REDACTED FOR PRIVACY",
+          "type": "object redacted due to authorization"
+        }
+      ],
+      "roles": [
+        "administrative",
+        "technical",
+        "registrant"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            ""
+          ]
+        ]
+      ]
+    }
+  ],
+  "events": [
+    {
+      "eventAction": "registration",
+      "eventActor": "TheRegistrar",
+      "eventDate": "1999-01-01T00:00:00.000Z"
+    },
+    {
+      "eventAction": "expiration",
+      "eventDate": "2001-01-01T00:00:00.000Z"
+    },
+    {
+      "eventAction": "last update of RDAP database",
+      "eventDate": "2000-01-01T00:00:00.000Z"
+    }
+  ],
+  "handle": "28-LOL",
+  "ldhName": "renew.lol",
+  "links": [
+    {
+      "href": "https://example.tld/rdap/domain/renew.lol",
+      "rel": "self",
+      "type": "application/rdap+json"
+    }
+  ],
+  "nameservers": [
+    {
+      "objectClassName": "nameserver",
+      "handle": "8-ROID",
+      "ldhName": "ns1.cat.lol",
+      "links": [
+        {
+          "href": "https://example.tld/rdap/nameserver/ns1.cat.lol",
+          "rel": "self",
+          "type": "application/rdap+json"
+        }
+      ],
+      "remarks": [
+        {
+          "description": [
+            "Summary data only. For complete data, send a specific query for the object."
+          ],
+          "title": "Incomplete Data",
+          "type": "object truncated due to unexplainable reasons"
+        }
+      ]
+    }
+  ],
+  "secureDNS": {
+    "delegationSigned": false,
+    "zoneSigned": true
+  },
+  "status": [
+    "active",
+    "renew period"
+  ]
+}

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_pending_delete_redemption_grace_period.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_pending_delete_redemption_grace_period.json
@@ -1,0 +1,161 @@
+{
+  "rdapConformance": [
+    "rdap_level_0",
+    "icann_rdap_response_profile_0",
+    "icann_rdap_technical_implementation_guide_0"
+  ],
+  "objectClassName": "domain",
+  "entities": [
+    {
+      "objectClassName": "entity",
+      "handle": "1",
+      "links": [
+        {
+          "href": "https://example.tld/rdap/entity/1",
+          "rel": "self",
+          "type": "application/rdap+json"
+        }
+      ],
+      "publicIds": [
+        {
+          "identifier": "1",
+          "type": "IANA Registrar ID"
+        }
+      ],
+      "remarks": [
+        {
+          "description": [
+            "Summary data only. For complete data, send a specific query for the object."
+          ],
+          "title": "Incomplete Data",
+          "type": "object truncated due to unexplainable reasons"
+        }
+      ],
+      "roles": [
+        "registrar"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "The Registrar"
+          ]
+        ]
+      ]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "",
+      "remarks": [
+        {
+          "description": [
+            "Some of the data in this object has been removed.",
+            "Contact personal data is visible only to the owning registrar."
+          ],
+          "links": [
+            {
+              "href": "https://github.com/google/nomulus/blob/master/docs/rdap.md#authentication",
+              "rel": "alternate",
+              "type": "text/html"
+            }
+          ],
+          "title": "REDACTED FOR PRIVACY",
+          "type": "object redacted due to authorization"
+        },
+        {
+          "description": [
+            "Please query the RDDS service of the Registrar of Record identifies in this output for information on how to contact the Registrant of the queried domain name."
+          ],
+          "title": "EMAIL REDACTED FOR PRIVACY",
+          "type": "object redacted due to authorization"
+        }
+      ],
+      "roles": [
+        "administrative",
+        "technical",
+        "registrant"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            ""
+          ]
+        ]
+      ]
+    }
+  ],
+  "events": [
+    {
+      "eventAction": "registration",
+      "eventActor": "TheRegistrar",
+      "eventDate": "1999-01-01T00:00:00.000Z"
+    },
+    {
+      "eventAction": "expiration",
+      "eventDate": "294247-01-10T04:00:54.775Z"
+    },
+    {
+      "eventAction": "last update of RDAP database",
+      "eventDate": "2000-01-01T00:00:00.000Z"
+    }
+  ],
+  "handle": "28-LOL",
+  "ldhName": "redemption.lol",
+  "links": [
+    {
+      "href": "https://example.tld/rdap/domain/redemption.lol",
+      "rel": "self",
+      "type": "application/rdap+json"
+    }
+  ],
+  "nameservers": [
+    {
+      "objectClassName": "nameserver",
+      "handle": "8-ROID",
+      "ldhName": "ns1.cat.lol",
+      "links": [
+        {
+          "href": "https://example.tld/rdap/nameserver/ns1.cat.lol",
+          "rel": "self",
+          "type": "application/rdap+json"
+        }
+      ],
+      "remarks": [
+        {
+          "description": [
+            "Summary data only. For complete data, send a specific query for the object."
+          ],
+          "title": "Incomplete Data",
+          "type": "object truncated due to unexplainable reasons"
+        }
+      ]
+    }
+  ],
+  "secureDNS": {
+    "delegationSigned": false,
+    "zoneSigned": true
+  },
+  "status": [
+    "pending delete",
+    "redemption period"
+  ]
+}

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_transfer_grace_period.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_transfer_grace_period.json
@@ -1,0 +1,161 @@
+{
+  "rdapConformance": [
+    "rdap_level_0",
+    "icann_rdap_response_profile_0",
+    "icann_rdap_technical_implementation_guide_0"
+  ],
+  "objectClassName": "domain",
+  "entities": [
+    {
+      "objectClassName": "entity",
+      "handle": "1",
+      "links": [
+        {
+          "href": "https://example.tld/rdap/entity/1",
+          "rel": "self",
+          "type": "application/rdap+json"
+        }
+      ],
+      "publicIds": [
+        {
+          "identifier": "1",
+          "type": "IANA Registrar ID"
+        }
+      ],
+      "remarks": [
+        {
+          "description": [
+            "Summary data only. For complete data, send a specific query for the object."
+          ],
+          "title": "Incomplete Data",
+          "type": "object truncated due to unexplainable reasons"
+        }
+      ],
+      "roles": [
+        "registrar"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            "The Registrar"
+          ]
+        ]
+      ]
+    },
+    {
+      "objectClassName": "entity",
+      "handle": "",
+      "remarks": [
+        {
+          "description": [
+            "Some of the data in this object has been removed.",
+            "Contact personal data is visible only to the owning registrar."
+          ],
+          "links": [
+            {
+              "href": "https://github.com/google/nomulus/blob/master/docs/rdap.md#authentication",
+              "rel": "alternate",
+              "type": "text/html"
+            }
+          ],
+          "title": "REDACTED FOR PRIVACY",
+          "type": "object redacted due to authorization"
+        },
+        {
+          "description": [
+            "Please query the RDDS service of the Registrar of Record identifies in this output for information on how to contact the Registrant of the queried domain name."
+          ],
+          "title": "EMAIL REDACTED FOR PRIVACY",
+          "type": "object redacted due to authorization"
+        }
+      ],
+      "roles": [
+        "administrative",
+        "technical",
+        "registrant"
+      ],
+      "vcardArray": [
+        "vcard",
+        [
+          [
+            "version",
+            {},
+            "text",
+            "4.0"
+          ],
+          [
+            "fn",
+            {},
+            "text",
+            ""
+          ]
+        ]
+      ]
+    }
+  ],
+  "events": [
+    {
+      "eventAction": "registration",
+      "eventActor": "TheRegistrar",
+      "eventDate": "1999-07-01T00:00:00.000Z"
+    },
+    {
+      "eventAction": "expiration",
+      "eventDate": "2001-01-01T00:00:00.000Z"
+    },
+    {
+      "eventAction": "last update of RDAP database",
+      "eventDate": "2000-01-01T00:00:00.000Z"
+    }
+  ],
+  "handle": "28-LOL",
+  "ldhName": "transfer.lol",
+  "links": [
+    {
+      "href": "https://example.tld/rdap/domain/transfer.lol",
+      "rel": "self",
+      "type": "application/rdap+json"
+    }
+  ],
+  "nameservers": [
+    {
+      "objectClassName": "nameserver",
+      "handle": "8-ROID",
+      "ldhName": "ns1.cat.lol",
+      "links": [
+        {
+          "href": "https://example.tld/rdap/nameserver/ns1.cat.lol",
+          "rel": "self",
+          "type": "application/rdap+json"
+        }
+      ],
+      "remarks": [
+        {
+          "description": [
+            "Summary data only. For complete data, send a specific query for the object."
+          ],
+          "title": "Incomplete Data",
+          "type": "object truncated due to unexplainable reasons"
+        }
+      ]
+    }
+  ],
+  "secureDNS": {
+    "delegationSigned": false,
+    "zoneSigned": true
+  },
+  "status": [
+    "active",
+    "transfer period"
+  ]
+}


### PR DESCRIPTION
We do this for WHOIS results so we should do it for RDAP results as well (especially since they're mostly already included in the response profile).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2606)
<!-- Reviewable:end -->
