### PR TITLE
Reduce log level to info when no email is found from the OIDC token

### DIFF
--- a/core/src/main/java/google/registry/request/auth/OidcTokenAuthenticationMechanism.java
+++ b/core/src/main/java/google/registry/request/auth/OidcTokenAuthenticationMechanism.java
@@ -106,7 +106,7 @@ public abstract class OidcTokenAuthenticationMechanism implements Authentication
 
     String email = (String) token.getPayload().get("email");
     if (email == null) {
-      logger.atWarning().log("No email address from the OIDC token:\n%s", token.getPayload());
+      logger.atInfo().log("No email address from the OIDC token:\n%s", token.getPayload());
       return AuthResult.NOT_AUTHENTICATED;
     }
     Optional<User> maybeUser =


### PR DESCRIPTION
This can happen on public endpoints (in pubapi) where the service is
behind IAP but all users (including not-logged-in ones) are allowed. IAP
will add an OIDC token with no email field in the request header.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2694)
<!-- Reviewable:end -->
