### PR TITLE
Update resource allocation for proxy deployment

### DIFF
--- a/proxy/deploy-proxy-for-env.sh
+++ b/proxy/deploy-proxy-for-env.sh
@@ -33,6 +33,7 @@ do
     --project "${project}" --zone "${parts[1]}"
   sed s/GCP_PROJECT/${project}/g "./kubernetes/proxy-deployment-${environment}.yaml" | \
   kubectl apply -f -
+  kubectl apply -f "./kubernetes/proxy-limit-range.yaml" --force
   kubectl apply -f "./kubernetes/proxy-service.yaml" --force
   # Alpha does not have canary
   if [[ ${environment} != "alpha" ]]; then

--- a/proxy/kubernetes/proxy-limit-range.yaml
+++ b/proxy/kubernetes/proxy-limit-range.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: resource-limits
+  namespace: default
+spec:
+  limits:
+  - type: Container
+    default:
+      cpu: "300m"
+      memory: "512Mi"
+    defaultRequest:
+      cpu: "100m"
+      memory: "350Mi"

--- a/proxy/kubernetes/proxy-service-canary.yaml
+++ b/proxy/kubernetes/proxy-service-canary.yaml
@@ -33,3 +33,10 @@ spec:
     name: proxy-deployment-canary
   maxReplicas: 10
   minReplicas: 1
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 100

--- a/proxy/kubernetes/proxy-service.yaml
+++ b/proxy/kubernetes/proxy-service.yaml
@@ -33,3 +33,11 @@ spec:
     name: proxy-deployment
   maxReplicas: 50
   minReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 100
+


### PR DESCRIPTION
Missing resource requests as well as metrics for when to evict pods
produced situation when under load k8s struggled to assign pods. This
adds default resource requirements based on 2 weeks metrics and
instructions when pods should be evicted.

Resolves b/435171505.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2794)
<!-- Reviewable:end -->
