### PR TITLE
Change AllocationToken behavior in non-catastrophic situations

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -42,7 +42,6 @@ import static google.registry.model.tld.label.ReservationType.RESERVED_FOR_ANCHO
 import static google.registry.model.tld.label.ReservationType.RESERVED_FOR_SPECIFIC_USE;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.pricing.PricingEngineProxy.isDomainPremium;
-import static google.registry.util.CollectionUtils.isNullOrEmpty;
 import static google.registry.util.CollectionUtils.nullToEmpty;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.DateTimeUtils.isAtOrAfter;
@@ -67,7 +66,6 @@ import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import com.google.common.net.InternetDomainName;
 import google.registry.flows.EppException;
-import google.registry.flows.EppException.AssociationProhibitsOperationException;
 import google.registry.flows.EppException.AuthorizationErrorException;
 import google.registry.flows.EppException.CommandUseErrorException;
 import google.registry.flows.EppException.ObjectDoesNotExistException;
@@ -77,8 +75,6 @@ import google.registry.flows.EppException.ParameterValueSyntaxErrorException;
 import google.registry.flows.EppException.RequiredParameterMissingException;
 import google.registry.flows.EppException.StatusProhibitsOperationException;
 import google.registry.flows.EppException.UnimplementedOptionException;
-import google.registry.flows.domain.DomainPricingLogic.AllocationTokenInvalidForPremiumNameException;
-import google.registry.flows.domain.token.AllocationTokenFlowUtils;
 import google.registry.flows.exceptions.ResourceHasClientUpdateProhibitedException;
 import google.registry.model.EppResource;
 import google.registry.model.billing.BillingBase.Flag;
@@ -101,7 +97,6 @@ import google.registry.model.domain.fee.BaseFee.FeeType;
 import google.registry.model.domain.fee.Credit;
 import google.registry.model.domain.fee.Fee;
 import google.registry.model.domain.fee.FeeQueryCommandExtensionItem;
-import google.registry.model.domain.fee.FeeQueryCommandExtensionItem.CommandName;
 import google.registry.model.domain.fee.FeeQueryResponseExtensionItem;
 import google.registry.model.domain.fee.FeeTransformCommandExtension;
 import google.registry.model.domain.fee.FeeTransformResponseExtension;
@@ -1231,52 +1226,6 @@ public class DomainFlowUtils {
         .setParameter("beginning", now.minus(maxSearchPeriod))
         .setParameter("repoId", domain.getRepoId())
         .getResultList();
-  }
-
-  /**
-   * Checks if there is a valid default token to be used for a domain create command.
-   *
-   * <p>If there is more than one valid default token for the registration, only the first valid
-   * token found on the TLD's default token list will be returned.
-   */
-  public static Optional<AllocationToken> checkForDefaultToken(
-      Tld tld, String domainName, CommandName commandName, String registrarId, DateTime now)
-      throws EppException {
-    if (isNullOrEmpty(tld.getDefaultPromoTokens())) {
-      return Optional.empty();
-    }
-    Map<VKey<AllocationToken>, Optional<AllocationToken>> tokens =
-        AllocationToken.getAll(tld.getDefaultPromoTokens());
-    ImmutableList<Optional<AllocationToken>> tokenList =
-        tld.getDefaultPromoTokens().stream()
-            .map(tokens::get)
-            .filter(Optional::isPresent)
-            .collect(toImmutableList());
-    checkState(
-        !isNullOrEmpty(tokenList),
-        "Failure while loading default TLD promotions from the database");
-    // Check if any of the tokens are valid for this domain registration
-    for (Optional<AllocationToken> token : tokenList) {
-      try {
-        AllocationTokenFlowUtils.validateToken(
-            InternetDomainName.from(domainName),
-            token.get(),
-            commandName,
-            registrarId,
-            isDomainPremium(domainName, now),
-            now);
-      } catch (AssociationProhibitsOperationException
-          | StatusProhibitsOperationException
-          | AllocationTokenInvalidForPremiumNameException e) {
-        // Allocation token was not valid for this registration, continue to check the next token in
-        // the list
-        continue;
-      }
-      // Only use the first valid token in the list
-      return token;
-    }
-    // No valid default token found
-    return Optional.empty();
   }
 
   /** Resource linked to this domain does not exist. */

--- a/core/src/main/java/google/registry/flows/domain/token/AllocationTokenFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/token/AllocationTokenFlowUtils.java
@@ -15,218 +15,97 @@
 package google.registry.flows.domain.token;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.pricing.PricingEngineProxy.isDomainPremium;
+import static google.registry.util.CollectionUtils.isNullOrEmpty;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
+import com.google.common.collect.ImmutableList;
 import com.google.common.net.InternetDomainName;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.AssociationProhibitsOperationException;
 import google.registry.flows.EppException.AuthorizationErrorException;
 import google.registry.flows.EppException.StatusProhibitsOperationException;
-import google.registry.flows.domain.DomainPricingLogic.AllocationTokenInvalidForPremiumNameException;
-import google.registry.model.billing.BillingBase.RenewalPriceBehavior;
+import google.registry.model.billing.BillingBase;
 import google.registry.model.billing.BillingRecurrence;
 import google.registry.model.domain.Domain;
-import google.registry.model.domain.DomainCommand;
 import google.registry.model.domain.fee.FeeQueryCommandExtensionItem.CommandName;
 import google.registry.model.domain.token.AllocationToken;
 import google.registry.model.domain.token.AllocationToken.TokenBehavior;
-import google.registry.model.domain.token.AllocationToken.TokenStatus;
 import google.registry.model.domain.token.AllocationTokenExtension;
 import google.registry.model.reporting.HistoryEntry.HistoryEntryId;
 import google.registry.model.tld.Tld;
 import google.registry.persistence.VKey;
-import jakarta.inject.Inject;
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.joda.time.DateTime;
 
 /** Utility functions for dealing with {@link AllocationToken}s in domain flows. */
 public class AllocationTokenFlowUtils {
 
-  @Inject
-  public AllocationTokenFlowUtils() {}
-
-  /**
-   * Checks if the allocation token applies to the given domain names, used for domain checks.
-   *
-   * @return A map of domain names to domain check error response messages. If a message is present
-   *     for a a given domain then it does not validate with this allocation token; domains that do
-   *     validate have blank messages (i.e. no error).
-   */
-  public AllocationTokenDomainCheckResults checkDomainsWithToken(
-      List<InternetDomainName> domainNames, String token, String registrarId, DateTime now) {
-    // If the token is completely invalid, return the error message for all domain names
-    AllocationToken tokenEntity;
-    try {
-      tokenEntity = loadToken(token);
-    } catch (EppException e) {
-      return new AllocationTokenDomainCheckResults(
-          Optional.empty(), Maps.toMap(domainNames, ignored -> e.getMessage()));
-    }
-
-    // If the token is only invalid for some domain names (e.g. an invalid TLD), include those error
-    // results for only those domain names
-    ImmutableMap.Builder<InternetDomainName, String> resultsBuilder = new ImmutableMap.Builder<>();
-    for (InternetDomainName domainName : domainNames) {
-      try {
-        validateToken(
-            domainName,
-            tokenEntity,
-            CommandName.CREATE,
-            registrarId,
-            isDomainPremium(domainName.toString(), now),
-            now);
-        resultsBuilder.put(domainName, "");
-      } catch (EppException e) {
-        resultsBuilder.put(domainName, e.getMessage());
-      }
-    }
-    return new AllocationTokenDomainCheckResults(Optional.of(tokenEntity), resultsBuilder.build());
-  }
+  private AllocationTokenFlowUtils() {}
 
   /** Redeems a SINGLE_USE {@link AllocationToken}, returning the redeemed copy. */
-  public AllocationToken redeemToken(AllocationToken token, HistoryEntryId redemptionHistoryId) {
+  public static AllocationToken redeemToken(
+      AllocationToken token, HistoryEntryId redemptionHistoryId) {
     checkArgument(
         token.getTokenType().isOneTimeUse(), "Only SINGLE_USE tokens can be marked as redeemed");
     return token.asBuilder().setRedemptionHistoryId(redemptionHistoryId).build();
   }
 
-  /**
-   * Validates a given token. The token could be invalid if it has allowed client IDs or TLDs that
-   * do not include this client ID / TLD, or if the token has a promotion that is not currently
-   * running, or the token is not valid for a premium name when necessary.
-   *
-   * @throws EppException if the token is invalid in any way
-   */
-  public static void validateToken(
-      InternetDomainName domainName,
-      AllocationToken token,
-      CommandName commandName,
-      String registrarId,
-      boolean isPremium,
-      DateTime now)
-      throws EppException {
-
-    // Only tokens with default behavior require validation
-    if (!TokenBehavior.DEFAULT.equals(token.getTokenBehavior())) {
-      return;
-    }
-    validateTokenForPossiblePremiumName(Optional.of(token), isPremium);
-    if (!token.getAllowedEppActions().isEmpty()
-        && !token.getAllowedEppActions().contains(commandName)) {
-      throw new AllocationTokenNotValidForCommandException();
-    }
-    if (!token.getAllowedRegistrarIds().isEmpty()
-        && !token.getAllowedRegistrarIds().contains(registrarId)) {
-      throw new AllocationTokenNotValidForRegistrarException();
-    }
-    if (!token.getAllowedTlds().isEmpty()
-        && !token.getAllowedTlds().contains(domainName.parent().toString())) {
-      throw new AllocationTokenNotValidForTldException();
-    }
-    if (token.getDomainName().isPresent()
-        && !token.getDomainName().get().equals(domainName.toString())) {
-      throw new AllocationTokenNotValidForDomainException();
-    }
-    // Tokens without status transitions will just have a single-entry NOT_STARTED map, so only
-    // check the status transitions map if it's non-trivial.
-    if (token.getTokenStatusTransitions().size() > 1
-        && !TokenStatus.VALID.equals(token.getTokenStatusTransitions().getValueAtTime(now))) {
-      throw new AllocationTokenNotInPromotionException();
-    }
-  }
-
-  /** Validates that the given token is valid for a premium name if the name is premium. */
-  public static void validateTokenForPossiblePremiumName(
-      Optional<AllocationToken> token, boolean isPremium)
-      throws AllocationTokenInvalidForPremiumNameException {
-    if (token.isPresent()
-        && (token.get().getDiscountFraction() != 0.0 || token.get().getDiscountPrice().isPresent())
+  /** Don't apply discounts on premium domains if the token isn't configured that way. */
+  public static boolean discountTokenInvalidForPremiumName(
+      AllocationToken token, boolean isPremium) {
+    return (token.getDiscountFraction() != 0.0 || token.getDiscountPrice().isPresent())
         && isPremium
-        && !token.get().shouldDiscountPremiums()) {
-      throw new AllocationTokenInvalidForPremiumNameException();
-    }
+        && !token.shouldDiscountPremiums();
   }
 
-  /** Loads a given token and validates that it is not redeemed */
-  private static AllocationToken loadToken(String token) throws EppException {
-    if (Strings.isNullOrEmpty(token)) {
-      // We load the token directly from the input XML. If it's null or empty we should throw
-      // an InvalidAllocationTokenException before the database load attempt fails.
-      // See https://tools.ietf.org/html/draft-ietf-regext-allocation-token-04#section-2.1
-      throw new InvalidAllocationTokenException();
-    }
-
-    Optional<AllocationToken> maybeTokenEntity = AllocationToken.maybeGetStaticTokenInstance(token);
-    if (maybeTokenEntity.isPresent()) {
-      return maybeTokenEntity.get();
-    }
-
-    // TODO(b/368069206): `reTransact` needed by tests only.
-    maybeTokenEntity =
-        tm().reTransact(() -> tm().loadByKeyIfPresent(VKey.create(AllocationToken.class, token)));
-
-    if (maybeTokenEntity.isEmpty()) {
-      throw new InvalidAllocationTokenException();
-    }
-    if (maybeTokenEntity.get().isRedeemed()) {
-      throw new AlreadyRedeemedAllocationTokenException();
-    }
-    return maybeTokenEntity.get();
-  }
-
-  /** Verifies and returns the allocation token if one is specified, otherwise does nothing. */
-  public Optional<AllocationToken> verifyAllocationTokenCreateIfPresent(
-      DomainCommand.Create command,
-      Tld tld,
+  /** Loads and verifies the allocation token if one is specified, otherwise does nothing. */
+  public static Optional<AllocationToken> loadAllocationTokenFromExtension(
       String registrarId,
+      String domainName,
       DateTime now,
       Optional<AllocationTokenExtension> extension)
-      throws EppException {
+      throws NonexistentAllocationTokenException, AllocationTokenInvalidException {
     if (extension.isEmpty()) {
       return Optional.empty();
     }
-    AllocationToken tokenEntity = loadToken(extension.get().getAllocationToken());
-    validateToken(
-        InternetDomainName.from(command.getDomainName()),
-        tokenEntity,
-        CommandName.CREATE,
-        registrarId,
-        isDomainPremium(command.getDomainName(), now),
-        now);
-    return Optional.of(tokenEntity);
+    return Optional.of(
+        loadAndValidateToken(extension.get().getAllocationToken(), registrarId, domainName, now));
   }
 
-  /** Verifies and returns the allocation token if one is specified, otherwise does nothing. */
-  public Optional<AllocationToken> verifyAllocationTokenIfPresent(
-      Domain existingDomain,
-      Tld tld,
+  /**
+   * Loads the relevant token, if present, for the given extension + request.
+   *
+   * <p>This may be the allocation token provided in the request, if it is present and valid for the
+   * request. Otherwise, it may be a default allocation token if one is present and valid for the
+   * request.
+   */
+  public static Optional<AllocationToken> loadTokenFromExtensionOrGetDefault(
       String registrarId,
       DateTime now,
-      CommandName commandName,
-      Optional<AllocationTokenExtension> extension)
-      throws EppException {
-    if (extension.isEmpty()) {
-      return Optional.empty();
+      Optional<AllocationTokenExtension> extension,
+      Tld tld,
+      String domainName,
+      CommandName commandName)
+      throws NonexistentAllocationTokenException, AllocationTokenInvalidException {
+    Optional<AllocationToken> fromExtension =
+        loadAllocationTokenFromExtension(registrarId, domainName, now, extension);
+    if (fromExtension.isPresent()
+        && tokenIsValidAgainstDomain(
+            InternetDomainName.from(domainName), fromExtension.get(), commandName, now)) {
+      return fromExtension;
     }
-    AllocationToken tokenEntity = loadToken(extension.get().getAllocationToken());
-    validateToken(
-        InternetDomainName.from(existingDomain.getDomainName()),
-        tokenEntity,
-        commandName,
-        registrarId,
-        isDomainPremium(existingDomain.getDomainName(), now),
-        now);
-    return Optional.of(tokenEntity);
+    return checkForDefaultToken(tld, domainName, commandName, registrarId, now);
   }
 
-  public static void verifyTokenAllowedOnDomain(
+  /** Verifies that the given domain can have a bulk pricing token removed from it. */
+  public static void verifyBulkTokenAllowedOnDomain(
       Domain domain, Optional<AllocationToken> allocationToken) throws EppException {
-
     boolean domainHasBulkToken = domain.getCurrentBulkToken().isPresent();
     boolean hasRemoveBulkPricingToken =
         allocationToken.isPresent()
@@ -239,6 +118,11 @@ public class AllocationTokenFlowUtils {
     }
   }
 
+  /**
+   * Removes the bulk pricing token from the provided domain, if applicable.
+   *
+   * @param allocationToken the (possibly) REMOVE_BULK_PRICING token provided by the client.
+   */
   public static Domain maybeApplyBulkPricingRemovalToken(
       Domain domain, Optional<AllocationToken> allocationToken) {
     if (allocationToken.isEmpty()
@@ -249,7 +133,7 @@ public class AllocationTokenFlowUtils {
     BillingRecurrence newBillingRecurrence =
         tm().loadByKey(domain.getAutorenewBillingEvent())
             .asBuilder()
-            .setRenewalPriceBehavior(RenewalPriceBehavior.DEFAULT)
+            .setRenewalPriceBehavior(BillingBase.RenewalPriceBehavior.DEFAULT)
             .setRenewalPrice(null)
             .build();
 
@@ -267,35 +151,139 @@ public class AllocationTokenFlowUtils {
         .build();
   }
 
+  /**
+   * Checks if the given token is valid for the given request.
+   *
+   * <p>Note that if the token is not valid, that is not a catastrophic error -- we may move on to
+   * trying a different token or skip token usage entirely.
+   */
+  @VisibleForTesting
+  static boolean tokenIsValidAgainstDomain(
+      InternetDomainName domainName, AllocationToken token, CommandName commandName, DateTime now) {
+    if (discountTokenInvalidForPremiumName(token, isDomainPremium(domainName.toString(), now))) {
+      return false;
+    }
+    if (!token.getAllowedEppActions().isEmpty()
+        && !token.getAllowedEppActions().contains(commandName)) {
+      return false;
+    }
+    if (!token.getAllowedTlds().isEmpty()
+        && !token.getAllowedTlds().contains(domainName.parent().toString())) {
+      return false;
+    }
+    return token.getDomainName().isEmpty()
+        || token.getDomainName().get().equals(domainName.toString());
+  }
+
+  /**
+   * Checks if there is a valid default token to be used for a domain create command.
+   *
+   * <p>If there is more than one valid default token for the registration, only the first valid
+   * token found on the TLD's default token list will be returned.
+   */
+  private static Optional<AllocationToken> checkForDefaultToken(
+      Tld tld, String domainName, CommandName commandName, String registrarId, DateTime now) {
+    ImmutableList<VKey<AllocationToken>> tokensFromTld = tld.getDefaultPromoTokens();
+    if (isNullOrEmpty(tokensFromTld)) {
+      return Optional.empty();
+    }
+    Map<VKey<AllocationToken>, Optional<AllocationToken>> tokens =
+        AllocationToken.getAll(tokensFromTld);
+    checkState(
+        !isNullOrEmpty(tokens), "Failure while loading default TLD tokens from the database");
+    // Iterate over the list to maintain token ordering (since we return the first valid token)
+    ImmutableList<AllocationToken> tokenList =
+        tokensFromTld.stream()
+            .map(tokens::get)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(toImmutableList());
+
+    // Check if any of the tokens are valid for this domain registration
+    for (AllocationToken token : tokenList) {
+      try {
+        validateTokenEntity(token, registrarId, domainName, now);
+      } catch (AllocationTokenInvalidException e) {
+        // Token is not valid for this registrar, etc. -- continue trying tokens
+        continue;
+      }
+      if (tokenIsValidAgainstDomain(InternetDomainName.from(domainName), token, commandName, now)) {
+        return Optional.of(token);
+      }
+    }
+    // No valid default token found
+    return Optional.empty();
+  }
+
+  /** Loads a given token and validates it against the registrar, time, etc */
+  private static AllocationToken loadAndValidateToken(
+      String token, String registrarId, String domainName, DateTime now)
+      throws NonexistentAllocationTokenException, AllocationTokenInvalidException {
+    if (Strings.isNullOrEmpty(token)) {
+      // We load the token directly from the input XML. If it's null or empty we should throw
+      // an NonexistentAllocationTokenException before the database load attempt fails.
+      // See https://tools.ietf.org/html/draft-ietf-regext-allocation-token-04#section-2.1
+      throw new NonexistentAllocationTokenException();
+    }
+
+    Optional<AllocationToken> maybeTokenEntity = AllocationToken.maybeGetStaticTokenInstance(token);
+    if (maybeTokenEntity.isPresent()) {
+      return maybeTokenEntity.get();
+    }
+
+    maybeTokenEntity = AllocationToken.get(VKey.create(AllocationToken.class, token));
+    if (maybeTokenEntity.isEmpty()) {
+      throw new NonexistentAllocationTokenException();
+    }
+    AllocationToken tokenEntity = maybeTokenEntity.get();
+    validateTokenEntity(tokenEntity, registrarId, domainName, now);
+    return tokenEntity;
+  }
+
+  private static void validateTokenEntity(
+      AllocationToken token, String registrarId, String domainName, DateTime now)
+      throws AllocationTokenInvalidException {
+    if (token.isRedeemed()) {
+      throw new AlreadyRedeemedAllocationTokenException();
+    }
+    if (!token.getAllowedRegistrarIds().isEmpty()
+        && !token.getAllowedRegistrarIds().contains(registrarId)) {
+      throw new AllocationTokenNotValidForRegistrarException();
+    }
+    // Tokens without status transitions will just have a single-entry NOT_STARTED map, so only
+    // check the status transitions map if it's non-trivial.
+    if (token.getTokenStatusTransitions().size() > 1
+        && !AllocationToken.TokenStatus.VALID.equals(
+            token.getTokenStatusTransitions().getValueAtTime(now))) {
+      throw new AllocationTokenNotInPromotionException();
+    }
+
+    if (token.getDomainName().isPresent() && !token.getDomainName().get().equals(domainName)) {
+      throw new AllocationTokenNotValidForDomainException();
+    }
+  }
+
   // Note: exception messages should be <= 32 characters long for domain check results
+
+  /** The allocation token exists but is not valid, e.g. the wrong registrar. */
+  public abstract static class AllocationTokenInvalidException
+      extends StatusProhibitsOperationException {
+    AllocationTokenInvalidException(String message) {
+      super(message);
+    }
+  }
 
   /** The allocation token is not currently valid. */
   public static class AllocationTokenNotInPromotionException
-      extends StatusProhibitsOperationException {
+      extends AllocationTokenInvalidException {
     AllocationTokenNotInPromotionException() {
       super("Alloc token not in promo period");
     }
   }
 
-  /** The allocation token is not valid for this TLD. */
-  public static class AllocationTokenNotValidForTldException
-      extends AssociationProhibitsOperationException {
-    AllocationTokenNotValidForTldException() {
-      super("Alloc token invalid for TLD");
-    }
-  }
-
-  /** The allocation token is not valid for this domain. */
-  public static class AllocationTokenNotValidForDomainException
-      extends AssociationProhibitsOperationException {
-    AllocationTokenNotValidForDomainException() {
-      super("Alloc token invalid for domain");
-    }
-  }
-
   /** The allocation token is not valid for this registrar. */
   public static class AllocationTokenNotValidForRegistrarException
-      extends AssociationProhibitsOperationException {
+      extends AllocationTokenInvalidException {
     AllocationTokenNotValidForRegistrarException() {
       super("Alloc token invalid for client");
     }
@@ -303,23 +291,23 @@ public class AllocationTokenFlowUtils {
 
   /** The allocation token was already redeemed. */
   public static class AlreadyRedeemedAllocationTokenException
-      extends AssociationProhibitsOperationException {
+      extends AllocationTokenInvalidException {
     AlreadyRedeemedAllocationTokenException() {
       super("Alloc token was already redeemed");
     }
   }
 
-  /** The allocation token is not valid for this EPP command. */
-  public static class AllocationTokenNotValidForCommandException
-      extends AssociationProhibitsOperationException {
-    AllocationTokenNotValidForCommandException() {
-      super("Allocation token not valid for the EPP command");
+  /** The allocation token is not valid for this domain. */
+  public static class AllocationTokenNotValidForDomainException
+      extends AllocationTokenInvalidException {
+    AllocationTokenNotValidForDomainException() {
+      super("Alloc token invalid for domain");
     }
-  }
+    }
 
   /** The allocation token is invalid. */
-  public static class InvalidAllocationTokenException extends AuthorizationErrorException {
-    InvalidAllocationTokenException() {
+  public static class NonexistentAllocationTokenException extends AuthorizationErrorException {
+    NonexistentAllocationTokenException() {
       super("The allocation token is invalid");
     }
   }

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
@@ -52,12 +52,11 @@ import google.registry.flows.ResourceFlowUtils.BadAuthInfoForResourceException;
 import google.registry.flows.ResourceFlowUtils.ResourceDoesNotExistException;
 import google.registry.flows.ResourceFlowUtils.ResourceNotOwnedException;
 import google.registry.flows.domain.DomainFlowUtils.NotAuthorizedForTldException;
+import google.registry.flows.domain.token.AllocationTokenFlowUtils;
 import google.registry.flows.domain.token.AllocationTokenFlowUtils.AllocationTokenNotInPromotionException;
-import google.registry.flows.domain.token.AllocationTokenFlowUtils.AllocationTokenNotValidForDomainException;
 import google.registry.flows.domain.token.AllocationTokenFlowUtils.AllocationTokenNotValidForRegistrarException;
-import google.registry.flows.domain.token.AllocationTokenFlowUtils.AllocationTokenNotValidForTldException;
 import google.registry.flows.domain.token.AllocationTokenFlowUtils.AlreadyRedeemedAllocationTokenException;
-import google.registry.flows.domain.token.AllocationTokenFlowUtils.InvalidAllocationTokenException;
+import google.registry.flows.domain.token.AllocationTokenFlowUtils.NonexistentAllocationTokenException;
 import google.registry.flows.exceptions.NotPendingTransferException;
 import google.registry.model.billing.BillingBase;
 import google.registry.model.billing.BillingBase.Reason;
@@ -897,7 +896,7 @@ class DomainTransferApproveFlowTest
   @Test
   void testFailure_invalidAllocationToken() throws Exception {
     setEppInput("domain_transfer_approve_allocation_token.xml");
-    EppException thrown = assertThrows(InvalidAllocationTokenException.class, this::runFlow);
+    EppException thrown = assertThrows(NonexistentAllocationTokenException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
@@ -910,9 +909,12 @@ class DomainTransferApproveFlowTest
             .setDomainName("otherdomain.tld")
             .build());
     setEppInput("domain_transfer_approve_allocation_token.xml");
-    EppException thrown =
-        assertThrows(AllocationTokenNotValidForDomainException.class, this::runFlow);
-    assertAboutEppExceptions().that(thrown).marshalsToXml();
+    assertAboutEppExceptions()
+        .that(
+            assertThrows(
+                AllocationTokenFlowUtils.AllocationTokenNotValidForDomainException.class,
+                this::runFlow))
+        .marshalsToXml();
   }
 
   @Test
@@ -971,8 +973,7 @@ class DomainTransferApproveFlowTest
                     .build())
             .build());
     setEppInput("domain_transfer_approve_allocation_token.xml");
-    EppException thrown = assertThrows(AllocationTokenNotValidForTldException.class, this::runFlow);
-    assertAboutEppExceptions().that(thrown).marshalsToXml();
+    runFlowAssertResponse(loadFile("domain_transfer_approve_response.xml"));
   }
 
   @Test

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
@@ -79,11 +79,9 @@ import google.registry.flows.domain.DomainFlowUtils.PremiumNameBlockedException;
 import google.registry.flows.domain.DomainFlowUtils.RegistrarMustBeActiveForThisOperationException;
 import google.registry.flows.domain.DomainFlowUtils.UnsupportedFeeAttributeException;
 import google.registry.flows.domain.token.AllocationTokenFlowUtils.AllocationTokenNotInPromotionException;
-import google.registry.flows.domain.token.AllocationTokenFlowUtils.AllocationTokenNotValidForDomainException;
 import google.registry.flows.domain.token.AllocationTokenFlowUtils.AllocationTokenNotValidForRegistrarException;
-import google.registry.flows.domain.token.AllocationTokenFlowUtils.AllocationTokenNotValidForTldException;
 import google.registry.flows.domain.token.AllocationTokenFlowUtils.AlreadyRedeemedAllocationTokenException;
-import google.registry.flows.domain.token.AllocationTokenFlowUtils.InvalidAllocationTokenException;
+import google.registry.flows.domain.token.AllocationTokenFlowUtils.NonexistentAllocationTokenException;
 import google.registry.flows.exceptions.AlreadyPendingTransferException;
 import google.registry.flows.exceptions.InvalidTransferPeriodValueException;
 import google.registry.flows.exceptions.MissingTransferRequestAuthInfoException;
@@ -505,7 +503,7 @@ class DomainTransferRequestFlowTest
         implicitTransferTime,
         transferCost,
         originalGracePeriods,
-        /* expectTransferBillingEvent = */ true,
+        /* expectTransferBillingEvent= */ true,
         extraExpectedBillingEvents);
 
     assertPollMessagesEmitted(expectedExpirationTime, implicitTransferTime);
@@ -1859,22 +1857,7 @@ class DomainTransferRequestFlowTest
   void testFailure_invalidAllocationToken() throws Exception {
     setupDomain("example", "tld");
     setEppInput("domain_transfer_request_allocation_token.xml", ImmutableMap.of("TOKEN", "abc123"));
-    EppException thrown = assertThrows(InvalidAllocationTokenException.class, this::runFlow);
-    assertAboutEppExceptions().that(thrown).marshalsToXml();
-  }
-
-  @Test
-  void testFailure_allocationTokenIsForDifferentName() throws Exception {
-    setupDomain("example", "tld");
-    persistResource(
-        new AllocationToken.Builder()
-            .setToken("abc123")
-            .setTokenType(SINGLE_USE)
-            .setDomainName("otherdomain.tld")
-            .build());
-    setEppInput("domain_transfer_request_allocation_token.xml", ImmutableMap.of("TOKEN", "abc123"));
-    EppException thrown =
-        assertThrows(AllocationTokenNotValidForDomainException.class, this::runFlow);
+    EppException thrown = assertThrows(NonexistentAllocationTokenException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
@@ -1917,27 +1900,6 @@ class DomainTransferRequestFlowTest
     setEppInput("domain_transfer_request_allocation_token.xml", ImmutableMap.of("TOKEN", "abc123"));
     EppException thrown =
         assertThrows(AllocationTokenNotValidForRegistrarException.class, this::runFlow);
-    assertAboutEppExceptions().that(thrown).marshalsToXml();
-  }
-
-  @Test
-  void testFailure_allocationTokenNotValidForTld() throws Exception {
-    setupDomain("example", "tld");
-    persistResource(
-        new AllocationToken.Builder()
-            .setToken("abc123")
-            .setTokenType(UNLIMITED_USE)
-            .setAllowedTlds(ImmutableSet.of("example"))
-            .setDiscountFraction(0.5)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
-                    .build())
-            .build());
-    setEppInput("domain_transfer_request_allocation_token.xml", ImmutableMap.of("TOKEN", "abc123"));
-    EppException thrown = assertThrows(AllocationTokenNotValidForTldException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee.xml
@@ -6,6 +6,7 @@
         <domain:name>example1.tld</domain:name>
         <domain:name>example2.example</domain:name>
         <domain:name>reserved.tld</domain:name>
+        <domain:name>rich.example</domain:name>
       </domain:check>
     </check>
     <extension>
@@ -35,6 +36,12 @@
           <fee:period unit="y">1</fee:period>
         </fee:domain>
         <fee:domain>
+          <fee:name>rich.example</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">1</fee:period>
+        </fee:domain>
+        <fee:domain>
           <fee:name>example1.tld</fee:name>
           <fee:currency>USD</fee:currency>
           <fee:command>renew</fee:command>
@@ -48,6 +55,12 @@
         </fee:domain>
         <fee:domain>
           <fee:name>reserved.tld</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>renew</fee:command>
+          <fee:period unit="y">1</fee:period>
+        </fee:domain>
+        <fee:domain>
+          <fee:name>rich.example</fee:name>
           <fee:currency>USD</fee:currency>
           <fee:command>renew</fee:command>
           <fee:period unit="y">1</fee:period>

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee_anchor_response.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee_anchor_response.xml
@@ -17,6 +17,10 @@
             <domain:name avail="false">reserved.tld</domain:name>
             <domain:reason>Alloc token invalid for domain</domain:reason>
         </domain:cd>
+        <domain:cd>
+          <domain:name avail="false">rich.example</domain:name>
+          <domain:reason>Alloc token invalid for domain</domain:reason>
+        </domain:cd>
       </domain:chkData>
     </resData>
     <extension>
@@ -43,6 +47,13 @@
           <fee:class>token-not-supported</fee:class>
         </fee:cd>
         <fee:cd>
+          <fee:name>rich.example</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:class>token-not-supported</fee:class>
+        </fee:cd>
+        <fee:cd>
           <fee:name>example1.tld</fee:name>
           <fee:currency>USD</fee:currency>
           <fee:command>renew</fee:command>
@@ -59,6 +70,13 @@
         </fee:cd>
         <fee:cd>
           <fee:name>reserved.tld</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>renew</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:class>token-not-supported</fee:class>
+        </fee:cd>
+        <fee:cd>
+          <fee:name>rich.example</fee:name>
           <fee:currency>USD</fee:currency>
           <fee:command>renew</fee:command>
           <fee:period unit="y">1</fee:period>

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee_response.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee_response.xml
@@ -16,6 +16,9 @@
           <domain:name avail="false">reserved.tld</domain:name>
           <domain:reason>Reserved</domain:reason>
         </domain:cd>
+        <domain:cd>
+          <domain:name avail="true">rich.example</domain:name>
+        </domain:cd>
       </domain:chkData>
     </resData>
     <extension>
@@ -42,25 +45,41 @@
           <fee:class>reserved</fee:class>
         </fee:cd>
         <fee:cd>
+          <fee:name>rich.example</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>create</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:fee description="create">100.00</fee:fee>
+          <fee:class>premium</fee:class>
+        </fee:cd>
+        <fee:cd>
           <fee:name>example1.tld</fee:name>
           <fee:currency>USD</fee:currency>
           <fee:command>renew</fee:command>
           <fee:period unit="y">1</fee:period>
-          <fee:class>token-not-supported</fee:class>
+          <fee:fee description="renew">11.00</fee:fee>
         </fee:cd>
         <fee:cd>
           <fee:name>example2.example</fee:name>
           <fee:currency>USD</fee:currency>
           <fee:command>renew</fee:command>
           <fee:period unit="y">1</fee:period>
-          <fee:class>token-not-supported</fee:class>
+          <fee:fee description="renew">11.00</fee:fee>
         </fee:cd>
         <fee:cd>
           <fee:name>reserved.tld</fee:name>
           <fee:currency>USD</fee:currency>
           <fee:command>renew</fee:command>
           <fee:period unit="y">1</fee:period>
-          <fee:class>token-not-supported</fee:class>
+          <fee:fee description="renew">11.00</fee:fee>
+        </fee:cd>
+        <fee:cd>
+          <fee:name>rich.example</fee:name>
+          <fee:currency>USD</fee:currency>
+          <fee:command>renew</fee:command>
+          <fee:period unit="y">1</fee:period>
+          <fee:fee description="renew">100.00</fee:fee>
+          <fee:class>premium</fee:class>
         </fee:cd>
       </fee:chkData>
     </extension>

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee_specificuse_response.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_allocationtoken_fee_specificuse_response.xml
@@ -16,7 +16,7 @@
         </domain:cd>
         <domain:cd>
           <domain:name avail="false">reserved.tld</domain:name>
-          <domain:reason>Reserved</domain:reason>
+          <domain:reason>Alloc token invalid for domain</domain:reason>
         </domain:cd>
         <domain:cd>
           <domain:name avail="true">specificuse.tld</domain:name>

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_fee_multiple_commands_allocationtoken_response_v06.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_fee_multiple_commands_allocationtoken_response_v06.xml
@@ -17,14 +17,14 @@
           <fee:currency>USD</fee:currency>
           <fee:command>create</fee:command>
           <fee:period unit="y">1</fee:period>
-          <fee:fee description="create">13.00</fee:fee>
+          <fee:fee description="create">11.70</fee:fee>
         </fee:cd>
         <fee:cd xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
           <fee:name>example1.tld</fee:name>
           <fee:currency>USD</fee:currency>
           <fee:command>renew</fee:command>
           <fee:period unit="y">1</fee:period>
-          <fee:class>token-not-supported</fee:class>
+          <fee:fee description="renew">11.00</fee:fee>
         </fee:cd>
         <fee:cd xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
           <fee:name>example1.tld</fee:name>
@@ -38,14 +38,14 @@
           <fee:currency>USD</fee:currency>
           <fee:command>restore</fee:command>
           <fee:period unit="y">1</fee:period>
-          <fee:class>token-not-supported</fee:class>
+          <fee:fee description="restore">17.00</fee:fee>
         </fee:cd>
         <fee:cd xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
           <fee:name>example1.tld</fee:name>
           <fee:currency>USD</fee:currency>
           <fee:command>update</fee:command>
           <fee:period unit="y">1</fee:period>
-          <fee:class>token-not-supported</fee:class>
+          <fee:fee description="update">0.00</fee:fee>
         </fee:cd>
       </fee:chkData>
     </extension>

--- a/core/src/test/resources/google/registry/flows/domain/domain_check_fee_multiple_commands_allocationtoken_response_v12.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_check_fee_multiple_commands_allocationtoken_response_v12.xml
@@ -19,7 +19,7 @@
           </fee:object>
           <fee:command name="create">
             <fee:period unit="y">1</fee:period>
-            <fee:fee description="create">13.00</fee:fee>
+            <fee:fee description="create">11.70</fee:fee>
           </fee:command>
         </fee:cd>
         <fee:cd>
@@ -28,7 +28,7 @@
           </fee:object>
           <fee:command name="renew">
             <fee:period unit="y">1</fee:period>
-            <fee:class>token-not-supported</fee:class>
+            <fee:fee description="renew">11.00</fee:fee>
           </fee:command>
         </fee:cd>
         <fee:cd>
@@ -46,7 +46,7 @@
           </fee:object>
           <fee:command name="restore">
             <fee:period unit="y">1</fee:period>
-            <fee:class>token-not-supported</fee:class>
+            <fee:fee description="restore">17.00</fee:fee>
           </fee:command>
         </fee:cd>
         <fee:cd>
@@ -55,7 +55,7 @@
           </fee:object>
           <fee:command name="update">
             <fee:period unit="y">1</fee:period>
-            <fee:class>token-not-supported</fee:class>
+            <fee:fee description="update">0.00</fee:fee>
           </fee:command>
         </fee:cd>
       </fee:chkData>


### PR DESCRIPTION
We're changing the way that allocation tokens work in suboptimal (i.e. incorrect) situations in the domain check, creation, and renewal process. Currently, if a token is not applicable, in any way, to any of the operations (including when a check has multiple operations requested) we return some variation of "Allocation token not valid" for all of those options. We wish to allow for a more lenient process, where if a token is "not applicable" instead of "invalid", we just pass through that part of the request as if the token were not there.

Types of errors that will remain catastrophic, where we'll basically return a token error immediately in all cases:
- nonexistent or null token
- token is assigned to a particular domain and the request isn't for that domain
- token is not valid for this registrar
- token is a single-use token that has already been redeemed
- token has a promotional schedule and it's no longer valid

Types of errors that will now be a silent pass-through, as if the user did not issue a token:
- token is not allowed for this TLD
- token has a discount, is not valid for premium names, and the domain name is premium
- token does not allow the provided EPP action

Currently, the last three types of errors cause that generic "token invalid" message but in the future, we'll pass the requests through as if the user did not pass in a token. This does allow for a default token to apply to these requests if available, meaning that it's possible that a single DomainCheckFlow with multiple check requests could use the provided token for some check(s), and a default token for others.

The flip side of this is that if the user passes in a catastrophically invalid token (the first five error messages above), we will return that result to any/all checks that they request, even if there are other issues with that request (e.g. the domain is reserved or already registered).

See b/315504612 for more details and background

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2730)
<!-- Reviewable:end -->
