### PR TITLE
Fix create_cdns_tld command

### DIFF
--- a/core/src/main/java/google/registry/tools/CreateCdnsTld.java
+++ b/core/src/main/java/google/registry/tools/CreateCdnsTld.java
@@ -72,11 +72,11 @@ final class CreateCdnsTld extends ConfirmingCommand {
             .setDescription(description)
             .setNameServerSet(
                 RegistryToolEnvironment.get() == RegistryToolEnvironment.PRODUCTION
-                ? "cloud-dns-registry"
-                : "cloud-dns-registry-test")
+                    ? "cloud-dns-registry"
+                    : "cloud-dns-registry-test")
             .setDnsName(dnsName)
             .setName((name != null) ? name : dnsName)
-            .setDnssecConfig(new ManagedZoneDnsSecConfig().setNonExistence("NSEC").setState("ON"));
+            .setDnssecConfig(new ManagedZoneDnsSecConfig().setNonExistence("nsec").setState("on"));
   }
 
   @Override

--- a/core/src/test/java/google/registry/tools/CreateCdnsTldTest.java
+++ b/core/src/test/java/google/registry/tools/CreateCdnsTldTest.java
@@ -55,7 +55,7 @@ class CreateCdnsTldTest extends CommandTestCase<CreateCdnsTld> {
         .setDnsName(dnsName)
         .setDescription(description)
         .setName(name)
-        .setDnssecConfig(new ManagedZoneDnsSecConfig().setState("ON").setNonExistence("NSEC"));
+        .setDnssecConfig(new ManagedZoneDnsSecConfig().setState("on").setNonExistence("nsec"));
   }
 
   @Test


### PR DESCRIPTION
The Cloud DNS rest api is now case-sensitive about enum names (must be lower case, counterintuitively).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2760)
<!-- Reviewable:end -->
