### PR TITLE
Log transaction durations

### DIFF
--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -276,6 +276,10 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
       }
       T result = work.call();
       txn.commit();
+      long duration = clock.nowUtc().getMillis() - txnInfo.transactionTime.getMillis();
+      if (duration >= 100) {
+        logger.atInfo().log("Transaction duration: %d milliseconds", duration);
+      }
       return result;
     } catch (Throwable e) {
       // Catch a Throwable here so even Errors would lead to a rollback.


### PR DESCRIPTION
There can be delays in releasing predicate locks when we have transactions that are long-lived -- even delays in releasing predicate locks acquired by shorter-lived transactions. Logging the transaction duration will allow us to get a sense as to transaction durations during busy times.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2682)
<!-- Reviewable:end -->
