### PR TITLE
Allow for no fee extension with free premium domains

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/FeesAndCredits.java
+++ b/core/src/main/java/google/registry/flows/domain/FeesAndCredits.java
@@ -64,7 +64,7 @@ public class FeesAndCredits extends ImmutableObject implements Buildable {
   }
 
   public boolean hasAnyPremiumFees() {
-    return fees.stream().anyMatch(BaseFee::isPremium);
+    return fees.stream().anyMatch(fee -> fee.isPremium() && !fee.hasZeroCost());
   }
 
   /** Returns the create cost for the event. */

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -1742,6 +1742,27 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   }
 
   @Test
+  void testSuccess_token_premiumDomainZeroPrice_noFeeExtension() throws Exception {
+    createTld("example");
+    persistContactsAndHosts();
+    persistResource(
+        new AllocationToken.Builder()
+            .setToken("abc123")
+            .setTokenType(SINGLE_USE)
+            .setDiscountFraction(1)
+            .setDiscountPremiums(true)
+            .setDomainName("rich.example")
+            .build());
+    setEppInput(
+        "domain_create_allocationtoken.xml",
+        ImmutableMap.of("YEARS", "1", "DOMAIN", "rich.example"));
+    // The response should be the standard successful create response, but with 1 year instead of 2
+    runFlowAssertResponse(
+        loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "rich.example"))
+            .replace("2001", "2000"));
+  }
+
+  @Test
   void testFailure_promotionNotActive() {
     persistContactsAndHosts();
     persistResource(


### PR DESCRIPTION
This isn't a situation we'll encounter often, but if the client has an allocation token that's valid for premium domains that gives a 0 cost, we shouldn't require them to include the fee extension when creating the domain. We already don't require it for standard domains.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2660)
<!-- Reviewable:end -->
