### PR TITLE
Add a rate limiter to remove all domain contacts action

### DIFF
--- a/core/src/main/java/google/registry/batch/BatchModule.java
+++ b/core/src/main/java/google/registry/batch/BatchModule.java
@@ -29,9 +29,11 @@ import static google.registry.request.RequestParameters.extractRequiredParameter
 import static google.registry.request.RequestParameters.extractSetOfDatetimeParameters;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.RateLimiter;
 import dagger.Module;
 import dagger.Provides;
 import google.registry.request.Parameter;
+import jakarta.inject.Named;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Optional;
 import org.joda.time.DateTime;
@@ -136,5 +138,19 @@ public class BatchModule {
   @Parameter(PARAM_FAST)
   static boolean provideIsFast(HttpServletRequest req) {
     return extractBooleanParameter(req, PARAM_FAST);
+  }
+
+  private static final int DEFAULT_MAX_QPS = 10;
+
+  @Provides
+  @Parameter("maxQps")
+  static int provideMaxQps(HttpServletRequest req) {
+    return extractOptionalIntParameter(req, "maxQps").orElse(DEFAULT_MAX_QPS);
+  }
+
+  @Provides
+  @Named("removeAllDomainContacts")
+  static RateLimiter provideRemoveAllDomainContactsRateLimiter(@Parameter("maxQps") int maxQps) {
+    return RateLimiter.create(maxQps);
   }
 }

--- a/core/src/test/java/google/registry/batch/RemoveAllDomainContactsActionTest.java
+++ b/core/src/test/java/google/registry/batch/RemoveAllDomainContactsActionTest.java
@@ -23,9 +23,11 @@ import static google.registry.testing.DatabaseHelper.newDomain;
 import static google.registry.testing.DatabaseHelper.persistActiveContact;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.util.concurrent.RateLimiter;
 import google.registry.flows.DaggerEppTestComponent;
 import google.registry.flows.EppController;
 import google.registry.flows.EppTestComponent.FakesAndMocksModule;
@@ -51,6 +53,7 @@ class RemoveAllDomainContactsActionTest {
       new JpaTestExtensions.Builder().buildIntegrationTestExtension();
 
   private final FakeResponse response = new FakeResponse();
+  private final RateLimiter rateLimiter = mock(RateLimiter.class);
   private RemoveAllDomainContactsAction action;
 
   @BeforeEach
@@ -69,7 +72,7 @@ class RemoveAllDomainContactsActionTest {
             .eppController();
     action =
         new RemoveAllDomainContactsAction(
-            eppController, "NewRegistrar", new FakeLockHandler(true), response);
+            eppController, "NewRegistrar", new FakeLockHandler(true), rateLimiter, response);
   }
 
   @Test


### PR DESCRIPTION
The maximum QPS defaults to 10, but can also be specified at runtime through use of a query-string parameter.

BUG = http://b/439636188

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/2838)
<!-- Reviewable:end -->
