### PR TITLE
Remove transaction duration logging

### DIFF
--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -276,10 +276,6 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
       }
       T result = work.call();
       txn.commit();
-      long duration = clock.nowUtc().getMillis() - txnInfo.transactionTime.getMillis();
-      if (duration >= 100) {
-        logger.atInfo().log("Transaction duration: %d milliseconds", duration);
-      }
       return result;
     } catch (Throwable e) {
       // Catch a Throwable here so even Errors would lead to a rollback.


### PR DESCRIPTION
We suspected this could be a cause of optimistic locking failures (because long transactions would lead to optimistic locks not being released) but this didn't end up being the case. Let's remove this to reduce log spam.