### PR TITLE
Use sql instance name in SecretManager

### DIFF
--- a/core/src/main/java/google/registry/config/RegistryConfig.java
+++ b/core/src/main/java/google/registry/config/RegistryConfig.java
@@ -385,27 +385,6 @@ public final class RegistryConfig {
     }
 
     @Provides
-    @Config("cloudSqlInstanceConnectionName")
-    public static String provideCloudSqlInstanceConnectionName(RegistryConfigSettings config) {
-      return config.cloudSql.instanceConnectionName;
-    }
-
-    @Provides
-    @Config("cloudSqlReplicaInstanceConnectionName")
-    public static Optional<String> provideCloudSqlReplicaInstanceConnectionName(
-        RegistryConfigSettings config) {
-      return Optional.ofNullable(config.cloudSql.replicaInstanceConnectionName);
-    }
-
-    @Provides
-    @Config("cloudSqlDbInstanceName")
-    public static String provideCloudSqlDbInstance(RegistryConfigSettings config) {
-      // Format of instanceConnectionName: project-id:region:instance-name
-      int lastColonIndex = config.cloudSql.instanceConnectionName.lastIndexOf(':');
-      return config.cloudSql.instanceConnectionName.substring(lastColonIndex + 1);
-    }
-
-    @Provides
     @Config("cloudDnsRootUrl")
     public static Optional<String> getCloudDnsRootUrl(RegistryConfigSettings config) {
       return Optional.ofNullable(config.cloudDns.rootUrl);

--- a/core/src/main/java/google/registry/config/RegistryConfigSettings.java
+++ b/core/src/main/java/google/registry/config/RegistryConfigSettings.java
@@ -133,7 +133,7 @@ public class RegistryConfigSettings {
   /** Configuration for Cloud SQL. */
   public static class CloudSql {
     public String jdbcUrl;
-    // TODO(05012021): remove username field after it is removed from all yaml files.
+    // TODO(05012021): remove 3 fields below after they are removed from all yaml files.
     public String username;
     public String instanceConnectionName;
     public String replicaInstanceConnectionName;

--- a/core/src/main/java/google/registry/keyring/KeyringModule.java
+++ b/core/src/main/java/google/registry/keyring/KeyringModule.java
@@ -21,6 +21,7 @@ import dagger.Provides;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.keyring.api.Keyring;
 import java.util.Map;
+import java.util.Optional;
 import javax.inject.Singleton;
 
 /** Dagger module for {@link Keyring} */
@@ -37,5 +38,26 @@ public final class KeyringModule {
         activeKeyring,
         keyrings.keySet());
     return keyrings.get(activeKeyring);
+  }
+
+  @Provides
+  @Config("cloudSqlInstanceConnectionName")
+  public static String provideCloudSqlInstanceConnectionName(Keyring keyring) {
+    return keyring.getSqlPrimaryConnectionName();
+  }
+
+  @Provides
+  @Config("cloudSqlReplicaInstanceConnectionName")
+  public static Optional<String> provideCloudSqlReplicaInstanceConnectionName(Keyring keyring) {
+    return Optional.ofNullable(keyring.getSqlReplicaConnectionName());
+  }
+
+  @Provides
+  @Config("cloudSqlDbInstanceName")
+  public static String provideCloudSqlDbInstance(
+      @Config("cloudSqlInstanceConnectionName") String instanceConnectionName) {
+    // Format of instanceConnectionName: project-id:region:instance-name
+    int lastColonIndex = instanceConnectionName.lastIndexOf(':');
+    return instanceConnectionName.substring(lastColonIndex + 1);
   }
 }

--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -34,10 +34,13 @@ import dagger.BindsOptionalOf;
 import dagger.Module;
 import dagger.Provides;
 import google.registry.config.RegistryConfig.Config;
+import google.registry.keyring.KeyringModule;
+import google.registry.keyring.api.DummyKeyringModule;
 import google.registry.persistence.transaction.CloudSqlCredentialSupplier;
 import google.registry.persistence.transaction.JpaTransactionManager;
 import google.registry.persistence.transaction.JpaTransactionManagerImpl;
 import google.registry.persistence.transaction.TransactionManager;
+import google.registry.privileges.secretmanager.SecretManagerModule;
 import google.registry.privileges.secretmanager.SqlCredential;
 import google.registry.privileges.secretmanager.SqlCredentialStore;
 import google.registry.privileges.secretmanager.SqlUser;
@@ -63,7 +66,7 @@ import javax.inject.Singleton;
 import org.hibernate.cfg.Environment;
 
 /** Dagger module class for the persistence layer. */
-@Module
+@Module(includes = {KeyringModule.class, SecretManagerModule.class, DummyKeyringModule.class})
 public abstract class PersistenceModule {
 
   // This name must be the same as the one defined in persistence.xml.


### PR DESCRIPTION
Tested: In crash, deployed the nomulus server, and tested the get_sql_credential command.

Note: new SecretManager entries have been added in all environments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2625)
<!-- Reviewable:end -->
