### PR TITLE
Abort schema verifier when pg_dump fails

### DIFF
--- a/release/schema-verifier/verify_deployed_sql_schema.sh
+++ b/release/schema-verifier/verify_deployed_sql_schema.sh
@@ -69,6 +69,14 @@ PGPASSWORD=${db_password} pg_dump -h localhost -U "${db_user}" \
     --exclude-table flyway_schema_history \
     postgres
 
+if [ $? -ne 0 ]; then
+  echo "Failed to dump schema."
+  exit 1
+else
+  echo "Schema dumped."
+fi
+
+
 raw_diff=$(diff /schema/nomulus.golden.sql /schema/nomulus.actual.sql)
 # Clean up the raw_diff:
 # - Remove diff locations (e.g. "5,6c5,6): grep "^[<>]"


### PR DESCRIPTION
Failed pg_dump may not leave a file, failing the subsequent diffing and causing the verifier to return success.

The verifier should abort in this case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2681)
<!-- Reviewable:end -->
