### PR TITLE
Handle SPECIFIED renewal price w/token in check flow

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainPricingLogic.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainPricingLogic.java
@@ -287,6 +287,9 @@ public final class DomainPricingLogic {
           || token.getRenewalPriceBehavior().equals(RenewalPriceBehavior.NONPREMIUM)) {
         return tld.getStandardRenewCost(dateTime).multipliedBy(years);
       }
+      if (token.getRenewalPriceBehavior().equals(RenewalPriceBehavior.SPECIFIED)) {
+        return token.getRenewalPrice().get();
+      }
     }
     return getDomainCostWithDiscount(
         domainPrices.isPremium(),

--- a/core/src/test/java/google/registry/flows/domain/DomainPricingLogicTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainPricingLogicTest.java
@@ -1242,4 +1242,23 @@ public class DomainPricingLogicTest {
                 .addFeeOrCredit(Fee.create(new BigDecimal("120.00"), CREATE, true))
                 .build());
   }
+
+  @Test
+  void testDomainRenewPrice_specifiedToken() throws Exception {
+    AllocationToken allocationToken =
+        persistResource(
+            new AllocationToken.Builder()
+                .setToken("abc123")
+                .setTokenType(SINGLE_USE)
+                .setDomainName("premium.example")
+                .setRenewalPriceBehavior(SPECIFIED)
+                .setRenewalPrice(Money.of(USD, 5))
+                .build());
+    assertThat(
+            domainPricingLogic
+                .getRenewPrice(
+                    tld, "premium.example", clock.nowUtc(), 1, null, Optional.of(allocationToken))
+                .getRenewCost())
+        .isEqualTo(Money.of(USD, 5));
+  }
 }


### PR DESCRIPTION
This is kinda nonsensical because this use case is trying to apply a single use token multiple times in the same domain:check request -- like, trying to use a single-use token for both create, renew, and transfer while having a $0 create price and a premium renewal price.

This change doesn't affect any actual business / costs, since SPECIFIED token renewal prices were already set on the BillingRecurrence

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2651)
<!-- Reviewable:end -->
