### PR TITLE
Refactor console bulk domain action types

### DIFF
--- a/core/src/main/java/google/registry/ui/server/console/domains/ConsoleBulkDomainDeleteActionType.java
+++ b/core/src/main/java/google/registry/ui/server/console/domains/ConsoleBulkDomainDeleteActionType.java
@@ -14,12 +14,11 @@
 
 package google.registry.ui.server.console.domains;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonElement;
 import google.registry.model.console.ConsolePermission;
 
 /** An action that will run a delete EPP command on the given domain. */
-public class ConsoleBulkDomainDeleteActionType implements ConsoleDomainActionType {
+public class ConsoleBulkDomainDeleteActionType extends ConsoleDomainActionType {
 
   private static final String DOMAIN_DELETE_XML =
       """
@@ -42,16 +41,13 @@ public class ConsoleBulkDomainDeleteActionType implements ConsoleDomainActionTyp
   </command>
 </epp>""";
 
-  private final String reason;
-
   public ConsoleBulkDomainDeleteActionType(JsonElement jsonElement) {
-    this.reason = jsonElement.getAsJsonObject().get("reason").getAsString();
+    super(jsonElement);
   }
 
   @Override
-  public String getXmlContentsToRun(String domainName) {
-    return ConsoleDomainActionType.fillSubstitutions(
-        DOMAIN_DELETE_XML, ImmutableMap.of("DOMAIN_NAME", domainName, "REASON", reason));
+  protected String getXmlTemplate() {
+    return DOMAIN_DELETE_XML;
   }
 
   @Override

--- a/core/src/main/java/google/registry/ui/server/console/domains/ConsoleBulkDomainSuspendActionType.java
+++ b/core/src/main/java/google/registry/ui/server/console/domains/ConsoleBulkDomainSuspendActionType.java
@@ -14,12 +14,11 @@
 
 package google.registry.ui.server.console.domains;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonElement;
 import google.registry.model.console.ConsolePermission;
 
 /** An action that will suspend the given domain, assigning all 5 server*Prohibited statuses. */
-public class ConsoleBulkDomainSuspendActionType implements ConsoleDomainActionType {
+public class ConsoleBulkDomainSuspendActionType extends ConsoleDomainActionType {
 
   private static final String DOMAIN_SUSPEND_XML =
       """
@@ -52,16 +51,13 @@ public class ConsoleBulkDomainSuspendActionType implements ConsoleDomainActionTy
   </command>
 </epp>""";
 
-  private final String reason;
-
   public ConsoleBulkDomainSuspendActionType(JsonElement jsonElement) {
-    this.reason = jsonElement.getAsJsonObject().get("reason").getAsString();
+    super(jsonElement);
   }
 
   @Override
-  public String getXmlContentsToRun(String domainName) {
-    return ConsoleDomainActionType.fillSubstitutions(
-        DOMAIN_SUSPEND_XML, ImmutableMap.of("DOMAIN_NAME", domainName, "REASON", reason));
+  protected String getXmlTemplate() {
+    return DOMAIN_SUSPEND_XML;
   }
 
   @Override

--- a/core/src/main/java/google/registry/ui/server/console/domains/ConsoleBulkDomainUnsuspendActionType.java
+++ b/core/src/main/java/google/registry/ui/server/console/domains/ConsoleBulkDomainUnsuspendActionType.java
@@ -14,12 +14,11 @@
 
 package google.registry.ui.server.console.domains;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.gson.JsonElement;
 import google.registry.model.console.ConsolePermission;
 
 /** An action that will unsuspend the given domain, removing all 5 server*Prohibited statuses. */
-public class ConsoleBulkDomainUnsuspendActionType implements ConsoleDomainActionType {
+public class ConsoleBulkDomainUnsuspendActionType extends ConsoleDomainActionType {
 
   private static final String DOMAIN_SUSPEND_XML =
       """
@@ -52,16 +51,13 @@ public class ConsoleBulkDomainUnsuspendActionType implements ConsoleDomainAction
   </command>
 </epp>""";
 
-  private final String reason;
-
   public ConsoleBulkDomainUnsuspendActionType(JsonElement jsonElement) {
-    this.reason = jsonElement.getAsJsonObject().get("reason").getAsString();
+    super(jsonElement);
   }
 
   @Override
-  public String getXmlContentsToRun(String domainName) {
-    return ConsoleDomainActionType.fillSubstitutions(
-        DOMAIN_SUSPEND_XML, ImmutableMap.of("DOMAIN_NAME", domainName, "REASON", reason));
+  protected String getXmlTemplate() {
+    return DOMAIN_SUSPEND_XML;
   }
 
   @Override


### PR DESCRIPTION
This makes the action types a bit simpler -- this is possible because
we've reduced the scope of domain actions that we want to natively
support

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2708)
<!-- Reviewable:end -->
