### PR TITLE
Fix failures in retries when inserting new objects

### DIFF
--- a/core/src/main/java/google/registry/model/smd/SignedMarkRevocationList.java
+++ b/core/src/main/java/google/registry/model/smd/SignedMarkRevocationList.java
@@ -95,10 +95,4 @@ public class SignedMarkRevocationList extends ImmutableObject {
   public int size() {
     return revokes.size();
   }
-
-  /** Save this list to Cloud SQL. Returns {@code this}. */
-  public SignedMarkRevocationList save() {
-    SignedMarkRevocationListDao.save(this);
-    return this;
-  }
 }

--- a/core/src/main/java/google/registry/model/tld/label/ReservedListDao.java
+++ b/core/src/main/java/google/registry/model/tld/label/ReservedListDao.java
@@ -27,14 +27,26 @@ public class ReservedListDao {
 
   private ReservedListDao() {}
 
-  /** Persist a new reserved list to Cloud SQL. */
-  public static void save(ReservedList reservedList) {
+  /**
+   * Persists a new reserved list to Cloud SQL and returns the persisted entity.
+   *
+   * <p>Note that the input parameter is untouched. Use the returned object if metadata fields like
+   * {@code revisionId} are needed.
+   */
+  public static ReservedList save(ReservedList reservedList) {
     checkArgumentNotNull(reservedList, "Must specify reservedList");
     logger.atInfo().log("Saving reserved list %s to Cloud SQL.", reservedList.getName());
-    tm().transact(() -> tm().insert(reservedList));
+    var persisted =
+        tm().transact(
+                () -> {
+                  var entity = reservedList.asBuilder().build();
+                  tm().insert(entity);
+                  return entity;
+                });
     logger.atInfo().log(
         "Saved reserved list %s with %d entries to Cloud SQL.",
         reservedList.getName(), reservedList.getReservedListEntries().size());
+    return persisted;
   }
 
   /** Deletes a reserved list from Cloud SQL. */

--- a/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
+++ b/core/src/main/java/google/registry/persistence/transaction/JpaTransactionManagerImpl.java
@@ -344,6 +344,18 @@ public class JpaTransactionManagerImpl implements JpaTransactionManager {
     return txnInfo.transactionTime;
   }
 
+  /**
+   * Inserts an object into the database.
+   *
+   * <p>If {@code entity} has an auto-generated identity field (i.e., a field annotated with {@link
+   * jakarta.persistence.GeneratedValue}), the caller must not assign a value to this field,
+   * otherwise Hibernate would mistake the entity as detached and raise an error.
+   *
+   * <p>The practical implication of the above is that when inserting such an entity using a
+   * retriable transaction , the entity should be instantiated inside the transaction body. A failed
+   * attempt may still assign and ID to the entity, therefore reusing the same entity would cause
+   * retries to fail.
+   */
   @Override
   public void insert(Object entity) {
     checkArgumentNotNull(entity, "entity must be specified");

--- a/core/src/main/java/google/registry/tmch/TmchSmdrlAction.java
+++ b/core/src/main/java/google/registry/tmch/TmchSmdrlAction.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.flogger.FluentLogger;
 import google.registry.keyring.api.KeyModule.Key;
 import google.registry.model.smd.SignedMarkRevocationList;
+import google.registry.model.smd.SignedMarkRevocationListDao;
 import google.registry.request.Action;
 import google.registry.request.Action.GaeService;
 import google.registry.request.auth.Auth;
@@ -57,7 +58,7 @@ public final class TmchSmdrlAction implements Runnable {
     } catch (GeneralSecurityException | IOException | PGPException e) {
       throw new RuntimeException(e);
     }
-    smdrl.save();
+    smdrl = SignedMarkRevocationListDao.save(smdrl);
     logger.atInfo().log(
         "Inserted %,d smd revocations into the database, created at %s.",
         smdrl.size(), smdrl.getCreationTime());

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -179,6 +179,7 @@ import google.registry.model.reporting.DomainTransactionRecord;
 import google.registry.model.reporting.DomainTransactionRecord.TransactionReportField;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.reporting.HistoryEntry.HistoryEntryId;
+import google.registry.model.smd.SignedMarkRevocationListDao;
 import google.registry.model.tld.Tld;
 import google.registry.model.tld.Tld.TldState;
 import google.registry.model.tld.Tld.TldType;
@@ -2727,8 +2728,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Test
   void testFail_startDateSunriseRegistration_revokedSignedMark() throws Exception {
-    SmdrlCsvParser.parse(TmchTestData.loadFile("smd/smdrl.csv").lines().collect(toImmutableList()))
-        .save();
+    SignedMarkRevocationListDao.save(
+        SmdrlCsvParser.parse(
+            TmchTestData.loadFile("smd/smdrl.csv").lines().collect(toImmutableList())));
     createTld("tld", START_DATE_SUNRISE);
     clock.setTo(SMD_VALID_TIME);
     String revokedSmd =
@@ -2753,9 +2755,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     if (labels.isEmpty()) {
       return;
     }
-    SmdrlCsvParser.parse(
-            TmchTestData.loadFile("idn/idn_smdrl.csv").lines().collect(toImmutableList()))
-        .save();
+    SignedMarkRevocationListDao.save(
+        SmdrlCsvParser.parse(
+            TmchTestData.loadFile("idn/idn_smdrl.csv").lines().collect(toImmutableList())));
     createTld("tld", START_DATE_SUNRISE);
     clock.setTo(SMD_VALID_TIME);
     String revokedSmd =

--- a/core/src/test/java/google/registry/model/smd/SignedMarkRevocationListTest.java
+++ b/core/src/test/java/google/registry/model/smd/SignedMarkRevocationListTest.java
@@ -48,7 +48,8 @@ public class SignedMarkRevocationListTest {
     for (int i = 0; i < rows; i++) {
       revokes.put(Integer.toString(i), clock.nowUtc());
     }
-    SignedMarkRevocationList.create(clock.nowUtc(), revokes.build()).save();
+    SignedMarkRevocationListDao.save(
+        SignedMarkRevocationList.create(clock.nowUtc(), revokes.build()));
     SignedMarkRevocationList res = SignedMarkRevocationList.get();
     assertThat(res.size()).isEqualTo(rows);
     return res;


### PR DESCRIPTION
Given an entity with auto-filled id fields (annotated with @GeneratedValue, with null as initial value), when inserting it using Hibernate, the id fields will be filled with non-nulls even if the transaction fails.

If the same entity instance is used again in a retry, Hibernate mistakes it as a detached entity and raises an error.

The work around is to make a new copy of the entity in each transaction. This PR applies this pattern to affected entity types.

We considered applying this pattern to JpaTransactionManagerImpl's insert method so that individual call sites do not have to change. However, we decided against it because:

- It is unnecessary for entity types that do not have auto-filled id

- The JpaTransactionManager cannot tell if copying is cheap or expensive. It is better exposing this to the user.

- The JpaTransactionManager needs to know how to clone entities. A new interface may need to be introduced just for a handful of use cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2788)
<!-- Reviewable:end -->
