### PR TITLE
Allow top level tld creation in Sandbox

### DIFF
--- a/core/src/test/java/google/registry/tools/CreateCdnsTldTest.java
+++ b/core/src/test/java/google/registry/tools/CreateCdnsTldTest.java
@@ -76,11 +76,37 @@ class CreateCdnsTldTest extends CommandTestCase<CreateCdnsTld> {
 
   @Test
   @MockitoSettings(strictness = Strictness.LENIENT)
-  void testSandboxTldRestrictions() {
+  void testSandboxTldRestrictions_Disallowed() {
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> runCommandInEnvironment(RegistryToolEnvironment.SANDBOX, "--dns_name=foobar."));
-    assertThat(thrown).hasMessageThat().contains("Sandbox TLDs must be of the form \"*.test.\"");
+            () ->
+                runCommandInEnvironment(
+                    RegistryToolEnvironment.SANDBOX,
+                    "--dns_name=foobar.",
+                    "--description=test run",
+                    "--force"));
+    assertThat(thrown)
+        .hasMessageThat()
+        .contains("Sandbox TLDs must be approved or in the form \"*.test.\"");
+  }
+
+  @Test
+  void testSandboxTldRestrictions_tldCheckSkipped() throws Exception {
+    runCommandInEnvironment(
+        RegistryToolEnvironment.SANDBOX,
+        "--dns_name=foobar.",
+        "--description=test run",
+        "--force",
+        "--skip_sandbox_tld_check");
+  }
+
+  @Test
+  void testSandboxTldRestrictions_testTld() throws Exception {
+    runCommandInEnvironment(
+        RegistryToolEnvironment.SANDBOX,
+        "--dns_name=abc.test.",
+        "--description=test run",
+        "--force");
   }
 }


### PR DESCRIPTION
Add a flag to the CreateCdnsTld command to bypass the dns name format check in Sandbox (limiting names to `*.test.`). With this flag, we can create TLDs for RST testing in Sandbox.

Note that if the new flag is wrongly set for a disallowed name, the request to the Cloud DNS API will fail. The format check in the command just provides a user-friendly error message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2835)
<!-- Reviewable:end -->
