### PR TITLE
Make k8s adjustments

### DIFF
--- a/core/src/main/java/google/registry/config/files/default-config.yaml
+++ b/core/src/main/java/google/registry/config/files/default-config.yaml
@@ -255,7 +255,7 @@ hibernate:
   # The fetch size is the number of entities retrieved at a time from the
   # database cursor. Here we set a small default geared toward Nomulus server
   # transactions. Large queries can override the defaults on a per-query basis.
-  jdbcFetchSize: 20
+  jdbcFetchSize: 40
 
 cloudSql:
   # jdbc url for the Cloud SQL database.

--- a/jetty/kubernetes/nomulus-backend.yaml
+++ b/jetty/kubernetes/nomulus-backend.yaml
@@ -29,7 +29,7 @@ spec:
             memory: "1Gi"
           limits:
             cpu: "1000m"
-            memory: "1Gi"
+            memory: "1.5Gi"
         args: [ENVIRONMENT]
         env:
         - name: POD_ID

--- a/jetty/kubernetes/nomulus-frontend.yaml
+++ b/jetty/kubernetes/nomulus-frontend.yaml
@@ -25,7 +25,7 @@ spec:
           name: http
         resources:
           requests:
-            cpu: "1000m"
+            cpu: "600m"
             memory: "1Gi"
           limits:
             cpu: "1000m"
@@ -53,11 +53,11 @@ spec:
           name: epp
         resources:
           requests:
-            cpu: "1000m"
+            cpu: "600m"
             memory: "512Mi"
           limits:
             cpu: "1000m"
-            memory: "512Mi"
+            memory: "1Gi"
         args: [--env, PROXY_ENV, --log, --local]
         env:
         - name: POD_ID
@@ -88,8 +88,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: frontend
-  minReplicas: 5
-  maxReplicas: 20
+  minReplicas: 8
+  maxReplicas: 16
   metrics:
   - type: Resource
     resource:

--- a/proxy/kubernetes/proxy-service.yaml
+++ b/proxy/kubernetes/proxy-service.yaml
@@ -39,5 +39,5 @@ spec:
       name: cpu
       target:
         type: Utilization
-        averageUtilization: 100
+        averageUtilization: 80
 


### PR DESCRIPTION
This increases hikari fetch size to 40 from 20 in order to decrease the amount of round trips
This also sets lower CPU as we seem to have overshot CPU consumption 
This also sets min replicas to 8 for EPP and max to 16 as we've been running on 8-10 for the last week

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2803)
<!-- Reviewable:end -->
