### PR TITLE
Fix console user creation role param

### DIFF
--- a/core/src/main/java/google/registry/ui/server/console/ConsoleUsersAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleUsersAction.java
@@ -225,7 +225,8 @@ public class ConsoleUsersAction extends ConsoleApiAction {
 
     UserRoles userRoles =
         new UserRoles.Builder()
-            .setRegistrarRoles(ImmutableMap.of(registrarId, ACCOUNT_MANAGER))
+            .setRegistrarRoles(
+                ImmutableMap.of(registrarId, RegistrarRole.valueOf(userData.get().role)))
             .build();
 
     User.Builder builder = new User.Builder().setUserRoles(userRoles).setEmailAddress(newEmail);


### PR DESCRIPTION
Discovered this during testing. I think it slipped through the cracks after one of the updates to the screen 