### PR TITLE
Add RDAP latency metrics

### DIFF
--- a/core/src/main/java/google/registry/rdap/RdapActionBase.java
+++ b/core/src/main/java/google/registry/rdap/RdapActionBase.java
@@ -52,6 +52,8 @@ import google.registry.util.Clock;
 import jakarta.inject.Inject;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 import org.joda.time.DateTime;
 
@@ -132,7 +134,7 @@ public abstract class RdapActionBase implements Runnable {
 
   @Override
   public void run() {
-    java.time.Instant startTime = clock.now();
+    Instant startTime = clock.now();
     metricInformationBuilder.setIncludeDeleted(includeDeletedParam.orElse(false));
     metricInformationBuilder.setRole(rdapAuthorization.role());
     metricInformationBuilder.setRequestMethod(requestMethod);
@@ -181,7 +183,7 @@ public abstract class RdapActionBase implements Runnable {
       setError(SC_INTERNAL_SERVER_ERROR, "Internal Server Error", "An error was encountered");
       logger.atSevere().withCause(e).log("Exception encountered while processing RDAP command.");
     }
-    long processingTime = java.time.Duration.between(startTime, clock.now()).toMillis();
+    long processingTime = Duration.between(startTime, clock.now()).toMillis();
     RdapMetrics.RdapMetricInformation metricInfo = metricInformationBuilder.build();
     rdapMetrics.updateMetrics(metricInfo);
     rdapMetrics.recordProcessingTime(metricInfo, processingTime);

--- a/core/src/main/java/google/registry/rdap/RdapActionBase.java
+++ b/core/src/main/java/google/registry/rdap/RdapActionBase.java
@@ -182,9 +182,9 @@ public abstract class RdapActionBase implements Runnable {
       logger.atSevere().withCause(e).log("Exception encountered while processing RDAP command.");
     }
     long processingTime = Duration.between(startTime, clock.now()).toMillis();
-    RdapMetrics.RdapMetricInformation metricInfo = metricInformationBuilder.build();
-    rdapMetrics.updateMetrics(metricInfo);
-    rdapMetrics.recordProcessingTime(metricInfo, processingTime);
+    metricInformationBuilder.setProcessingTime(processingTime);
+    
+    rdapMetrics.updateMetrics(metricInformationBuilder.build());
   }
 
   void setError(int status, String title, String description) {

--- a/core/src/main/java/google/registry/rdap/RdapActionBase.java
+++ b/core/src/main/java/google/registry/rdap/RdapActionBase.java
@@ -183,7 +183,7 @@ public abstract class RdapActionBase implements Runnable {
     }
     long processingTime = Duration.between(startTime, clock.now()).toMillis();
     metricInformationBuilder.setProcessingTime(processingTime);
-    
+
     rdapMetrics.updateMetrics(metricInformationBuilder.build());
   }
 

--- a/core/src/main/java/google/registry/rdap/RdapActionBase.java
+++ b/core/src/main/java/google/registry/rdap/RdapActionBase.java
@@ -132,6 +132,7 @@ public abstract class RdapActionBase implements Runnable {
 
   @Override
   public void run() {
+    java.time.Instant startTime = clock.now();
     metricInformationBuilder.setIncludeDeleted(includeDeletedParam.orElse(false));
     metricInformationBuilder.setRole(rdapAuthorization.role());
     metricInformationBuilder.setRequestMethod(requestMethod);
@@ -180,7 +181,10 @@ public abstract class RdapActionBase implements Runnable {
       setError(SC_INTERNAL_SERVER_ERROR, "Internal Server Error", "An error was encountered");
       logger.atSevere().withCause(e).log("Exception encountered while processing RDAP command.");
     }
-    rdapMetrics.updateMetrics(metricInformationBuilder.build());
+    long processingTime = java.time.Duration.between(startTime, clock.now()).toMillis();
+    RdapMetrics.RdapMetricInformation metricInfo = metricInformationBuilder.build();
+    rdapMetrics.updateMetrics(metricInfo);
+    rdapMetrics.recordProcessingTime(metricInfo, processingTime);
   }
 
   void setError(int status, String title, String description) {

--- a/core/src/main/java/google/registry/rdap/RdapMetrics.java
+++ b/core/src/main/java/google/registry/rdap/RdapMetrics.java
@@ -204,7 +204,6 @@ public class RdapMetrics {
     }
   }
 
-
   /**
    * Information on RDAP metrics.
    *

--- a/core/src/main/java/google/registry/rdap/RdapMetrics.java
+++ b/core/src/main/java/google/registry/rdap/RdapMetrics.java
@@ -193,19 +193,17 @@ public class RdapMetrics {
           getLabelStringForPrefixLength(rdapMetricInformation.prefixLength()),
           rdapMetricInformation.includeDeleted() ? "YES" : "NO");
     }
+    if (rdapMetricInformation.processingTime().isPresent()) {
+      requestTime.record(
+          rdapMetricInformation.processingTime().get(),
+          rdapMetricInformation.endpointType().toString(),
+          rdapMetricInformation.searchType().toString(),
+          rdapMetricInformation.wildcardType().toString(),
+          String.valueOf(rdapMetricInformation.statusCode()),
+          rdapMetricInformation.incompletenessWarningType().toString());
+    }
   }
 
-  /** Records the processing time for an RDAP request. */
-  public void recordProcessingTime(
-      RdapMetricInformation rdapMetricInformation, long processingTime) {
-    requestTime.record(
-        processingTime,
-        rdapMetricInformation.endpointType().toString(),
-        rdapMetricInformation.searchType().toString(),
-        rdapMetricInformation.wildcardType().toString(),
-        String.valueOf(rdapMetricInformation.statusCode()),
-        rdapMetricInformation.incompletenessWarningType().toString());
-  }
 
   /**
    * Information on RDAP metrics.
@@ -226,6 +224,8 @@ public class RdapMetrics {
    *     than were actually returned in the response; absent if a search was not performed.
    * @param numHostsRetrieved Number of hosts retrieved from the database; this might be more than
    *     were actually returned in the response; absent if a search was not performed.
+   * @param processingTime The processing time for the request in milliseconds; absent if not
+   *     recorded.
    */
   public record RdapMetricInformation(
       EndpointType endpointType,
@@ -239,7 +239,8 @@ public class RdapMetrics {
       int statusCode,
       IncompletenessWarningType incompletenessWarningType,
       Optional<Long> numDomainsRetrieved,
-      Optional<Long> numHostsRetrieved) {
+      Optional<Long> numHostsRetrieved,
+      Optional<Long> processingTime) {
 
     @AutoBuilder
     interface Builder {
@@ -267,8 +268,11 @@ public class RdapMetrics {
 
       Builder setNumHostsRetrieved(long numHostsRetrieved);
 
+      Builder setProcessingTime(long processingTime);
+
       RdapMetricInformation build();
     }
+
 
     static Builder builder() {
       return new AutoBuilder_RdapMetrics_RdapMetricInformation_Builder()

--- a/core/src/main/java/google/registry/rdap/RdapMetrics.java
+++ b/core/src/main/java/google/registry/rdap/RdapMetrics.java
@@ -14,6 +14,8 @@
 
 package google.registry.rdap;
 
+import static com.google.monitoring.metrics.EventMetric.DEFAULT_FITTER;
+
 import com.google.auto.value.AutoBuilder;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
@@ -141,7 +143,7 @@ public class RdapMetrics {
               "RDAP Request Time",
               "milliseconds",
               LABEL_DESCRIPTORS_FOR_RESPONSES,
-              EventMetric.DEFAULT_FITTER);
+              DEFAULT_FITTER);
 
   @Inject
   public RdapMetrics() {}

--- a/core/src/main/java/google/registry/rdap/RdapMetrics.java
+++ b/core/src/main/java/google/registry/rdap/RdapMetrics.java
@@ -133,6 +133,16 @@ public class RdapMetrics {
               LABEL_DESCRIPTORS_FOR_RETRIEVAL_COUNTS,
               FIBONACCI_FITTER);
 
+  @VisibleForTesting
+  static final EventMetric requestTime =
+      MetricRegistryImpl.getDefault()
+          .newEventMetric(
+              "/rdap/request_time",
+              "RDAP Request Time",
+              "milliseconds",
+              LABEL_DESCRIPTORS_FOR_RESPONSES,
+              EventMetric.DEFAULT_FITTER);
+
   @Inject
   public RdapMetrics() {}
 
@@ -181,6 +191,18 @@ public class RdapMetrics {
           getLabelStringForPrefixLength(rdapMetricInformation.prefixLength()),
           rdapMetricInformation.includeDeleted() ? "YES" : "NO");
     }
+  }
+
+  /** Records the processing time for an RDAP request. */
+  public void recordProcessingTime(
+      RdapMetricInformation rdapMetricInformation, long processingTime) {
+    requestTime.record(
+        processingTime,
+        rdapMetricInformation.endpointType().toString(),
+        rdapMetricInformation.searchType().toString(),
+        rdapMetricInformation.wildcardType().toString(),
+        String.valueOf(rdapMetricInformation.statusCode()),
+        rdapMetricInformation.incompletenessWarningType().toString());
   }
 
   /**

--- a/core/src/test/java/google/registry/rdap/RdapActionBaseTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapActionBaseTest.java
@@ -172,4 +172,13 @@ class RdapActionBaseTest extends RdapActionBaseTestCase<RdapActionBaseTest.RdapT
     assertThat(payload).contains("\n");
     assertThat(parseJsonObject(payload)).isEqualTo(loadJsonFile("rdapjson_toplevel.json"));
   }
+
+  @Test
+  void testMetrics_recordsProcessingTime() {
+    generateActualJson("no.thing");
+    verify(rdapMetrics)
+        .recordProcessingTime(
+            org.mockito.ArgumentMatchers.any(RdapMetrics.RdapMetricInformation.class),
+            org.mockito.ArgumentMatchers.anyLong());
+  }
 }

--- a/core/src/test/java/google/registry/rdap/RdapActionBaseTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapActionBaseTest.java
@@ -21,6 +21,7 @@ import static google.registry.rdap.RdapTestHelper.parseJsonObject;
 import static google.registry.request.Action.Method.GET;
 import static google.registry.request.Action.Method.HEAD;
 import static google.registry.testing.DatabaseHelper.createTld;
+import static org.joda.time.Duration.millis;
 import static org.mockito.Mockito.verify;
 
 import google.registry.rdap.RdapMetrics.EndpointType;
@@ -31,6 +32,7 @@ import google.registry.rdap.RdapObjectClasses.ReplyPayloadBase;
 import google.registry.rdap.RdapSearchResults.IncompletenessWarningType;
 import google.registry.request.Action;
 import google.registry.request.auth.Auth;
+import google.registry.testing.FakeClock;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -62,6 +64,9 @@ class RdapActionBaseTest extends RdapActionBaseTestCase<RdapActionBaseTest.RdapT
       }
       if (pathSearchString.equals("RuntimeException")) {
         throw new RuntimeException();
+      }
+      if (pathSearchString.equals("advanceClock")) {
+        ((FakeClock) clock).advanceBy(millis(50));
       }
       return new ReplyPayloadBase(BoilerplateType.OTHER) {
         @JsonableElement public String key = "value";
@@ -175,10 +180,21 @@ class RdapActionBaseTest extends RdapActionBaseTestCase<RdapActionBaseTest.RdapT
 
   @Test
   void testMetrics_recordsProcessingTime() {
-    generateActualJson("no.thing");
+    generateActualJson("advanceClock");
     verify(rdapMetrics)
         .recordProcessingTime(
-            org.mockito.ArgumentMatchers.any(RdapMetrics.RdapMetricInformation.class),
-            org.mockito.ArgumentMatchers.anyLong());
+            RdapMetrics.RdapMetricInformation.builder()
+                .setEndpointType(EndpointType.HELP)
+                .setSearchType(SearchType.NONE)
+                .setWildcardType(WildcardType.INVALID)
+                .setPrefixLength(0)
+                .setIncludeDeleted(false)
+                .setRegistrarSpecified(false)
+                .setRole(RdapAuthorization.Role.PUBLIC)
+                .setRequestMethod(Action.Method.GET)
+                .setStatusCode(200)
+                .setIncompletenessWarningType(IncompletenessWarningType.COMPLETE)
+                .build(),
+            50L);
   }
 }

--- a/core/src/test/java/google/registry/rdap/RdapActionBaseTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapActionBaseTest.java
@@ -135,6 +135,7 @@ class RdapActionBaseTest extends RdapActionBaseTestCase<RdapActionBaseTest.RdapT
                 .setRequestMethod(Action.Method.GET)
                 .setStatusCode(200)
                 .setIncompletenessWarningType(IncompletenessWarningType.COMPLETE)
+                .setProcessingTime(0L)
                 .build());
   }
 
@@ -154,6 +155,7 @@ class RdapActionBaseTest extends RdapActionBaseTestCase<RdapActionBaseTest.RdapT
                 .setRequestMethod(Action.Method.GET)
                 .setStatusCode(400)
                 .setIncompletenessWarningType(IncompletenessWarningType.COMPLETE)
+                .setProcessingTime(0L)
                 .build());
   }
 
@@ -182,7 +184,7 @@ class RdapActionBaseTest extends RdapActionBaseTestCase<RdapActionBaseTest.RdapT
   void testMetrics_recordsProcessingTime() {
     generateActualJson("advanceClock");
     verify(rdapMetrics)
-        .recordProcessingTime(
+        .updateMetrics(
             RdapMetrics.RdapMetricInformation.builder()
                 .setEndpointType(EndpointType.HELP)
                 .setSearchType(SearchType.NONE)
@@ -194,7 +196,7 @@ class RdapActionBaseTest extends RdapActionBaseTestCase<RdapActionBaseTest.RdapT
                 .setRequestMethod(Action.Method.GET)
                 .setStatusCode(200)
                 .setIncompletenessWarningType(IncompletenessWarningType.COMPLETE)
-                .build(),
-            50L);
+                .setProcessingTime(50L)
+                .build());
   }
 }

--- a/core/src/test/java/google/registry/rdap/RdapDomainActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapDomainActionTest.java
@@ -435,6 +435,7 @@ class RdapDomainActionTest extends RdapActionBaseTestCase<RdapDomainAction> {
                 .setRequestMethod(Action.Method.GET)
                 .setStatusCode(200)
                 .setIncompletenessWarningType(IncompletenessWarningType.COMPLETE)
+                            .setProcessingTime(0L)
                 .build());
   }
 

--- a/core/src/test/java/google/registry/rdap/RdapDomainActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapDomainActionTest.java
@@ -435,7 +435,7 @@ class RdapDomainActionTest extends RdapActionBaseTestCase<RdapDomainAction> {
                 .setRequestMethod(Action.Method.GET)
                 .setStatusCode(200)
                 .setIncompletenessWarningType(IncompletenessWarningType.COMPLETE)
-                            .setProcessingTime(0L)
+                .setProcessingTime(0L)
                 .build());
   }
 

--- a/core/src/test/java/google/registry/rdap/RdapEntityActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapEntityActionTest.java
@@ -235,6 +235,7 @@ class RdapEntityActionTest extends RdapActionBaseTestCase<RdapEntityAction> {
                 .setRequestMethod(Action.Method.GET)
                 .setStatusCode(200)
                 .setIncompletenessWarningType(IncompletenessWarningType.COMPLETE)
+                .setProcessingTime(0L)
                 .build());
   }
 }

--- a/core/src/test/java/google/registry/rdap/RdapHelpActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapHelpActionTest.java
@@ -82,6 +82,7 @@ class RdapHelpActionTest extends RdapActionBaseTestCase<RdapHelpAction> {
                 .setRequestMethod(Action.Method.GET)
                 .setStatusCode(200)
                 .setIncompletenessWarningType(IncompletenessWarningType.COMPLETE)
+                .setProcessingTime(0L)
                 .build());
   }
 }

--- a/core/src/test/java/google/registry/rdap/RdapMetricsTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapMetricsTest.java
@@ -278,7 +278,7 @@ class RdapMetricsTest {
 
   @Test
   void testRecordProcessingTime() {
-    rdapMetrics.recordProcessingTime(getBuilder().build(), 100L);
+    rdapMetrics.updateMetrics(getBuilder().setProcessingTime(100L).build());
     assertThat(RdapMetrics.requestTime)
         .hasDataSetForLabels(ImmutableSet.of(100L), "DOMAINS", "NONE", "INVALID", "200", "COMPLETE")
         .and()

--- a/core/src/test/java/google/registry/rdap/RdapMetricsTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapMetricsTest.java
@@ -37,6 +37,7 @@ class RdapMetricsTest {
     RdapMetrics.responses.reset();
     RdapMetrics.numberOfDomainsRetrieved.reset();
     RdapMetrics.numberOfHostsRetrieved.reset();
+    RdapMetrics.requestTime.reset();
   }
 
   private RdapMetrics.RdapMetricInformation.Builder getBuilder() {
@@ -273,5 +274,14 @@ class RdapMetricsTest {
         .hasNoOtherValues();
     assertThat(RdapMetrics.numberOfDomainsRetrieved).hasNoOtherValues();
     assertThat(RdapMetrics.numberOfHostsRetrieved).hasNoOtherValues();
+  }
+
+  @Test
+  void testRecordProcessingTime() {
+    rdapMetrics.recordProcessingTime(getBuilder().build(), 100L);
+    assertThat(RdapMetrics.requestTime)
+        .hasDataSetForLabels(ImmutableSet.of(100L), "DOMAINS", "NONE", "INVALID", "200", "COMPLETE")
+        .and()
+        .hasNoOtherValues();
   }
 }

--- a/core/src/test/java/google/registry/rdap/RdapNameserverActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapNameserverActionTest.java
@@ -287,6 +287,7 @@ class RdapNameserverActionTest extends RdapActionBaseTestCase<RdapNameserverActi
                 .setRequestMethod(Action.Method.GET)
                 .setStatusCode(200)
                 .setIncompletenessWarningType(IncompletenessWarningType.COMPLETE)
+                .setProcessingTime(0L)
                 .build());
   }
 }

--- a/core/src/test/java/google/registry/rdap/RdapSearchActionTestCase.java
+++ b/core/src/test/java/google/registry/rdap/RdapSearchActionTestCase.java
@@ -90,7 +90,8 @@ public abstract class RdapSearchActionTestCase<A extends RdapSearchActionBase>
             .setRole(metricRole)
             .setRequestMethod(requestMethod)
             .setStatusCode(metricStatusCode)
-            .setIncompletenessWarningType(incompletenessWarningType);
+            .setIncompletenessWarningType(incompletenessWarningType)
+            .setProcessingTime(0L);
     numDomainsRetrieved.ifPresent(builder::setNumDomainsRetrieved);
     numHostsRetrieved.ifPresent(builder::setNumHostsRetrieved);
     verify(rdapMetrics).updateMetrics(builder.build());


### PR DESCRIPTION
Add RDAP latency metrics to compare against RDAP SLA, as described in [go/domain-registry-deployment](http://goto.google.com/domain-registry-deployment)

b/503799160

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3015)
<!-- Reviewable:end -->
