### PR TITLE
Enable nested transaction warning in production

### DIFF
--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -71,6 +71,7 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -177,9 +178,9 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
       if (!getHibernateAllowNestedTransactions()) {
         throw new IllegalStateException(NESTED_TRANSACTION_MESSAGE);
       }
-      if (RegistryEnvironment.get() != RegistryEnvironment.PRODUCTION
-          && RegistryEnvironment.get() != RegistryEnvironment.UNITTEST) {
-        logger.atWarning().withStackTrace(StackSize.MEDIUM).log(NESTED_TRANSACTION_MESSAGE);
+      if (RegistryEnvironment.get() != RegistryEnvironment.UNITTEST) {
+        logger.atWarning().withStackTrace(StackSize.MEDIUM).atMostEvery(1, TimeUnit.MINUTES).log(
+            NESTED_TRANSACTION_MESSAGE);
       }
       // This prevents inner transaction from retrying, thus avoiding a cascade retry effect.
       return transactNoRetry(isolationLevel, work);


### PR DESCRIPTION
Knonw nested transact calls that are not using the `reTransact` method have been refactored away in Sandbox. Enable logging in production to catch any missing cases. Logging is throttled at 1 message per minute per VM.

Once production is cleaned up, we will forbid such transactions in the code, and start factoring away the `reTransact` method.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2628)
<!-- Reviewable:end -->
