### PR TITLE
Fix GCB failures

### DIFF
--- a/release/cloudbuild-release.yaml
+++ b/release/cloudbuild-release.yaml
@@ -235,6 +235,7 @@ steps:
   - -c
   - |
     set -e
+    rm -rf gcompute-tools
     cp -rf nomulus-release/.git .
     rm -rf nomulus-release
     git config --global user.name "Cloud Build"


### PR DESCRIPTION
We start seeing failures such as this one:

https://pantheon.corp.google.com/cloud-build/builds;region=global/843b9bd7-9c09-4221-ae4c-6e2dd2918f04?inv=1&invt=Aborfg&project=domain-registry-alpha

It looks like the inclusion of gcompute-module which itself is a git repo caused the problem. I don't understand why it wasn't an issue before. My guess is that GCB started using a newer version of git which is more strict about this.