### PR TITLE
Add an aggregate module for DNS writers

### DIFF
--- a/core/src/main/java/google/registry/dns/writer/DnsWritersModule.java
+++ b/core/src/main/java/google/registry/dns/writer/DnsWritersModule.java
@@ -1,0 +1,29 @@
+// Copyright 2025 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.dns.writer;
+
+import dagger.Module;
+import google.registry.dns.writer.clouddns.CloudDnsWriterModule;
+import google.registry.dns.writer.dnsupdate.DnsUpdateWriterModule;
+
+/**
+ * Groups all {@link DnsWriter} implementations to be installed.
+ *
+ * <p>To cherry-pick the DNS writers to install, overwrite this file with your private version in
+ * the release process.
+ */
+@Module(
+    includes = {CloudDnsWriterModule.class, DnsUpdateWriterModule.class, VoidDnsWriterModule.class})
+public class DnsWritersModule {}

--- a/core/src/main/java/google/registry/module/RequestComponent.java
+++ b/core/src/main/java/google/registry/module/RequestComponent.java
@@ -38,10 +38,8 @@ import google.registry.dns.PublishDnsUpdatesAction;
 import google.registry.dns.ReadDnsRefreshRequestsAction;
 import google.registry.dns.RefreshDnsAction;
 import google.registry.dns.RefreshDnsOnHostRenameAction;
-import google.registry.dns.writer.VoidDnsWriterModule;
-import google.registry.dns.writer.clouddns.CloudDnsWriterModule;
+import google.registry.dns.writer.DnsWritersModule;
 import google.registry.dns.writer.dnsupdate.DnsUpdateConfigModule;
-import google.registry.dns.writer.dnsupdate.DnsUpdateWriterModule;
 import google.registry.export.ExportDomainListsAction;
 import google.registry.export.ExportPremiumTermsAction;
 import google.registry.export.ExportReservedTermsAction;
@@ -140,14 +138,13 @@ import google.registry.whois.WhoisModule;
       BatchModule.class,
       BillingModule.class,
       CheckApiModule.class,
-      CloudDnsWriterModule.class,
       ConsoleModule.class,
       CronModule.class,
       CustomLogicModule.class,
       DnsCountQueryCoordinatorModule.class,
       DnsModule.class,
       DnsUpdateConfigModule.class,
-      DnsUpdateWriterModule.class,
+      DnsWritersModule.class,
       EppTlsModule.class,
       EppToolModule.class,
       IcannReportingModule.class,
@@ -160,7 +157,6 @@ import google.registry.whois.WhoisModule;
       Spec11Module.class,
       TmchModule.class,
       ToolsServerModule.class,
-      VoidDnsWriterModule.class,
       WhiteboxModule.class,
       WhoisModule.class,
     })

--- a/core/src/main/java/google/registry/module/backend/BackendComponent.java
+++ b/core/src/main/java/google/registry/module/backend/BackendComponent.java
@@ -22,7 +22,6 @@ import google.registry.bigquery.BigqueryModule;
 import google.registry.config.CloudTasksUtilsModule;
 import google.registry.config.CredentialModule;
 import google.registry.config.RegistryConfig.ConfigModule;
-import google.registry.dns.writer.VoidDnsWriterModule;
 import google.registry.export.DriveModule;
 import google.registry.export.sheet.SheetsServiceModule;
 import google.registry.flows.ServerTridProviderModule;
@@ -73,7 +72,6 @@ import jakarta.inject.Singleton;
       SheetsServiceModule.class,
       StackdriverModule.class,
       UrlConnectionServiceModule.class,
-      VoidDnsWriterModule.class,
       UtilsModule.class
     })
 interface BackendComponent {

--- a/core/src/main/java/google/registry/module/backend/BackendRequestComponent.java
+++ b/core/src/main/java/google/registry/module/backend/BackendRequestComponent.java
@@ -34,10 +34,8 @@ import google.registry.dns.PublishDnsUpdatesAction;
 import google.registry.dns.ReadDnsRefreshRequestsAction;
 import google.registry.dns.RefreshDnsAction;
 import google.registry.dns.RefreshDnsOnHostRenameAction;
-import google.registry.dns.writer.VoidDnsWriterModule;
-import google.registry.dns.writer.clouddns.CloudDnsWriterModule;
+import google.registry.dns.writer.DnsWritersModule;
 import google.registry.dns.writer.dnsupdate.DnsUpdateConfigModule;
-import google.registry.dns.writer.dnsupdate.DnsUpdateWriterModule;
 import google.registry.export.ExportDomainListsAction;
 import google.registry.export.ExportPremiumTermsAction;
 import google.registry.export.ExportReservedTermsAction;
@@ -82,13 +80,12 @@ import google.registry.tmch.TmchSmdrlAction;
     modules = {
       BatchModule.class,
       BillingModule.class,
-      CloudDnsWriterModule.class,
       CronModule.class,
       CustomLogicModule.class,
       DnsCountQueryCoordinatorModule.class,
       DnsModule.class,
       DnsUpdateConfigModule.class,
-      DnsUpdateWriterModule.class,
+      DnsWritersModule.class,
       IcannReportingModule.class,
       RdeModule.class,
       ReportingModule.class,
@@ -96,7 +93,6 @@ import google.registry.tmch.TmchSmdrlAction;
       SheetModule.class,
       Spec11Module.class,
       TmchModule.class,
-      VoidDnsWriterModule.class,
       WhiteboxModule.class,
     })
 public interface BackendRequestComponent {

--- a/core/src/main/java/google/registry/tools/RegistryToolComponent.java
+++ b/core/src/main/java/google/registry/tools/RegistryToolComponent.java
@@ -23,9 +23,7 @@ import google.registry.config.CloudTasksUtilsModule;
 import google.registry.config.CredentialModule.LocalCredentialJson;
 import google.registry.config.RegistryConfig.Config;
 import google.registry.config.RegistryConfig.ConfigModule;
-import google.registry.dns.writer.VoidDnsWriterModule;
-import google.registry.dns.writer.clouddns.CloudDnsWriterModule;
-import google.registry.dns.writer.dnsupdate.DnsUpdateWriterModule;
+import google.registry.dns.writer.DnsWritersModule;
 import google.registry.keyring.KeyringModule;
 import google.registry.keyring.api.KeyModule;
 import google.registry.model.ModelModule;
@@ -56,9 +54,8 @@ import javax.annotation.Nullable;
       BatchModule.class,
       BigqueryModule.class,
       ConfigModule.class,
-      CloudDnsWriterModule.class,
       CloudTasksUtilsModule.class,
-      DnsUpdateWriterModule.class,
+      DnsWritersModule.class,
       GsonModule.class,
       KeyModule.class,
       KeyringModule.class,
@@ -71,7 +68,6 @@ import javax.annotation.Nullable;
       SecretManagerModule.class,
       UrlConnectionServiceModule.class,
       UtilsModule.class,
-      VoidDnsWriterModule.class,
       NonCachingWhoisModule.class
     })
 interface RegistryToolComponent {


### PR DESCRIPTION
Add a new DnsWritersModule for use by the component classes.

To override the set of writers installed, we can easily overwrite this file with a private version.

Tested in crash both the server and the tool.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2769)
<!-- Reviewable:end -->
