### PR TITLE
Add an annotation to the deployment

### DIFF
--- a/jetty/kubernetes/gateway/nomulus-gateway.yaml
+++ b/jetty/kubernetes/gateway/nomulus-gateway.yaml
@@ -4,6 +4,11 @@ metadata:
   name: nomulus
 spec:
   gatewayClassName: gke-l7-global-external-managed-mc
+  addresses:
+  - type: NamedAddress
+    value: nomulus-ipv4-address
+  - type: NamedAddress
+    value: nomulus-ipv6-address
   listeners:
   - name: http
     protocol: HTTP

--- a/jetty/kubernetes/nomulus-backend.yaml
+++ b/jetty/kubernetes/nomulus-backend.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: backend
+  annotations:
+    tag: "latest"
 spec:
   selector:
     matchLabels:

--- a/jetty/kubernetes/nomulus-console.yaml
+++ b/jetty/kubernetes/nomulus-console.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: console
+  annotations:
+    tag: "latest"
 spec:
   selector:
     matchLabels:

--- a/jetty/kubernetes/nomulus-frontend.yaml
+++ b/jetty/kubernetes/nomulus-frontend.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
+  annotations:
+    tag: "latest"
 spec:
   selector:
     matchLabels:

--- a/jetty/kubernetes/nomulus-pubapi.yaml
+++ b/jetty/kubernetes/nomulus-pubapi.yaml
@@ -2,6 +2,8 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pubapi
+  annotations:
+    tag: "latest"
 spec:
   selector:
     matchLabels:

--- a/release/cloudbuild-release.yaml
+++ b/release/cloudbuild-release.yaml
@@ -188,6 +188,7 @@ steps:
       do
         # non-canary
         sed s/GCP_PROJECT/${PROJECT_ID}/g ./jetty/kubernetes/nomulus-${service}.yaml | \
+          sed s/latest/${TAG_NAME}/g | \
           sed s/ENVIRONMENT/${env}/g | \
           sed s/PROXY_ENV/"${env}"/g | \
           sed s/EPP/"epp"/g > ./jetty/kubernetes/nomulus-${env}-${service}.yaml
@@ -203,6 +204,7 @@ steps:
         fi
         # canary
         sed s/GCP_PROJECT/${PROJECT_ID}/g ./jetty/kubernetes/nomulus-${service}.yaml | \
+          sed s/latest/${TAG_NAME}/g | \
           sed s/ENVIRONMENT/${env}/g | \
           sed s/PROXY_ENV/"${env}_canary"/g | \
           sed s/EPP/"epp-canary"/g | \


### PR DESCRIPTION
This allows us to easily tell which tag was deployed.

Also set the gateway to use named address so they are stable, and so
that we can attach an IPv6 record to it. Auto-provisioned addresses are
IPv4 only.
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2683)
<!-- Reviewable:end -->
