### PR TITLE
Fix a Cloud Scheduler deployment bug

### DIFF
--- a/core/src/main/java/google/registry/config/files/tasks/cloud-scheduler-tasks-production.xml
+++ b/core/src/main/java/google/registry/config/files/tasks/cloud-scheduler-tasks-production.xml
@@ -301,6 +301,7 @@
     <url><![CDATA[/_dr/task/bsaValidate]]></url>
     <name>bsaValidate</name>
     <service>bsa</service>
+    <timeout>10m</timeout>
     <description>
       Validates the processed BSA data in the database against the original
       block lists.


### PR DESCRIPTION
For GKE all tasks should be on backend, BSA was on its own service
because of egress IP constraint.

Also made it possible to specify a timeout for the Cloud Scheduler job,
with the default (3m) suitable for most tasks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2707)
<!-- Reviewable:end -->
