### PR TITLE
Remove superfluous DatabaseHelper db methods

### DIFF
--- a/core/src/test/java/google/registry/batch/DeleteProberDataActionTest.java
+++ b/core/src/test/java/google/registry/batch/DeleteProberDataActionTest.java
@@ -27,7 +27,6 @@ import static google.registry.testing.DatabaseHelper.persistActiveHost;
 import static google.registry.testing.DatabaseHelper.persistDeletedDomain;
 import static google.registry.testing.DatabaseHelper.persistDomainAsDeleted;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.testing.DatabaseHelper.persistSimpleResource;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -287,7 +286,7 @@ class DeleteProberDataActionTest {
   private static Set<ImmutableObject> persistDomainAndDescendants(String fqdn) {
     Domain domain = persistDeletedDomain(fqdn, DELETION_TIME);
     DomainHistory historyEntry =
-        persistSimpleResource(
+        persistResource(
             new DomainHistory.Builder()
                 .setDomain(domain)
                 .setType(HistoryEntry.Type.DOMAIN_CREATE)
@@ -295,7 +294,7 @@ class DeleteProberDataActionTest {
                 .setModificationTime(DELETION_TIME.minusYears(3))
                 .build());
     BillingEvent billingEvent =
-        persistSimpleResource(
+        persistResource(
             new BillingEvent.Builder()
                 .setDomainHistory(historyEntry)
                 .setBillingTime(DELETION_TIME.plusYears(1))
@@ -307,7 +306,7 @@ class DeleteProberDataActionTest {
                 .setTargetId(fqdn)
                 .build());
     PollMessage.OneTime pollMessage =
-        persistSimpleResource(
+        persistResource(
             new PollMessage.OneTime.Builder()
                 .setHistoryEntry(historyEntry)
                 .setEventTime(DELETION_TIME)
@@ -315,7 +314,7 @@ class DeleteProberDataActionTest {
                 .setMsg("Domain registered")
                 .build());
     GracePeriod gracePeriod =
-        persistSimpleResource(
+        persistResource(
             GracePeriod.create(
                 ADD,
                 domain.getRepoId(),

--- a/core/src/test/java/google/registry/batch/SendExpiringCertificateNotificationEmailActionTest.java
+++ b/core/src/test/java/google/registry/batch/SendExpiringCertificateNotificationEmailActionTest.java
@@ -18,7 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.JpaTransactionManagerExtension.makeRegistrar1;
 import static google.registry.testing.DatabaseHelper.loadByEntity;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.testing.DatabaseHelper.persistSimpleResources;
+import static google.registry.testing.DatabaseHelper.persistResources;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -62,7 +62,8 @@ class SendExpiringCertificateNotificationEmailActionTest {
        Kind update your account using the following steps:
         1. Navigate to support and login using your %4$s@registry.example credentials.
         2. Click Settings -> Privacy on the top left corner.
-        3. Click Edit and enter certificate string.  3. Click SaveRegards,Example Registry""";
+        3. Click Edit and enter certificate string.  3. Click SaveRegards,Example Registry\
+      """;
 
   private static final String EXPIRATION_WARNING_EMAIL_SUBJECT_TEXT = "Expiration Warning Email";
 
@@ -223,7 +224,7 @@ class SendExpiringCertificateNotificationEmailActionTest {
                 .setVisibleInWhoisAsAdmin(true)
                 .setVisibleInWhoisAsTech(false)
                 .build());
-    persistSimpleResources(contacts);
+    persistResources(contacts);
     RuntimeException thrown =
         assertThrows(
             RuntimeException.class,
@@ -548,7 +549,7 @@ class SendExpiringCertificateNotificationEmailActionTest {
                 .setTypes(ImmutableSet.of(RegistrarPoc.Type.ADMIN))
                 .setVisibleInWhoisAsTech(true)
                 .build());
-    persistSimpleResources(contacts);
+    persistResources(contacts);
     assertThat(action.getEmailAddresses(registrar, Type.TECH))
         .containsExactly(
             new InternetAddress("will@example-registrar.tld"),
@@ -700,7 +701,7 @@ class SendExpiringCertificateNotificationEmailActionTest {
   /** Returns persisted sample contacts with a customized contact email type. */
   private static ImmutableList<RegistrarPoc> persistSampleContacts(
       Registrar registrar, RegistrarPoc.Type emailType) {
-    return persistSimpleResources(
+    return persistResources(
         ImmutableList.of(
             new RegistrarPoc.Builder()
                 .setRegistrar(registrar)

--- a/core/src/test/java/google/registry/beam/common/RegistryJpaReadTest.java
+++ b/core/src/test/java/google/registry/beam/common/RegistryJpaReadTest.java
@@ -15,9 +15,10 @@
 package google.registry.beam.common;
 
 import static google.registry.persistence.transaction.JpaTransactionManagerExtension.makeRegistrar1;
-import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.newContact;
 import static google.registry.testing.DatabaseHelper.newTld;
+import static google.registry.testing.DatabaseHelper.persistResource;
+import static google.registry.testing.DatabaseHelper.persistResources;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
@@ -75,7 +76,7 @@ public class RegistryJpaReadTest {
   @BeforeEach
   void beforeEach() {
     Registrar ofyRegistrar = JpaIntegrationTestExtension.makeRegistrar2();
-    insertInDb(ofyRegistrar);
+    persistResource(ofyRegistrar);
 
     ImmutableList.Builder<Contact> builder = new ImmutableList.Builder<>();
 
@@ -84,7 +85,7 @@ public class RegistryJpaReadTest {
       builder.add(contact);
     }
     contacts = builder.build();
-    insertInDb(contacts);
+    persistResources(contacts);
   }
 
   @Test
@@ -211,6 +212,6 @@ public class RegistryJpaReadTest {
                     null,
                     100L))
             .build();
-    insertInDb(registry, registrar, contact, domain);
+    persistResources(registry, registrar, contact, domain);
   }
 }

--- a/core/src/test/java/google/registry/beam/rde/RdePipelineTest.java
+++ b/core/src/test/java/google/registry/beam/rde/RdePipelineTest.java
@@ -30,7 +30,6 @@ import static google.registry.rde.RdeResourceType.DOMAIN;
 import static google.registry.rde.RdeResourceType.HOST;
 import static google.registry.rde.RdeResourceType.REGISTRAR;
 import static google.registry.testing.DatabaseHelper.createTld;
-import static google.registry.testing.DatabaseHelper.insertSimpleResources;
 import static google.registry.testing.DatabaseHelper.newDomain;
 import static google.registry.testing.DatabaseHelper.persistActiveContact;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
@@ -38,6 +37,7 @@ import static google.registry.testing.DatabaseHelper.persistActiveHost;
 import static google.registry.testing.DatabaseHelper.persistEppResource;
 import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
+import static google.registry.testing.DatabaseHelper.persistResources;
 import static google.registry.util.ResourceUtils.readResourceUtf8;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertThrows;
@@ -223,7 +223,7 @@ public class RdePipelineTest {
 
   @BeforeEach
   void beforeEach() throws Exception {
-    insertSimpleResources(ImmutableList.of(makeRegistrar1(), makeRegistrar2()));
+    persistResources(ImmutableList.of(makeRegistrar1(), makeRegistrar2()));
 
     // Two real registrars have been created by loadInitialData(), named "New Registrar" and "The
     // Registrar". Create one included registrar (external_monitoring) and two excluded ones.
@@ -403,7 +403,8 @@ public class RdePipelineTest {
                                   <rdeDomain:crRr>TheRegistrar</rdeDomain:crRr>
                                   <rdeDomain:crDate>1970-01-01T00:00:00Z</rdeDomain:crDate>
                                   <rdeDomain:exDate>294247-01-10T04:00:54Z</rdeDomain:exDate>
-                              </rdeDomain:domain>""");
+                              </rdeDomain:domain>\
+                              """);
                     }
                     if (kv.getKey().mode().equals(FULL)) {
                       // Contact fragments for hello.soy.
@@ -441,7 +442,8 @@ public class RdePipelineTest {
                                     <rdeDomain:crRr>TheRegistrar</rdeDomain:crRr>
                                     <rdeDomain:crDate>1970-01-01T00:00:00Z</rdeDomain:crDate>
                                     <rdeDomain:exDate>294247-01-10T04:00:54Z</rdeDomain:exDate>
-                                </rdeDomain:domain>""");
+                                </rdeDomain:domain>\
+                                """);
                       } else {
                         // Contact fragments for cat.fun.
                         assertThat(
@@ -484,7 +486,8 @@ public class RdePipelineTest {
                                   <rdeDomain:crRr>TheRegistrar</rdeDomain:crRr>
                                   <rdeDomain:crDate>1970-01-01T00:00:00Z</rdeDomain:crDate>
                                   <rdeDomain:exDate>294247-01-10T04:00:54Z</rdeDomain:exDate>
-                              </rdeDomain:domain>""");
+                              </rdeDomain:domain>\
+                              """);
                     }
                   });
               return null;

--- a/core/src/test/java/google/registry/export/sheet/SyncRegistrarsSheetTest.java
+++ b/core/src/test/java/google/registry/export/sheet/SyncRegistrarsSheetTest.java
@@ -23,7 +23,7 @@ import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.loadByKey;
 import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.testing.DatabaseHelper.persistSimpleResources;
+import static google.registry.testing.DatabaseHelper.persistResources;
 import static org.joda.money.CurrencyUnit.JPY;
 import static org.joda.money.CurrencyUnit.USD;
 import static org.joda.time.DateTimeZone.UTC;
@@ -179,7 +179,7 @@ public class SyncRegistrarsSheetTest {
                 .build());
     // Use registrar key for contacts' parent.
     DateTime registrarCreationTime = persistResource(registrar).getCreationTime();
-    persistSimpleResources(contacts);
+    persistResources(contacts);
 
     clock.advanceBy(standardMinutes(1));
     newSyncRegistrarsSheet().run("foobar");

--- a/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
@@ -150,53 +150,50 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
       StatusValue... statusValues)
       throws Exception {
     Domain domain = DatabaseHelper.newDomain(getUniqueIdFromCommand());
-    tm().transact(
-            () -> {
-              try {
-                DomainHistory historyEntryDomainCreate =
-                    new DomainHistory.Builder()
-                        .setDomain(domain)
-                        .setType(HistoryEntry.Type.DOMAIN_CREATE)
-                        .setModificationTime(clock.nowUtc())
-                        .setRegistrarId(domain.getCreationRegistrarId())
-                        .build();
-                BillingRecurrence autorenewEvent =
-                    new BillingRecurrence.Builder()
-                        .setReason(Reason.RENEW)
-                        .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
-                        .setTargetId(getUniqueIdFromCommand())
-                        .setRegistrarId("TheRegistrar")
-                        .setEventTime(expirationTime)
-                        .setRecurrenceEndTime(END_OF_TIME)
-                        .setDomainHistory(historyEntryDomainCreate)
-                        .setRenewalPriceBehavior(renewalPriceBehavior)
-                        .setRenewalPrice(renewalPrice)
-                        .build();
-                PollMessage.Autorenew autorenewPollMessage =
-                    new PollMessage.Autorenew.Builder()
-                        .setTargetId(getUniqueIdFromCommand())
-                        .setRegistrarId("TheRegistrar")
-                        .setEventTime(expirationTime)
-                        .setAutorenewEndTime(END_OF_TIME)
-                        .setMsg("Domain was auto-renewed.")
-                        .setHistoryEntry(historyEntryDomainCreate)
-                        .build();
-                Domain newDomain =
-                    domain
-                        .asBuilder()
-                        .setRegistrationExpirationTime(expirationTime)
-                        .setStatusValues(ImmutableSet.copyOf(statusValues))
-                        .setAutorenewBillingEvent(autorenewEvent.createVKey())
-                        .setAutorenewPollMessage(autorenewPollMessage.createVKey())
-                        .build();
-                persistResources(
-                    ImmutableSet.of(
-                        historyEntryDomainCreate, autorenewEvent,
-                        autorenewPollMessage, newDomain));
-              } catch (Exception e) {
-                throw new RuntimeException("Error persisting domain", e);
-              }
-            });
+    try {
+      DomainHistory historyEntryDomainCreate =
+          new DomainHistory.Builder()
+              .setDomain(domain)
+              .setType(HistoryEntry.Type.DOMAIN_CREATE)
+              .setModificationTime(clock.nowUtc())
+              .setRegistrarId(domain.getCreationRegistrarId())
+              .build();
+      BillingRecurrence autorenewEvent =
+          new BillingRecurrence.Builder()
+              .setReason(Reason.RENEW)
+              .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
+              .setTargetId(getUniqueIdFromCommand())
+              .setRegistrarId("TheRegistrar")
+              .setEventTime(expirationTime)
+              .setRecurrenceEndTime(END_OF_TIME)
+              .setDomainHistory(historyEntryDomainCreate)
+              .setRenewalPriceBehavior(renewalPriceBehavior)
+              .setRenewalPrice(renewalPrice)
+              .build();
+      PollMessage.Autorenew autorenewPollMessage =
+          new PollMessage.Autorenew.Builder()
+              .setTargetId(getUniqueIdFromCommand())
+              .setRegistrarId("TheRegistrar")
+              .setEventTime(expirationTime)
+              .setAutorenewEndTime(END_OF_TIME)
+              .setMsg("Domain was auto-renewed.")
+              .setHistoryEntry(historyEntryDomainCreate)
+              .build();
+      Domain newDomain =
+          domain
+              .asBuilder()
+              .setRegistrationExpirationTime(expirationTime)
+              .setStatusValues(ImmutableSet.copyOf(statusValues))
+              .setAutorenewBillingEvent(autorenewEvent.createVKey())
+              .setAutorenewPollMessage(autorenewPollMessage.createVKey())
+              .build();
+      persistResources(
+          ImmutableSet.of(
+              historyEntryDomainCreate, autorenewEvent,
+              autorenewPollMessage, newDomain));
+    } catch (Exception e) {
+      throw new RuntimeException("Error persisting domain", e);
+    }
     clock.advanceOneMilli();
   }
 

--- a/core/src/test/java/google/registry/model/OteAccountBuilderTest.java
+++ b/core/src/test/java/google/registry/model/OteAccountBuilderTest.java
@@ -24,7 +24,7 @@ import static google.registry.testing.CertificateSamples.SAMPLE_CERT_HASH;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.loadByKeyIfPresent;
 import static google.registry.testing.DatabaseHelper.persistPremiumList;
-import static google.registry.testing.DatabaseHelper.persistSimpleResource;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.joda.money.CurrencyUnit.USD;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -275,7 +275,7 @@ public final class OteAccountBuilderTest {
 
   @Test
   void testCreateOteEntities_registrarExists_failsWhenNotReplaceExisting() {
-    persistSimpleResource(makeRegistrar1().asBuilder().setRegistrarId("myclientid-1").build());
+    persistResource(makeRegistrar1().asBuilder().setRegistrarId("myclientid-1").build());
 
     OteAccountBuilder oteSetupHelper = OteAccountBuilder.forRegistrarId("myclientid");
 
@@ -301,7 +301,7 @@ public final class OteAccountBuilderTest {
 
   @Test
   void testCreateOteEntities_entitiesExist_succeedsWhenReplaceExisting() {
-    persistSimpleResource(makeRegistrar1().asBuilder().setRegistrarId("myclientid-1").build());
+    persistResource(makeRegistrar1().asBuilder().setRegistrarId("myclientid-1").build());
     // we intentionally create the -ga TLD with the wrong state, to make sure it's overwritten.
     createTld("myclientid-ga", START_DATE_SUNRISE);
 

--- a/core/src/test/java/google/registry/model/common/DnsRefreshRequestTest.java
+++ b/core/src/test/java/google/registry/model/common/DnsRefreshRequestTest.java
@@ -16,7 +16,7 @@ package google.registry.model.common;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.loadAllOf;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -41,7 +41,7 @@ public class DnsRefreshRequestTest extends EntityTestCase {
   void testPersistence() {
     assertThat(request.getLastProcessTime()).isEqualTo(START_OF_TIME);
     fakeClock.advanceOneMilli();
-    insertInDb(request);
+    tm().transact(() -> tm().insert(request));
     fakeClock.advanceOneMilli();
     ImmutableList<DnsRefreshRequest> requests = loadAllOf(DnsRefreshRequest.class);
     assertThat(requests.size()).isEqualTo(1);

--- a/core/src/test/java/google/registry/model/contact/ContactTest.java
+++ b/core/src/test/java/google/registry/model/contact/ContactTest.java
@@ -20,7 +20,6 @@ import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableO
 import static google.registry.testing.ContactSubject.assertAboutContacts;
 import static google.registry.testing.DatabaseHelper.cloneAndSetAutoTimestamps;
 import static google.registry.testing.DatabaseHelper.createTld;
-import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.loadByEntity;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.SqlHelper.assertThrowForeignKeyViolation;
@@ -132,7 +131,7 @@ public class ContactTest extends EntityTestCase {
   void testCloudSqlPersistence_failWhenViolateForeignKeyConstraint() {
     assertThrowForeignKeyViolation(
         () ->
-            insertInDb(
+            persistResource(
                 originalContact
                     .asBuilder()
                     .setRepoId("2-FOOBAR")

--- a/core/src/test/java/google/registry/model/domain/DomainTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainTest.java
@@ -23,12 +23,12 @@ import static google.registry.model.domain.token.AllocationToken.TokenType.BULK_
 import static google.registry.model.domain.token.AllocationToken.TokenType.SINGLE_USE;
 import static google.registry.testing.DatabaseHelper.cloneAndSetAutoTimestamps;
 import static google.registry.testing.DatabaseHelper.createTld;
-import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.newHost;
 import static google.registry.testing.DatabaseHelper.persistActiveContact;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistActiveHost;
 import static google.registry.testing.DatabaseHelper.persistResource;
+import static google.registry.testing.DatabaseHelper.persistResources;
 import static google.registry.testing.DomainSubject.assertAboutDomains;
 import static google.registry.testing.SqlHelper.saveRegistrar;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
@@ -162,7 +162,7 @@ public class DomainTest {
             .setRecurrenceEndTime(END_OF_TIME)
             .setDomainHistory(historyEntry)
             .build();
-    insertInDb(historyEntry, billingEventBill, billingRecurrence);
+    persistResources(historyEntry, billingEventBill, billingRecurrence);
     recurrenceBillKey = billingRecurrence.createVKey();
     VKey<PollMessage.Autorenew> autorenewPollKey = VKey.create(PollMessage.Autorenew.class, 3L);
     VKey<PollMessage.OneTime> onetimePollKey = VKey.create(PollMessage.OneTime.class, 1L);

--- a/core/src/test/java/google/registry/model/eppcommon/AddressTest.java
+++ b/core/src/test/java/google/registry/model/eppcommon/AddressTest.java
@@ -16,8 +16,8 @@ package google.registry.model.eppcommon;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.loadByEntity;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
@@ -50,25 +50,25 @@ class AddressTest {
 
   private static final String ENTITY_XML =
       """
-          <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-          <testEntity>
-              <address>
-                  <street>123 W 14th St</street>
-                  <street>8th Fl</street>
-                  <street>Rm 8</street>
-                  <city>New York</city>
-                  <sp>NY</sp>
-                  <pc>10011</pc>
-                  <cc>US</cc>
-              </address>
-          </testEntity>
-          """;
+      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <testEntity>
+          <address>
+              <street>123 W 14th St</street>
+              <street>8th Fl</street>
+              <street>Rm 8</street>
+              <city>New York</city>
+              <sp>NY</sp>
+              <pc>10011</pc>
+              <cc>US</cc>
+          </address>
+      </testEntity>
+      """;
 
   private TestAddress address = createAddress("123 W 14th St", "8th Fl", "Rm 8");
   private TestEntity entity = new TestEntity(1L, address);
 
   private static TestEntity saveAndLoad(TestEntity entity) {
-    insertInDb(entity);
+    persistResource(entity);
     return loadByEntity(entity);
   }
 

--- a/core/src/test/java/google/registry/model/history/ContactHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/ContactHistoryTest.java
@@ -17,9 +17,9 @@ package google.registry.model.history;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.loadByEntity;
 import static google.registry.testing.DatabaseHelper.newContactWithRoid;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableList;
@@ -45,10 +45,10 @@ public class ContactHistoryTest extends EntityTestCase {
   @Test
   void testPersistence() {
     Contact contact = newContactWithRoid("contactId", "contact1");
-    insertInDb(contact);
+    persistResource(contact);
     Contact contactFromDb = loadByEntity(contact);
     ContactHistory contactHistory = createContactHistory(contactFromDb);
-    insertInDb(contactHistory);
+    persistResource(contactHistory);
     tm().transact(
             () -> {
               ContactHistory fromDatabase = tm().loadByKey(contactHistory.createVKey());
@@ -60,10 +60,10 @@ public class ContactHistoryTest extends EntityTestCase {
   @Test
   void testSerializable() {
     Contact contact = newContactWithRoid("contactId", "contact1");
-    insertInDb(contact);
+    persistResource(contact);
     Contact contactFromDb = loadByEntity(contact);
     ContactHistory contactHistory = createContactHistory(contactFromDb);
-    insertInDb(contactHistory);
+    persistResource(contactHistory);
     ContactHistory fromDatabase = tm().transact(() -> tm().loadByKey(contactHistory.createVKey()));
     assertThat(SerializeUtils.serializeDeserialize(fromDatabase)).isEqualTo(fromDatabase);
   }

--- a/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/DomainHistoryTest.java
@@ -18,10 +18,10 @@ import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.createTld;
-import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.newContactWithRoid;
 import static google.registry.testing.DatabaseHelper.newDomain;
 import static google.registry.testing.DatabaseHelper.newHostWithRoid;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -60,7 +60,7 @@ public class DomainHistoryTest extends EntityTestCase {
   void testPersistence() {
     Domain domain = addGracePeriodForSql(createDomainWithContactsAndHosts());
     DomainHistory domainHistory = createDomainHistory(domain);
-    insertInDb(domainHistory);
+    persistResource(domainHistory);
 
     tm().transact(
             () -> {
@@ -74,7 +74,7 @@ public class DomainHistoryTest extends EntityTestCase {
   void testSerializable() {
     Domain domain = addGracePeriodForSql(createDomainWithContactsAndHosts());
     DomainHistory domainHistory = createDomainHistory(domain);
-    insertInDb(domainHistory);
+    persistResource(domainHistory);
     DomainHistory fromDatabase = tm().transact(() -> tm().loadByKey(domainHistory.createVKey()));
     assertThat(SerializeUtils.serializeDeserialize(fromDatabase)).isEqualTo(fromDatabase);
   }
@@ -96,7 +96,7 @@ public class DomainHistoryTest extends EntityTestCase {
             .setNameservers(host.createVKey())
             .setDsData(ImmutableSet.of(DomainDsData.create(1, 2, 3, new byte[] {0, 1, 2})))
             .build();
-    insertInDb(domain);
+    persistResource(domain);
     return domain;
   }
 

--- a/core/src/test/java/google/registry/model/history/HostHistoryTest.java
+++ b/core/src/test/java/google/registry/model/history/HostHistoryTest.java
@@ -17,9 +17,9 @@ package google.registry.model.history;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.loadByEntity;
 import static google.registry.testing.DatabaseHelper.newHostWithRoid;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import google.registry.model.EntityTestCase;
@@ -41,10 +41,10 @@ public class HostHistoryTest extends EntityTestCase {
   @Test
   void testPersistence() {
     Host host = newHostWithRoid("ns1.example.com", "host1");
-    insertInDb(host);
+    persistResource(host);
     Host hostFromDb = loadByEntity(host);
     HostHistory hostHistory = createHostHistory(hostFromDb);
-    insertInDb(hostHistory);
+    persistResource(hostHistory);
     tm().transact(
             () -> {
               HostHistory fromDatabase = tm().loadByKey(hostHistory.createVKey());
@@ -56,10 +56,10 @@ public class HostHistoryTest extends EntityTestCase {
   @Test
   void testSerializable() {
     Host host = newHostWithRoid("ns1.example.com", "host1");
-    insertInDb(host);
+    persistResource(host);
     Host hostFromDb = loadByEntity(host);
     HostHistory hostHistory = createHostHistory(hostFromDb);
-    insertInDb(hostHistory);
+    persistResource(hostHistory);
     HostHistory fromDatabase = tm().transact(() -> tm().loadByKey(hostHistory.createVKey()));
     assertThat(SerializeUtils.serializeDeserialize(fromDatabase)).isEqualTo(fromDatabase);
   }

--- a/core/src/test/java/google/registry/model/poll/PollMessageTest.java
+++ b/core/src/test/java/google/registry/model/poll/PollMessageTest.java
@@ -17,7 +17,6 @@ package google.registry.model.poll;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.createTld;
-import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.loadByKey;
 import static google.registry.testing.DatabaseHelper.persistActiveContact;
 import static google.registry.testing.DatabaseHelper.persistResource;
@@ -90,12 +89,12 @@ public class PollMessageTest extends EntityTestCase {
 
   @Test
   void testCloudSqlSupportForPolymorphicVKey() {
-    insertInDb(oneTime);
+    persistResource(oneTime);
     PollMessage persistedOneTime = loadByKey(VKey.create(PollMessage.class, oneTime.getId()));
     assertThat(persistedOneTime).isInstanceOf(PollMessage.OneTime.class);
     assertThat(persistedOneTime).isEqualTo(oneTime);
 
-    insertInDb(autoRenew);
+    persistResource(autoRenew);
     PollMessage persistedAutoRenew = loadByKey(VKey.create(PollMessage.class, autoRenew.getId()));
     assertThat(persistedAutoRenew).isInstanceOf(PollMessage.Autorenew.class);
     assertThat(persistedAutoRenew).isEqualTo(autoRenew);

--- a/core/src/test/java/google/registry/model/registrar/RegistrarTest.java
+++ b/core/src/test/java/google/registry/model/registrar/RegistrarTest.java
@@ -25,8 +25,7 @@ import static google.registry.testing.DatabaseHelper.cloneAndSetAutoTimestamps;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.newTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.testing.DatabaseHelper.persistSimpleResource;
-import static google.registry.testing.DatabaseHelper.persistSimpleResources;
+import static google.registry.testing.DatabaseHelper.persistResources;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.joda.money.CurrencyUnit.JPY;
 import static org.joda.money.CurrencyUnit.USD;
@@ -132,7 +131,7 @@ class RegistrarTest extends EntityTestCase {
             .setFaxNumber("+1.2125551213")
             .setTypes(ImmutableSet.of(RegistrarPoc.Type.ABUSE, RegistrarPoc.Type.ADMIN))
             .build();
-    persistSimpleResources(
+    persistResources(
         ImmutableList.of(
             abuseAdminContact,
             new RegistrarPoc.Builder()
@@ -301,7 +300,7 @@ class RegistrarTest extends EntityTestCase {
 
   @Test
   void testSuccess_emptyContactTypesAllowed() {
-    persistSimpleResource(
+    persistResource(
         new RegistrarPoc.Builder()
             .setRegistrar(registrar)
             .setName("John Abussy")
@@ -318,7 +317,7 @@ class RegistrarTest extends EntityTestCase {
   @Test
   void testSuccess_getContactsByType() {
     RegistrarPoc newTechContact =
-        persistSimpleResource(
+        persistResource(
             new RegistrarPoc.Builder()
                 .setRegistrar(registrar)
                 .setName("Jake Tech")
@@ -330,7 +329,7 @@ class RegistrarTest extends EntityTestCase {
                 .setTypes(ImmutableSet.of(RegistrarPoc.Type.TECH))
                 .build());
     RegistrarPoc newTechAbuseContact =
-        persistSimpleResource(
+        persistResource(
             new RegistrarPoc.Builder()
                 .setRegistrar(registrar)
                 .setName("Jim Tech-Abuse")

--- a/core/src/test/java/google/registry/persistence/EntityCallbacksListenerTest.java
+++ b/core/src/test/java/google/registry/persistence/EntityCallbacksListenerTest.java
@@ -18,7 +18,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 
 import com.google.common.collect.ImmutableSet;
 import google.registry.model.ImmutableObject;
@@ -51,7 +51,7 @@ class EntityCallbacksListenerTest {
   @Test
   void verifyAllCallbacks_executedExpectedTimes() {
     TestEntity testPersist = new TestEntity();
-    insertInDb(testPersist);
+    tm().transact(() -> tm().insert(testPersist));
     checkAll(testPersist, 1, 0, 0, 0);
 
     TestEntity testUpdate = new TestEntity();
@@ -99,7 +99,7 @@ class EntityCallbacksListenerTest {
 
   @Test
   void verifyCallbacksNotCalledOnCommit() {
-    insertInDb(new TestEntity());
+    persistResource(new TestEntity());
 
     TestEntity testLoad = tm().transact(() -> tm().loadByKey(VKey.create(TestEntity.class, "id")));
     assertThat(testLoad.entityPreUpdate).isEqualTo(0);

--- a/core/src/test/java/google/registry/persistence/converter/AllocationTokenStatusTransitionUserTypeTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/AllocationTokenStatusTransitionUserTypeTest.java
@@ -19,7 +19,7 @@ import static google.registry.model.domain.token.AllocationToken.TokenStatus.END
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.NOT_STARTED;
 import static google.registry.model.domain.token.AllocationToken.TokenStatus.VALID;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
 import com.google.common.collect.ImmutableSortedMap;
@@ -59,7 +59,7 @@ public class AllocationTokenStatusTransitionUserTypeTest {
         TimedTransitionProperty.fromValueMap(values);
     AllocationTokenStatusTransitionConverterTestEntity testEntity =
         new AllocationTokenStatusTransitionConverterTestEntity(timedTransitionProperty);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     AllocationTokenStatusTransitionConverterTestEntity persisted =
         tm().transact(
                 () ->

--- a/core/src/test/java/google/registry/persistence/converter/AllocationTokenVkeyListUserTypeTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/AllocationTokenVkeyListUserTypeTest.java
@@ -18,7 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.domain.token.AllocationToken.TokenType.SINGLE_USE;
 import static google.registry.model.domain.token.AllocationToken.TokenType.UNLIMITED_USE;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 
 import com.google.common.collect.ImmutableList;
 import google.registry.model.ImmutableObject;
@@ -51,7 +51,7 @@ public class AllocationTokenVkeyListUserTypeTest {
     List<VKey<AllocationToken>> tokens = ImmutableList.of(token1.createVKey(), token2.createVKey());
     TestAllocationTokenVKeyList testAllocationTokenVKeyList =
         new TestAllocationTokenVKeyList(tokens);
-    insertInDb(testAllocationTokenVKeyList);
+    persistResource(testAllocationTokenVKeyList);
     TestAllocationTokenVKeyList persisted =
         tm().transact(() -> tm().getEntityManager().find(TestAllocationTokenVKeyList.class, "id"));
     assertThat(persisted.tokenList).isEqualTo(tokens);

--- a/core/src/test/java/google/registry/persistence/converter/BillingCostTransitionUserTypeTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/BillingCostTransitionUserTypeTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.joda.money.CurrencyUnit.USD;
 
@@ -52,7 +52,7 @@ public class BillingCostTransitionUserTypeTest {
     TimedTransitionProperty<Money> timedTransitionProperty =
         TimedTransitionProperty.fromValueMap(values);
     TestEntity testEntity = new TestEntity(timedTransitionProperty);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.timedTransitionProperty.toValueMap())

--- a/core/src/test/java/google/registry/persistence/converter/BloomFilterConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/BloomFilterConverterTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.converter;
 import static com.google.common.hash.Funnels.stringFunnel;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
 import com.google.common.collect.ImmutableSet;
@@ -41,7 +41,7 @@ class BloomFilterConverterTest {
     BloomFilter<String> bloomFilter = BloomFilter.create(stringFunnel(US_ASCII), 3);
     ImmutableSet.of("foo", "bar", "baz").forEach(bloomFilter::put);
     TestEntity entity = new TestEntity(bloomFilter);
-    insertInDb(entity);
+    persistResource(entity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.bloomFilter).isEqualTo(bloomFilter);

--- a/core/src/test/java/google/registry/persistence/converter/CidrBlockListUserTypeTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/CidrBlockListUserTypeTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 
 import com.google.common.collect.ImmutableList;
 import google.registry.model.ImmutableObject;
@@ -47,7 +47,7 @@ public class CidrBlockListUserTypeTest {
             CidrAddressBlock.create("8000::/1"),
             CidrAddressBlock.create("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128"));
     TestEntity testEntity = new TestEntity(addresses);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.addresses).isEqualTo(addresses);

--- a/core/src/test/java/google/registry/persistence/converter/CurrencyToStringMapUserTypeTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/CurrencyToStringMapUserTypeTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.ImmutableObject;
@@ -44,7 +44,7 @@ public class CurrencyToStringMapUserTypeTest {
             CurrencyUnit.of("USD"), "accountId1",
             CurrencyUnit.of("CNY"), "accountId2");
     TestEntity testEntity = new TestEntity(currencyToBilling);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.currencyToBilling).containsExactlyEntriesIn(currencyToBilling);

--- a/core/src/test/java/google/registry/persistence/converter/CurrencyUnitConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/CurrencyUnitConverterTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.model.ImmutableObject;
@@ -39,7 +39,7 @@ public class CurrencyUnitConverterTest {
   @Test
   void roundTripConversion() {
     TestEntity entity = new TestEntity(CurrencyUnit.EUR);
-    insertInDb(entity);
+    persistResource(entity);
     assertThat(
             tm().transact(
                     () ->

--- a/core/src/test/java/google/registry/persistence/converter/DateTimeConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/DateTimeConverterTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static java.time.ZoneOffset.UTC;
 
 import google.registry.model.ImmutableObject;
@@ -75,7 +75,7 @@ public class DateTimeConverterTest {
   void converter_generatesTimestampWithNormalizedZone() {
     DateTime dt = parseDateTime("2019-09-01T01:01:01Z");
     TestEntity entity = new TestEntity("normalized_utc_time", dt);
-    insertInDb(entity);
+    persistResource(entity);
     TestEntity retrievedEntity =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "normalized_utc_time"));
     assertThat(retrievedEntity.dt.toString()).isEqualTo("2019-09-01T01:01:01.000Z");
@@ -86,7 +86,7 @@ public class DateTimeConverterTest {
     DateTime dt = parseDateTime("2019-09-01T01:01:01-05:00");
     TestEntity entity = new TestEntity("new_york_time", dt);
 
-    insertInDb(entity);
+    persistResource(entity);
     TestEntity retrievedEntity =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "new_york_time"));
     assertThat(retrievedEntity.dt.toString()).isEqualTo("2019-09-01T06:01:01.000Z");

--- a/core/src/test/java/google/registry/persistence/converter/DurationUserTypeTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/DurationUserTypeTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 
 import google.registry.model.ImmutableObject;
 import google.registry.persistence.transaction.JpaTestExtensions;
@@ -39,7 +39,7 @@ public class DurationUserTypeTest {
   @Test
   void testNulls() {
     DurationTestEntity entity = new DurationTestEntity(null);
-    insertInDb(entity);
+    persistResource(entity);
     DurationTestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(DurationTestEntity.class, "id"));
     assertThat(persisted.duration).isNull();
@@ -90,7 +90,7 @@ public class DurationUserTypeTest {
 
   private void assertPersistedEntityHasSameDuration(Duration duration) {
     DurationTestEntity entity = new DurationTestEntity(duration);
-    insertInDb(entity);
+    persistResource(entity);
     DurationTestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(DurationTestEntity.class, "id"));
     assertThat(persisted.duration.getMillis()).isEqualTo(duration.getMillis());

--- a/core/src/test/java/google/registry/persistence/converter/InetAddressSetUserTypeTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/InetAddressSetUserTypeTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.InetAddresses;
@@ -64,7 +64,7 @@ public class InetAddressSetUserTypeTest {
 
   private void verifySaveAndLoad(@Nullable Set<InetAddress> inetAddresses) {
     InetAddressSetTestEntity testEntity = new InetAddressSetTestEntity(inetAddresses);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     InetAddressSetTestEntity persisted =
         tm().transact(() -> tm().loadByKey(VKey.create(InetAddressSetTestEntity.class, "id")));
     assertThat(persisted.addresses).isEqualTo(inetAddresses);

--- a/core/src/test/java/google/registry/persistence/converter/JodaMoneyTypeTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/JodaMoneyTypeTest.java
@@ -15,7 +15,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
@@ -57,7 +57,7 @@ public class JodaMoneyTypeTest {
     Money money = Money.of(CurrencyUnit.USD, 100.12);
     assertThat(money.getAmount().scale()).isEqualTo(2);
     TestEntity entity = new TestEntity(money);
-    insertInDb(entity);
+    persistResource(entity);
     List<?> result =
         tm().transact(
                 () ->
@@ -81,7 +81,7 @@ public class JodaMoneyTypeTest {
     Money money = Money.ofMajor(CurrencyUnit.JPY, 100);
     assertThat(money.getAmount().scale()).isEqualTo(0); // JPY's amount has scale at 0.
     TestEntity entity = new TestEntity(money);
-    insertInDb(entity);
+    persistResource(entity);
     List<?> result =
         tm().transact(
                 () ->
@@ -121,7 +121,7 @@ public class JodaMoneyTypeTest {
             "dos", Money.ofMajor(CurrencyUnit.JPY, 2000),
             "tres", Money.of(CurrencyUnit.GBP, 20));
     ComplexTestEntity entity = new ComplexTestEntity(moneyMap, myMoney, yourMoney);
-    insertInDb(entity);
+    persistResource(entity);
     List<?> result =
         tm().transact(
                 () ->

--- a/core/src/test/java/google/registry/persistence/converter/LocalDateConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/LocalDateConverterTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 
 import google.registry.model.ImmutableObject;
 import google.registry.persistence.VKey;
@@ -54,7 +54,7 @@ public class LocalDateConverterTest {
 
   private LocalDateConverterTestEntity persistAndLoadTestEntity(LocalDate date) {
     LocalDateConverterTestEntity entity = new LocalDateConverterTestEntity(date);
-    insertInDb(entity);
+    persistResource(entity);
     return tm().transact(
             () -> tm().loadByKey(VKey.create(LocalDateConverterTestEntity.class, "id")));
   }

--- a/core/src/test/java/google/registry/persistence/converter/RegistrarToRoleMapUserTypeTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/RegistrarToRoleMapUserTypeTest.java
@@ -48,7 +48,7 @@ public class RegistrarToRoleMapUserTypeTest {
             "FooRegistrar",
             RegistrarRole.TECH_CONTACT);
     TestEntity entity = new TestEntity(map);
-    DatabaseHelper.insertInDb(entity);
+    DatabaseHelper.persistResource(entity);
     TestEntity persisted = Iterables.getOnlyElement(DatabaseHelper.loadAllOf(TestEntity.class));
     assertThat(persisted.map).isEqualTo(map);
   }

--- a/core/src/test/java/google/registry/persistence/converter/StringCollectionUserTypeTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringCollectionUserTypeTest.java
@@ -17,7 +17,7 @@ package google.registry.persistence.converter;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
@@ -45,7 +45,7 @@ public class StringCollectionUserTypeTest {
     List<ListElement> value =
         ImmutableList.of(new ListElement("app"), new ListElement("dev"), new ListElement("com"));
     TestEntity testEntity = new TestEntity(value);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.value).containsExactlyElementsIn(value);
@@ -56,7 +56,7 @@ public class StringCollectionUserTypeTest {
     List<ListElement> value =
         ImmutableList.of(new ListElement("app"), new ListElement("dev"), new ListElement("com"));
     TestEntity testEntity = new TestEntity(value);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     persisted.value = ImmutableList.of(new ListElement("app"), new ListElement("org"));
@@ -68,7 +68,7 @@ public class StringCollectionUserTypeTest {
   @Test
   void testNullValue_writesAndReadsNullSuccessfully() {
     TestEntity testEntity = new TestEntity(null);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.value).isNull();
@@ -77,7 +77,7 @@ public class StringCollectionUserTypeTest {
   @Test
   void testEmptyCollection_writesAndReadsEmptyCollectionSuccessfully() {
     TestEntity testEntity = new TestEntity(ImmutableList.of());
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.value).isEmpty();

--- a/core/src/test/java/google/registry/persistence/converter/StringListConversionTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringListConversionTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
@@ -41,7 +41,7 @@ public class StringListConversionTest {
   void roundTripConversion_returnsSameStringList() {
     List<String> tlds = ImmutableList.of("app", "dev", "how");
     TestEntity testEntity = new TestEntity(tlds);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).containsExactly("app", "dev", "how");
@@ -51,7 +51,7 @@ public class StringListConversionTest {
   void testMerge_succeeds() {
     List<String> tlds = ImmutableList.of("app", "dev", "how");
     TestEntity testEntity = new TestEntity(tlds);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     persisted.tlds = ImmutableList.of("com", "gov");
@@ -63,7 +63,7 @@ public class StringListConversionTest {
   @Test
   void testNullValue_writesAndReadsNullSuccessfully() {
     TestEntity testEntity = new TestEntity(null);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).isNull();
@@ -72,7 +72,7 @@ public class StringListConversionTest {
   @Test
   void testEmptyCollection_writesAndReadsEmptyCollectionSuccessfully() {
     TestEntity testEntity = new TestEntity(ImmutableList.of());
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).isEmpty();

--- a/core/src/test/java/google/registry/persistence/converter/StringMapUserTypeTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringMapUserTypeTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
@@ -47,7 +47,7 @@ public class StringMapUserTypeTest {
   @Test
   void roundTripConversion_returnsSameMap() {
     TestEntity testEntity = new TestEntity(MAP);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.map).containsExactlyEntriesIn(MAP);
@@ -56,7 +56,7 @@ public class StringMapUserTypeTest {
   @Test
   void testUpdateColumn_succeeds() {
     TestEntity testEntity = new TestEntity(MAP);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.map).containsExactlyEntriesIn(MAP);
@@ -69,7 +69,7 @@ public class StringMapUserTypeTest {
   @Test
   void testNullValue_writesAndReadsNullSuccessfully() {
     TestEntity testEntity = new TestEntity(null);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.map).isNull();
@@ -78,7 +78,7 @@ public class StringMapUserTypeTest {
   @Test
   void testEmptyMap_writesAndReadsEmptyCollectionSuccessfully() {
     TestEntity testEntity = new TestEntity(ImmutableMap.of());
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.map).isEmpty();

--- a/core/src/test/java/google/registry/persistence/converter/StringSetConversionTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringSetConversionTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 
 import com.google.common.collect.ImmutableSet;
 import google.registry.model.ImmutableObject;
@@ -39,7 +39,7 @@ public class StringSetConversionTest {
   void roundTripConversion_returnsSameStringList() {
     Set<String> tlds = ImmutableSet.of("app", "dev", "how");
     TestEntity testEntity = new TestEntity(tlds);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).containsExactly("app", "dev", "how");
@@ -48,7 +48,7 @@ public class StringSetConversionTest {
   @Test
   void testNullValue_writesAndReadsNullSuccessfully() {
     TestEntity testEntity = new TestEntity(null);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).isNull();
@@ -57,7 +57,7 @@ public class StringSetConversionTest {
   @Test
   void testEmptyCollection_writesAndReadsEmptyCollectionSuccessfully() {
     TestEntity testEntity = new TestEntity(ImmutableSet.of());
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.tlds).isEmpty();

--- a/core/src/test/java/google/registry/persistence/converter/StringValueEnumeratedTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/StringValueEnumeratedTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 
 import google.registry.model.ImmutableObject;
 import google.registry.model.registrar.Registrar.State;
@@ -39,7 +39,7 @@ public class StringValueEnumeratedTest {
   @Test
   void roundTripConversion_returnsSameEnum() {
     TestEntity testEntity = new TestEntity(State.ACTIVE);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.state).isEqualTo(State.ACTIVE);
@@ -48,7 +48,7 @@ public class StringValueEnumeratedTest {
   @Test
   void testNativeQuery_succeeds() {
     TestEntity testEntity = new TestEntity(State.DISABLED);
-    insertInDb(testEntity);
+    persistResource(testEntity);
 
     assertThat(
             tm().transact(

--- a/core/src/test/java/google/registry/persistence/converter/TimedTransitionBaseUserTypeTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/TimedTransitionBaseUserTypeTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -55,7 +55,7 @@ class TimedTransitionBaseUserTypeTest {
   @Test
   void roundTripConversion_returnsSameTimedTransitionProperty() {
     TestEntity testEntity = new TestEntity(TIMED_TRANSITION_PROPERTY);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.property.toValueMap())
@@ -65,7 +65,7 @@ class TimedTransitionBaseUserTypeTest {
   @Test
   void testUpdateColumn_succeeds() {
     TestEntity testEntity = new TestEntity(TIMED_TRANSITION_PROPERTY);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.property.toValueMap())
@@ -80,7 +80,7 @@ class TimedTransitionBaseUserTypeTest {
   @Test
   void testNullValue_writesAndReadsNullSuccessfully() {
     TestEntity testEntity = new TestEntity(null);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.property).isNull();

--- a/core/src/test/java/google/registry/persistence/converter/TldStateTransitionUserTypeTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/TldStateTransitionUserTypeTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 
 import com.google.common.collect.ImmutableSortedMap;
@@ -55,7 +55,7 @@ class TldStateTransitionUserTypeTest {
     TimedTransitionProperty<TldState> timedTransitionProperty =
         TimedTransitionProperty.fromValueMap(values);
     TestEntity testEntity = new TestEntity(timedTransitionProperty);
-    insertInDb(testEntity);
+    persistResource(testEntity);
     TestEntity persisted =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "id"));
     assertThat(persisted.timedTransitionProperty.toValueMap())

--- a/core/src/test/java/google/registry/persistence/converter/VKeyConverterTest.java
+++ b/core/src/test/java/google/registry/persistence/converter/VKeyConverterTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.converter;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResources;
 
 import google.registry.model.ImmutableObject;
 import google.registry.persistence.VKey;
@@ -50,7 +50,7 @@ public class VKeyConverterTest {
     TestLongEntity longEntity = new TestLongEntity(300L);
     VKey<TestLongEntity> longKey = VKey.create(TestLongEntity.class, 300L);
     TestEntity original = new TestEntity(1984L, stringKey, longKey);
-    insertInDb(stringEntity, longEntity, original);
+    persistResources(stringEntity, longEntity, original);
 
     TestEntity retrieved =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, 1984L));

--- a/core/src/test/java/google/registry/persistence/transaction/CriteriaQueryBuilderTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/CriteriaQueryBuilderTest.java
@@ -16,7 +16,7 @@ package google.registry.persistence.transaction;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResources;
 
 import com.google.common.collect.ImmutableList;
 import google.registry.model.ImmutableObject;
@@ -50,7 +50,7 @@ class CriteriaQueryBuilderTest {
 
   @BeforeEach
   void beforeEach() {
-    insertInDb(entity1, entity2, entity3);
+    persistResources(entity1, entity2, entity3);
   }
 
   @Test

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerExtension.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerExtension.java
@@ -17,7 +17,7 @@ package google.registry.persistence.transaction;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertWithMessage;
-import static google.registry.testing.DatabaseHelper.insertSimpleResources;
+import static google.registry.testing.DatabaseHelper.persistResources;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT;
 
@@ -444,7 +444,7 @@ public abstract class JpaTransactionManagerExtension
 
   /** Create some fake registrars. */
   public static void loadInitialData() {
-    insertSimpleResources(
+    persistResources(
         ImmutableList.of(
             makeRegistrar1(),
             makeRegistrarContact1(),

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerExtensionTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerExtensionTest.java
@@ -17,7 +17,7 @@ package google.registry.persistence.transaction;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.replicaTm;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.model.ImmutableObject;
@@ -76,7 +76,7 @@ public class JpaTransactionManagerExtensionTest {
     // This test verifies that 1) withEntityClass() has registered TestEntity and 2) The table
     // has been created, implying withProperty(HBM2DDL_AUTO, "update") worked.
     TestEntity original = new TestEntity("key", "value");
-    insertInDb(original);
+    persistResource(original);
     TestEntity retrieved =
         tm().transact(() -> tm().getEntityManager().find(TestEntity.class, "key"));
     assertThat(retrieved).isEqualTo(original);

--- a/core/src/test/java/google/registry/rdap/RdapDomainActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapDomainActionTest.java
@@ -21,7 +21,7 @@ import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistDomainWithDependentResources;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.testing.DatabaseHelper.persistSimpleResources;
+import static google.registry.testing.DatabaseHelper.persistResources;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeAndPersistHost;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeDomain;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeHistoryEntry;
@@ -78,7 +78,7 @@ class RdapDomainActionTest extends RdapActionBaseTestCase<RdapDomainAction> {
     createTld("lol");
     Registrar registrarLol = persistResource(makeRegistrar(
         "evilregistrar", "Yes Virginia <script>", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarPocs(registrarLol));
+    persistResources(makeRegistrarPocs(registrarLol));
     registrantLol =
         FullFieldsTestEntityHelper.makeAndPersistContact(
             "5372808-ERL",
@@ -152,7 +152,7 @@ class RdapDomainActionTest extends RdapActionBaseTestCase<RdapDomainAction> {
     createTld("xn--q9jyb4c");
     Registrar registrarIdn =
         persistResource(makeRegistrar("idnregistrar", "IDN Registrar", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarPocs(registrarIdn));
+    persistResources(makeRegistrarPocs(registrarIdn));
     Contact registrantIdn =
         FullFieldsTestEntityHelper.makeAndPersistContact(
             "5372808-ERL",
@@ -188,7 +188,7 @@ class RdapDomainActionTest extends RdapActionBaseTestCase<RdapDomainAction> {
     createTld("1.tld");
     Registrar registrar1Tld = persistResource(
         makeRegistrar("1tldregistrar", "Multilevel Registrar", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarPocs(registrar1Tld));
+    persistResources(makeRegistrarPocs(registrar1Tld));
     Contact registrant1Tld =
         FullFieldsTestEntityHelper.makeAndPersistContact(
             "5372808-ERL",

--- a/core/src/test/java/google/registry/rdap/RdapDomainSearchActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapDomainSearchActionTest.java
@@ -21,7 +21,6 @@ import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistDomainAsDeleted;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DatabaseHelper.persistResources;
-import static google.registry.testing.DatabaseHelper.persistSimpleResources;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeDomain;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeHistoryEntry;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrar;
@@ -131,7 +130,7 @@ class RdapDomainSearchActionTest extends RdapSearchActionTestCase<RdapDomainSear
     registrar =
         persistResource(
             makeRegistrar("evilregistrar", "Yes Virginia <script>", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     contact1 =
         FullFieldsTestEntityHelper.makeAndPersistContact(
             "5372808-ERL", "Goblin Market", "lol@cat.lol", clock.nowUtc().minusYears(1), registrar);
@@ -209,7 +208,7 @@ class RdapDomainSearchActionTest extends RdapSearchActionTestCase<RdapDomainSear
     registrar =
         persistResource(
             makeRegistrar("goodregistrar", "St. John Chrysostom", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     domainCatExample =
         persistResource(
             makeDomain(
@@ -246,7 +245,7 @@ class RdapDomainSearchActionTest extends RdapSearchActionTestCase<RdapDomainSear
     // cat.みんな
     createTld("xn--q9jyb4c");
     registrar = persistResource(makeRegistrar("unicoderegistrar", "みんな", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     domainIdn =
         persistResource(
             makeDomain(
@@ -285,7 +284,7 @@ class RdapDomainSearchActionTest extends RdapSearchActionTestCase<RdapDomainSear
     // cat.1.test
     createTld("1.test");
     registrar = persistResource(makeRegistrar("multiregistrar", "1.test", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     domainMultipart =
         persistResource(
             makeDomain(

--- a/core/src/test/java/google/registry/rdap/RdapEntityActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapEntityActionTest.java
@@ -17,7 +17,7 @@ package google.registry.rdap;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.testing.DatabaseHelper.persistSimpleResources;
+import static google.registry.testing.DatabaseHelper.persistResources;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeAndPersistDeletedContact;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeDomain;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeHost;
@@ -63,7 +63,7 @@ class RdapEntityActionTest extends RdapActionBaseTestCase<RdapEntityAction> {
     createTld("lol");
     registrarLol = persistResource(makeRegistrar(
         "evilregistrar", "Yes Virginia <script>", Registrar.State.ACTIVE, 101L));
-    persistSimpleResources(makeRegistrarPocs(registrarLol));
+    persistResources(makeRegistrarPocs(registrarLol));
     registrant =
         FullFieldsTestEntityHelper.makeAndPersistContact(
             "8372808-REG",
@@ -96,16 +96,16 @@ class RdapEntityActionTest extends RdapActionBaseTestCase<RdapEntityAction> {
     createTld("xn--q9jyb4c");
     Registrar registrarIdn = persistResource(
         makeRegistrar("idnregistrar", "IDN Registrar", Registrar.State.ACTIVE, 102L));
-    persistSimpleResources(makeRegistrarPocs(registrarIdn));
+    persistResources(makeRegistrarPocs(registrarIdn));
     // 1.tld
     createTld("1.tld");
     Registrar registrar1tld = persistResource(
         makeRegistrar("1tldregistrar", "Multilevel Registrar", Registrar.State.ACTIVE, 103L));
-    persistSimpleResources(makeRegistrarPocs(registrar1tld));
+    persistResources(makeRegistrarPocs(registrar1tld));
     // deleted registrar
     Registrar registrarDeleted = persistResource(
         makeRegistrar("deletedregistrar", "Yes Virginia <script>", Registrar.State.PENDING, 104L));
-    persistSimpleResources(makeRegistrarPocs(registrarDeleted));
+    persistResources(makeRegistrarPocs(registrarDeleted));
     // other contacts
     disconnectedContact =
         FullFieldsTestEntityHelper.makeAndPersistContact(

--- a/core/src/test/java/google/registry/rdap/RdapEntitySearchActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapEntitySearchActionTest.java
@@ -20,7 +20,6 @@ import static google.registry.request.Action.Method.GET;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DatabaseHelper.persistResources;
-import static google.registry.testing.DatabaseHelper.persistSimpleResources;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeAndPersistDeletedContact;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeHistoryEntry;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrar;
@@ -109,12 +108,12 @@ class RdapEntitySearchActionTest extends RdapSearchActionTestCase<RdapEntitySear
     registrarDeleted =
         persistResource(
             makeRegistrar("2-Registrar", "Yes Virginia <script>", Registrar.State.ACTIVE, 20L));
-    persistSimpleResources(makeRegistrarPocs(registrarDeleted));
+    persistResources(makeRegistrarPocs(registrarDeleted));
 
     // inactive
     registrarInactive =
         persistResource(makeRegistrar("2-RegistrarInact", "No Way", Registrar.State.PENDING, 21L));
-    persistSimpleResources(makeRegistrarPocs(registrarInactive));
+    persistResources(makeRegistrarPocs(registrarInactive));
 
     // test
     registrarTest =
@@ -124,7 +123,7 @@ class RdapEntitySearchActionTest extends RdapSearchActionTestCase<RdapEntitySear
                 .setType(Registrar.Type.TEST)
                 .setIanaIdentifier(null)
                 .build());
-    persistSimpleResources(makeRegistrarPocs(registrarTest));
+    persistResources(makeRegistrarPocs(registrarTest));
 
     FullFieldsTestEntityHelper.makeAndPersistContact(
         "blinky",

--- a/core/src/test/java/google/registry/rdap/RdapJsonFormatterTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapJsonFormatterTest.java
@@ -18,7 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static google.registry.rdap.RdapDataStructures.EventAction.TRANSFER;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.testing.DatabaseHelper.persistSimpleResources;
+import static google.registry.testing.DatabaseHelper.persistResources;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeAndPersistHost;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeDomain;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeHistoryEntry;
@@ -95,7 +95,7 @@ class RdapJsonFormatterTest {
     clock.setTo(DateTime.parse("2000-01-01T00:00:00Z"));
     registrar = persistResource(registrar);
 
-    persistSimpleResources(makeMoreRegistrarContacts(registrar));
+    persistResources(makeMoreRegistrarContacts(registrar));
 
     contactRegistrant =
         FullFieldsTestEntityHelper.makeAndPersistContact(

--- a/core/src/test/java/google/registry/rdap/RdapNameserverSearchActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapNameserverSearchActionTest.java
@@ -21,7 +21,6 @@ import static google.registry.request.Action.Method.GET;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DatabaseHelper.persistResources;
-import static google.registry.testing.DatabaseHelper.persistSimpleResources;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeDomain;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrar;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrarPocs;
@@ -103,7 +102,7 @@ class RdapNameserverSearchActionTest extends RdapSearchActionTestCase<RdapNamese
     Registrar registrar =
         persistResource(
             makeRegistrar("evilregistrar", "Yes Virginia <script>", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     hostNs1CatLol =
         FullFieldsTestEntityHelper.makeAndPersistHost(
             "ns1.cat.lol", "1.2.3.4", clock.nowUtc().minusYears(1));
@@ -118,14 +117,14 @@ class RdapNameserverSearchActionTest extends RdapSearchActionTestCase<RdapNamese
     // cat.みんな
     createTld("xn--q9jyb4c");
     registrar = persistResource(makeRegistrar("unicoderegistrar", "みんな", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     FullFieldsTestEntityHelper.makeAndPersistHost(
         "ns1.cat.みんな", "1.2.3.5", clock.nowUtc().minusYears(1));
 
     // cat.1.test
     createTld("1.test");
     registrar = persistResource(makeRegistrar("multiregistrar", "1.test", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     FullFieldsTestEntityHelper.makeAndPersistHost(
         "ns1.cat.1.test", "1.2.3.6", clock.nowUtc().minusYears(1));
 

--- a/core/src/test/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsActionTest.java
+++ b/core/src/test/java/google/registry/rdap/UpdateRegistrarRdapBaseUrlsActionTest.java
@@ -17,7 +17,7 @@ package google.registry.rdap;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.loadRegistrar;
-import static google.registry.testing.DatabaseHelper.persistSimpleResource;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static jakarta.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static jakarta.servlet.http.HttpServletResponse.SC_OK;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -94,7 +94,7 @@ public final class UpdateRegistrarRdapBaseUrlsActionTest {
 
   private static void persistRegistrar(
       String registrarId, Long ianaId, Registrar.Type type, String... rdapBaseUrls) {
-    persistSimpleResource(
+    persistResource(
         new Registrar.Builder()
             .setRegistrarId(registrarId)
             .setRegistrarName(registrarId)

--- a/core/src/test/java/google/registry/rde/RdeFixtures.java
+++ b/core/src/test/java/google/registry/rde/RdeFixtures.java
@@ -18,7 +18,6 @@ import static com.google.common.io.BaseEncoding.base16;
 import static google.registry.testing.DatabaseHelper.generateNewContactHostRoid;
 import static google.registry.testing.DatabaseHelper.generateNewDomainRoid;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.testing.DatabaseHelper.persistSimpleResource;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static org.joda.money.CurrencyUnit.USD;
 
@@ -168,7 +167,7 @@ final class RdeFixtures {
                             .build())
                     .createVKey())
             .setAutorenewPollMessage(
-                persistSimpleResource(
+                persistResource(
                         new PollMessage.Autorenew.Builder()
                             .setTargetId(tld)
                             .setRegistrarId("TheRegistrar")

--- a/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
+++ b/core/src/test/java/google/registry/rde/RdeUploadActionTest.java
@@ -23,7 +23,6 @@ import static google.registry.model.rde.RdeMode.FULL;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.testing.DatabaseHelper.persistSimpleResource;
 import static google.registry.testing.GpgSystemCommandExtension.GPG_BINARY;
 import static google.registry.testing.SystemInfo.hasCommand;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -375,7 +374,7 @@ public class RdeUploadActionTest {
     URI uploadUrl = URI.create(String.format("sftp://user:password@localhost:%d/", port));
     DateTime stagingCursor = DateTime.parse("2010-10-18TZ");
     DateTime uploadCursor = DateTime.parse("2010-10-17TZ");
-    persistSimpleResource(Cursor.createScoped(RDE_STAGING, stagingCursor, Tld.get("tld")));
+    persistResource(Cursor.createScoped(RDE_STAGING, stagingCursor, Tld.get("tld")));
     BlobId ghostrydeR1FileWithPrefix =
         BlobId.of("bucket", JOB_PREFIX + "-job-name/tld_2010-10-17_full_S1_R1.xml.ghostryde");
     BlobId lengthR1FileWithPrefix =

--- a/core/src/test/java/google/registry/request/auth/OidcTokenAuthenticationMechanismTest.java
+++ b/core/src/test/java/google/registry/request/auth/OidcTokenAuthenticationMechanismTest.java
@@ -19,7 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static google.registry.request.auth.AuthModule.BEARER_PREFIX;
 import static google.registry.request.auth.AuthModule.IAP_HEADER_NAME;
 import static google.registry.testing.DatabaseHelper.createAdminUser;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -139,12 +139,12 @@ public class OidcTokenAuthenticationMechanismTest {
   @Test
   void testAuthenticate_bothUserAndServiceAccount() throws Exception {
     User serviceUser =
-        new User.Builder()
-            .setEmailAddress("service@email.test")
-            .setUserRoles(
-                new UserRoles.Builder().setIsAdmin(true).setGlobalRole(GlobalRole.FTE).build())
-            .build();
-    insertInDb(serviceUser);
+        persistResource(
+            new User.Builder()
+                .setEmailAddress("service@email.test")
+                .setUserRoles(
+                    new UserRoles.Builder().setIsAdmin(true).setGlobalRole(GlobalRole.FTE).build())
+                .build());
     payload.setEmail("service@email.test");
     authResult = authenticationMechanism.authenticate(request);
     assertThat(authResult.isAuthenticated()).isTrue();

--- a/core/src/test/java/google/registry/schema/registrar/RegistrarDaoTest.java
+++ b/core/src/test/java/google/registry/schema/registrar/RegistrarDaoTest.java
@@ -16,11 +16,9 @@ package google.registry.schema.registrar;
 
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.testing.DatabaseHelper.existsInDb;
-import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.loadByKey;
-import static google.registry.testing.DatabaseHelper.updateInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static org.joda.time.DateTimeZone.UTC;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import google.registry.model.registrar.Registrar;
@@ -68,30 +66,24 @@ public class RegistrarDaoTest {
   @Test
   void saveNew_worksSuccessfully() {
     assertThat(existsInDb(testRegistrar)).isFalse();
-    insertInDb(testRegistrar);
+    persistResource(testRegistrar);
     assertThat(existsInDb(testRegistrar)).isTrue();
   }
 
   @Test
   void update_worksSuccessfully() {
-    insertInDb(testRegistrar);
+    persistResource(testRegistrar);
     Registrar persisted = loadByKey(registrarKey);
     assertThat(persisted.getRegistrarName()).isEqualTo("registrarName");
-    updateInDb(persisted.asBuilder().setRegistrarName("changedRegistrarName").build());
+    persistResource(persisted.asBuilder().setRegistrarName("changedRegistrarName").build());
     Registrar updated = loadByKey(registrarKey);
     assertThat(updated.getRegistrarName()).isEqualTo("changedRegistrarName");
   }
 
   @Test
-  void update_throwsExceptionWhenEntityDoesNotExist() {
-    assertThat(existsInDb(testRegistrar)).isFalse();
-    assertThrows(IllegalArgumentException.class, () -> updateInDb(testRegistrar));
-  }
-
-  @Test
   void load_worksSuccessfully() {
     assertThat(existsInDb(testRegistrar)).isFalse();
-    insertInDb(testRegistrar);
+    persistResource(testRegistrar);
     Registrar persisted = loadByKey(registrarKey);
 
     assertThat(persisted.getRegistrarId()).isEqualTo("registrarId");

--- a/core/src/test/java/google/registry/schema/registrar/RegistrarPocTest.java
+++ b/core/src/test/java/google/registry/schema/registrar/RegistrarPocTest.java
@@ -18,7 +18,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
 import static google.registry.model.registrar.RegistrarPoc.Type.WHOIS;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.insertInDb;
+import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.SqlHelper.saveRegistrar;
 
 import com.google.common.collect.ImmutableSet;
@@ -62,7 +62,7 @@ class RegistrarPocTest {
 
   @Test
   void testPersistence_succeeds() {
-    insertInDb(testRegistrarPoc);
+    persistResource(testRegistrarPoc);
     assertAboutImmutableObjects()
         .that(testRegistrarPoc)
         .isEqualExceptFields(testRegistrarPoc, "id");
@@ -70,7 +70,7 @@ class RegistrarPocTest {
 
   @Test
   void testSerializable_succeeds() {
-    insertInDb(testRegistrarPoc);
+    persistResource(testRegistrarPoc);
     RegistrarPoc persisted = tm().transact(() -> tm().loadByEntity(testRegistrarPoc));
     assertThat(SerializeUtils.serializeDeserialize(persisted)).isEqualTo(persisted);
   }

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -762,7 +762,7 @@ public final class DatabaseHelper {
       String registrarName,
       Registrar.Type type,
       @Nullable Long ianaIdentifier) {
-    return persistSimpleResource(
+    return persistResource(
         new Registrar.Builder()
             .setRegistrarId(registrarId)
             .setRegistrarName(registrarName)
@@ -986,7 +986,13 @@ public final class DatabaseHelper {
   }
 
   /** Persists the specified resources to the DB. */
-  public static <R extends ImmutableObject> void persistResources(final Iterable<R> resources) {
+  public static <R extends ImmutableObject> ImmutableList<R> persistResources(R... resources) {
+    return persistResources(ImmutableList.copyOf(resources));
+  }
+
+  /** Persists the specified resources to the DB. */
+  public static <R extends ImmutableObject> ImmutableList<R> persistResources(
+      final Iterable<R> resources) {
     for (R resource : resources) {
       assertWithMessage("Attempting to persist a Builder is almost certainly an error in test code")
           .that(resource)
@@ -994,6 +1000,7 @@ public final class DatabaseHelper {
     }
     tm().transact(() -> resources.forEach(e -> tm().put(e)));
     maybeAdvanceClock();
+    return loadByEntitiesIfPresent(resources);
   }
 
   /**
@@ -1147,29 +1154,6 @@ public final class DatabaseHelper {
             .build());
   }
 
-  /** Persists a single resource, without adjusting foreign resources or keys. */
-  public static <R> R persistSimpleResource(final R resource) {
-    return persistSimpleResources(ImmutableList.of(resource)).get(0);
-  }
-
-  /**
-   * Like persistResource but for multiple entities, with no helper for saving
-   * ForeignKeyedEppResources.
-   */
-  public static <R> ImmutableList<R> persistSimpleResources(final Iterable<R> resources) {
-    insertSimpleResources(resources);
-    return tm().transact(() -> tm().loadByEntities(resources));
-  }
-
-  /**
-   * Like {@link #persistSimpleResources(Iterable)} but without reloading/returning the saved
-   * entities.
-   */
-  public static <R> void insertSimpleResources(final Iterable<R> resources) {
-    tm().transact(() -> tm().putAll(ImmutableList.copyOf(resources)));
-    maybeAdvanceClock();
-  }
-
   public static void deleteResource(final Object resource) {
     tm().transact(() -> tm().delete(resource));
   }
@@ -1230,8 +1214,8 @@ public final class DatabaseHelper {
   /**
    * Loads (i.e. reloads) the specified entity from the DB.
    *
-   * <p>If the transaction manager is Cloud SQL, then this creates an inner wrapping transaction for
-   * convenience, so you don't need to wrap it in a transaction at the call site.
+   * <p>This creates an inner wrapping transaction for convenience, so you don't need to wrap it in
+   * a transaction at the call site.
    */
   public static <T> T loadByEntity(T entity) {
     return tm().transact(() -> tm().loadByEntity(entity));
@@ -1240,8 +1224,8 @@ public final class DatabaseHelper {
   /**
    * Loads the specified entity by its key from the DB.
    *
-   * <p>If the transaction manager is Cloud SQL, then this creates an inner wrapping transaction for
-   * convenience, so you don't need to wrap it in a transaction at the call site.
+   * <p>This creates an inner wrapping transaction for convenience, so you don't need to wrap it in
+   * a transaction at the call site.
    */
   public static <T> T loadByKey(VKey<T> key) {
     return tm().transact(() -> tm().loadByKey(key));
@@ -1250,8 +1234,8 @@ public final class DatabaseHelper {
   /**
    * Loads the specified entity by its key from the DB or empty if it doesn't exist.
    *
-   * <p>If the transaction manager is Cloud SQL, then this creates an inner wrapping transaction for
-   * convenience, so you don't need to wrap it in a transaction at the call site.
+   * <p>This creates an inner wrapping transaction for convenience, so you don't need to wrap it in
+   * a transaction at the call site.
    */
   public static <T> Optional<T> loadByKeyIfPresent(VKey<T> key) {
     return tm().transact(() -> tm().loadByKeyIfPresent(key));
@@ -1260,8 +1244,8 @@ public final class DatabaseHelper {
   /**
    * Loads the specified entities by their keys from the DB.
    *
-   * <p>If the transaction manager is Cloud SQL, then this creates an inner wrapping transaction for
-   * convenience, so you don't need to wrap it in a transaction at the call site.
+   * <p>This creates an inner wrapping transaction for convenience, so you don't need to wrap it in
+   * a transaction at the call site.
    */
   public static <T> ImmutableCollection<T> loadByKeys(Iterable<? extends VKey<? extends T>> keys) {
     return tm().transact(() -> tm().loadByKeys(keys).values());
@@ -1270,8 +1254,8 @@ public final class DatabaseHelper {
   /**
    * Loads all the entities of the specified type from the DB.
    *
-   * <p>If the transaction manager is Cloud SQL, then this creates an inner wrapping transaction for
-   * convenience, so you don't need to wrap it in a transaction at the call site.
+   * <p>This creates an inner wrapping transaction for convenience, so you don't need to wrap it in
+   * a transaction at the call site.
    */
   public static <T> ImmutableList<T> loadAllOf(Class<T> clazz) {
     return tm().transact(() -> tm().loadAllOf(clazz));
@@ -1280,8 +1264,8 @@ public final class DatabaseHelper {
   /**
    * Loads the set of entities by their keys from the DB.
    *
-   * <p>If the transaction manager is Cloud SQL, then this creates an inner wrapping transaction for
-   * convenience, so you don't need to wrap it in a transaction at the call site.
+   * <p>This creates an inner wrapping transaction for convenience, so you don't need to wrap it in
+   * a transaction at the call site.
    *
    * <p>Nonexistent keys / entities are absent from the resulting map, but no {@link
    * NoSuchElementException} will be thrown.
@@ -1294,8 +1278,8 @@ public final class DatabaseHelper {
   /**
    * Loads all given entities from the database if possible.
    *
-   * <p>If the transaction manager is Cloud SQL, then this creates an inner wrapping transaction for
-   * convenience, so you don't need to wrap it in a transaction at the call site.
+   * <p>This creates an inner wrapping transaction for convenience, so you don't need to wrap it in
+   * a transaction at the call site.
    *
    * <p>Nonexistent entities are absent from the resulting list, but no {@link
    * NoSuchElementException} will be thrown.
@@ -1312,36 +1296,6 @@ public final class DatabaseHelper {
   /** Returns whether or not the given entity exists in Cloud SQL. */
   public static boolean existsInDb(ImmutableObject object) {
     return tm().transact(() -> tm().exists(object));
-  }
-
-  /** Inserts the given entity/entities into Cloud SQL in a single transaction. */
-  public static <T extends ImmutableObject> void insertInDb(T... entities) {
-    tm().transact(() -> tm().insertAll(entities));
-  }
-
-  /** Inserts the given entities into Cloud SQL in a single transaction. */
-  public static <T extends ImmutableObject> void insertInDb(ImmutableCollection<T> entities) {
-    tm().transact(() -> tm().insertAll(entities));
-  }
-
-  /** Puts the given entity/entities into Cloud SQL in a single transaction. */
-  public static <T extends ImmutableObject> void putInDb(T... entities) {
-    tm().transact(() -> tm().putAll(entities));
-  }
-
-  /** Puts the given entities into Cloud SQL in a single transaction. */
-  public static <T extends ImmutableObject> void putInDb(ImmutableCollection<T> entities) {
-    tm().transact(() -> tm().putAll(entities));
-  }
-
-  /** Updates the given entities in Cloud SQL in a single transaction. */
-  public static <T extends ImmutableObject> void updateInDb(T... entities) {
-    tm().transact(() -> tm().updateAll(entities));
-  }
-
-  /** Updates the given entities in Cloud SQL in a single transaction. */
-  public static <T extends ImmutableObject> void updateInDb(ImmutableCollection<T> entities) {
-    tm().transact(() -> tm().updateAll(entities));
   }
 
   /**

--- a/core/src/test/java/google/registry/tools/GetAllocationTokenCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetAllocationTokenCommandTest.java
@@ -20,7 +20,7 @@ import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.createTlds;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.testing.DatabaseHelper.persistSimpleResources;
+import static google.registry.testing.DatabaseHelper.persistResources;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.beust.jcommander.ParameterException;
@@ -61,7 +61,7 @@ class GetAllocationTokenCommandTest extends CommandTestCase<GetAllocationTokenCo
                 .build());
     runCommand("foo");
     assertStdoutIs(
-        """
+"""
 AllocationToken: {
     allowedClientIds=[TheRegistrar]
     allowedEppActions=[CREATE]
@@ -94,7 +94,7 @@ Token foo was not redeemed.
   void testSuccess_multipleTokens() throws Exception {
     createTlds("baz");
     ImmutableList<AllocationToken> tokens =
-        persistSimpleResources(
+        persistResources(
             ImmutableList.of(
                 new AllocationToken.Builder()
                     .setToken("fee")

--- a/core/src/test/java/google/registry/tools/GetUserCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetUserCommandTest.java
@@ -29,7 +29,7 @@ public class GetUserCommandTest extends CommandTestCase<GetUserCommand> {
 
   @BeforeEach
   void beforeEach() {
-    DatabaseHelper.putInDb(
+    DatabaseHelper.persistResources(
         new User.Builder()
             .setEmailAddress("johndoe@theregistrar.com")
             .setUserRoles(

--- a/core/src/test/java/google/registry/tools/RegistrarPocCommandTest.java
+++ b/core/src/test/java/google/registry/tools/RegistrarPocCommandTest.java
@@ -23,9 +23,7 @@ import static google.registry.model.registrar.RegistrarPoc.Type.WHOIS;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.loadRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.testing.DatabaseHelper.persistSimpleResource;
-import static google.registry.testing.DatabaseHelper.persistSimpleResources;
-import static google.registry.testing.DatabaseHelper.putInDb;
+import static google.registry.testing.DatabaseHelper.persistResources;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -89,7 +87,7 @@ class RegistrarPocCommandTest extends CommandTestCase<RegistrarPocCommand> {
                 .setVisibleInWhoisAsTech(true)
                 .setVisibleInDomainWhoisAsAbuse(false)
                 .build());
-    persistSimpleResources(contacts);
+    persistResources(contacts);
     runCommandForced(
         "--mode=UPDATE",
         "--name=Judith Registrar",
@@ -124,13 +122,13 @@ class RegistrarPocCommandTest extends CommandTestCase<RegistrarPocCommand> {
   @Test
   void testUpdate_unsetOtherWhoisAbuseFlags() throws Exception {
     Registrar registrar = loadRegistrar("NewRegistrar");
-    persistSimpleResource(
+    persistResource(
         new RegistrarPoc.Builder()
             .setRegistrar(registrar)
             .setName("John Doe")
             .setEmailAddress("john.doe@example.com")
             .build());
-    persistSimpleResource(
+    persistResource(
         new RegistrarPoc.Builder()
             .setRegistrar(registrar)
             .setName("Johnna Doe")
@@ -156,7 +154,7 @@ class RegistrarPocCommandTest extends CommandTestCase<RegistrarPocCommand> {
   @Test
   void testUpdate_cannotUnsetOnlyWhoisAbuseContact() {
     Registrar registrar = loadRegistrar("NewRegistrar");
-    persistSimpleResource(
+    persistResource(
         new RegistrarPoc.Builder()
             .setRegistrar(registrar)
             .setName("John Doe")
@@ -183,7 +181,7 @@ class RegistrarPocCommandTest extends CommandTestCase<RegistrarPocCommand> {
   void testUpdate_emptyCommandModifiesNothing() throws Exception {
     Registrar registrar = loadRegistrar("NewRegistrar");
     RegistrarPoc existingContact =
-        persistSimpleResource(
+        persistResource(
             new RegistrarPoc.Builder()
                 .setRegistrar(registrar)
                 .setName("John Doe")
@@ -213,7 +211,7 @@ class RegistrarPocCommandTest extends CommandTestCase<RegistrarPocCommand> {
   @Test
   void testUpdate_listOfTypesWorks() throws Exception {
     Registrar registrar = loadRegistrar("NewRegistrar");
-    persistSimpleResource(
+    persistResource(
         new RegistrarPoc.Builder()
             .setRegistrar(registrar)
             .setName("John Doe")
@@ -237,7 +235,7 @@ class RegistrarPocCommandTest extends CommandTestCase<RegistrarPocCommand> {
   @Test
   void testUpdate_clearAllTypes() throws Exception {
     Registrar registrar = loadRegistrar("NewRegistrar");
-    persistSimpleResource(
+    persistResource(
         new RegistrarPoc.Builder()
             .setRegistrar(registrar)
             .setName("John Doe")
@@ -290,7 +288,7 @@ class RegistrarPocCommandTest extends CommandTestCase<RegistrarPocCommand> {
   @Test
   void testDelete_failsOnDomainWhoisAbuseContact() {
     RegistrarPoc registrarPoc = loadRegistrar("NewRegistrar").getContacts().asList().getFirst();
-    putInDb(registrarPoc.asBuilder().setVisibleInDomainWhoisAsAbuse(true).build());
+    persistResource(registrarPoc.asBuilder().setVisibleInDomainWhoisAsAbuse(true).build());
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,
@@ -338,7 +336,7 @@ class RegistrarPocCommandTest extends CommandTestCase<RegistrarPocCommand> {
   void testUpdate_setAllowedToSetRegistryLockPassword() throws Exception {
     Registrar registrar = loadRegistrar("NewRegistrar");
     RegistrarPoc registrarPoc =
-        persistSimpleResource(
+        persistResource(
             new RegistrarPoc.Builder()
                 .setRegistrar(registrar)
                 .setName("Jim Doe")
@@ -381,7 +379,7 @@ class RegistrarPocCommandTest extends CommandTestCase<RegistrarPocCommand> {
   void testUpdate_setAllowedToSetRegistryLockPassword_removesOldPassword() throws Exception {
     Registrar registrar = loadRegistrar("NewRegistrar");
     RegistrarPoc registrarPoc =
-        persistSimpleResource(
+        persistResource(
             new RegistrarPoc.Builder()
                 .setRegistrar(registrar)
                 .setName("Jim Doe")

--- a/core/src/test/java/google/registry/tools/SetupOteCommandTest.java
+++ b/core/src/test/java/google/registry/tools/SetupOteCommandTest.java
@@ -26,7 +26,6 @@ import static google.registry.testing.DatabaseHelper.loadExistingUser;
 import static google.registry.testing.DatabaseHelper.loadRegistrar;
 import static google.registry.testing.DatabaseHelper.persistPremiumList;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.testing.DatabaseHelper.putInDb;
 import static org.joda.money.CurrencyUnit.USD;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -448,7 +447,7 @@ class SetupOteCommandTest extends CommandTestCase<SetupOteCommand> {
 
   @Test
   void testFailure_userExists() {
-    putInDb(
+    persistResource(
         new User.Builder()
             .setEmailAddress("contact@email.com")
             .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.FTE).build())
@@ -494,7 +493,7 @@ class SetupOteCommandTest extends CommandTestCase<SetupOteCommand> {
 
   @Test
   void testSuccess_userExists_replaceExisting() throws Exception {
-    putInDb(
+    persistResource(
         new User.Builder()
             .setEmailAddress("contact@email.com")
             .setUserRoles(new UserRoles.Builder().setGlobalRole(GlobalRole.FTE).build())

--- a/core/src/test/java/google/registry/tools/UpdateUserCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateUserCommandTest.java
@@ -17,7 +17,6 @@ package google.registry.tools;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.testing.DatabaseHelper.loadExistingUser;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.testing.DatabaseHelper.putInDb;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
@@ -33,7 +32,7 @@ public class UpdateUserCommandTest extends CommandTestCase<UpdateUserCommand> {
 
   @BeforeEach
   void beforeEach() throws Exception {
-    putInDb(
+    persistResource(
         new User.Builder()
             .setEmailAddress("user@example.test")
             .setUserRoles(new UserRoles.Builder().build())
@@ -53,7 +52,7 @@ public class UpdateUserCommandTest extends CommandTestCase<UpdateUserCommand> {
 
   @Test
   void testSuccess_removeRegistryLockEmail() throws Exception {
-    putInDb(
+    persistResource(
         loadExistingUser("user@example.test")
             .asBuilder()
             .setRegistryLockEmailAddress("registrylock@otherexample.test")

--- a/core/src/test/java/google/registry/ui/server/console/settings/ContactActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/settings/ContactActionTest.java
@@ -21,9 +21,9 @@ import static google.registry.model.registrar.RegistrarPoc.Type.ADMIN;
 import static google.registry.model.registrar.RegistrarPoc.Type.MARKETING;
 import static google.registry.model.registrar.RegistrarPoc.Type.TECH;
 import static google.registry.testing.DatabaseHelper.deleteResource;
-import static google.registry.testing.DatabaseHelper.insertInDb;
 import static google.registry.testing.DatabaseHelper.loadAllOf;
 import static google.registry.testing.DatabaseHelper.persistResource;
+import static google.registry.testing.DatabaseHelper.persistResources;
 import static google.registry.testing.SqlHelper.saveRegistrar;
 import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN;
@@ -168,7 +168,7 @@ class ContactActionTest extends ConsoleActionBaseTestCase {
 
   @Test
   void testFailure_postUpdateContactInfo_duplicateEmails() throws IOException {
-    insertInDb(techPoc);
+    persistResource(techPoc);
     ContactAction action =
         createAction(
             Action.Method.POST,
@@ -323,7 +323,7 @@ class ContactActionTest extends ConsoleActionBaseTestCase {
 
   @Test
   void testSuccess_postDeleteContactInfo() throws IOException {
-    insertInDb(techPoc, marketingPoc);
+    persistResources(techPoc, marketingPoc);
     ContactAction action =
         createAction(Action.Method.DELETE, fteUser, testRegistrar.getRegistrarId(), marketingPoc);
     action.run();

--- a/core/src/test/java/google/registry/whois/RegistrarWhoisResponseTest.java
+++ b/core/src/test/java/google/registry/whois/RegistrarWhoisResponseTest.java
@@ -17,7 +17,7 @@ package google.registry.whois;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.testing.DatabaseHelper.persistSimpleResources;
+import static google.registry.testing.DatabaseHelper.persistResources;
 import static google.registry.whois.WhoisTestData.loadFile;
 
 import com.google.common.collect.ImmutableList;
@@ -113,7 +113,7 @@ class RegistrarWhoisResponseTest {
                 .setVisibleInWhoisAsTech(true)
                 .build());
     persistResource(registrar);
-    persistSimpleResources(contacts);
+    persistResources(contacts);
 
     RegistrarWhoisResponse registrarWhoisResponse =
         new RegistrarWhoisResponse(registrar, clock.nowUtc());

--- a/core/src/test/java/google/registry/whois/WhoisActionTest.java
+++ b/core/src/test/java/google/registry/whois/WhoisActionTest.java
@@ -24,7 +24,7 @@ import static google.registry.testing.DatabaseHelper.createTlds;
 import static google.registry.testing.DatabaseHelper.loadRegistrar;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.testing.DatabaseHelper.persistSimpleResources;
+import static google.registry.testing.DatabaseHelper.persistResources;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeDomain;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrar;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrarPocs;
@@ -134,7 +134,7 @@ public class WhoisActionTest {
     Registrar registrar =
         persistResource(makeRegistrar("evilregistrar", "Yes Virginia", ACTIVE));
     persistResource(makeDomainWithRegistrar(registrar));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     newWhoisAction("domain cat.lol\r\n").run();
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.getPayload()).isEqualTo(loadFile("whois_action_domain.txt"));
@@ -145,7 +145,7 @@ public class WhoisActionTest {
     Registrar registrar =
         persistResource(makeRegistrar("evilregistrar", "Yes Virginia", ACTIVE));
     persistResource(makeDomainWithRegistrar(registrar));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     // Populate the cache for both the domain and contact.
     Domain domain = loadByForeignKeyByCacheIfEnabled(Domain.class, "cat.lol", clock.nowUtc()).get();
     Contact contact =
@@ -178,7 +178,7 @@ public class WhoisActionTest {
 
     Registrar registrar = persistResource(makeRegistrar("evilregistrar", "Yes Virginia", ACTIVE));
     persistResource(makeDomainWithRegistrar(registrar));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     newWhoisAction("domain cat.lol\r\n").run();
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.getPayload()).isEqualTo(loadFile("whois_action_domain.txt"));
@@ -214,7 +214,7 @@ public class WhoisActionTest {
                     .setTransferRequestTrid(Trid.create("client-trid", "server-trid"))
                     .build())
             .build());
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     clock.setTo(DateTime.parse("2011-01-01T00:00:00Z"));
 
     newWhoisAction("domain cat.lol\r\n").run();
@@ -241,7 +241,7 @@ public class WhoisActionTest {
             persistResource(
                 FullFieldsTestEntityHelper.makeHost("ns2.cat.みんな", "bad:f00d:cafe::15:beef")),
             registrar));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     newWhoisAction("domain cat.みんな\r\n").run();
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.getPayload()).isEqualTo(loadFile("whois_action_idn_punycode.txt"));
@@ -265,7 +265,7 @@ public class WhoisActionTest {
             persistResource(
                 FullFieldsTestEntityHelper.makeHost("ns2.cat.みんな", "bad:f00d:cafe::15:beef")),
             registrar));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     newWhoisAction("domain cat.xn--q9jyb4c\r\n").run();
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.getPayload()).isEqualTo(loadFile("whois_action_idn_punycode.txt"));
@@ -311,7 +311,7 @@ public class WhoisActionTest {
             persistResource(
                 FullFieldsTestEntityHelper.makeHost("ns2.cat.lol", "bad:f00d:cafe::15:beef")),
             registrar));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     newWhoisAction("domain cat.lol\r\n").run();
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.getPayload()).isEqualTo(loadFile("whois_action_domain_not_found.txt"));
@@ -339,7 +339,7 @@ public class WhoisActionTest {
             .asBuilder()
             .setDeletionTime(clock.nowUtc().minusDays(1))
             .build());
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     newWhoisAction("domain cat.lol\r\n").run();
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.getPayload()).isEqualTo(loadFile("whois_action_domain_not_found.txt"));
@@ -396,7 +396,7 @@ public class WhoisActionTest {
                 .asBuilder()
                 .setCreationTimeForTest(clock.nowUtc())
                 .build());
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     assertThat(domain1.getRepoId()).isNotEqualTo(domain2.getRepoId());
     newWhoisAction("domain cat.lol\r\n").run();
     assertThat(response.getStatus()).isEqualTo(200);
@@ -546,7 +546,7 @@ public class WhoisActionTest {
   void testRun_registrarLookup_works() {
     Registrar registrar = persistResource(
         makeRegistrar("example", "Example Registrar, Inc.", ACTIVE));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     // Notice the partial search without "inc".
     newWhoisAction("registrar example registrar").run();
     assertThat(response.getStatus()).isEqualTo(200);
@@ -562,7 +562,7 @@ public class WhoisActionTest {
                 .setIanaIdentifier(9995L)
                 .setType(PDT)
                 .build());
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     // Notice the partial search without "inc".
     newWhoisAction("registrar example registrar").run();
     assertThat(response.getStatus()).isEqualTo(200);
@@ -573,7 +573,7 @@ public class WhoisActionTest {
   void testRun_registrarLookupInPendingState_returnsNotFound() {
     Registrar registrar = persistResource(
         makeRegistrar("example", "Example Registrar, Inc.", Registrar.State.PENDING));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     newWhoisAction("registrar Example Registrar, Inc.").run();
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.getPayload()).isEqualTo(loadFile("whois_action_registrar_not_found.txt"));
@@ -587,7 +587,7 @@ public class WhoisActionTest {
             .setIanaIdentifier(null)
             .setType(Registrar.Type.TEST)
             .build());
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     newWhoisAction("registrar Example Registrar, Inc.").run();
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.getPayload()).isEqualTo(loadFile("whois_action_registrar_not_found.txt"));
@@ -612,7 +612,7 @@ public class WhoisActionTest {
             persistResource(
                 FullFieldsTestEntityHelper.makeHost("ns2.cat.1.test", "bad:f00d:cafe::15:beef")),
             registrar));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
 
     newWhoisAction("domain cat.1.test\r\n").run();
     assertThat(response.getStatus()).isEqualTo(200);

--- a/core/src/test/java/google/registry/whois/WhoisHttpActionTest.java
+++ b/core/src/test/java/google/registry/whois/WhoisHttpActionTest.java
@@ -21,7 +21,7 @@ import static google.registry.model.registrar.Registrar.State.ACTIVE;
 import static google.registry.testing.DatabaseHelper.createTlds;
 import static google.registry.testing.DatabaseHelper.loadRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.testing.DatabaseHelper.persistSimpleResources;
+import static google.registry.testing.DatabaseHelper.persistResources;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeDomain;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrar;
 import static google.registry.testing.FullFieldsTestEntityHelper.makeRegistrarPocs;
@@ -137,7 +137,7 @@ class WhoisHttpActionTest {
             persistResource(
                 FullFieldsTestEntityHelper.makeHost("ns2.cat.lol", "bad:f00d:cafe::15:beef")),
             registrar));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     newWhoisHttpAction("/domain/cat.lol").run();
     assertThat(response.getStatus()).isEqualTo(404);
     assertThat(response.getContentType()).isEqualTo(PLAIN_TEXT_UTF_8);
@@ -162,7 +162,7 @@ class WhoisHttpActionTest {
             persistResource(
                 FullFieldsTestEntityHelper.makeHost("ns2.cat.みんな", "bad:f00d:cafe::15:beef")),
             registrar));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     newWhoisHttpAction("/domain/cat.みんな").run();
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.getPayload()).isEqualTo(loadFile("whois_action_idn_utf8.txt"));
@@ -243,7 +243,7 @@ class WhoisHttpActionTest {
             persistResource(
                 FullFieldsTestEntityHelper.makeHost("ns2.cat.lol", "bad:f00d:cafe::15:beef")),
             registrar));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     newWhoisHttpAction("domain cat.lol\r\n").run();
     assertThat(response.getStatus()).isEqualTo(200);
     assertThat(response.getPayload()).isEqualTo(loadFile("whois_action_domain.txt"));
@@ -288,7 +288,7 @@ class WhoisHttpActionTest {
             persistResource(
                 FullFieldsTestEntityHelper.makeHost("ns2.cat.みんな", "bad:f00d:cafe::15:beef")),
             registrar));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     newWhoisHttpAction("/domain/cat.xn--q9jyb4c").run();
     assertThat(response.getPayload()).isEqualTo(loadFile("whois_action_idn_utf8.txt"));
   }
@@ -392,7 +392,7 @@ class WhoisHttpActionTest {
   void testRun_registrarLookup_works() {
     Registrar registrar = persistResource(
         makeRegistrar("example", "Example Registrar, Inc.", Registrar.State.ACTIVE));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     // Notice the partial search without "inc".
     newWhoisHttpAction("/registrar/Example%20Registrar").run();
     assertThat(response.getStatus()).isEqualTo(200);
@@ -403,7 +403,7 @@ class WhoisHttpActionTest {
   void testRun_registrarLookupInPendingState_returnsNotFound() {
     Registrar registrar = persistResource(
         makeRegistrar("example", "Example Registrar, Inc.", Registrar.State.PENDING));
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     newWhoisHttpAction("/registrar/Example%20Registrar,%20Inc.").run();
     assertThat(response.getStatus()).isEqualTo(404);
     assertThat(response.getPayload()).isEqualTo(loadFile("whois_action_registrar_not_found.txt"));
@@ -414,7 +414,7 @@ class WhoisHttpActionTest {
     Registrar registrar = persistResource(
         makeRegistrar("example", "Example Registrar, Inc.", Registrar.State.ACTIVE)
             .asBuilder().setType(Registrar.Type.TEST).setIanaIdentifier(null).build());
-    persistSimpleResources(makeRegistrarPocs(registrar));
+    persistResources(makeRegistrarPocs(registrar));
     newWhoisHttpAction("/registrar/Example%20Registrar,%20Inc.").run();
     assertThat(response.getStatus()).isEqualTo(404);
     assertThat(response.getPayload()).isEqualTo(loadFile("whois_action_registrar_not_found.txt"));


### PR DESCRIPTION
Some of these have been around since the Datastore days and are no longer relevant (dealing with things like Datastore foreign keys). Let's simplify things.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2784)
<!-- Reviewable:end -->
