### PR TITLE
Fix keyring in BEAM pipeline

### DIFF
--- a/core/src/main/java/google/registry/persistence/PersistenceModule.java
+++ b/core/src/main/java/google/registry/persistence/PersistenceModule.java
@@ -36,6 +36,7 @@ import dagger.Provides;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.keyring.KeyringModule;
 import google.registry.keyring.api.DummyKeyringModule;
+import google.registry.keyring.secretmanager.SecretManagerKeyringModule;
 import google.registry.persistence.transaction.CloudSqlCredentialSupplier;
 import google.registry.persistence.transaction.JpaTransactionManager;
 import google.registry.persistence.transaction.JpaTransactionManagerImpl;
@@ -66,7 +67,14 @@ import javax.inject.Singleton;
 import org.hibernate.cfg.Environment;
 
 /** Dagger module class for the persistence layer. */
-@Module(includes = {KeyringModule.class, SecretManagerModule.class, DummyKeyringModule.class})
+// TODO(b/388835696): Use SecreteManagerKeyring in all environments and drop the `includes` below.
+@Module(
+    includes = {
+      KeyringModule.class,
+      SecretManagerModule.class,
+      DummyKeyringModule.class,
+      SecretManagerKeyringModule.class
+    })
 public abstract class PersistenceModule {
 
   // This name must be the same as the one defined in persistence.xml.


### PR DESCRIPTION
SecretManager based keyring not included in keyring bindings, resulting in runtime failure.

We should simply keyring bindings. There is no use case for multiple implementations. See b/388835696.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2632)
<!-- Reviewable:end -->
