### PR TITLE
Fix urs command after DomainUpdateFlow change

### DIFF
--- a/core/src/main/java/google/registry/tools/UniformRapidSuspensionCommand.java
+++ b/core/src/main/java/google/registry/tools/UniformRapidSuspensionCommand.java
@@ -146,7 +146,7 @@ final class UniformRapidSuspensionCommand extends MutatingEppToolCommand {
               ? ImmutableSet.of(StatusValue.CLIENT_HOLD.getXmlName())
               : ImmutableSet.of();
     } else {
-      statusesToApply = URS_LOCKS;
+      statusesToApply = ImmutableSet.copyOf(difference(URS_LOCKS, existingLocks));
     }
 
     // trigger renew flow

--- a/core/src/test/java/google/registry/tools/UniformRapidSuspensionCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UniformRapidSuspensionCommandTest.java
@@ -95,6 +95,34 @@ class UniformRapidSuspensionCommandTest
   }
 
   @Test
+  void testCommand_respectExistingStatuses() throws Exception {
+    persistDomainWithHosts(
+        defaultDomain
+            .asBuilder()
+            .addStatusValues(ImmutableSet.of(StatusValue.SERVER_DELETE_PROHIBITED))
+            .build(),
+        defaultDsData,
+        ns1,
+        ns2);
+    runCommandForced(
+        "--domain_name=evil.tld",
+        "--hosts=urs1.example.com,urs2.example.com",
+        "--dsdata=1 1 1 A94A8FE5CCB19BA61C4C0873D391E987982FBBD3",
+        "--renew_one_year=false");
+    eppVerifier
+        .expectRegistrarId("CharlestonRoad")
+        .expectSuperuser()
+        .verifySent("uniform_rapid_suspension_with_forbid_delete.xml")
+        .verifyNoMoreSent();
+    assertInStdout("uniform_rapid_suspension --undo");
+    assertInStdout("--domain_name evil.tld");
+    assertInStdout("--hosts ns1.example.com,ns2.example.com");
+    assertInStdout("--dsdata 1 2 3 DEAD,4 5 6 BEEF");
+    assertInStdout("--locks_to_preserve serverDeleteProhibited");
+    assertNotInStdout("--restore_client_hold");
+  }
+
+  @Test
   void testCommand_respectsExistingHost() throws Exception {
     persistDomainWithHosts(defaultDomain, defaultDsData, urs2, ns1);
     runCommandForced(

--- a/core/src/test/resources/google/registry/tools/server/uniform_rapid_suspension_with_forbid_delete.xml
+++ b/core/src/test/resources/google/registry/tools/server/uniform_rapid_suspension_with_forbid_delete.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<epp xmlns="urn:ietf:params:xml:ns:epp-1.0">
+  <command>
+    <update>
+      <domain:update xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+        <domain:name>evil.tld</domain:name>
+        <domain:add>
+          <domain:ns>
+            <domain:hostObj>urs1.example.com</domain:hostObj>
+            <domain:hostObj>urs2.example.com</domain:hostObj>
+          </domain:ns>
+          <domain:status s="serverTransferProhibited" />
+          <domain:status s="serverUpdateProhibited" />
+        </domain:add>
+        <domain:rem>
+          <domain:ns>
+            <domain:hostObj>ns2.example.com</domain:hostObj>
+            <domain:hostObj>ns1.example.com</domain:hostObj>
+          </domain:ns>
+        </domain:rem>
+      </domain:update>
+    </update>
+    <extension>
+      <secDNS:update xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1">
+        <secDNS:rem>
+          <secDNS:all>true</secDNS:all>
+        </secDNS:rem>
+        <secDNS:add>
+          <secDNS:dsData>
+            <secDNS:keyTag>1</secDNS:keyTag>
+            <secDNS:alg>1</secDNS:alg>
+            <secDNS:digestType>1</secDNS:digestType>
+            <secDNS:digest>A94A8FE5CCB19BA61C4C0873D391E987982FBBD3</secDNS:digest>
+          </secDNS:dsData>
+        </secDNS:add>
+      </secDNS:update>
+      <superuser:domainUpdate xmlns:superuser="urn:google:params:xml:ns:superuser-1.0">
+        <superuser:autorenews>false</superuser:autorenews>
+      </superuser:domainUpdate>
+      <metadata:metadata xmlns:metadata="urn:google:params:xml:ns:metadata-1.0">
+        <metadata:reason>Uniform Rapid Suspension</metadata:reason>
+        <metadata:requestedByRegistrar>false</metadata:requestedByRegistrar>
+      </metadata:metadata>
+    </extension>
+    <clTRID>RegistryTool</clTRID>
+  </command>
+</epp>


### PR DESCRIPTION
PR 2930 forbids adding statuses that already exist on a domain. This PR updates the uniform_rapid_suspension command to conform.

PR 2930 also forbids removing non-existent statuses, but it does not affect this command.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3008)
<!-- Reviewable:end -->
