### PR TITLE
Fix the schema-verifier in Cloud Build

### DIFF
--- a/release/schema-verifier/allowed_diffs.txt
+++ b/release/schema-verifier/allowed_diffs.txt
@@ -6,3 +6,5 @@ COMMENT ON EXTENSION pg_stat_statements IS 'track execution statistics of all SQ
 SET transaction_timeout = 0;
 SET default_table_access_method = heap;
 SET default_with_oids = false;
+^\\restrict
+^\\unrestrict


### PR DESCRIPTION
This is the same problem as the one that broke the Java test:

pg_dump upgrade to 17.6 added new meta command lines.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2812)
<!-- Reviewable:end -->
