### PR TITLE
Make it possible to ignore comment lines when comparing schemas

### DIFF
--- a/db/src/test/java/google/registry/sql/flyway/SchemaTest.java
+++ b/db/src/test/java/google/registry/sql/flyway/SchemaTest.java
@@ -115,6 +115,7 @@ class SchemaTest {
             Joiner.on(File.separatorChar).join(MOUNTED_RESOURCE_PATH, DUMP_OUTPUT_FILE));
 
     assertThat(dumpedSchema)
+        .ignoringLinesThatStartWith("--")
         .hasSameContentAs(Resources.getResource("sql/schema/nomulus.golden.sql"));
   }
 


### PR DESCRIPTION
We now pin to postgreSQL v17 when running tests, which means that minor
version might increase without our intervention. This causes (at least)
the comment in the golden schema to change, and failing the test as a
result.

This PR adds the ability to strip lines that we deem as comment from the
comparison, so we don't have to do trivial upgrades to the gold schema
whenever there's minor version upgrade.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2690)
<!-- Reviewable:end -->
