### PR TITLE
Update golden schema comparison in schema test

### DIFF
--- a/common/src/testing/java/google/registry/testing/truth/TextDiffSubject.java
+++ b/common/src/testing/java/google/registry/testing/truth/TextDiffSubject.java
@@ -92,17 +92,19 @@ public class TextDiffSubject extends Subject {
 
   private ImmutableList<String> filterComments(List<String> lines) {
     return lines.stream()
+        .filter(line -> !line.isBlank())
         .filter(line -> comments.stream().noneMatch(line::startsWith))
         .collect(ImmutableList.toImmutableList());
   }
 
   public void hasSameContentAs(List<String> expectedContent) {
     checkNotNull(expectedContent, "expectedContent");
-    ImmutableList<String> expected = filterComments(expectedContent);
-    if (filterComments(expected).equals(filterComments(actual))) {
+    ImmutableList<String> filteredExpected = filterComments(expectedContent);
+    ImmutableList<String> filteredActual = filterComments(actual);
+    if (filteredExpected.equals(filteredActual)) {
       return;
     }
-    String diffString = diffFormat.generateDiff(expected, actual);
+    String diffString = diffFormat.generateDiff(filteredExpected, filteredActual);
     failWithoutActual(
         Fact.simpleFact(
             Joiner.on('\n')

--- a/db/src/test/java/google/registry/sql/flyway/SchemaTest.java
+++ b/db/src/test/java/google/registry/sql/flyway/SchemaTest.java
@@ -115,7 +115,7 @@ class SchemaTest {
             Joiner.on(File.separatorChar).join(MOUNTED_RESOURCE_PATH, DUMP_OUTPUT_FILE));
 
     assertThat(dumpedSchema)
-        .ignoringLinesStartingWith("--")
+        .ignoringLinesStartingWith("--", "\\restrict", "\\unrestrict")
         .hasSameContentAs(Resources.getResource("sql/schema/nomulus.golden.sql"));
   }
 


### PR DESCRIPTION
Postgresql-17.6 introduces two new lines in pg_dump output as a security feature: `\restrict {HASH}` and `\unrestrict {HASH}`.

We filter out lines starting with these two prefixes when comparing schemas.

The db upgrade also adds two empty lines to the pg_dump output. We know ignore
all blank lines (which includes empty lines) when comparing schemas.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2805)
<!-- Reviewable:end -->
