### PR TITLE
Use nomulus-gke tagging mechanism in sql-int tests

### DIFF
--- a/integration/run_compatibility_tests.sh
+++ b/integration/run_compatibility_tests.sh
@@ -111,7 +111,7 @@ fi
 if [[ "${SUT}" = "nomulus" ]]; then
   DEPLOYED_SYSTEM="sql"
 elif [[ "${SUT}" = "sql" ]]; then
-  DEPLOYED_SYSTEM="nomulus"
+  DEPLOYED_SYSTEM="nomulus-gke"
 else
   echo "${USAGE}"
   exit 1


### PR DESCRIPTION
Had to temporarily create the files in
gs://domain-registry-dev-deployed-tags but the automated release process will take care of that soon

This is what's causing the ever-present Kokoro CI builds as well as the failures in any change that affects SQL 
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2702)
<!-- Reviewable:end -->
