### PR TITLE
Remove spurious parenthesis in URS command output

### DIFF
--- a/core/src/main/java/google/registry/tools/UniformRapidSuspensionCommand.java
+++ b/core/src/main/java/google/registry/tools/UniformRapidSuspensionCommand.java
@@ -251,11 +251,12 @@ final class UniformRapidSuspensionCommand extends MutatingEppToolCommand {
     if (undo) {
       return "";
     }
-    StringBuilder undoBuilder = new StringBuilder("UNDO COMMAND:\n\n)")
-        .append("nomulus -e ")
-        .append(RegistryToolEnvironment.get())
-        .append(" uniform_rapid_suspension --undo --domain_name ")
-        .append(domainName);
+    StringBuilder undoBuilder =
+        new StringBuilder("UNDO COMMAND:\n\n")
+            .append("nomulus -e ")
+            .append(RegistryToolEnvironment.get())
+            .append(" uniform_rapid_suspension --undo --domain_name ")
+            .append(domainName);
     if (!existingNameservers.isEmpty()) {
       undoBuilder.append(" --hosts ").append(Joiner.on(',').join(existingNameservers));
     }


### PR DESCRIPTION
It was making the undo nomulus command look like this:

)nomulus ...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2767)
<!-- Reviewable:end -->
