### PR TITLE
Chage run-time of DeleteExpiredDomainsAction

### DIFF
--- a/core/src/main/java/google/registry/config/files/tasks/cloud-scheduler-tasks-alpha.xml
+++ b/core/src/main/java/google/registry/config/files/tasks/cloud-scheduler-tasks-alpha.xml
@@ -88,6 +88,7 @@
       should exist between the RECURRING_BILLING cursor's time and the execution
       time of the action.
     </description>
+    <!-- Runs shortly after DeleteExpiredDomainsAction so it can delete domains before they renew -->
     <schedule>0 3 * * *</schedule>
   </task>
 
@@ -98,7 +99,8 @@
       This job runs an action that deletes domains that are past their
       autorenew end date.
     </description>
-    <schedule>7 3 * * *</schedule>
+    <!-- Runs shortly before ExpandBillingRecurrencesPipeline to catch and delete domains before they renew -->
+    <schedule>45 2 * * *</schedule>
   </task>
 
   <task>

--- a/core/src/main/java/google/registry/config/files/tasks/cloud-scheduler-tasks-crash.xml
+++ b/core/src/main/java/google/registry/config/files/tasks/cloud-scheduler-tasks-crash.xml
@@ -146,6 +146,7 @@
       This job runs an action that deletes domains that are past their
       autorenew end date.
     </description>
-    <schedule>7 3 * * *</schedule>
+    <!-- Runs shortly before ExpandBillingRecurrencesPipeline to catch and delete domains before they renew -->
+    <schedule>45 2 * * *</schedule>
   </task>
 </entries>

--- a/core/src/main/java/google/registry/config/files/tasks/cloud-scheduler-tasks-production.xml
+++ b/core/src/main/java/google/registry/config/files/tasks/cloud-scheduler-tasks-production.xml
@@ -130,6 +130,7 @@
       should exist between the RECURRING_BILLING cursor's time and the execution
       time of the action.
     </description>
+    <!-- Runs shortly after DeleteExpiredDomainsAction so it can delete domains before they renew -->
     <schedule>0 3 * * *</schedule>
   </task>
 
@@ -140,7 +141,8 @@
       This job runs an action that deletes domains that are past their
       autorenew end date.
     </description>
-    <schedule>7 3 * * *</schedule>
+    <!-- Runs shortly before ExpandBillingRecurrencesPipeline to catch and delete domains before they renew -->
+    <schedule>45 2 * * *</schedule>
   </task>
 
   <task>

--- a/core/src/main/java/google/registry/config/files/tasks/cloud-scheduler-tasks-qa.xml
+++ b/core/src/main/java/google/registry/config/files/tasks/cloud-scheduler-tasks-qa.xml
@@ -57,6 +57,7 @@
       This job runs an action that deletes domains that are past their
       autorenew end date.
     </description>
-    <schedule>7 3 * * *</schedule>
+    <!-- Runs shortly before ExpandBillingRecurrencesPipeline to catch and delete domains before they renew -->
+    <schedule>45 2 * * *</schedule>
   </task>
 </entries>

--- a/core/src/main/java/google/registry/config/files/tasks/cloud-scheduler-tasks-sandbox.xml
+++ b/core/src/main/java/google/registry/config/files/tasks/cloud-scheduler-tasks-sandbox.xml
@@ -90,6 +90,7 @@
       should exist between the RECURRING_BILLING cursor's time and the execution
       time of the action.
     </description>
+    <!-- Runs shortly after DeleteExpiredDomainsAction so it can delete domains before they renew -->
     <schedule>0 3 * * *</schedule>
   </task>
 
@@ -113,7 +114,8 @@
       This job runs an action that deletes domains that are past their
       autorenew end date.
     </description>
-    <schedule>7 3 * * *</schedule>
+    <!-- Runs shortly before ExpandBillingRecurrencesPipeline to catch and delete domains before they renew -->
+    <schedule>45 2 * * *</schedule>
   </task>
 
   <task>


### PR DESCRIPTION
We probably want this to run before the billing recurrence expansion pipeline just in case there are any domains that should be deleted before their billing recurrence gets expanded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2801)
<!-- Reviewable:end -->
