### PR TITLE
Add a redirect for the console bare domain

### DIFF
--- a/jetty/kubernetes/gateway/nomulus-route-console.yaml
+++ b/jetty/kubernetes/gateway/nomulus-route-console.yaml
@@ -11,6 +11,9 @@ spec:
   rules:
   - matches:
     - path:
+        type: Exact
+        value: /
+    - path:
         type: PathPrefix
         value: /console-api
     - path:
@@ -22,6 +25,12 @@ spec:
       name: console
       port: 80
   - matches:
+    - path:
+        type: Exact
+        value: /
+      headers:
+      - name: "canary"
+        value: "true"
     - path:
         type: PathPrefix
         value: /console-api

--- a/jetty/src/main/jetty-base/webapps/root/index.html
+++ b/jetty/src/main/jetty-base/webapps/root/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta http-equiv="refresh" content="0;URL=/console">
+<title>Nomulus</title>
+<body lang="en-US">
+If this page doesn't change automatically, please click <a href="/console">here</a>


### PR DESCRIPTION
This allows us to access the console at console.[basedomain] instead of console.[basedomain]/console. Although most users probably will stick with using the /console path in their requests, it could save some time and mental energy having to remember to type /console every time.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2633)
<!-- Reviewable:end -->
