### PR TITLE
Enable password reset for non-admins

### DIFF
--- a/console-webapp/src/app/settings/security/eppPasswordEdit.component.html
+++ b/console-webapp/src/app/settings/security/eppPasswordEdit.component.html
@@ -21,7 +21,6 @@
     [formGroup]="passwordUpdateForm"
     (submitResults)="save($event)"
   />
-  @if(userDataService.userData()?.isAdmin) {
   <div class="settings-security__reset-password-field">
     <h2>Need to reset your EPP password?</h2>
     <button
@@ -33,5 +32,4 @@
       Reset EPP password via email
     </button>
   </div>
-  }
 </div>

--- a/console-webapp/src/app/users/userEditForm.component.html
+++ b/console-webapp/src/app/users/userEditForm.component.html
@@ -44,7 +44,6 @@
       Save
     </button>
   </form>
-  @if(userDataService.userData()?.isAdmin) {
   <button
     mat-flat-button
     color="primary"
@@ -53,5 +52,4 @@
   >
     Reset registry lock password
   </button>
-  }
 </div>

--- a/core/src/main/java/google/registry/ui/server/console/PasswordResetRequestAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/PasswordResetRequestAction.java
@@ -62,10 +62,6 @@ public class PasswordResetRequestAction extends ConsoleApiAction {
 
   @Override
   protected void postHandler(User user) {
-    // Temporary flag when testing email sending etc
-    if (!user.getUserRoles().isAdmin()) {
-      setFailedResponse("", HttpServletResponse.SC_FORBIDDEN);
-    }
     tm().transact(() -> performRequest(user));
     consoleApiParams.response().setStatus(HttpServletResponse.SC_OK);
   }

--- a/core/src/main/java/google/registry/ui/server/console/PasswordResetVerifyAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/PasswordResetVerifyAction.java
@@ -60,11 +60,6 @@ public class PasswordResetVerifyAction extends ConsoleApiAction {
 
   @Override
   protected void getHandler(User user) {
-    // Temporary flag when testing email sending etc
-    if (!user.getUserRoles().isAdmin()) {
-      setFailedResponse("", HttpServletResponse.SC_FORBIDDEN);
-      return;
-    }
     PasswordResetRequest request = tm().transact(() -> loadAndValidateResetRequest(user));
     ImmutableMap<String, ?> result =
         ImmutableMap.of("type", request.getType(), "registrarId", request.getRegistrarId());
@@ -74,11 +69,6 @@ public class PasswordResetVerifyAction extends ConsoleApiAction {
 
   @Override
   protected void postHandler(User user) {
-    // Temporary flag when testing email sending etc
-    if (!user.getUserRoles().isAdmin()) {
-      setFailedResponse("", HttpServletResponse.SC_FORBIDDEN);
-      return;
-    }
     checkArgument(!Strings.isNullOrEmpty(newPassword.orElse(null)), "Password must be provided");
     tm().transact(
             () -> {


### PR DESCRIPTION
Tested EPP password and registry lock password using the CharlestonRoad registrar entity and the emails look simple and effective.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2823)
<!-- Reviewable:end -->
