### PR TITLE
Expose Web WHOIS redirects

### DIFF
--- a/jetty/kubernetes/nomulus-pubapi.yaml
+++ b/jetty/kubernetes/nomulus-pubapi.yaml
@@ -38,6 +38,10 @@ spec:
         ports:
         - containerPort: 30001
           name: whois
+        - containerPort: 30010
+          name: http-whois
+        - containerPort: 30011
+          name: https-whois
         resources:
           requests:
             cpu: "500m"
@@ -104,6 +108,12 @@ spec:
   - port: 43
     targetPort: whois
     name: whois
+  - port: 80
+    targetPort: http-whois
+    name: http-whois
+  - port: 443
+    targetPort: https-whois
+    name: https-whois
 ---
 apiVersion: net.gke.io/v1
 kind: ServiceExport


### PR DESCRIPTION
We are required to respond to HTTP(S) requests on port 80/443 on the
same domain where we serve port 43 WHOIS requests. The proxy already
does this by redirecting to the web WHOIS lookup page on the marketing
website.

This PR makes it so that requests to port 80/443 can be routed to the
proxy for redirect.

TESTED=tested on crash and the redirect works.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2634)
<!-- Reviewable:end -->
