### PR TITLE
Add a GCB script for monitoring ZFA accessibility

### DIFF
--- a/release/cloudbuild-monitor-zfa.yaml
+++ b/release/cloudbuild-monitor-zfa.yaml
@@ -1,0 +1,22 @@
+# This runs a simple dig request against the provided ZFA server and TLD
+# to verify that the server is up and responding to zone file requests.
+#
+# This build should be run on a schedule, with pub/sub notifications configured
+# so that some sort of alert is fired on failure.
+#
+# To manually trigger a build on GCB, run:
+# gcloud builds submit --config cloudbuild-monitor-zfa.yaml --substitutions \
+#   _ZFA_SERVER_IP=X.X.X.X,_TLD=gmail
+
+steps:
+# Note: the AXFR request should fail because we don't have the key,
+# but the request itself should go through
+- name: 'ubuntu'
+  entrypoint: '/bin/bash'
+  args:
+    - -c
+    - |
+      set -e
+      apt-get update
+      apt-get install dnsutils -y
+      dig @${_ZFA_SERVER_IP} ${_TLD} axfr | grep "Transfer failed"


### PR DESCRIPTION
This doesn't check for correctness (we have other scripts that do that) but just that the service is available at all (the other scripts do not do that).

This should, and will, be configured with a scheduled trigger in GCB (for us, in the domain-registry-dev project) and configuration to send some sort of pub/sub notification on failure (for us, this is already set up on domain-registry-dev and it sends messages to the "Domain Registry Notifications" chat channel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2719)
<!-- Reviewable:end -->
