### PR TITLE
Use Locale.ROOT in TimeOfYear toString

### DIFF
--- a/core/src/main/java/google/registry/model/common/TimeOfYear.java
+++ b/core/src/main/java/google/registry/model/common/TimeOfYear.java
@@ -29,6 +29,7 @@ import google.registry.model.ImmutableObject;
 import google.registry.model.UnsafeSerializable;
 import jakarta.persistence.Embeddable;
 import java.util.List;
+import java.util.Locale;
 import org.joda.time.DateTime;
 
 /**
@@ -60,11 +61,13 @@ public class TimeOfYear extends ImmutableObject implements UnsafeSerializable {
   public static TimeOfYear fromDateTime(DateTime dateTime) {
     DateTime nextYear = dateTime.plusYears(1);  // This turns February 29 into February 28.
     TimeOfYear instance = new TimeOfYear();
-    instance.timeString = String.format(
-        "%02d %02d %08d",
-        nextYear.getMonthOfYear(),
-        nextYear.getDayOfMonth(),
-        nextYear.getMillisOfDay());
+    instance.timeString =
+        String.format(
+            Locale.ROOT,
+            "%02d %02d %08d",
+            nextYear.getMonthOfYear(),
+            nextYear.getDayOfMonth(),
+            nextYear.getMillisOfDay());
     return instance;
   }
 

--- a/core/src/main/java/google/registry/model/poll/PollMessageExternalKeyConverter.java
+++ b/core/src/main/java/google/registry/model/poll/PollMessageExternalKeyConverter.java
@@ -17,6 +17,7 @@ package google.registry.model.poll;
 import com.google.common.base.Splitter;
 import google.registry.persistence.VKey;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * A converter between external key strings for {@link PollMessage}s (i.e. what registrars use to
@@ -41,7 +42,8 @@ public final class PollMessageExternalKeyConverter {
 
   /** Returns an external poll message ID for the given poll message. */
   public static String makePollMessageExternalId(PollMessage pollMessage) {
-    return String.format("%d-%d", pollMessage.getId(), pollMessage.getEventTime().getYear());
+    return String.format(
+        Locale.ROOT, "%d-%d", pollMessage.getId(), pollMessage.getEventTime().getYear());
   }
 
   /**


### PR DESCRIPTION
There are some situations where we change locales in tests statically and that can cause conflicts, i.e. two billing recurrences being compared to each other where they have the same eventTime but different recurrenceTimeOfYears.

also added it in one other place just in case 
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3014)
<!-- Reviewable:end -->
