### PR TITLE
Delete step to push to release repo, trigger next release steps based on tag format

### DIFF
--- a/release/cloudbuild-release.yaml
+++ b/release/cloudbuild-release.yaml
@@ -274,11 +274,11 @@ steps:
   - |
     set -e
     # Check for a nomulus release tag (e.g., "v1.2.3")
-    if [[ "${TAG_NAME}" =~ ^nomulus-[0-9]{8}-RC[0-9]{2}$ ]]; then
+    if [[ "${TAG_NAME}" =~ ^nomulus-20\d{2}[0-1]\d[0-3]\d-RC\d{2}$ ]]; then
       echo "Tag format matches a nomulus release. Triggering nomulus build..."
       gcloud builds submit . --config=release/cloudbuild-nomulus.yaml --substitutions=TAG_NAME=$TAG_NAME
     # Check for a proxy release tag (e.g., "proxy-v1.2.3")
-    elif [[ "${TAG_NAME}" =~ ^proxy-[0-9]{8}-RC[0-9]{2}$ ]]; then
+    elif [[ "${TAG_NAME}" =~ ^proxy-20\d{2}[0-1]\d[0-3]\d-RC\d{2}$ ]]; then
       echo "Tag format matches a proxy release. Triggering proxy build..."
       gcloud builds submit . --config=release/cloudbuild-proxy.yaml --substitutions=TAG_NAME=$TAG_NAME
     else


### PR DESCRIPTION
This is to migrate out of Cloud Source repository. The alternatives researched in b/375660349 involve a lot of work arounds, for example source code should be stored only in approved products. Even then we would security exceptions to have a robot push code without human approval, these exceptions are also meant to be temporary.

I believe the simplest and most mantainable way to move forward is to just skip this step entirely and deprecate the repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2833)
<!-- Reviewable:end -->
