### PR TITLE
Implement the contacts prohibited feature flag for minimum data set

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -72,7 +72,9 @@ import google.registry.flows.custom.DomainCreateFlowCustomLogic;
 import google.registry.flows.custom.DomainCreateFlowCustomLogic.BeforeResponseParameters;
 import google.registry.flows.custom.DomainCreateFlowCustomLogic.BeforeResponseReturnData;
 import google.registry.flows.custom.EntityChanges;
+import google.registry.flows.domain.DomainFlowUtils.RegistrantProhibitedException;
 import google.registry.flows.domain.token.AllocationTokenFlowUtils;
+import google.registry.flows.exceptions.ContactsProhibitedException;
 import google.registry.flows.exceptions.ResourceAlreadyExistsForThisClientException;
 import google.registry.flows.exceptions.ResourceCreateContentionException;
 import google.registry.model.ImmutableObject;
@@ -147,6 +149,7 @@ import org.joda.time.Duration;
  * @error {@link DomainCreateFlow.NoGeneralRegistrationsInCurrentPhaseException}
  * @error {@link DomainCreateFlow.NoTrademarkedRegistrationsBeforeSunriseException}
  * @error {@link BulkDomainRegisteredForTooManyYearsException}
+ * @error {@link ContactsProhibitedException}
  * @error {@link DomainCreateFlow.SignedMarksOnlyDuringSunriseException}
  * @error {@link DomainFlowTmchUtils.NoMarksFoundMatchingDomainException}
  * @error {@link DomainFlowTmchUtils.FoundMarkNotYetValidException}
@@ -194,6 +197,7 @@ import org.joda.time.Duration;
  * @error {@link DomainFlowUtils.NameserversNotSpecifiedForTldWithNameserverAllowListException}
  * @error {@link DomainFlowUtils.PremiumNameBlockedException}
  * @error {@link DomainFlowUtils.RegistrantNotAllowedException}
+ * @error {@link RegistrantProhibitedException}
  * @error {@link DomainFlowUtils.RegistrarMustBeActiveForThisOperationException}
  * @error {@link DomainFlowUtils.TldDoesNotExistException}
  * @error {@link DomainFlowUtils.TooManyDsRecordsException}
@@ -244,7 +248,7 @@ public final class DomainCreateFlow implements MutatingFlow {
     verifyResourceDoesNotExist(Domain.class, targetId, now, registrarId);
     // Validate that this is actually a legal domain name on a TLD that the registrar has access to.
     InternetDomainName domainName = validateDomainName(command.getDomainName());
-    String domainLabel = domainName.parts().get(0);
+    String domainLabel = domainName.parts().getFirst();
     Tld tld = Tld.get(domainName.parent().toString());
     validateCreateCommandContactsAndNameservers(command, tld, domainName);
     TldState tldState = tld.getTldState(now);

--- a/core/src/main/java/google/registry/flows/exceptions/ContactsProhibitedException.java
+++ b/core/src/main/java/google/registry/flows/exceptions/ContactsProhibitedException.java
@@ -1,0 +1,24 @@
+// Copyright 2025 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.flows.exceptions;
+
+import google.registry.flows.EppException.ParameterValuePolicyErrorException;
+
+/** Having contacts is prohibited by registry policy */
+public class ContactsProhibitedException extends ParameterValuePolicyErrorException {
+  public ContactsProhibitedException() {
+    super("Having contacts is prohibited by registry policy");
+  }
+}

--- a/core/src/main/java/google/registry/tools/CreateDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateDomainCommand.java
@@ -16,6 +16,8 @@ package google.registry.tools;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static google.registry.model.common.FeatureFlag.FeatureName.MINIMUM_DATASET_CONTACTS_OPTIONAL;
+import static google.registry.model.common.FeatureFlag.FeatureName.MINIMUM_DATASET_CONTACTS_PROHIBITED;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.pricing.PricingEngineProxy.getPricesForDomainName;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
@@ -62,8 +64,8 @@ final class CreateDomainCommand extends CreateOrUpdateDomainCommand {
   protected void initMutatingEppToolCommand() {
     tm().transact(
             () -> {
-              if (!FeatureFlag.isActiveNowOrElse(
-                  FeatureFlag.FeatureName.MINIMUM_DATASET_CONTACTS_OPTIONAL, false)) {
+              if (!FeatureFlag.isActiveNow(MINIMUM_DATASET_CONTACTS_OPTIONAL)
+                  && !FeatureFlag.isActiveNow(MINIMUM_DATASET_CONTACTS_PROHIBITED)) {
                 checkArgumentNotNull(registrant, "Registrant must be specified");
                 checkArgument(!admins.isEmpty(), "At least one admin must be specified");
                 checkArgument(!techs.isEmpty(), "At least one tech must be specified");

--- a/core/src/test/java/google/registry/model/common/FeatureFlagTest.java
+++ b/core/src/test/java/google/registry/model/common/FeatureFlagTest.java
@@ -56,6 +56,7 @@ public class FeatureFlagTest extends EntityTestCase {
     persistResource(featureFlag);
     FeatureFlag flagFromDb = loadByEntity(featureFlag);
     assertThat(featureFlag).isEqualTo(flagFromDb);
+    assertThat(featureFlag.getFeatureName()).isEqualTo(TEST_FEATURE);
   }
 
   @Test
@@ -217,23 +218,12 @@ public class FeatureFlagTest extends EntityTestCase {
             .build());
     tm().transact(
             () -> {
-              assertThat(FeatureFlag.isActiveNowOrElse(TEST_FEATURE, false)).isFalse();
-              assertThat(FeatureFlag.isActiveNowOrElse(TEST_FEATURE, true)).isFalse();
+              assertThat(FeatureFlag.isActiveNow(TEST_FEATURE)).isFalse();
             });
     fakeClock.advanceBy(Duration.standardDays(365));
     tm().transact(
             () -> {
-              assertThat(FeatureFlag.isActiveNowOrElse(TEST_FEATURE, false)).isTrue();
-              assertThat(FeatureFlag.isActiveNowOrElse(TEST_FEATURE, true)).isTrue();
-            });
-  }
-
-  @Test
-  void testSuccess_default_doesNotExist() {
-    tm().transact(
-            () -> {
-              assertThat(FeatureFlag.isActiveNowOrElse(TEST_FEATURE, false)).isFalse();
-              assertThat(FeatureFlag.isActiveNowOrElse(TEST_FEATURE, true)).isTrue();
+              assertThat(FeatureFlag.isActiveNow(TEST_FEATURE)).isTrue();
             });
   }
 }

--- a/core/src/test/java/google/registry/tools/CreateDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateDomainCommandTest.java
@@ -16,6 +16,7 @@ package google.registry.tools;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.common.FeatureFlag.FeatureName.MINIMUM_DATASET_CONTACTS_OPTIONAL;
+import static google.registry.model.common.FeatureFlag.FeatureName.MINIMUM_DATASET_CONTACTS_PROHIBITED;
 import static google.registry.model.common.FeatureFlag.FeatureStatus.ACTIVE;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.createTld;
@@ -115,11 +116,24 @@ class CreateDomainCommandTest extends EppToolCommandTestCase<CreateDomainCommand
   }
 
   @Test
-  void testSuccess_minimal() throws Exception {
+  void testSuccess_minimumDatasetPhase1_noContacts() throws Exception {
     persistResource(
         new FeatureFlag()
             .asBuilder()
             .setFeatureName(MINIMUM_DATASET_CONTACTS_OPTIONAL)
+            .setStatusMap(ImmutableSortedMap.of(START_OF_TIME, ACTIVE))
+            .build());
+    // Test that each optional field can be omitted. Also tests the auto-gen password.
+    runCommandForced("--client=NewRegistrar", "example.tld");
+    eppVerifier.verifySent("domain_create_minimal.xml");
+  }
+
+  @Test
+  void testSuccess_minimumDatasetPhase2_noContacts() throws Exception {
+    persistResource(
+        new FeatureFlag()
+            .asBuilder()
+            .setFeatureName(MINIMUM_DATASET_CONTACTS_PROHIBITED)
             .setStatusMap(ImmutableSortedMap.of(START_OF_TIME, ACTIVE))
             .build());
     // Test that each optional field can be omitted. Also tests the auto-gen password.

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_no_contacts.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_no_contacts.xml
@@ -1,0 +1,19 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <command>
+    <create>
+      <domain:create
+       xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>example.tld</domain:name>
+        <domain:period unit="y">2</domain:period>
+        <domain:ns>
+          <domain:hostObj>ns1.example.net</domain:hostObj>
+          <domain:hostObj>ns2.example.net</domain:hostObj>
+        </domain:ns>
+        <domain:authInfo>
+          <domain:pw>2fooBAR</domain:pw>
+        </domain:authInfo>
+      </domain:create>
+    </create>
+    <clTRID>ABC-12345</clTRID>
+  </command>
+</epp>

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_response_eap_fee.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_response_eap_fee.xml
@@ -15,7 +15,7 @@
       <fee:creData xmlns:fee="urn:ietf:params:xml:ns:fee-%FEE_VERSION%">
         <fee:currency>USD</fee:currency>
         <fee:fee description="create">24.00</fee:fee>
-        <fee:fee description="Early Access Period, fee expires: 1999-04-04T22:00:00.024Z">100.00</fee:fee>
+        <fee:fee description="Early Access Period, fee expires: 1999-04-04T22:00:00.023Z">100.00</fee:fee>
       </fee:creData>
     </extension>
     <trID>

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_response_premium_eap.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_response_premium_eap.xml
@@ -15,7 +15,7 @@
       <fee:creData xmlns:fee="urn:ietf:params:xml:ns:fee-0.6">
         <fee:currency>USD</fee:currency>
         <fee:fee description="create">200.00</fee:fee>
-        <fee:fee description="Early Access Period, fee expires: 1999-04-04T22:00:00.028Z">100.00
+        <fee:fee description="Early Access Period, fee expires: 1999-04-04T22:00:00.027Z">100.00
         </fee:fee>
       </fee:creData>
     </extension>

--- a/core/src/test/resources/google/registry/flows/domain/domain_update_remove_all_contacts.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_update_remove_all_contacts.xml
@@ -1,0 +1,20 @@
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <command>
+    <update>
+      <domain:update
+       xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>example.tld</domain:name>
+        <domain:add/>
+        <domain:rem>
+          <domain:contact type="admin">sh8013</domain:contact>
+          <domain:contact type="billing">sh8013</domain:contact>
+          <domain:contact type="tech">sh8013</domain:contact>
+        </domain:rem>
+        <domain:chg>
+          <domain:registrant/>
+        </domain:chg>
+      </domain:update>
+    </update>
+    <clTRID>ABC-12345</clTRID>
+  </command>
+</epp>


### PR DESCRIPTION
This prohibits all contact data on create and update EPP flows for both domain and contact flows. It also refactors how default values on FeatureFlags work, as it's safer to specify a single default on the flag itself rather than have to specify it independently at a number of callsites (and potentially end up having an inconsistent value).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2781)
<!-- Reviewable:end -->
