### PR TITLE
Use the primary DB for DomainInfoFlow

### DIFF
--- a/core/src/test/java/google/registry/flows/FlowModuleTest.java
+++ b/core/src/test/java/google/registry/flows/FlowModuleTest.java
@@ -58,7 +58,7 @@ public class FlowModuleTest {
 
   @Test
   void givenNonMutatingFlow_thenReplicaTmIsUsed() throws EppException {
-    String eppInputXmlFilename = "domain_info.xml";
+    String eppInputXmlFilename = "domain_check.xml";
     FlowModule flowModule =
         new FlowModule.Builder().setEppInput(getEppInput(eppInputXmlFilename)).build();
     JpaTransactionManager tm =

--- a/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
@@ -179,7 +179,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
       ImmutableMap<String, String> substitutions,
       boolean expectHistoryAndBilling)
       throws Exception {
-    assertMutatingFlow(false);
+    assertMutatingFlow(true);
     String expected =
         loadFile(expectedXmlFilename, updateSubstitutions(substitutions, "ROID", "2FF-TLD"));
     if (inactive) {

--- a/core/src/test/resources/google/registry/flows/domain_check.xml
+++ b/core/src/test/resources/google/registry/flows/domain_check.xml
@@ -1,0 +1,11 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <command>
+    <check>
+      <domain:check
+       xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>%DOMAIN%</domain:name>
+      </domain:check>
+    </check>
+    <clTRID>ABC-12345</clTRID>
+  </command>
+</epp>


### PR DESCRIPTION
This avoids potential replication lag issues when requesting info on domains that were just created.

Only about 9% of EPP requests were domain info requests so this shouldn't have a gigantic impact (roughly 84% are domain check requests, which will remain on the replica) 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2750)
<!-- Reviewable:end -->
