### PR TITLE
Revert "Add a redirect for the console bare domain (#2718)"

### DIFF
--- a/jetty/kubernetes/gateway/nomulus-route-console.yaml
+++ b/jetty/kubernetes/gateway/nomulus-route-console.yaml
@@ -12,9 +12,6 @@ spec:
   rules:
   - matches:
     - path:
-        type: Exact
-        value: /
-    - path:
         type: PathPrefix
         value: /console-api
     - path:
@@ -26,12 +23,6 @@ spec:
       name: console
       port: 80
   - matches:
-    - path:
-        type: Exact
-        value: /
-      headers:
-      - name: "canary"
-        value: "true"
     - path:
         type: PathPrefix
         value: /console-api

--- a/jetty/src/main/jetty-base/webapps/root/index.html
+++ b/jetty/src/main/jetty-base/webapps/root/index.html
@@ -1,5 +1,0 @@
-<!doctype html>
-<meta http-equiv="refresh" content="0;URL=/console">
-<title>Nomulus</title>
-<body lang="en-US">
-If this page doesn't change automatically, please click <a href="/console">here</a>


### PR DESCRIPTION
This reverts commit 2a01c12b14d713158be0209bae95dd090e6eec13.

The `root` folder overrides all routing rules. We need to rethink how to only redirect `/index.html`, Maybe through an action, or some special Jetty config.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2724)
<!-- Reviewable:end -->
