### PR TITLE
Increase hikari maximum pool size to 20

### DIFF
--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -243,7 +243,7 @@ hibernate:
   # that BEAM pipelines are not subject to the maximumPoolSize value defined
   # here. See PersistenceModule.java for more information.
   hikariMinimumIdle: 1
-  hikariMaximumPoolSize: 10
+  hikariMaximumPoolSize: 20
   hikariIdleTimeout: 300000
   # The batch size is basically the number of insertions / updates in a single
   # transaction that will be batched together into one INSERT/UPDATE statement.


### PR DESCRIPTION
Our connections hover around 20-30% all the time, so this max pool size limitation has been dragging us down. I will double it and monitor for active connections for a week.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2742)
<!-- Reviewable:end -->
