### PR TITLE
Use READ ONLY for DomainInfoFlow

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainInfoFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainInfoFlow.java
@@ -103,6 +103,7 @@ public final class DomainInfoFlow implements MutatingFlow {
 
   @Override
   public EppResponse run() throws EppException {
+    tm().getEntityManager().createNativeQuery("SET TRANSACTION READ ONLY").executeUpdate();
     extensionManager.register(FeeInfoCommandExtensionV06.class, BulkTokenExtension.class);
     flowCustomLogic.beforeValidation();
     validateRegistrarIsLoggedIn(registrarId);


### PR DESCRIPTION
For immediate-results purposes we use MutatingFlow for DomainInfoFlow (even though it's read-only). Let's explicitly set read-only for this in an attempt to grab fewer locks.

I don't think this makes a material difference for us, but 1. it might
2. it's good to do regardless

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2831)
<!-- Reviewable:end -->
