### PR TITLE
Add headers to record WHOIS client IPs

### DIFF
--- a/proxy/deploy-proxy-for-env.sh
+++ b/proxy/deploy-proxy-for-env.sh
@@ -40,7 +40,8 @@ do
     kubectl apply -f -
     kubectl apply -f "./kubernetes/proxy-service-canary.yaml" --force
   fi
-  # Kills all running pods, new pods created will be pulling the new image.
-  kubectl delete pods --all
+  # Restart all running pods, new pods created will be pulling the new image.
+  kubectl rollout restart deployment/proxy-deployment
+  kubectl rollout restart deployment/proxy-deployment-canary
 done < <(gcloud container clusters list --project ${project} | grep proxy-cluster)
 kubectl config use-context "$current_context"


### PR DESCRIPTION
The headers can be used by Cloud Armor to perform IP-based rate
limiting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2695)
<!-- Reviewable:end -->
