### PR TITLE
Record http request parameters in log metadata

### DIFF
--- a/core/src/main/java/google/registry/module/RegistryServlet.java
+++ b/core/src/main/java/google/registry/module/RegistryServlet.java
@@ -14,7 +14,9 @@
 
 package google.registry.module;
 
+import static google.registry.util.GcpJsonFormatter.setCurrentRequest;
 import static google.registry.util.GcpJsonFormatter.setCurrentTraceId;
+import static google.registry.util.GcpJsonFormatter.unsetCurrentRequest;
 import static google.registry.util.RandomStringGenerator.insecureRandomStringGenerator;
 import static google.registry.util.StringGenerator.Alphabets.HEX_DIGITS_ONLY;
 
@@ -67,10 +69,16 @@ public class RegistryServlet extends ServletBase {
   @Override
   public void service(HttpServletRequest req, HttpServletResponse rsp) throws IOException {
     setCurrentTraceId(traceId());
+    String requestMethod = req.getMethod();
+    String requestUrl = req.getRequestURI();
+    String userAgent = String.valueOf(req.getHeader("User-Agent"));
+    String protocol = req.getProtocol();
+    setCurrentRequest(requestMethod, requestUrl, userAgent, protocol);
     try {
       super.service(req, rsp);
     } finally {
       setCurrentTraceId(null);
+      unsetCurrentRequest();
     }
   }
 

--- a/core/src/main/java/google/registry/tools/RegistryCli.java
+++ b/core/src/main/java/google/registry/tools/RegistryCli.java
@@ -43,7 +43,8 @@ import org.postgresql.util.PSQLException;
 final class RegistryCli implements CommandRunner {
 
   private static final ImmutableSet<RegistryToolEnvironment> DEFAULT_GKE_ENVIRONMENTS =
-      ImmutableSet.of(RegistryToolEnvironment.ALPHA, RegistryToolEnvironment.QA);
+      ImmutableSet.of(
+          RegistryToolEnvironment.ALPHA, RegistryToolEnvironment.CRASH, RegistryToolEnvironment.QA);
 
   // The environment parameter is parsed twice: once here, and once with {@link
   // RegistryToolEnvironment#parseFromArgs} in the {@link RegistryTool#main} function.


### PR DESCRIPTION
This allows us to search for logs for a given path using a filter like
this:

jsonPayload.httpRequest.requestUrl="/_dr/blah"

TESTED=tested on crash

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2642)
<!-- Reviewable:end -->
