### PR TITLE
Use pipe as extension URI separator

### DIFF
--- a/core/src/main/java/google/registry/flows/CookieSessionMetadata.java
+++ b/core/src/main/java/google/registry/flows/CookieSessionMetadata.java
@@ -103,7 +103,7 @@ public class CookieSessionMetadata extends SessionMetadata {
   @Override
   public Set<String> getServiceExtensionUris() {
     return Optional.ofNullable(data.getOrDefault(SERVICE_EXTENSIONS, null))
-        .map(s -> Splitter.on('.').splitToList(s))
+        .map(s -> Splitter.on(URI_SEPARATOR).splitToList(s))
         .map(ImmutableSet::copyOf)
         .orElse(ImmutableSet.of());
   }
@@ -125,7 +125,7 @@ public class CookieSessionMetadata extends SessionMetadata {
     if (serviceExtensionUris == null || serviceExtensionUris.isEmpty()) {
       data.remove(SERVICE_EXTENSIONS);
     } else {
-      data.put(SERVICE_EXTENSIONS, Joiner.on('.').join(serviceExtensionUris));
+      data.put(SERVICE_EXTENSIONS, Joiner.on(URI_SEPARATOR).join(serviceExtensionUris));
     }
   }
 

--- a/core/src/main/java/google/registry/flows/SessionMetadata.java
+++ b/core/src/main/java/google/registry/flows/SessionMetadata.java
@@ -24,6 +24,8 @@ import java.util.Set;
 /** Object to allow setting and retrieving session information in flows. */
 public abstract class SessionMetadata {
 
+  protected static final char URI_SEPARATOR = '|';
+
   /**
    * Invalidates the session. A new instance must be created after this for future sessions.
    * Attempts to invoke methods of this class after this method has been called will throw {@code
@@ -50,7 +52,9 @@ public abstract class SessionMetadata {
     return toStringHelper(getClass())
         .add("clientId", getRegistrarId())
         .add("failedLoginAttempts", getFailedLoginAttempts())
-        .add("serviceExtensionUris", Joiner.on('.').join(nullToEmpty(getServiceExtensionUris())))
+        .add(
+            "serviceExtensionUris",
+            Joiner.on(URI_SEPARATOR).join(nullToEmpty(getServiceExtensionUris())))
         .toString();
   }
 

--- a/core/src/test/java/google/registry/flows/CookieSessionMetadataTest.java
+++ b/core/src/test/java/google/registry/flows/CookieSessionMetadataTest.java
@@ -47,7 +47,7 @@ public class CookieSessionMetadataTest {
             "THIS_COOKIE=foo; SESSION_INFO="
                 + encode(
                     "CookieSessionMetadata{clientId=test_registrar, failedLoginAttempts=5, "
-                        + " serviceExtensionUris=A.B.C}")
+                        + " serviceExtensionUris=A|B|C}")
                 + "; THAT_COOKIE=bar");
     cookieSessionMetadata = new CookieSessionMetadata(request);
     assertThat(cookieSessionMetadata.getRegistrarId()).isEqualTo("test_registrar");
@@ -62,7 +62,7 @@ public class CookieSessionMetadataTest {
             "SESSION_INFO="
                 + encode(
                     "CookieSessionMetadata{clientId=null, failedLoginAttempts=5, "
-                        + " serviceExtensionUris=A.B.C}"));
+                        + " serviceExtensionUris=A|B|C}"));
     cookieSessionMetadata = new CookieSessionMetadata(request);
     assertThat(cookieSessionMetadata.getRegistrarId()).isNull();
     assertThat(cookieSessionMetadata.getFailedLoginAttempts()).isEqualTo(5);
@@ -151,10 +151,11 @@ public class CookieSessionMetadataTest {
                     "CookieSessionMetadata{clientId=test_registrar, failedLoginAttempts=5, "
                         + " serviceExtensionUris=Foo}"));
     cookieSessionMetadata = new CookieSessionMetadata(request);
-    cookieSessionMetadata.setServiceExtensionUris(ImmutableSet.of("Bar", "Baz"));
+    cookieSessionMetadata.setServiceExtensionUris(ImmutableSet.of("Bar", "Baz", "foo:bar:baz-1.3"));
     assertThat(cookieSessionMetadata.getRegistrarId()).isEqualTo("test_registrar");
     assertThat(cookieSessionMetadata.getFailedLoginAttempts()).isEqualTo(5);
-    assertThat(cookieSessionMetadata.getServiceExtensionUris()).containsExactly("Bar", "Baz");
+    assertThat(cookieSessionMetadata.getServiceExtensionUris())
+        .containsExactly("Bar", "Baz", "foo:bar:baz-1.3");
   }
 
   @Test
@@ -206,6 +207,6 @@ public class CookieSessionMetadataTest {
     assertThat(value)
         .isEqualTo(
             "CookieSessionMetadata{clientId=new_registrar, failedLoginAttempts=1,"
-                + " serviceExtensionUris=Bar.Baz}");
+                + " serviceExtensionUris=Bar|Baz}");
   }
 }


### PR DESCRIPTION
It turns out period can be used in the URI, such as in
"urn:ietf:params:xml:ns:fee-0.12". I don't think pipe is used, at least
not according to EPP URI namespace naming convention.

Ideally we'd use serialization, but using the default serialization runs
the risk of it being platform/JDK dependent, so a new deployment might
not be able to deserialize existing cookies. A custom serializer that
guarantees stability would have been needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2737)
<!-- Reviewable:end -->
