### PR TITLE
Add an "about" link to registrars in RDAP

### DIFF
--- a/core/src/main/java/google/registry/rdap/RdapJsonFormatter.java
+++ b/core/src/main/java/google/registry/rdap/RdapJsonFormatter.java
@@ -721,6 +721,15 @@ public class RdapJsonFormatter {
       builder.linksBuilder().add(makeSelfLink("entity", ianaIdentifier.toString()));
     }
 
+    // RDAP Response Profile 2.4.6: must have a links entry pointing to the registrar URL, with a
+    // rel:about and a value containing the registrar RDAP base URL (if present)
+    if (registrar.getUrl() != null) {
+      Link.Builder registrarLinkBuilder =
+          Link.builder().setHref(registrar.getUrl()).setRel("about").setType("text/html");
+      registrar.getRdapBaseUrls().stream().findFirst().ifPresent(registrarLinkBuilder::setValue);
+      builder.linksBuilder().add(registrarLinkBuilder.build());
+    }
+
     // There's no mention of the registrar STATUS in the RDAP Response Profile, so we'll only add it
     // for FULL response
     // We could probably not add it at all, but it could be useful for us internally

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerExtension.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerExtension.java
@@ -379,6 +379,7 @@ public abstract class JpaTransactionManagerExtension
         .setPassword("foo-BAR2")
         .setPhoneNumber("+1.3334445555")
         .setPhonePasscode("12345")
+        .setRdapBaseUrls(ImmutableSet.of("https://rdap.newregistrar.com/"))
         .setRegistryLockAllowed(false)
         .build();
   }
@@ -393,6 +394,7 @@ public abstract class JpaTransactionManagerExtension
         .setPassword("password2")
         .setPhoneNumber("+1.2223334444")
         .setPhonePasscode("22222")
+        .setRdapBaseUrls(ImmutableSet.of("https://rdap.theregistrar.com/"))
         .setRegistryLockAllowed(true)
         .build();
   }

--- a/core/src/test/java/google/registry/testing/FullFieldsTestEntityHelper.java
+++ b/core/src/test/java/google/registry/testing/FullFieldsTestEntityHelper.java
@@ -84,9 +84,7 @@ public final class FullFieldsTestEntityHelper {
         .setFaxNumber("+1.2125551213")
         .setEmailAddress("contact-us@example.com")
         .setWhoisServer("whois.example.com")
-        .setRdapBaseUrls(
-            ImmutableSet.of(
-                "https://rdap.example.com/withSlash/", "https://rdap.example.com/withoutSlash"))
+        .setRdapBaseUrls(ImmutableSet.of("https://rdap.example.com/withSlash/"))
         .setUrl("http://my.fake.url")
         .build();
   }

--- a/core/src/test/resources/google/registry/rdap/rdap_domain.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain.json
@@ -25,12 +25,6 @@
       "type": "application/rdap+json",
       "rel": "related",
       "value": "%REQUEST_URL%"
-    },
-    {
-      "href": "https://rdap.example.com/withoutSlash/domain/%DOMAIN_PUNYCODE_NAME_1%",
-      "type": "application/rdap+json",
-      "rel": "related",
-      "value": "%REQUEST_URL%"
     }
   ],
   "events": [
@@ -122,6 +116,12 @@
           "type": "application/rdap+json",
           "rel": "self",
           "value": "%REQUEST_URL%"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "vcardArray" : [

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_add_grace_period.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_add_grace_period.json
@@ -15,6 +15,12 @@
           "rel": "self",
           "type": "application/rdap+json",
           "value": "https://example.tld/rdap/domain/addgraceperiod.lol"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.theregistrar.com/"
         }
       ],
       "publicIds": [
@@ -126,6 +132,12 @@
     {
       "href": "https://example.tld/rdap/domain/addgraceperiod.lol",
       "rel": "self",
+      "type": "application/rdap+json",
+      "value": "https://example.tld/rdap/domain/addgraceperiod.lol"
+    },
+    {
+      "href": "https://rdap.theregistrar.com/domain/addgraceperiod.lol",
+      "rel": "related",
       "type": "application/rdap+json",
       "value": "https://example.tld/rdap/domain/addgraceperiod.lol"
     }

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_auto_renew_grace_period.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_auto_renew_grace_period.json
@@ -15,6 +15,12 @@
           "rel": "self",
           "type": "application/rdap+json",
           "value": "https://example.tld/rdap/domain/autorenew.lol"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.theregistrar.com/"
         }
       ],
       "publicIds": [
@@ -130,6 +136,12 @@
     {
       "href": "https://example.tld/rdap/domain/autorenew.lol",
       "rel": "self",
+      "type": "application/rdap+json",
+      "value": "https://example.tld/rdap/domain/autorenew.lol"
+    },
+    {
+      "href": "https://rdap.theregistrar.com/domain/autorenew.lol",
+      "rel": "related",
       "type": "application/rdap+json",
       "value": "https://example.tld/rdap/domain/autorenew.lol"
     }

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_cat2.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_cat2.json
@@ -25,12 +25,6 @@
       "type": "application/rdap+json",
       "rel": "related",
       "value": "https://example.tld/rdap/domains"
-    },
-    {
-      "href": "https://rdap.example.com/withoutSlash/domain/%DOMAIN_PUNYCODE_NAME_1%",
-      "type": "application/rdap+json",
-      "rel": "related",
-      "value": "https://example.tld/rdap/domains"
     }
   ],
   "events": [
@@ -105,6 +99,12 @@
           "type": "application/rdap+json",
           "rel": "self",
           "value": "https://example.tld/rdap/domains"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "vcardArray" : [

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_deleted.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_deleted.json
@@ -26,12 +26,6 @@
       "type": "application/rdap+json",
       "rel": "related",
       "value": "%REQUEST_URL%"
-    },
-    {
-      "href": "https://rdap.example.com/withoutSlash/domain/%DOMAIN_PUNYCODE_NAME_1%",
-      "type": "application/rdap+json",
-      "rel": "related",
-      "value": "%REQUEST_URL%"
     }
   ],
   "events": [
@@ -117,6 +111,12 @@
           "type": "application/rdap+json",
           "rel": "self",
           "value": "%REQUEST_URL%"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "vcardArray" : [

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_explicit_renew_grace_period.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_explicit_renew_grace_period.json
@@ -15,6 +15,12 @@
           "rel": "self",
           "type": "application/rdap+json",
           "value": "https://example.tld/rdap/domain/renew.lol"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.theregistrar.com/"
         }
       ],
       "publicIds": [
@@ -126,6 +132,12 @@
     {
       "href": "https://example.tld/rdap/domain/renew.lol",
       "rel": "self",
+      "type": "application/rdap+json",
+      "value": "https://example.tld/rdap/domain/renew.lol"
+    },
+    {
+      "href": "https://rdap.theregistrar.com/domain/renew.lol",
+      "rel": "related",
       "type": "application/rdap+json",
       "value": "https://example.tld/rdap/domain/renew.lol"
     }

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_no_contacts_exist_with_remark.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_no_contacts_exist_with_remark.json
@@ -25,12 +25,6 @@
       "type": "application/rdap+json",
       "rel": "related",
       "value": "https://example.tld/rdap/domain/cat.lol"
-    },
-    {
-      "href": "https://rdap.example.com/withoutSlash/domain/%DOMAIN_PUNYCODE_NAME_1%",
-      "type": "application/rdap+json",
-      "rel": "related",
-      "value": "https://example.tld/rdap/domain/cat.lol"
     }
   ],
   "events": [
@@ -112,6 +106,12 @@
           "href" : "https://example.tld/rdap/entity/1",
           "type" : "application/rdap+json",
           "value": "https://example.tld/rdap/domain/cat.lol"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds" : [

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_no_registrant_with_remark.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_no_registrant_with_remark.json
@@ -25,12 +25,6 @@
       "type": "application/rdap+json",
       "rel": "related",
       "value": "https://example.tld/rdap/domain/cat.lol"
-    },
-    {
-      "href": "https://rdap.example.com/withoutSlash/domain/%DOMAIN_PUNYCODE_NAME_1%",
-      "type": "application/rdap+json",
-      "rel": "related",
-      "value": "https://example.tld/rdap/domain/cat.lol"
     }
   ],
   "events": [
@@ -112,6 +106,12 @@
           "href" : "https://example.tld/rdap/entity/1",
           "type" : "application/rdap+json",
           "value": "https://example.tld/rdap/domain/cat.lol"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds" : [

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_pending_delete_redemption_grace_period.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_pending_delete_redemption_grace_period.json
@@ -15,6 +15,12 @@
           "rel": "self",
           "type": "application/rdap+json",
           "value": "https://example.tld/rdap/domain/redemption.lol"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.theregistrar.com/"
         }
       ],
       "publicIds": [
@@ -126,6 +132,12 @@
     {
       "href": "https://example.tld/rdap/domain/redemption.lol",
       "rel": "self",
+      "type": "application/rdap+json",
+      "value": "https://example.tld/rdap/domain/redemption.lol"
+    },
+    {
+      "href": "https://rdap.theregistrar.com/domain/redemption.lol",
+      "rel": "related",
       "type": "application/rdap+json",
       "value": "https://example.tld/rdap/domain/redemption.lol"
     }

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_redacted_contacts_with_remark.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_redacted_contacts_with_remark.json
@@ -25,12 +25,6 @@
       "type": "application/rdap+json",
       "rel": "related",
       "value": "%REQUEST_URL%"
-    },
-    {
-      "href": "https://rdap.example.com/withoutSlash/domain/%DOMAIN_PUNYCODE_NAME_1%",
-      "type": "application/rdap+json",
-      "rel": "related",
-      "value": "%REQUEST_URL%"
     }
   ],
   "events": [
@@ -112,6 +106,12 @@
           "href" : "https://example.tld/rdap/entity/1",
           "type" : "application/rdap+json",
           "value": "%REQUEST_URL%"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds" : [

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_transfer_grace_period.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_transfer_grace_period.json
@@ -15,6 +15,12 @@
           "rel": "self",
           "type": "application/rdap+json",
           "value": "https://example.tld/rdap/domain/transfer.lol"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.theregistrar.com/"
         }
       ],
       "publicIds": [
@@ -126,6 +132,12 @@
     {
       "href": "https://example.tld/rdap/domain/transfer.lol",
       "rel": "self",
+      "type": "application/rdap+json",
+      "value": "https://example.tld/rdap/domain/transfer.lol"
+    },
+    {
+      "href": "https://rdap.theregistrar.com/domain/transfer.lol",
+      "rel": "related",
       "type": "application/rdap+json",
       "value": "https://example.tld/rdap/domain/transfer.lol"
     }

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_unicode.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_unicode.json
@@ -26,12 +26,6 @@
       "type": "application/rdap+json",
       "rel": "related",
       "value": "%REQUEST_URL%"
-    },
-    {
-      "href": "https://rdap.example.com/withoutSlash/domain/%DOMAIN_PUNYCODE_NAME_1%",
-      "type": "application/rdap+json",
-      "rel": "related",
-      "value": "%REQUEST_URL%"
     }
   ],
   "events": [
@@ -115,6 +109,12 @@
           "type": "application/rdap+json",
           "rel": "self",
           "value": "%REQUEST_URL%"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "vcardArray" : [

--- a/core/src/test/resources/google/registry/rdap/rdap_domain_unicode_no_contacts_with_remark.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_domain_unicode_no_contacts_with_remark.json
@@ -26,12 +26,6 @@
       "type": "application/rdap+json",
       "rel": "related",
       "value": "https://example.tld/rdap/domains"
-    },
-    {
-      "href": "https://rdap.example.com/withoutSlash/domain/%DOMAIN_PUNYCODE_NAME_1%",
-      "type": "application/rdap+json",
-      "rel": "related",
-      "value": "https://example.tld/rdap/domains"
     }
   ],
   "events": [
@@ -115,6 +109,12 @@
           "href" : "https://example.tld/rdap/entity/1",
           "type" : "application/rdap+json",
           "value": "https://example.tld/rdap/domains"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds" : [

--- a/core/src/test/resources/google/registry/rdap/rdap_host.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_host.json
@@ -39,6 +39,12 @@
           "href" : "https://example.tld/rdap/entity/1",
           "type" : "application/rdap+json",
           "value": "%REQUEST_URL%"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.theregistrar.com/"
         }
       ],
       "publicIds" :

--- a/core/src/test/resources/google/registry/rdap/rdap_host_external.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_host_external.json
@@ -36,6 +36,12 @@
           "href" : "https://example.tld/rdap/entity/1",
           "type" : "application/rdap+json",
           "value": "%REQUEST_URL%"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.theregistrar.com/"
         }
       ],
       "publicIds" :

--- a/core/src/test/resources/google/registry/rdap/rdap_host_linked.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_host_linked.json
@@ -42,6 +42,12 @@
           "href" : "https://example.tld/rdap/entity/1",
           "type" : "application/rdap+json",
           "value": "%REQUEST_URL%"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.theregistrar.com/"
         }
       ],
       "publicIds" :

--- a/core/src/test/resources/google/registry/rdap/rdap_host_unicode.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_host_unicode.json
@@ -40,6 +40,12 @@
           "href" : "https://example.tld/rdap/entity/1",
           "type" : "application/rdap+json",
           "value": "%REQUEST_URL%"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.theregistrar.com/"
         }
       ],
       "publicIds" :

--- a/core/src/test/resources/google/registry/rdap/rdap_nontruncated_registrars.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_nontruncated_registrars.json
@@ -11,6 +11,12 @@
           "href": "https://example.tld/rdap/entity/301",
           "type": "application/rdap+json",
           "value": "https://example.tld/rdap/entities"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds":
@@ -69,6 +75,12 @@
           "href": "https://example.tld/rdap/entity/302",
           "type": "application/rdap+json",
           "value": "https://example.tld/rdap/entities"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds":
@@ -127,6 +139,12 @@
           "href": "https://example.tld/rdap/entity/303",
           "type": "application/rdap+json",
           "value": "https://example.tld/rdap/entities"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds":
@@ -185,6 +203,12 @@
           "href": "https://example.tld/rdap/entity/304",
           "type": "application/rdap+json",
           "value": "https://example.tld/rdap/entities"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds":

--- a/core/src/test/resources/google/registry/rdap/rdap_registrar.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_registrar.json
@@ -15,6 +15,12 @@
       "href": "https://example.tld/rdap/entity/%REGISTRAR_HANDLE_1%",
       "type" : "application/rdap+json",
       "value": "%REQUEST_URL%"
+    },
+    {
+      "rel": "about",
+      "href": "http://my.fake.url",
+      "type": "text/html",
+      "value": "https://rdap.example.com/withSlash/"
     }
   ],
   "publicIds" :

--- a/core/src/test/resources/google/registry/rdap/rdap_registrar_test.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_registrar_test.json
@@ -6,6 +6,14 @@
   ],
   "objectClassName" : "entity",
   "handle" : "%REGISTRAR_HANDLE_1%",
+  "links" : [
+    {
+      "rel": "about",
+      "href": "http://my.fake.url",
+      "type": "text/html",
+      "value": "https://rdap.example.com/withSlash/"
+    }
+  ],
   "status" : ["%STATUS_1%"],
   "roles" : ["registrar"],
   "events": [

--- a/core/src/test/resources/google/registry/rdap/rdap_truncated_mixed_entities.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_truncated_mixed_entities.json
@@ -64,9 +64,9 @@
       "links" :
       [
         {
-          "rel" : "self",
+          "rel": "self",
           "href": "https://example.tld/rdap/entity/0002-ROID",
-          "type" : "application/rdap+json",
+          "type": "application/rdap+json",
           "value": "https://example.tld/rdap/entities"
         }
       ],
@@ -182,6 +182,12 @@
           "href": "https://example.tld/rdap/entity/301",
           "type" : "application/rdap+json",
           "value": "https://example.tld/rdap/entities"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds" :

--- a/core/src/test/resources/google/registry/rdap/rdap_truncated_registrars.json
+++ b/core/src/test/resources/google/registry/rdap/rdap_truncated_registrars.json
@@ -11,6 +11,12 @@
           "href": "https://example.tld/rdap/entity/301",
           "type" : "application/rdap+json",
           "value": "https://example.tld/rdap/entities"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds" :
@@ -69,6 +75,12 @@
           "href": "https://example.tld/rdap/entity/302",
           "type" : "application/rdap+json",
           "value": "https://example.tld/rdap/entities"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds" :
@@ -127,6 +139,12 @@
           "href": "https://example.tld/rdap/entity/303",
           "type" : "application/rdap+json",
           "value": "https://example.tld/rdap/entities"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds" :
@@ -185,6 +203,12 @@
           "href": "https://example.tld/rdap/entity/304",
           "type" : "application/rdap+json",
           "value": "https://example.tld/rdap/entities"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds" :

--- a/core/src/test/resources/google/registry/rdap/rdapjson_domain_full.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_domain_full.json
@@ -21,11 +21,6 @@
       "rel" : "related",
       "href" : "https://rdap.example.com/withSlash/domain/cat.xn--q9jyb4c",
       "type" : "application/rdap+json"
-    },
-    {
-      "rel" : "related",
-      "href" : "https://rdap.example.com/withoutSlash/domain/cat.xn--q9jyb4c",
-      "type" : "application/rdap+json"
     }
   ],
   "events": [
@@ -112,6 +107,12 @@
           "rel" : "self",
           "href" : "https://example.tld/rdap/entity/1",
           "type" : "application/rdap+json"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds" :

--- a/core/src/test/resources/google/registry/rdap/rdapjson_domain_logged_out.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_domain_logged_out.json
@@ -21,11 +21,6 @@
       "href": "https://rdap.example.com/withSlash/domain/cat.xn--q9jyb4c",
       "type": "application/rdap+json",
       "rel": "related"
-    },
-    {
-      "href": "https://rdap.example.com/withoutSlash/domain/cat.xn--q9jyb4c",
-      "type": "application/rdap+json",
-      "rel": "related"
     }
   ],
   "events": [
@@ -109,6 +104,12 @@
           "rel": "self",
           "href": "https://example.tld/rdap/entity/1",
           "type": "application/rdap+json"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds": [

--- a/core/src/test/resources/google/registry/rdap/rdapjson_domain_no_nameservers.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_domain_no_nameservers.json
@@ -22,11 +22,6 @@
       "href": "https://rdap.example.com/withSlash/domain/fish.xn--q9jyb4c",
       "type": "application/rdap+json",
       "rel": "related"
-    },
-    {
-      "href": "https://rdap.example.com/withoutSlash/domain/fish.xn--q9jyb4c",
-      "type": "application/rdap+json",
-      "rel": "related"
     }
   ],
   "events": [
@@ -60,6 +55,12 @@
           "rel": "self",
           "href": "https://example.tld/rdap/entity/1",
           "type": "application/rdap+json"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds":

--- a/core/src/test/resources/google/registry/rdap/rdapjson_host_both.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_host_both.json
@@ -34,6 +34,12 @@
           "rel" : "self",
           "href" : "https://example.tld/rdap/entity/1",
           "type" : "application/rdap+json"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds" :

--- a/core/src/test/resources/google/registry/rdap/rdapjson_host_ipv4.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_host_ipv4.json
@@ -30,6 +30,12 @@
           "rel": "self",
           "href": "https://example.tld/rdap/entity/1",
           "type": "application/rdap+json"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds":

--- a/core/src/test/resources/google/registry/rdap/rdapjson_host_ipv6.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_host_ipv6.json
@@ -30,6 +30,12 @@
           "rel": "self",
           "href": "https://example.tld/rdap/entity/1",
           "type": "application/rdap+json"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds":

--- a/core/src/test/resources/google/registry/rdap/rdapjson_host_no_addresses.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_host_no_addresses.json
@@ -29,6 +29,12 @@
           "rel" : "self",
           "href" : "https://example.tld/rdap/entity/1",
           "type" : "application/rdap+json"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds" :

--- a/core/src/test/resources/google/registry/rdap/rdapjson_host_not_linked.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_host_not_linked.json
@@ -29,6 +29,12 @@
           "rel" : "self",
           "href" : "https://example.tld/rdap/entity/1",
           "type" : "application/rdap+json"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds" :

--- a/core/src/test/resources/google/registry/rdap/rdapjson_host_pending_transfer.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_host_pending_transfer.json
@@ -29,6 +29,12 @@
           "rel" : "self",
           "href" : "https://example.tld/rdap/entity/1",
           "type" : "application/rdap+json"
+        },
+        {
+          "rel": "about",
+          "href": "http://my.fake.url",
+          "type": "text/html",
+          "value": "https://rdap.example.com/withSlash/"
         }
       ],
       "publicIds" :

--- a/core/src/test/resources/google/registry/rdap/rdapjson_registrar.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_registrar.json
@@ -9,6 +9,12 @@
       "rel" : "self",
       "href" : "https://example.tld/rdap/entity/1",
       "type" : "application/rdap+json"
+    },
+    {
+      "rel": "about",
+      "href": "http://my.fake.url",
+      "type": "text/html",
+      "value": "https://rdap.example.com/withSlash/"
     }
   ],
   "events": [

--- a/core/src/test/resources/google/registry/rdap/rdapjson_registrar_summary.json
+++ b/core/src/test/resources/google/registry/rdap/rdapjson_registrar_summary.json
@@ -8,6 +8,12 @@
       "rel" : "self",
       "href" : "https://example.tld/rdap/entity/1",
       "type" : "application/rdap+json"
+    },
+    {
+      "rel": "about",
+      "href": "http://my.fake.url",
+      "type": "text/html",
+      "value": "https://rdap.example.com/withSlash/"
     }
   ],
   "events": [


### PR DESCRIPTION
From the response profile:
2.4.6. Registrar URL - The entity with the registrar role in the RDAP response MUST contain a links member [RFC9083]. The links object MUST contain the elements: value, identical to the the RDAP Base URL for the Registrar as provided in the IANA “Registrar IDs” registry (i.e., https://www.iana.org/assignments/registrar-ids); rel:about, and href containing the Registrar URL. Note: in cases where the Registry Operator acts as sponsoring Registrar (e.g., IANA Registrar ID 9999), the href shall contain a URL from the Registry.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2771)
<!-- Reviewable:end -->
