### PR TITLE
Fix loss of error info in UrlConnectionException

### DIFF
--- a/util/src/main/java/google/registry/util/UrlConnectionException.java
+++ b/util/src/main/java/google/registry/util/UrlConnectionException.java
@@ -37,13 +37,14 @@ public class UrlConnectionException extends RuntimeException {
   @Override
   public String getMessage() {
     byte[] resultContent;
-    int responseCode;
+    int responseCode = 0;
     try {
-      resultContent = ByteStreams.toByteArray(connection.getInputStream());
       responseCode = connection.getResponseCode();
-    } catch (IOException e) {
-      resultContent = new byte[] {};
-      responseCode = 0;
+      resultContent =
+          ByteStreams.toByteArray(
+              responseCode < 400 ? connection.getInputStream() : connection.getErrorStream());
+    } catch (IOException | NullPointerException e) {
+      resultContent = "-- Response is missing or has malformed content --".getBytes(UTF_8);
     }
     StringBuilder result =
         new StringBuilder(2048 + resultContent.length)


### PR DESCRIPTION
It does not get the error message for 400+ status codes.

It fails to get the status code if the response has neither data nor error.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2648)
<!-- Reviewable:end -->
