### PR TITLE
Fix console build for GKE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,26 +95,22 @@ task stage {
   description = 'Generates application directories for all services.'
 }
 
-// App-engine environment configuration.  We set up all of the variables in
-// the root project.
-
-def environments = ['production', 'sandbox', 'alpha', 'crash', 'qa']
-
 def gcpProject = null
 
 apply from: "${rootDir.path}/projects.gradle"
 
 if (environment == '') {
-    // Keep the project null, this will prevent deployment.  Set the
+    // Keep the project null, this will prevent deployment. Set the
     // environment to "alpha" because other code needs this property to
     // explode the war file.
     environment = 'alpha'
-} else if (environment != 'production' && environment != 'sandbox') {
+} else {
     gcpProject = projects[environment]
     if (gcpProject == null) {
         throw new GradleException("-Penvironment must be one of " +
                                   "${projects.keySet()}.")
     }
+    project(':console-webapp').setProperty('configuration', environment)
 }
 
 rootProject.ext.environment = environment

--- a/console-webapp/build.gradle
+++ b/console-webapp/build.gradle
@@ -40,9 +40,7 @@ task runConsoleWebappUnitTests(type: Exec) {
 task buildConsoleWebapp(type: Exec) {
   workingDir "${consoleDir}/"
   executable 'npm'
-  def configuration = project.hasProperty('configuration') ?
-    project.getProperty('configuration') :
-    'production'
+  def configuration = project.getProperty('configuration')
   args 'run', "build", "--configuration=${configuration}"
   doFirst {
     println "Building console for environment: ${configuration}"

--- a/console-webapp/gradle.properties
+++ b/console-webapp/gradle.properties
@@ -1,0 +1,1 @@
+configuration=production

--- a/release/build_nomulus_for_env.sh
+++ b/release/build_nomulus_for_env.sh
@@ -51,7 +51,7 @@ else
     mv services/"${service}"/build/staged-app "${dest}/${service}"
   done
 
-  ./gradlew :console-webapp:buildConsoleWebapp -Pconfiguration="${environment}"
+  ./gradlew :console-webapp:buildConsoleWebapp -Penvironment="${environment}"
   mkdir -p "${dest}/console" && cp -r console-webapp/staged/* "${dest}/console"
 
   mv core/build/resources/main/google/registry/env/common/META-INF \


### PR DESCRIPTION
We use the $environment property to set the console config. The default is 'production' as the console screenshot tests depend on it.

TESTED=ran :jetty:copyConsole with
-Penvironment=(sandbox|production|alpha) and checked the resulting js
file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2713)
<!-- Reviewable:end -->
