### PR TITLE
Cache history values for RDAP domain requests

### DIFF
--- a/core/src/test/java/google/registry/rdap/RdapJsonFormatterTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapJsonFormatterTest.java
@@ -462,12 +462,12 @@ class RdapJsonFormatterTest {
   }
 
   @Test
-  void testGetLastHistoryEntryByType() {
+  void testGetLastHistoryByType() {
     // Expected data are from "rdapjson_domain_summary.json"
     assertThat(
             Maps.transformValues(
-                rdapJsonFormatter.getLastHistoryEntryByType(domainFull),
-                HistoryEntry::getModificationTime))
+                RdapJsonFormatter.getLastHistoryByType(domainFull),
+                RdapJsonFormatter.HistoryTimeAndRegistrar::modificationTime))
         .containsExactlyEntriesIn(
             ImmutableMap.of(TRANSFER, DateTime.parse("1999-12-01T00:00:00.000Z")));
   }


### PR DESCRIPTION
In RDAP, domain queries are the most common by a factor of like 40,000 so we should optimize these as much as possible. We already have an EPP resource / foreign key cache which does improve performance somewhat but looking at some sample logs, it only cuts the RDAP request times by like 40% (looking at requests for the same domain a few seconds apart).

History entries don't change often, so we should cache them to make subsequent queries faster as well. In addition, we're only caching two fields per repo ID (modification time, registrar ID) so we can cache more entries than we can for the EPP resource cache (which stores large objects).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2777)
<!-- Reviewable:end -->
