### PR TITLE
Lowercase CreateCdnsTld DNSSEC params

### DIFF
--- a/core/src/main/java/google/registry/tools/CreateCdnsTld.java
+++ b/core/src/main/java/google/registry/tools/CreateCdnsTld.java
@@ -76,7 +76,7 @@ final class CreateCdnsTld extends ConfirmingCommand {
                 : "cloud-dns-registry-test")
             .setDnsName(dnsName)
             .setName((name != null) ? name : dnsName)
-            .setDnssecConfig(new ManagedZoneDnsSecConfig().setNonExistence("NSEC").setState("ON"));
+            .setDnssecConfig(new ManagedZoneDnsSecConfig().setNonExistence("nsec").setState("on"));
   }
 
   @Override

--- a/core/src/test/java/google/registry/tools/CreateCdnsTldTest.java
+++ b/core/src/test/java/google/registry/tools/CreateCdnsTldTest.java
@@ -55,7 +55,7 @@ class CreateCdnsTldTest extends CommandTestCase<CreateCdnsTld> {
         .setDnsName(dnsName)
         .setDescription(description)
         .setName(name)
-        .setDnssecConfig(new ManagedZoneDnsSecConfig().setState("ON").setNonExistence("NSEC"));
+        .setDnssecConfig(new ManagedZoneDnsSecConfig().setState("on").setNonExistence("nsec"));
   }
 
   @Test


### PR DESCRIPTION
From here https://cloud.google.com/dns/docs/reference/rest/v1/managedZones#ManagedZone.DnsSecConfig

Allowed values for state in ["off", "on", "transfer"];
Allowed values for nonExistence in ["nsec", "nsec3"];

Currently getting the following errors when using this command:

 "errors": [
    {
      "message": "Invalid value at 'managed_zone.dnssec_config.non_existence' (type.googleapis.com/cloud.dns.api.v1.NonExistenceType), \"NSEC\"\nInvalid value at 'managed_zone.dnssec_config.state' (type.googleapis.com/cloud.dns.api.v1.ManagedZone.DnsSecConfig.State), \"ON\"",
      "reason": "invalid"
    }
  ],