### PR TITLE
Update resource allocation for all Nomulus GKE deployments

### DIFF
--- a/jetty/kubernetes/nomulus-backend.yaml
+++ b/jetty/kubernetes/nomulus-backend.yaml
@@ -25,8 +25,11 @@ spec:
           name: http
         resources:
           requests:
-            cpu: "100m"
-            memory: "512Mi"
+            cpu: "500m"
+            memory: "1Gi"
+          limits:
+            cpu: "1000m"
+            memory: "1Gi"
         args: [ENVIRONMENT]
         env:
         - name: POD_ID
@@ -61,7 +64,7 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 100
+          averageUtilization: 80
 ---
 apiVersion: v1
 kind: Service

--- a/jetty/kubernetes/nomulus-console.yaml
+++ b/jetty/kubernetes/nomulus-console.yaml
@@ -41,7 +41,7 @@ spec:
             # class from performance, which has implicit pod-slots 1
             cloud.google.com/pod-slots: 0
             cpu: "500m"
-            memory: "2Gi"
+            memory: "1Gi"
         args: [ENVIRONMENT]
         env:
         - name: POD_ID
@@ -76,7 +76,7 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 100
+          averageUtilization: 80
 ---
 apiVersion: v1
 kind: Service

--- a/jetty/kubernetes/nomulus-frontend.yaml
+++ b/jetty/kubernetes/nomulus-frontend.yaml
@@ -25,8 +25,11 @@ spec:
           name: http
         resources:
           requests:
-            cpu: "100m"
+            cpu: "1000m"
             memory: "1Gi"
+          limits:
+            cpu: "1000m"
+            memory: "2Gi"
         args: [ENVIRONMENT]
         env:
         - name: POD_ID
@@ -50,7 +53,10 @@ spec:
           name: epp
         resources:
           requests:
-            cpu: "100m"
+            cpu: "1000m"
+            memory: "512Mi"
+          limits:
+            cpu: "1000m"
             memory: "512Mi"
         args: [--env, PROXY_ENV, --log, --local]
         env:
@@ -85,12 +91,12 @@ spec:
   minReplicas: 5
   maxReplicas: 20
   metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 100
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 80
 ---
 apiVersion: v1
 kind: Service

--- a/jetty/kubernetes/nomulus-pubapi.yaml
+++ b/jetty/kubernetes/nomulus-pubapi.yaml
@@ -34,13 +34,13 @@ spec:
             # explicit pod-slots 0 is required in order to downgrade node 
             # class from performance, which has implicit pod-slots 1
             cloud.google.com/pod-slots: 0
-            cpu: "100m"
+            cpu: "500m"
             memory: "1Gi"
           limits:
             # explicit pod-slots 0 is required in order to downgrade node 
             # class from performance, which has implicit pod-slots 1
             cloud.google.com/pod-slots: 0
-            cpu: "500m"
+            cpu: "1000m"
             memory: "2Gi"
         args: [ENVIRONMENT]
         env:
@@ -76,7 +76,7 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 100
+        averageUtilization: 80
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This has brought the start time for frontend instances from 16-18 seconds to 6-8. 

All deployments received update to averageUtilization cpu. This should allow us to stay ahead of the curve of traffic and create instances before we cpu reached the limit. 
Frontend cpu allocation has caused "noise neighbors" problem with pods assigned to nodes where there's not enough bursting capacity, so I increased it. Adjusted rest of the deployments according to their utilization.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2796)
<!-- Reviewable:end -->
