### PR TITLE
Let nomulus tool connect to sandbox GKE by default

### DIFF
--- a/core/src/main/java/google/registry/tools/RegistryCli.java
+++ b/core/src/main/java/google/registry/tools/RegistryCli.java
@@ -44,7 +44,10 @@ final class RegistryCli implements CommandRunner {
 
   private static final ImmutableSet<RegistryToolEnvironment> DEFAULT_GKE_ENVIRONMENTS =
       ImmutableSet.of(
-          RegistryToolEnvironment.ALPHA, RegistryToolEnvironment.CRASH, RegistryToolEnvironment.QA);
+          RegistryToolEnvironment.ALPHA,
+          RegistryToolEnvironment.CRASH,
+          RegistryToolEnvironment.QA,
+          RegistryToolEnvironment.SANDBOX);
 
   // The environment parameter is parsed twice: once here, and once with {@link
   // RegistryToolEnvironment#parseFromArgs} in the {@link RegistryTool#main} function.

--- a/jetty/deploy-nomulus-for-env.sh
+++ b/jetty/deploy-nomulus-for-env.sh
@@ -52,11 +52,6 @@ for service in frontend backend console pubapi
 do
   sed s/BASE_DOMAIN/"${base_domain}"/g "./kubernetes/gateway/nomulus-route-${service}.yaml" | \
   kubectl apply -f -
-  # Don't enable IAP on pubapi.
-  if [[ "${service}" == pubapi ]]
-  then
-    continue
-  fi
   sed s/SERVICE/"${service}"/g "./kubernetes/gateway/nomulus-backend-policy-${environment}.yaml" | \
   kubectl apply -f -
   sed s/SERVICE/"${service}-canary"/g "./kubernetes/gateway/nomulus-backend-policy-${environment}.yaml" | \

--- a/jetty/kubernetes/nomulus-backend.yaml
+++ b/jetty/kubernetes/nomulus-backend.yaml
@@ -27,6 +27,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: JETTY_WORKER_INSTANCE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: NAMESPACE_ID
           valueFrom:
             fieldRef:

--- a/jetty/kubernetes/nomulus-console.yaml
+++ b/jetty/kubernetes/nomulus-console.yaml
@@ -27,6 +27,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: JETTY_WORKER_INSTANCE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: NAMESPACE_ID
           valueFrom:
             fieldRef:

--- a/jetty/kubernetes/nomulus-frontend.yaml
+++ b/jetty/kubernetes/nomulus-frontend.yaml
@@ -27,6 +27,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: JETTY_WORKER_INSTANCE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: NAMESPACE_ID
           valueFrom:
             fieldRef:

--- a/jetty/kubernetes/nomulus-pubapi.yaml
+++ b/jetty/kubernetes/nomulus-pubapi.yaml
@@ -27,6 +27,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: JETTY_WORKER_INSTANCE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: NAMESPACE_ID
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Also set the `JETTY_WORKER_INSTANCE` variable so each pod is guaranteed to get a unique session cookie.

Jetty documentation says to use [`JETTY_WORKER_NAME`](https://jetty.org/docs/jetty/12/programming-guide/server/session.html#defaultidmgr), but the source code actually use [`JETTY_WORKER_INSTANCE`](https://sourcegraph.com/github.com/jetty/jetty.project/-/blob/jetty-core/jetty-session/src/main/java/org/eclipse/jetty/session/DefaultSessionIdManager.java?L314). I tested and the latter is indeed used.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2674)
<!-- Reviewable:end -->
