### PR TITLE
Use https in RDAP URLs provided

### DIFF
--- a/core/src/main/java/google/registry/request/RequestModule.java
+++ b/core/src/main/java/google/registry/request/RequestModule.java
@@ -135,7 +135,8 @@ public final class RequestModule {
   @Provides
   @RequestUrl
   static String provideRequestUrl(HttpServletRequest req) {
-    return req.getRequestURL().toString();
+    String url = req.getRequestURL().toString();
+    return url.startsWith("https") ? url : url.replaceFirst("http", "https");
   }
 
   @Provides


### PR DESCRIPTION
Load balancer / internal redirections can result in the final request URL lacking "https" when finally getting to the servlet. As a result, even if you use https in the request, the resulting URL can be plain http.

We need to include the actual (HTTPS) URL in the output, so replace it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2807)
<!-- Reviewable:end -->
