### PR TITLE
Migrate TMCH, SMD, and Fee models to java.time

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -15,7 +15,7 @@ This document outlines foundational mandates, architectural patterns, and projec
 
 ## 2. Time and Precision Handling (java.time Migration)
 
-- **Idiomatic java.time Usage:** Avoid redundant conversions between `Instant` and `DateTime`. If a field or parameter is an `Instant`, use it directly. Do not convert to `DateTime` just to call a deprecated method if an `Instant` alternative exists or can be easily created.
+- **Idiomatic java.time Usage:** Avoid redundant conversions between `Instant` and `DateTime`. If a field or parameter is an `Instant`, use it directly. Do not convert to `DateTime` just to call a deprecated method if an `Instant` alternative exists or can be easily created. Furthermore, you should not call `toInstant()` or `toDateTime()` conversion methods when not strictly necessary; always prefer to use an alternative method that returns the correct type if one exists (e.g. use `tm().getTxTime()` which returns an `Instant` instead of calling `tm().getTransactionTime().toInstant()`).
 - **Millisecond Precision:** Always truncate `Instant.now()` to milliseconds (using `.truncatedTo(ChronoUnit.MILLIS)`) to maintain consistency with Joda `DateTime` and the PostgreSQL schema (which enforces millisecond precision via JPA converters).
 - **Clock Injection:**
     - Avoid direct calls to `Instant.now()`, `DateTime.now()`, `ZonedDateTime.now()`, or `System.currentTimeMillis()`.
@@ -56,6 +56,7 @@ This document outlines foundational mandates, architectural patterns, and projec
 ## Performance and Efficiency
 - **Turn Minimization:** Aim for "perfect" code in the first iteration. Iterative fixes for checkstyle or compilation errors consume significant context and time.
 - **Context Management:** Use sub-agents for batch refactoring or high-volume output tasks to keep the main session history lean and efficient.
+- **Code Formatting:** Do not write custom Python scripts or manual regex replacements to fix code formatting issues (e.g., unused imports, import ordering, line length). Instead, use the project's built-in formatting tools: run `./gradlew spotlessApply` to fix unused/unordered imports and `./gradlew javaIncrementalFormatApply` (or `google-java-format --replace <files>`) to automatically fix Java formatting and indentation errors.
 
 ## General Code Review Lessons & Avoidable Mistakes
 Based on historical PR reviews, avoid the following common mistakes:
@@ -89,10 +90,27 @@ This document captures high-level architectural patterns, lessons learned from l
 - **Committing:** Always create a new commit on the branch if one hasn't been created yet for the branch's specific work. Only perform amending (`git commit --amend --no-edit`) for subsequent changes once the initial commit has been successfully created.
 - **One Commit Per PR:** All changes for a single PR must be squashed into a single commit before merging.
 - **Default to Amend:** Once an initial commit is created for a PR, all subsequent functional changes should be amended into that same commit by default (`git commit --amend --no-edit`). This ensures the PR remains a single, clean unit of work throughout the development lifecycle.
-- **Commit Message Style:** Follow standard Git commit best practices. The subject line (first line) should be concise, capitalized, and **must not end with punctuation** (e.g., a period).
-- **Final Validation:** Always run `git status` as the final step before declaring a task complete to ensure all changes are committed and the working directory is clean.
-- **Commit Verification:** After any commit or amendment, explicitly verify the success of the operation (e.g., using `git status` and reviewing the diff). Never report a Git operation as "done" without having first successfully executed the command and confirmed the repository state.
+- **Commit Message Style:** Follow standard Git commit best practices. The subject line (first line) MUST be a maximum of 50 characters, concise, capitalized, and **must not end with punctuation** (e.g., a period). The body MUST explicitly encapsulate and summarize all changes made across the entire diff, detailing the "what" and "why" comprehensively.
+- **Strict Completion Verification:** You MUST NEVER declare a task, commit, or amendment as complete until you have explicitly verified that the workspace is clean. You MUST follow this exact sequence of actions across multiple conversational turns if necessary:
+  1. Execute the `git commit` or `git commit --amend` command.
+  2. Wait for the tool to return successfully.
+  3. Execute `git status`.
+  4. Wait for the tool to return and explicitly verify the output contains `nothing to commit, working tree clean` (or similar indication that no unstaged changes remain). If changes remain, stage them and amend the commit, then repeat this verification loop.
+  5. **Only after** step 4 has successfully returned a clean working directory may you generate a text response to the user declaring that the task is complete.
 - **Diff Review:** Before finalizing a task, review the full diff (e.g., `git diff HEAD^`) to ensure all changes are functional and relevant. Identify and revert any formatting-only changes in files that do not contain functional updates to keep the commit focused.
+
+## Self-Review Guidelines
+Before finalizing any PR or declaring a task complete, you MUST perform a thorough, rigorous self-review of your entire diff. Run `git diff HEAD^` (or review the staged changes) and actively verify the following against every modified line:
+
+1. **Imports & FQNs:** Did I leave any fully-qualified class names or static variables inline? Did I add the necessary imports for them? *Crucial Exception:* If the file already imports a class with the identical name (e.g., it uses both `java.time.Duration` and `org.joda.time.Duration`), one MUST remain fully qualified to avoid a compilation conflict.
+2. **Redundant Conversions:** Did I use `toDateTime(clock.now())` where `clock.nowUtc()` would suffice? Did I use `toDateTime(END_INSTANT)` instead of `END_OF_TIME`? Did I use `.toInstant()` or `.toDateTime()` on something that could be avoided by using a different method overload (e.g., `tm().getTxTime()`)?
+3. **Verbose Math:** Did I write any verbose time conversions inline? Are there `DateTimeUtils` methods I should be using instead? If not, should I abstract this math into `DateTimeUtils`?
+4. **Assertion Cleanliness:** Am I polluting test assertions with `toDateTime(...)` wraps? If so, I need to add overloaded assertions to the Truth Subjects instead.
+5. **Diff Scope:** Are there any formatting-only changes in files that I did not functionally modify? If so, revert them. Does the total line count of the diff align with the approved scope (e.g., ~1,000 lines for migrations)?
+6. **Commit Message:** Does the commit message title fit within 50 characters? Does the body encapsulate the entirety of the changes across the diff cleanly and professionally?
+7. **Missing Tests & Coverage:** *Perform a structured check for any new methods or modified behavior.* Did I add a new utility method (like `plusMonths(Instant, int)`) or change core logic? If so, I MUST open the corresponding test file and write tests to cover the new functionality (including edge cases, negative values, and leap years) before considering the task complete. A code review is not thorough if it only checks for compilation. I must actively ensure every new branch of logic has a test.
+
+Only after actively confirming these checks against your diff are you permitted to finalize the task.
 
 ## Refactoring & Migration Guardrails
 
@@ -115,7 +133,10 @@ This project treats Error Prone warnings as errors.
 
 ## 🚫 Common Pitfalls to Avoid
 
+- **Redundant Parses:** Never write `toDateTime(Instant.parse(...))` or `toInstant(DateTime.parse(...))`. If you need a `DateTime`, use `DateTime.parse(...)` directly. If you need an `Instant`, use `Instant.parse(...)` directly.
+- **cloneProjectedAtTime vs cloneProjectedAtInstant:** When converting tests and logic that use `clock.now()` to project resource state into the future or past, do not wrap the Java `Instant` in `toDateTime()` just to call `cloneProjectedAtTime()`. Instead, switch the method call to use the native `cloneProjectedAtInstant()` method which is available on all `EppResource` models.
 - **Do not go in circles with the build:** If you see an `InlineMeSuggester` error, apply the suppression to **ALL** similar methods in that file and related files in one turn. Do not fix them one by one.
+- **Exception Conversion in Tests:** When migrating time types (e.g., from Joda `DateTime` to Java `Instant`), be extremely careful with tests that verify parsing failures (e.g., `assertThrows(IllegalArgumentException.class, ...)`). Joda's `DateTime.parse()` throws an `IllegalArgumentException` on failure, but `Instant.parse()` throws a `java.time.format.DateTimeParseException`. You must update the expected exception type in these tests to ensure they actually test the correct behavior, and verify the tests are not failing prematurely on the first line if it contains invalid data meant to be ignored.
 - Dagger/AutoValue corruption: If you modify a builder or a component incorrectly, Dagger will fail to generate code, leading to hundreds of "cannot find symbol" errors. If this happens, `git checkout` the last working state of the specific file and re-apply changes more surgically.
 - **`replace` tool context**: When using `replace` on large files (like `Tld.java` or `DomainBase.java`), provide significant surrounding context. These files have many similar method signatures (getters/setters) that can lead to incorrect replacements.
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -15,7 +15,7 @@ This document outlines foundational mandates, architectural patterns, and projec
 
 ## 2. Time and Precision Handling (java.time Migration)
 
-- **Idiomatic java.time Usage:** Avoid redundant conversions between `Instant` and `DateTime`. If a field or parameter is an `Instant`, use it directly. Do not convert to `DateTime` just to call a deprecated method if an `Instant` alternative exists or can be easily created.
+- **Idiomatic java.time Usage:** Avoid redundant conversions between `Instant` and `DateTime`. If a field or parameter is an `Instant`, use it directly. Do not convert to `DateTime` just to call a deprecated method if an `Instant` alternative exists or can be easily created. Furthermore, you should not call `toInstant()` or `toDateTime()` conversion methods when not strictly necessary; always prefer to use an alternative method that returns the correct type if one exists (e.g. use `tm().getTxTime()` which returns an `Instant` instead of calling `tm().getTransactionTime().toInstant()`).
 - **Millisecond Precision:** Always truncate `Instant.now()` to milliseconds (using `.truncatedTo(ChronoUnit.MILLIS)`) to maintain consistency with Joda `DateTime` and the PostgreSQL schema (which enforces millisecond precision via JPA converters).
 - **Clock Injection:**
     - Avoid direct calls to `Instant.now()`, `DateTime.now()`, `ZonedDateTime.now()`, or `System.currentTimeMillis()`.
@@ -56,6 +56,7 @@ This document outlines foundational mandates, architectural patterns, and projec
 ## Performance and Efficiency
 - **Turn Minimization:** Aim for "perfect" code in the first iteration. Iterative fixes for checkstyle or compilation errors consume significant context and time.
 - **Context Management:** Use sub-agents for batch refactoring or high-volume output tasks to keep the main session history lean and efficient.
+- **Code Formatting:** Do not write custom Python scripts or manual regex replacements to fix code formatting issues (e.g., unused imports, import ordering, line length). Instead, use the project's built-in formatting tools: run `./gradlew spotlessApply` to fix unused/unordered imports and `./gradlew javaIncrementalFormatApply` (or `google-java-format --replace <files>`) to automatically fix Java formatting and indentation errors.
 
 ## General Code Review Lessons & Avoidable Mistakes
 Based on historical PR reviews, avoid the following common mistakes:
@@ -90,8 +91,12 @@ This document captures high-level architectural patterns, lessons learned from l
 - **One Commit Per PR:** All changes for a single PR must be squashed into a single commit before merging.
 - **Default to Amend:** Once an initial commit is created for a PR, all subsequent functional changes should be amended into that same commit by default (`git commit --amend --no-edit`). This ensures the PR remains a single, clean unit of work throughout the development lifecycle.
 - **Commit Message Style:** Follow standard Git commit best practices. The subject line (first line) should be concise, capitalized, and **must not end with punctuation** (e.g., a period).
-- **Final Validation:** Always run `git status` as the final step before declaring a task complete to ensure all changes are committed and the working directory is clean.
-- **Commit Verification:** After any commit or amendment, explicitly verify the success of the operation (e.g., using `git status` and reviewing the diff). Never report a Git operation as "done" without having first successfully executed the command and confirmed the repository state.
+- **Strict Completion Verification:** You MUST NEVER declare a task, commit, or amendment as complete until you have explicitly verified that the workspace is clean. You MUST follow this exact sequence of actions across multiple conversational turns if necessary:
+  1. Execute the `git commit` or `git commit --amend` command.
+  2. Wait for the tool to return successfully.
+  3. Execute `git status`.
+  4. Wait for the tool to return and explicitly verify the output contains `nothing to commit, working tree clean` (or similar indication that no unstaged changes remain). If changes remain, stage them and amend the commit, then repeat this verification loop.
+  5. **Only after** step 4 has successfully returned a clean working directory may you generate a text response to the user declaring that the task is complete.
 - **Diff Review:** Before finalizing a task, review the full diff (e.g., `git diff HEAD^`) to ensure all changes are functional and relevant. Identify and revert any formatting-only changes in files that do not contain functional updates to keep the commit focused.
 
 ## Refactoring & Migration Guardrails
@@ -116,6 +121,7 @@ This project treats Error Prone warnings as errors.
 ## 🚫 Common Pitfalls to Avoid
 
 - **Do not go in circles with the build:** If you see an `InlineMeSuggester` error, apply the suppression to **ALL** similar methods in that file and related files in one turn. Do not fix them one by one.
+- **Exception Conversion in Tests:** When migrating time types (e.g., from Joda `DateTime` to Java `Instant`), be extremely careful with tests that verify parsing failures (e.g., `assertThrows(IllegalArgumentException.class, ...)`). Joda's `DateTime.parse()` throws an `IllegalArgumentException` on failure, but `Instant.parse()` throws a `java.time.format.DateTimeParseException`. You must update the expected exception type in these tests to ensure they actually test the correct behavior, and verify the tests are not failing prematurely on the first line if it contains invalid data meant to be ignored.
 - Dagger/AutoValue corruption: If you modify a builder or a component incorrectly, Dagger will fail to generate code, leading to hundreds of "cannot find symbol" errors. If this happens, `git checkout` the last working state of the specific file and re-apply changes more surgically.
 - **`replace` tool context**: When using `replace` on large files (like `Tld.java` or `DomainBase.java`), provide significant surrounding context. These files have many similar method signatures (getters/setters) that can lead to incorrect replacements.
 

--- a/common/src/main/java/google/registry/util/DateTimeUtils.java
+++ b/common/src/main/java/google/registry/util/DateTimeUtils.java
@@ -176,6 +176,18 @@ public abstract class DateTimeUtils {
         : now.atZone(ZoneOffset.UTC).plusYears(1).plusYears(years - 1).toInstant();
   }
 
+  /** Adds months to a date. */
+  public static Instant plusMonths(Instant now, int months) {
+    checkArgument(months >= 0);
+    return now.atZone(ZoneOffset.UTC).plusMonths(months).toInstant();
+  }
+
+  /** Subtracts months from a date. */
+  public static Instant minusMonths(Instant now, int months) {
+    checkArgument(months >= 0);
+    return now.atZone(ZoneOffset.UTC).minusMonths(months).toInstant();
+  }
+
   /**
    * Subtracts years from a date, in the {@code Duration} sense of semantic years. Use this instead
    * of {@link DateTime#minusYears} to ensure that we never end up on February 29.

--- a/core/src/main/java/google/registry/beam/billing/ExpandBillingRecurrencesPipeline.java
+++ b/core/src/main/java/google/registry/beam/billing/ExpandBillingRecurrencesPipeline.java
@@ -26,7 +26,6 @@ import static google.registry.util.DateTimeUtils.earliestOf;
 import static google.registry.util.DateTimeUtils.latestOf;
 import static google.registry.util.DateTimeUtils.minusYears;
 import static google.registry.util.DateTimeUtils.plusYears;
-import static google.registry.util.DateTimeUtils.toDateTime;
 import static org.apache.beam.sdk.values.TypeDescriptors.voids;
 
 import com.google.common.collect.ImmutableMap;
@@ -402,7 +401,7 @@ public class ExpandBillingRecurrencesPipeline implements Serializable {
                       .getRenewPrice(
                           tld,
                           billingRecurrence.getTargetId(),
-                          toDateTime(eventTime),
+                          eventTime,
                           1,
                           billingRecurrence,
                           Optional.empty())

--- a/core/src/main/java/google/registry/beam/billing/ExpandBillingRecurrencesPipeline.java
+++ b/core/src/main/java/google/registry/beam/billing/ExpandBillingRecurrencesPipeline.java
@@ -402,7 +402,7 @@ public class ExpandBillingRecurrencesPipeline implements Serializable {
                       .getRenewPrice(
                           tld,
                           billingRecurrence.getTargetId(),
-                          toDateTime(eventTime),
+                          eventTime,
                           1,
                           billingRecurrence,
                           Optional.empty())

--- a/core/src/main/java/google/registry/bsa/persistence/DomainsRefresher.java
+++ b/core/src/main/java/google/registry/bsa/persistence/DomainsRefresher.java
@@ -45,6 +45,7 @@ import google.registry.model.domain.Domain;
 import google.registry.model.tld.Tld;
 import google.registry.model.tld.Tld.TldType;
 import google.registry.util.BatchedStreams;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
@@ -95,7 +96,7 @@ public final class DomainsRefresher {
   public DomainsRefresher(
       Instant prevRefreshStartTime,
       Instant now,
-      java.time.Duration domainTxnMaxDuration,
+      Duration domainTxnMaxDuration,
       int transactionBatchSize) {
     this.prevRefreshStartTime = prevRefreshStartTime.minus(domainTxnMaxDuration);
     this.now = now;

--- a/core/src/main/java/google/registry/flows/CheckApiAction.java
+++ b/core/src/main/java/google/registry/flows/CheckApiAction.java
@@ -35,6 +35,7 @@ import static google.registry.monitoring.whitebox.CheckApiMetric.Tier.STANDARD;
 import static google.registry.persistence.PersistenceModule.TransactionIsolationLevel.TRANSACTION_REPEATABLE_READ;
 import static google.registry.persistence.transaction.TransactionManagerFactory.replicaTm;
 import static google.registry.pricing.PricingEngineProxy.isDomainPremium;
+import static google.registry.util.DateTimeUtils.toInstant;
 import static google.registry.util.DomainNameUtils.canonicalizeHostname;
 import static org.json.simple.JSONValue.toJSONString;
 
@@ -165,7 +166,7 @@ public class CheckApiAction implements Runnable {
       metricBuilder.status(SUCCESS).availability(availability);
       responseBuilder.put("status", "success").put("available", availability.equals(AVAILABLE));
 
-      boolean isPremium = isDomainPremium(domainString, now);
+      boolean isPremium = isDomainPremium(domainString, toInstant(now));
       metricBuilder.tier(isPremium ? PREMIUM : STANDARD);
       responseBuilder.put("tier", isPremium ? "premium" : "standard");
       if (!AVAILABLE.equals(availability)) {

--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -53,6 +53,7 @@ import static google.registry.model.tld.label.ReservationType.NAME_COLLISION;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.END_INSTANT;
 import static google.registry.util.DateTimeUtils.plusYears;
+import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -313,7 +314,7 @@ public final class DomainCreateFlow implements MutatingFlow {
       // at this point so that we can verify it before the "after validation" extension point.
       signedMarkId =
           tmchUtils
-              .verifySignedMarks(launchCreate.get().getSignedMarks(), domainLabel, now)
+              .verifySignedMarks(launchCreate.get().getSignedMarks(), domainLabel, toInstant(now))
               .getId();
     }
     verifyNotBlockedByBsa(domainName, tld, now, allocationToken);
@@ -327,7 +328,7 @@ public final class DomainCreateFlow implements MutatingFlow {
         eppInput.getSingleExtension(FeeCreateCommandExtension.class);
     FeesAndCredits feesAndCredits =
         pricingLogic.getCreatePrice(
-            tld, targetId, now, years, isAnchorTenant, isSunriseCreate, allocationToken);
+            tld, targetId, toInstant(now), years, isAnchorTenant, isSunriseCreate, allocationToken);
     validateFeeChallenge(feeCreate, feesAndCredits, defaultTokenUsed);
     Optional<SecDnsCreateExtension> secDnsCreate =
         validateSecDnsExtension(eppInput.getSingleExtension(SecDnsCreateExtension.class));
@@ -434,13 +435,21 @@ public final class DomainCreateFlow implements MutatingFlow {
     FeesAndCredits responseFeesAndCredits =
         shouldShowDefaultPrice
             ? pricingLogic.getCreatePrice(
-                tld, targetId, now, years, isAnchorTenant, isSunriseCreate, Optional.empty())
+                tld,
+                targetId,
+                toInstant(now),
+                years,
+                isAnchorTenant,
+                isSunriseCreate,
+                Optional.empty())
             : feesAndCredits;
 
     BeforeResponseReturnData responseData =
         flowCustomLogic.beforeResponse(
             BeforeResponseParameters.newBuilder()
-                .setResData(DomainCreateData.create(targetId, now, registrationExpirationTime))
+                .setResData(
+                    DomainCreateData.create(
+                        targetId, toInstant(now), toInstant(registrationExpirationTime)))
                 .setResponseExtensions(createResponseExtensions(feeCreate, responseFeesAndCredits))
                 .build());
     return responseBuilder

--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -53,6 +53,7 @@ import static google.registry.model.tld.label.ReservationType.NAME_COLLISION;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.END_INSTANT;
 import static google.registry.util.DateTimeUtils.plusYears;
+import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -313,7 +314,7 @@ public final class DomainCreateFlow implements MutatingFlow {
       // at this point so that we can verify it before the "after validation" extension point.
       signedMarkId =
           tmchUtils
-              .verifySignedMarks(launchCreate.get().getSignedMarks(), domainLabel, now)
+              .verifySignedMarks(launchCreate.get().getSignedMarks(), domainLabel, toInstant(now))
               .getId();
     }
     verifyNotBlockedByBsa(domainName, tld, now, allocationToken);
@@ -440,7 +441,9 @@ public final class DomainCreateFlow implements MutatingFlow {
     BeforeResponseReturnData responseData =
         flowCustomLogic.beforeResponse(
             BeforeResponseParameters.newBuilder()
-                .setResData(DomainCreateData.create(targetId, now, registrationExpirationTime))
+                .setResData(
+                    DomainCreateData.create(
+                        targetId, toInstant(now), toInstant(registrationExpirationTime)))
                 .setResponseExtensions(createResponseExtensions(feeCreate, responseFeesAndCredits))
                 .build());
     return responseBuilder

--- a/core/src/main/java/google/registry/flows/domain/DomainDeleteFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainDeleteFlow.java
@@ -422,7 +422,7 @@ public final class DomainDeleteFlow implements MutatingFlow, SqlStatementLogging
       // If we updated the autorenew billing event, reuse it.
       DateTime autoRenewTime =
           billingRecurrence.getRecurrenceTimeOfYear().getLastInstanceBeforeOrAt(now);
-      return getDomainRenewCost(targetId, autoRenewTime, 1);
+      return getDomainRenewCost(targetId, toInstant(autoRenewTime), 1);
     }
     return tm().loadByKey(checkNotNull(gracePeriod.getBillingEvent())).getCost();
   }

--- a/core/src/main/java/google/registry/flows/domain/DomainFlowTmchUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowTmchUtils.java
@@ -38,10 +38,10 @@ import java.security.SignatureException;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.CertificateRevokedException;
+import java.time.Instant;
 import javax.xml.crypto.MarshalException;
 import javax.xml.crypto.dsig.XMLSignatureException;
 import javax.xml.parsers.ParserConfigurationException;
-import org.joda.time.DateTime;
 import org.xml.sax.SAXException;
 
 /** TMCH utility functions for domain flows. */
@@ -55,7 +55,7 @@ public final class DomainFlowTmchUtils {
   }
 
   public SignedMark verifySignedMarks(
-      ImmutableList<AbstractSignedMark> signedMarks, String domainLabel, DateTime now)
+      ImmutableList<AbstractSignedMark> signedMarks, String domainLabel, Instant now)
       throws EppException {
     if (signedMarks.size() > 1) {
       throw new TooManySignedMarksException();
@@ -75,7 +75,7 @@ public final class DomainFlowTmchUtils {
     return signedMark;
   }
 
-  public SignedMark verifyEncodedSignedMark(EncodedSignedMark encodedSignedMark, DateTime now)
+  public SignedMark verifyEncodedSignedMark(EncodedSignedMark encodedSignedMark, Instant now)
       throws EppException {
     if (!encodedSignedMark.getEncoding().equals("base64")) {
       throw new Base64RequiredForEncodedSignedMarksException();

--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -40,7 +40,7 @@ import static google.registry.model.tld.label.ReservationType.RESERVED_FOR_SPECI
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.pricing.PricingEngineProxy.isDomainPremium;
 import static google.registry.util.CollectionUtils.nullToEmpty;
-import static google.registry.util.DateTimeUtils.END_OF_TIME;
+import static google.registry.util.DateTimeUtils.END_INSTANT;
 import static google.registry.util.DateTimeUtils.isAtOrAfter;
 import static google.registry.util.DateTimeUtils.plusYears;
 import static google.registry.util.DateTimeUtils.toInstant;
@@ -124,6 +124,7 @@ import google.registry.tldconfig.idn.IdnLabelValidator;
 import google.registry.tools.DigestType;
 import google.registry.util.Idn;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map.Entry;
@@ -474,7 +475,7 @@ public class DomainFlowUtils {
    */
   static void verifyPremiumNameIsNotBlocked(
       String domainName, DateTime priceTime, String registrarId) throws EppException {
-    if (isDomainPremium(domainName, priceTime)) {
+    if (isDomainPremium(domainName, toInstant(priceTime))) {
       if (Registrar.loadByRegistrarIdCached(registrarId).get().getBlockPremiumNames()) {
         throw new PremiumNameBlockedException();
       }
@@ -504,7 +505,7 @@ public class DomainFlowUtils {
         .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
         .setTargetId(domain.getDomainName())
         .setRegistrarId(domain.getCurrentSponsorRegistrarId())
-        .setEventTime(domain.getRegistrationExpirationDateTime());
+        .setEventTime(domain.getRegistrationExpirationTime());
   }
 
   /**
@@ -515,7 +516,7 @@ public class DomainFlowUtils {
     return new Autorenew.Builder()
         .setTargetId(domain.getDomainName())
         .setRegistrarId(domain.getCurrentSponsorRegistrarId())
-        .setEventTime(domain.getRegistrationExpirationDateTime())
+        .setEventTime(domain.getRegistrationExpirationTime())
         .setMsg("Domain was auto-renewed.");
   }
 
@@ -587,7 +588,7 @@ public class DomainFlowUtils {
       boolean isAvailable,
       @Nullable BillingRecurrence billingRecurrence)
       throws EppException {
-    DateTime now = currentDate;
+    Instant now = toInstant(currentDate);
     // Use the custom effective date specified in the fee check request, if there is one.
     if (feeRequest.getEffectiveDate().isPresent()) {
       now = feeRequest.getEffectiveDate().get();
@@ -659,7 +660,7 @@ public class DomainFlowUtils {
         // process, don't count as expired for the purposes of requiring an added year of renewal on
         // restore because they can't be restored in the first place.
         boolean isExpired =
-            domain.isPresent() && domain.get().getRegistrationExpirationDateTime().isBefore(now);
+            domain.isPresent() && domain.get().getRegistrationExpirationTime().isBefore(now);
         fees = pricingLogic.getRestorePrice(tld, domainNameString, now, isExpired).getFees();
       }
       case TRANSFER -> {
@@ -700,16 +701,16 @@ public class DomainFlowUtils {
     // Set the fees, and based on the validDateRange of the fees, set the notAfterDate.
     if (!fees.isEmpty()) {
       builder.setFees(fees);
-      DateTime notAfterDate = null;
+      Instant notAfterDate = null;
       for (Fee fee : fees) {
         if (fee.hasValidDateRange()) {
-          DateTime endDate = fee.getValidDateRange().upperEndpoint();
+          Instant endDate = fee.getValidDateRange().upperEndpoint();
           if (notAfterDate == null || notAfterDate.isAfter(endDate)) {
             notAfterDate = endDate;
           }
         }
       }
-      if (notAfterDate != null && !notAfterDate.equals(END_OF_TIME)) {
+      if (notAfterDate != null && !notAfterDate.equals(END_INSTANT)) {
         builder.setNotAfterDateIfSupported(notAfterDate);
       }
     }

--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -504,7 +504,7 @@ public class DomainFlowUtils {
         .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
         .setTargetId(domain.getDomainName())
         .setRegistrarId(domain.getCurrentSponsorRegistrarId())
-        .setEventTime(domain.getRegistrationExpirationDateTime());
+        .setEventTime(domain.getRegistrationExpirationTime());
   }
 
   /**
@@ -515,7 +515,7 @@ public class DomainFlowUtils {
     return new Autorenew.Builder()
         .setTargetId(domain.getDomainName())
         .setRegistrarId(domain.getCurrentSponsorRegistrarId())
-        .setEventTime(domain.getRegistrationExpirationDateTime())
+        .setEventTime(domain.getRegistrationExpirationTime())
         .setMsg("Domain was auto-renewed.");
   }
 
@@ -659,7 +659,7 @@ public class DomainFlowUtils {
         // process, don't count as expired for the purposes of requiring an added year of renewal on
         // restore because they can't be restored in the first place.
         boolean isExpired =
-            domain.isPresent() && domain.get().getRegistrationExpirationDateTime().isBefore(now);
+            domain.isPresent() && domain.get().getRegistrationExpirationTime().isBefore(now);
         fees = pricingLogic.getRestorePrice(tld, domainNameString, now, isExpired).getFees();
       }
       case TRANSFER -> {

--- a/core/src/main/java/google/registry/flows/domain/DomainInfoFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainInfoFlow.java
@@ -121,10 +121,10 @@ public final class DomainInfoFlow implements MutatingFlow {
             .setStatusValues(domain.getStatusValues())
             .setNameservers(
                 hostsRequest.requestDelegated() ? domain.loadNameserverHostNames() : null)
-            .setCreationTime(domain.getCreationTime())
-            .setLastEppUpdateTime(domain.getLastEppUpdateDateTime())
-            .setRegistrationExpirationTime(domain.getRegistrationExpirationDateTime())
-            .setLastTransferTime(domain.getLastTransferTime());
+            .setCreationTime(domain.getCreationTimeInstant())
+            .setLastEppUpdateTime(domain.getLastEppUpdateTime())
+            .setRegistrationExpirationTime(domain.getRegistrationExpirationTime())
+            .setLastTransferTime(domain.getLastTransferTimeInstant());
 
     // If authInfo is non-null, then the caller is authorized to see the full information since we
     // will have already verified the authInfo is valid.

--- a/core/src/main/java/google/registry/flows/domain/DomainPricingLogic.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainPricingLogic.java
@@ -18,6 +18,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.flows.domain.DomainFlowUtils.zeroInCurrency;
 import static google.registry.flows.domain.token.AllocationTokenFlowUtils.discountTokenInvalidForPremiumName;
 import static google.registry.pricing.PricingEngineProxy.getPricesForDomainName;
+import static google.registry.util.DateTimeUtils.toDateTime;
 import static google.registry.util.PreconditionsUtils.checkArgumentPresent;
 
 import com.google.common.net.InternetDomainName;
@@ -41,11 +42,11 @@ import google.registry.model.pricing.PremiumPricingEngine.DomainPrices;
 import google.registry.model.tld.Tld;
 import jakarta.inject.Inject;
 import java.math.RoundingMode;
+import java.time.Instant;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 
 /**
  * Provides pricing for create, renew, etc, operations, with call-outs that can be customized by
@@ -70,7 +71,7 @@ public final class DomainPricingLogic {
   public FeesAndCredits getCreatePrice(
       Tld tld,
       String domainName,
-      DateTime dateTime,
+      Instant dateTime,
       int years,
       boolean isAnchorTenant,
       boolean isSunriseCreate,
@@ -116,7 +117,7 @@ public final class DomainPricingLogic {
             .setFeesAndCredits(feesBuilder.build())
             .setTld(tld)
             .setDomainName(InternetDomainName.from(domainName))
-            .setAsOfDate(dateTime)
+            .setAsOfDate(toDateTime(dateTime))
             .setYears(years)
             .build());
   }
@@ -125,7 +126,7 @@ public final class DomainPricingLogic {
   public FeesAndCredits getRenewPrice(
       Tld tld,
       String domainName,
-      DateTime dateTime,
+      Instant dateTime,
       int years,
       @Nullable BillingRecurrence billingRecurrence,
       Optional<AllocationToken> allocationToken) {
@@ -187,14 +188,14 @@ public final class DomainPricingLogic {
                     .build())
             .setTld(tld)
             .setDomainName(InternetDomainName.from(domainName))
-            .setAsOfDate(dateTime)
+            .setAsOfDate(toDateTime(dateTime))
             .setYears(years)
             .build());
   }
 
   /** Returns a new restore price for the pricer. */
   public FeesAndCredits getRestorePrice(
-      Tld tld, String domainName, DateTime dateTime, boolean isExpired) throws EppException {
+      Tld tld, String domainName, Instant dateTime, boolean isExpired) throws EppException {
     DomainPrices domainPrices = getPricesForDomainName(domainName, dateTime);
     FeesAndCredits.Builder feesAndCredits =
         new FeesAndCredits.Builder()
@@ -211,13 +212,13 @@ public final class DomainPricingLogic {
             .setFeesAndCredits(feesAndCredits.build())
             .setTld(tld)
             .setDomainName(InternetDomainName.from(domainName))
-            .setAsOfDate(dateTime)
+            .setAsOfDate(toDateTime(dateTime))
             .build());
   }
 
   /** Returns a new transfer price for the pricer. */
   public FeesAndCredits getTransferPrice(
-      Tld tld, String domainName, DateTime dateTime, @Nullable BillingRecurrence billingRecurrence)
+      Tld tld, String domainName, Instant dateTime, @Nullable BillingRecurrence billingRecurrence)
       throws EppException {
     FeesAndCredits renewPrice =
         getRenewPrice(tld, domainName, dateTime, 1, billingRecurrence, Optional.empty());
@@ -234,12 +235,12 @@ public final class DomainPricingLogic {
                     .build())
             .setTld(tld)
             .setDomainName(InternetDomainName.from(domainName))
-            .setAsOfDate(dateTime)
+            .setAsOfDate(toDateTime(dateTime))
             .build());
   }
 
   /** Returns a new update price for the pricer. */
-  public FeesAndCredits getUpdatePrice(Tld tld, String domainName, DateTime dateTime)
+  public FeesAndCredits getUpdatePrice(Tld tld, String domainName, Instant dateTime)
       throws EppException {
     CurrencyUnit currency = tld.getCurrency();
     BaseFee feeOrCredit = Fee.create(zeroInCurrency(currency), FeeType.UPDATE, false);
@@ -252,7 +253,7 @@ public final class DomainPricingLogic {
                     .build())
             .setTld(tld)
             .setDomainName(InternetDomainName.from(domainName))
-            .setAsOfDate(dateTime)
+            .setAsOfDate(toDateTime(dateTime))
             .build());
   }
 
@@ -272,7 +273,7 @@ public final class DomainPricingLogic {
   private Money getDomainRenewCostWithDiscount(
       Tld tld,
       DomainPrices domainPrices,
-      DateTime dateTime,
+      Instant dateTime,
       int years,
       Optional<AllocationToken> allocationToken) {
     // Short-circuit if the user sent an anchor-tenant or otherwise NONPREMIUM-renewal token
@@ -349,7 +350,7 @@ public final class DomainPricingLogic {
   }
 
   private DomainPrices applyTokenToDomainPrices(
-      DomainPrices domainPrices, Tld tld, DateTime dateTime, int years, AllocationToken token) {
+      DomainPrices domainPrices, Tld tld, Instant dateTime, int years, AllocationToken token) {
     // Convert to nonpremium iff no premium charges are included (either in create or any renewal)
     boolean convertToNonPremium =
         token.getRegistrationBehavior().equals(RegistrationBehavior.NONPREMIUM_CREATE)

--- a/core/src/main/java/google/registry/flows/domain/DomainPricingLogic.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainPricingLogic.java
@@ -41,11 +41,11 @@ import google.registry.model.pricing.PremiumPricingEngine.DomainPrices;
 import google.registry.model.tld.Tld;
 import jakarta.inject.Inject;
 import java.math.RoundingMode;
+import java.time.Instant;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 
 /**
  * Provides pricing for create, renew, etc, operations, with call-outs that can be customized by
@@ -70,7 +70,7 @@ public final class DomainPricingLogic {
   public FeesAndCredits getCreatePrice(
       Tld tld,
       String domainName,
-      DateTime dateTime,
+      Instant dateTime,
       int years,
       boolean isAnchorTenant,
       boolean isSunriseCreate,
@@ -125,7 +125,7 @@ public final class DomainPricingLogic {
   public FeesAndCredits getRenewPrice(
       Tld tld,
       String domainName,
-      DateTime dateTime,
+      Instant dateTime,
       int years,
       @Nullable BillingRecurrence billingRecurrence,
       Optional<AllocationToken> allocationToken) {
@@ -194,7 +194,7 @@ public final class DomainPricingLogic {
 
   /** Returns a new restore price for the pricer. */
   public FeesAndCredits getRestorePrice(
-      Tld tld, String domainName, DateTime dateTime, boolean isExpired) throws EppException {
+      Tld tld, String domainName, Instant dateTime, boolean isExpired) throws EppException {
     DomainPrices domainPrices = getPricesForDomainName(domainName, dateTime);
     FeesAndCredits.Builder feesAndCredits =
         new FeesAndCredits.Builder()
@@ -217,7 +217,7 @@ public final class DomainPricingLogic {
 
   /** Returns a new transfer price for the pricer. */
   public FeesAndCredits getTransferPrice(
-      Tld tld, String domainName, DateTime dateTime, @Nullable BillingRecurrence billingRecurrence)
+      Tld tld, String domainName, Instant dateTime, @Nullable BillingRecurrence billingRecurrence)
       throws EppException {
     FeesAndCredits renewPrice =
         getRenewPrice(tld, domainName, dateTime, 1, billingRecurrence, Optional.empty());
@@ -239,7 +239,7 @@ public final class DomainPricingLogic {
   }
 
   /** Returns a new update price for the pricer. */
-  public FeesAndCredits getUpdatePrice(Tld tld, String domainName, DateTime dateTime)
+  public FeesAndCredits getUpdatePrice(Tld tld, String domainName, Instant dateTime)
       throws EppException {
     CurrencyUnit currency = tld.getCurrency();
     BaseFee feeOrCredit = Fee.create(zeroInCurrency(currency), FeeType.UPDATE, false);
@@ -272,7 +272,7 @@ public final class DomainPricingLogic {
   private Money getDomainRenewCostWithDiscount(
       Tld tld,
       DomainPrices domainPrices,
-      DateTime dateTime,
+      Instant dateTime,
       int years,
       Optional<AllocationToken> allocationToken) {
     // Short-circuit if the user sent an anchor-tenant or otherwise NONPREMIUM-renewal token
@@ -349,7 +349,7 @@ public final class DomainPricingLogic {
   }
 
   private DomainPrices applyTokenToDomainPrices(
-      DomainPrices domainPrices, Tld tld, DateTime dateTime, int years, AllocationToken token) {
+      DomainPrices domainPrices, Tld tld, Instant dateTime, int years, AllocationToken token) {
     // Convert to nonpremium iff no premium charges are included (either in create or any renewal)
     boolean convertToNonPremium =
         token.getRegistrationBehavior().equals(RegistrationBehavior.NONPREMIUM_CREATE)

--- a/core/src/main/java/google/registry/flows/domain/DomainRenewFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRenewFlow.java
@@ -35,6 +35,7 @@ import static google.registry.flows.domain.token.AllocationTokenFlowUtils.verify
 import static google.registry.model.reporting.HistoryEntry.Type.DOMAIN_RENEW;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.plusYears;
+import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -201,7 +202,7 @@ public final class DomainRenewFlow implements MutatingFlow {
         pricingLogic.getRenewPrice(
             Tld.get(existingDomain.getTld()),
             targetId,
-            now,
+            toInstant(now),
             years,
             existingBillingRecurrence,
             allocationToken);

--- a/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
@@ -31,6 +31,7 @@ import static google.registry.flows.domain.DomainFlowUtils.verifyRegistrarIsActi
 import static google.registry.model.reporting.HistoryEntry.Type.DOMAIN_RESTORE;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.END_INSTANT;
+import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -140,7 +141,8 @@ public final class DomainRestoreRequestFlow implements MutatingFlow {
     Domain existingDomain = loadAndVerifyExistence(Domain.class, targetId, now);
     boolean isExpired = existingDomain.getRegistrationExpirationDateTime().isBefore(now);
     FeesAndCredits feesAndCredits =
-        pricingLogic.getRestorePrice(Tld.get(existingDomain.getTld()), targetId, now, isExpired);
+        pricingLogic.getRestorePrice(
+            Tld.get(existingDomain.getTld()), targetId, toInstant(now), isExpired);
     Optional<FeeUpdateCommandExtension> feeUpdate =
         eppInput.getSingleExtension(FeeUpdateCommandExtension.class);
     verifyRestoreAllowed(command, existingDomain, feeUpdate, feesAndCredits, now);

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferApproveFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferApproveFlow.java
@@ -163,7 +163,7 @@ public final class DomainTransferApproveFlow implements MutatingFlow {
                             .getTransferPrice(
                                 Tld.get(tldStr),
                                 targetId,
-                                transferData.getTransferRequestTime(),
+                                transferData.getTransferRequestTimeInstant(),
                                 // When removing a domain from bulk pricing it should return to the
                                 // default recurrence billing behavior so the existing recurrence
                                 // billing event should not be passed in.

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
@@ -198,7 +198,9 @@ public final class DomainTransferRequestFlow implements MutatingFlow {
       feesAndCredits = Optional.empty();
     } else if (existingDomain.getCurrentBulkToken().isEmpty()) {
       feesAndCredits =
-          Optional.of(pricingLogic.getTransferPrice(tld, targetId, now, existingBillingRecurrence));
+          Optional.of(
+              pricingLogic.getTransferPrice(
+                  tld, targetId, toInstant(now), existingBillingRecurrence));
     } else {
       // If existing domain is in a bulk pricing package, calculate the transfer price with default
       // renewal price
@@ -206,7 +208,7 @@ public final class DomainTransferRequestFlow implements MutatingFlow {
       feesAndCredits =
           period.getValue() == 0
               ? Optional.empty()
-              : Optional.of(pricingLogic.getTransferPrice(tld, targetId, now, null));
+              : Optional.of(pricingLogic.getTransferPrice(tld, targetId, toInstant(now), null));
     }
 
     if (feesAndCredits.isPresent()) {

--- a/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
@@ -38,6 +38,7 @@ import static google.registry.flows.domain.DomainFlowUtils.verifyClientUpdateNot
 import static google.registry.flows.domain.DomainFlowUtils.verifyNotInPendingDelete;
 import static google.registry.model.reporting.HistoryEntry.Type.DOMAIN_UPDATE;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -227,7 +228,7 @@ public final class DomainUpdateFlow implements MutatingFlow {
     Tld tld = Tld.get(tldStr);
     Optional<FeeUpdateCommandExtension> feeUpdate =
         eppInput.getSingleExtension(FeeUpdateCommandExtension.class);
-    FeesAndCredits feesAndCredits = pricingLogic.getUpdatePrice(tld, targetId, now);
+    FeesAndCredits feesAndCredits = pricingLogic.getUpdatePrice(tld, targetId, toInstant(now));
     validateFeesAckedIfPresent(feeUpdate, feesAndCredits, false);
     verifyNotInPendingDelete(add.getNameservers());
     validateNameserversAllowedOnTld(tldStr, add.getNameserverHostNames());

--- a/core/src/main/java/google/registry/flows/domain/token/AllocationTokenFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/token/AllocationTokenFlowUtils.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.pricing.PricingEngineProxy.isDomainPremium;
 import static google.registry.util.CollectionUtils.isNullOrEmpty;
+import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -166,7 +167,8 @@ public class AllocationTokenFlowUtils {
   @VisibleForTesting
   static boolean tokenIsValidAgainstDomain(
       InternetDomainName domainName, AllocationToken token, CommandName commandName, DateTime now) {
-    if (discountTokenInvalidForPremiumName(token, isDomainPremium(domainName.toString(), now))) {
+    if (discountTokenInvalidForPremiumName(
+        token, isDomainPremium(domainName.toString(), toInstant(now)))) {
       return false;
     }
     if (!token.getAllowedEppActions().isEmpty()
@@ -242,12 +244,13 @@ public class AllocationTokenFlowUtils {
       case CREATE ->
           pricingLogic
               .getCreatePrice(
-                  tld, domainName, now, yearsForAction, false, false, Optional.of(token))
+                  tld, domainName, toInstant(now), yearsForAction, false, false, Optional.of(token))
               .getTotalCost()
               .getAmount();
       case RENEW ->
           pricingLogic
-              .getRenewPrice(tld, domainName, now, yearsForAction, null, Optional.of(token))
+              .getRenewPrice(
+                  tld, domainName, toInstant(now), yearsForAction, null, Optional.of(token))
               .getTotalCost()
               .getAmount();
       default -> BigDecimal.ZERO;

--- a/core/src/main/java/google/registry/flows/host/HostCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostCreateFlow.java
@@ -25,6 +25,7 @@ import static google.registry.model.EppResourceUtils.createRepoId;
 import static google.registry.model.reporting.HistoryEntry.Type.HOST_CREATE;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.CollectionUtils.isNullOrEmpty;
+import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.google.common.collect.ImmutableSet;
 import google.registry.config.RegistryConfig.Config;
@@ -141,7 +142,7 @@ public final class HostCreateFlow implements MutatingFlow {
       requestHostDnsRefresh(targetId);
     }
     tm().insertAll(entitiesToInsert);
-    return responseBuilder.setResData(HostCreateData.create(targetId, now)).build();
+    return responseBuilder.setResData(HostCreateData.create(targetId, toInstant(now))).build();
   }
 
   /** Subordinate hosts must have an ip address. */

--- a/core/src/main/java/google/registry/flows/host/HostInfoFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostInfoFlow.java
@@ -19,7 +19,6 @@ import static google.registry.flows.ResourceFlowUtils.loadAndVerifyExistence;
 import static google.registry.flows.host.HostFlowUtils.validateHostName;
 import static google.registry.model.EppResourceUtils.isLinked;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.util.DateTimeUtils.toDateTime;
 
 import com.google.common.collect.ImmutableSet;
 import google.registry.flows.EppException;
@@ -81,14 +80,14 @@ public final class HostInfoFlow implements TransactionalFlow {
           tm().loadByKey(host.getSuperordinateDomain()).cloneProjectedAtTime(now);
       hostInfoDataBuilder
           .setCurrentSponsorRegistrarId(superordinateDomain.getCurrentSponsorRegistrarId())
-          .setLastTransferTime(toDateTime(host.computeLastTransferTime(superordinateDomain)));
+          .setLastTransferTime(host.computeLastTransferTime(superordinateDomain));
       if (superordinateDomain.getStatusValues().contains(StatusValue.PENDING_TRANSFER)) {
         statusValues.add(StatusValue.PENDING_TRANSFER);
       }
     } else {
       hostInfoDataBuilder
           .setCurrentSponsorRegistrarId(host.getPersistedCurrentSponsorRegistrarId())
-          .setLastTransferTime(host.getLastTransferTime());
+          .setLastTransferTime(host.getLastTransferTimeInstant());
     }
     return responseBuilder
         .setResData(
@@ -98,9 +97,9 @@ public final class HostInfoFlow implements TransactionalFlow {
                 .setStatusValues(statusValues.build())
                 .setInetAddresses(host.getInetAddresses())
                 .setCreationRegistrarId(host.getCreationRegistrarId())
-                .setCreationTime(host.getCreationTime())
+                .setCreationTime(host.getCreationTimeInstant())
                 .setLastEppUpdateRegistrarId(host.getLastEppUpdateRegistrarId())
-                .setLastEppUpdateTime(host.getLastEppUpdateDateTime())
+                .setLastEppUpdateTime(host.getLastEppUpdateTime())
                 .build())
         .build();
   }

--- a/core/src/main/java/google/registry/flows/poll/PollRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/poll/PollRequestFlow.java
@@ -77,7 +77,7 @@ public final class PollRequestFlow implements TransactionalFlow {
         .setResultFromCode(SUCCESS_WITH_ACK_MESSAGE)
         .setMessageQueueInfo(
             new MessageQueueInfo.Builder()
-                .setQueueDate(pollMessage.getEventTime())
+                .setQueueDate(pollMessage.getEventTimeInstant())
                 .setMsg(pollMessage.getMsg())
                 .setQueueLength(getPollMessageCount(registrarId, now))
                 .setMessageId(makePollMessageExternalId(pollMessage))

--- a/core/src/main/java/google/registry/flows/poll/PollRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/poll/PollRequestFlow.java
@@ -21,6 +21,7 @@ import static google.registry.model.eppoutput.Result.Code.SUCCESS_WITH_ACK_MESSA
 import static google.registry.model.eppoutput.Result.Code.SUCCESS_WITH_NO_MESSAGES;
 import static google.registry.model.poll.PollMessageExternalKeyConverter.makePollMessageExternalId;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.util.DateTimeUtils.toInstant;
 
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.ParameterValueSyntaxErrorException;
@@ -77,7 +78,7 @@ public final class PollRequestFlow implements TransactionalFlow {
         .setResultFromCode(SUCCESS_WITH_ACK_MESSAGE)
         .setMessageQueueInfo(
             new MessageQueueInfo.Builder()
-                .setQueueDate(pollMessage.getEventTime())
+                .setQueueDate(toInstant(pollMessage.getEventTime()))
                 .setMsg(pollMessage.getMsg())
                 .setQueueLength(getPollMessageCount(registrarId, now))
                 .setMessageId(makePollMessageExternalId(pollMessage))

--- a/core/src/main/java/google/registry/flows/session/HelloFlow.java
+++ b/core/src/main/java/google/registry/flows/session/HelloFlow.java
@@ -37,6 +37,6 @@ public final class HelloFlow implements Flow {
   @Override
   public Greeting run() throws EppException {
     extensionManager.validate(); // There are no legal extensions for this flow.
-    return Greeting.create(clock.nowUtc(), greetingServerId);
+    return Greeting.create(clock.now(), greetingServerId);
   }
 }

--- a/core/src/main/java/google/registry/model/contact/ContactInfoData.java
+++ b/core/src/main/java/google/registry/model/contact/ContactInfoData.java
@@ -25,8 +25,8 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.time.Instant;
 import javax.annotation.Nullable;
-import org.joda.time.DateTime;
 
 /** The {@link ResponseData} returned for an EPP info flow on a contact. */
 @XmlRootElement(name = "infData")
@@ -84,7 +84,7 @@ public abstract class ContactInfoData implements ResponseData {
   abstract String getCreationRegistrarId();
 
   @XmlElement(name = "crDate")
-  abstract DateTime getCreationTime();
+  abstract Instant getCreationTime();
 
   @XmlElement(name = "upID")
   @Nullable
@@ -92,11 +92,11 @@ public abstract class ContactInfoData implements ResponseData {
 
   @XmlElement(name = "upDate")
   @Nullable
-  abstract DateTime getLastEppUpdateTime();
+  abstract Instant getLastEppUpdateTime();
 
   @XmlElement(name = "trDate")
   @Nullable
-  abstract DateTime getLastTransferTime();
+  abstract Instant getLastTransferTime();
 
   @XmlElement(name = "authInfo")
   @Nullable
@@ -121,12 +121,14 @@ public abstract class ContactInfoData implements ResponseData {
 
     public abstract Builder setCreationRegistrarId(String creationRegistrarId);
 
-    public abstract Builder setCreationTime(DateTime creationTime);
+    public abstract Builder setCreationTime(Instant creationTime);
 
     public abstract Builder setLastEppUpdateRegistrarId(@Nullable String lastEppUpdateRegistrarId);
 
-    public abstract Builder setLastEppUpdateTime(@Nullable DateTime lastEppUpdateTime);
-    public abstract Builder setLastTransferTime(@Nullable DateTime lastTransferTime);
+    public abstract Builder setLastEppUpdateTime(@Nullable Instant lastEppUpdateTime);
+
+    public abstract Builder setLastTransferTime(@Nullable Instant lastTransferTime);
+
     public abstract Builder setAuthInfo(@Nullable ContactAuthInfo authInfo);
     public abstract Builder setDisclose(@Nullable Disclose disclose);
     public abstract ContactInfoData build();

--- a/core/src/main/java/google/registry/model/contact/package-info.java
+++ b/core/src/main/java/google/registry/model/contact/package-info.java
@@ -17,13 +17,18 @@
     xmlns = @XmlNs(prefix = "contact", namespaceURI = "urn:ietf:params:xml:ns:contact-1.0"),
     elementFormDefault = XmlNsForm.QUALIFIED)
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlJavaTypeAdapter(UtcDateTimeAdapter.class)
+@XmlJavaTypeAdapters({
+  @XmlJavaTypeAdapter(UtcDateTimeAdapter.class),
+  @XmlJavaTypeAdapter(UtcInstantAdapter.class)
+})
 package google.registry.model.contact;
 
 import google.registry.xml.UtcDateTimeAdapter;
+import google.registry.xml.UtcInstantAdapter;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlNs;
 import jakarta.xml.bind.annotation.XmlNsForm;
 import jakarta.xml.bind.annotation.XmlSchema;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapters;

--- a/core/src/main/java/google/registry/model/domain/DomainInfoData.java
+++ b/core/src/main/java/google/registry/model/domain/DomainInfoData.java
@@ -25,8 +25,8 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
+import java.time.Instant;
 import javax.annotation.Nullable;
-import org.joda.time.DateTime;
 
 /** The {@link ResponseData} returned for an EPP info flow on a domain. */
 @XmlRootElement(name = "infData")
@@ -88,7 +88,7 @@ public abstract class DomainInfoData implements ResponseData {
 
   @XmlElement(name = "crDate")
   @Nullable
-  abstract DateTime getCreationTime();
+  abstract Instant getCreationTime();
 
   @XmlElement(name = "upID")
   @Nullable
@@ -96,15 +96,15 @@ public abstract class DomainInfoData implements ResponseData {
 
   @XmlElement(name = "upDate")
   @Nullable
-  abstract DateTime getLastEppUpdateTime();
+  abstract Instant getLastEppUpdateTime();
 
   @XmlElement(name = "exDate")
   @Nullable
-  abstract DateTime getRegistrationExpirationTime();
+  abstract Instant getRegistrationExpirationTime();
 
   @XmlElement(name = "trDate")
   @Nullable
-  abstract DateTime getLastTransferTime();
+  abstract Instant getLastTransferTime();
 
   @XmlElement(name = "authInfo")
   @Nullable
@@ -127,14 +127,17 @@ public abstract class DomainInfoData implements ResponseData {
 
     public abstract Builder setCreationRegistrarId(@Nullable String creationRegistrarId);
 
-    public abstract Builder setCreationTime(@Nullable DateTime creationTime);
+    public abstract Builder setCreationTime(@Nullable Instant creationTime);
 
     public abstract Builder setLastEppUpdateRegistrarId(@Nullable String lastEppUpdateRegistrarId);
 
-    public abstract Builder setLastEppUpdateTime(@Nullable DateTime lastEppUpdateTime);
+    public abstract Builder setLastEppUpdateTime(@Nullable Instant lastEppUpdateTime);
+
     public abstract Builder setRegistrationExpirationTime(
-        @Nullable DateTime registrationExpirationTime);
-    public abstract Builder setLastTransferTime(@Nullable DateTime lastTransferTime);
+        @Nullable Instant registrationExpirationTime);
+
+    public abstract Builder setLastTransferTime(@Nullable Instant lastTransferTime);
+
     public abstract Builder setAuthInfo(@Nullable DomainAuthInfo authInfo);
 
     /** Internal accessor for use in {@link #build}. */

--- a/core/src/main/java/google/registry/model/domain/fee/BaseFee.java
+++ b/core/src/main/java/google/registry/model/domain/fee/BaseFee.java
@@ -32,7 +32,6 @@ import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.stream.Stream;
-import org.joda.time.DateTime;
 import org.joda.time.Period;
 
 /** Base class for the fee and credit types. */
@@ -104,9 +103,7 @@ public abstract class BaseFee extends ImmutableObject {
 
   @XmlTransient FeeType type;
 
-  @XmlTransient Range<DateTime> validDateRange;
-
-  @XmlTransient Range<Instant> validDateRangeInstant;
+  @XmlTransient Range<Instant> validDateRange;
 
   @XmlTransient boolean isPremium;
 
@@ -149,42 +146,13 @@ public abstract class BaseFee extends ImmutableObject {
 
   @JsonIgnore
   public boolean hasValidDateRange() {
-    return validDateRange != null || validDateRangeInstant != null;
+    return validDateRange != null;
   }
 
   @JsonIgnore
-  public Range<DateTime> getValidDateRange() {
+  public Range<Instant> getValidDateRange() {
     checkState(hasValidDateRange());
-    if (validDateRange != null) {
-      return validDateRange;
-    }
-    return convertRange(validDateRangeInstant, google.registry.util.DateTimeUtils::toDateTime);
-  }
-
-  @JsonIgnore
-  public Range<Instant> getValidDateRangeInstant() {
-    checkState(hasValidDateRange());
-    if (validDateRangeInstant != null) {
-      return validDateRangeInstant;
-    }
-    return convertRange(validDateRange, google.registry.util.DateTimeUtils::toInstant);
-  }
-
-  private static <S extends Comparable<? super S>, T extends Comparable<? super T>>
-      Range<T> convertRange(Range<S> range, java.util.function.Function<S, T> converter) {
-    if (range.hasLowerBound() && range.hasUpperBound()) {
-      return Range.range(
-          converter.apply(range.lowerEndpoint()),
-          range.lowerBoundType(),
-          converter.apply(range.upperEndpoint()),
-          range.upperBoundType());
-    } else if (range.hasLowerBound()) {
-      return Range.downTo(converter.apply(range.lowerEndpoint()), range.lowerBoundType());
-    } else if (range.hasUpperBound()) {
-      return Range.upTo(converter.apply(range.upperEndpoint()), range.upperBoundType());
-    } else {
-      return Range.all();
-    }
+    return validDateRange;
   }
 
   public boolean hasZeroCost() {

--- a/core/src/main/java/google/registry/model/domain/fee/Fee.java
+++ b/core/src/main/java/google/registry/model/domain/fee/Fee.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Range;
 import google.registry.model.eppcommon.ProtocolDefinition.ServiceExtension;
 import java.math.BigDecimal;
 import java.time.Instant;
-import org.joda.time.DateTime;
 
 /**
  * A fee, in currency units specified elsewhere in the xml, with type of the fee an optional fee
@@ -44,22 +43,10 @@ public class Fee extends BaseFee {
       BigDecimal cost,
       FeeType type,
       boolean isPremium,
-      Range<DateTime> validDateRange,
-      Object... descriptionArgs) {
-    Fee instance = create(cost, type, isPremium, descriptionArgs);
-    instance.validDateRange = validDateRange;
-    return instance;
-  }
-
-  /** Creates a Fee for the given cost, type, and valid date range with the default description. */
-  public static Fee createInstant(
-      BigDecimal cost,
-      FeeType type,
-      boolean isPremium,
       Range<Instant> validDateRange,
       Object... descriptionArgs) {
     Fee instance = create(cost, type, isPremium, descriptionArgs);
-    instance.validDateRangeInstant = validDateRange;
+    instance.validDateRange = validDateRange;
     return instance;
   }
 

--- a/core/src/main/java/google/registry/model/domain/fee/Fee.java
+++ b/core/src/main/java/google/registry/model/domain/fee/Fee.java
@@ -44,22 +44,10 @@ public class Fee extends BaseFee {
       BigDecimal cost,
       FeeType type,
       boolean isPremium,
-      Range<DateTime> validDateRange,
-      Object... descriptionArgs) {
-    Fee instance = create(cost, type, isPremium, descriptionArgs);
-    instance.validDateRange = validDateRange;
-    return instance;
-  }
-
-  /** Creates a Fee for the given cost, type, and valid date range with the default description. */
-  public static Fee createInstant(
-      BigDecimal cost,
-      FeeType type,
-      boolean isPremium,
       Range<Instant> validDateRange,
       Object... descriptionArgs) {
     Fee instance = create(cost, type, isPremium, descriptionArgs);
-    instance.validDateRangeInstant = validDateRange;
+    instance.validDateRange = validDateRange;
     return instance;
   }
 

--- a/core/src/main/java/google/registry/model/domain/fee/FeeQueryCommandExtensionItem.java
+++ b/core/src/main/java/google/registry/model/domain/fee/FeeQueryCommandExtensionItem.java
@@ -19,9 +19,9 @@ import static com.google.common.base.Preconditions.checkArgument;
 import google.registry.model.ImmutableObject;
 import google.registry.model.domain.Period;
 import jakarta.xml.bind.annotation.XmlTransient;
+import java.time.Instant;
 import java.util.Optional;
 import org.joda.money.CurrencyUnit;
-import org.joda.time.DateTime;
 
 /**
  * Abstract base class for the fee request query items used in Check and Info commands. It handles
@@ -86,7 +86,7 @@ public abstract class FeeQueryCommandExtensionItem extends ImmutableObject {
   public abstract CurrencyUnit getCurrency();
 
   /** The as-of date for the fee extension to run. */
-  public abstract Optional<DateTime> getEffectiveDate();
+  public abstract Optional<Instant> getEffectiveDate();
 
   /** The name of the command being checked. */
   public abstract CommandName getCommandName();

--- a/core/src/main/java/google/registry/model/domain/fee/FeeQueryResponseExtensionItem.java
+++ b/core/src/main/java/google/registry/model/domain/fee/FeeQueryResponseExtensionItem.java
@@ -24,9 +24,9 @@ import google.registry.model.domain.Period;
 import google.registry.model.domain.fee.FeeQueryCommandExtensionItem.CommandName;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlTransient;
+import java.time.Instant;
 import java.util.List;
 import org.joda.money.CurrencyUnit;
-import org.joda.time.DateTime;
 
 /**
  * Abstract base class for the fee request query items used in Check and Info responses. It handles
@@ -110,11 +110,11 @@ public class FeeQueryResponseExtensionItem extends ImmutableObject {
       return thisCastToDerived();  // Default impl is a noop.
     }
 
-    public B setEffectiveDateIfSupported(@SuppressWarnings("unused") DateTime effectiveDate) {
+    public B setEffectiveDateIfSupported(@SuppressWarnings("unused") Instant effectiveDate) {
       return thisCastToDerived();  // Default impl is a noop.
     }
 
-    public B setNotAfterDateIfSupported(@SuppressWarnings("unused") DateTime notAfterDate) {
+    public B setNotAfterDateIfSupported(@SuppressWarnings("unused") Instant notAfterDate) {
       return thisCastToDerived();  // Default impl is a noop.
     }
 

--- a/core/src/main/java/google/registry/model/domain/fee06/FeeCheckCommandExtensionItemV06.java
+++ b/core/src/main/java/google/registry/model/domain/fee06/FeeCheckCommandExtensionItemV06.java
@@ -17,9 +17,9 @@ package google.registry.model.domain.fee06;
 import google.registry.model.domain.fee.FeeCheckCommandExtensionItem;
 import google.registry.model.domain.fee.FeeExtensionCommandDescriptor;
 import jakarta.xml.bind.annotation.XmlType;
+import java.time.Instant;
 import java.util.Optional;
 import org.joda.money.CurrencyUnit;
-import org.joda.time.DateTime;
 
 /** An individual price check item in version 0.6 of the fee extension on Check commands. */
 @XmlType(propOrder = {"name", "currency", "command", "period"})
@@ -78,7 +78,7 @@ public class FeeCheckCommandExtensionItemV06 extends FeeCheckCommandExtensionIte
   }
 
   @Override
-  public Optional<DateTime> getEffectiveDate() {
+  public Optional<Instant> getEffectiveDate() {
     return Optional.empty();
   }
 }

--- a/core/src/main/java/google/registry/model/domain/fee06/FeeInfoCommandExtensionV06.java
+++ b/core/src/main/java/google/registry/model/domain/fee06/FeeInfoCommandExtensionV06.java
@@ -19,9 +19,9 @@ import google.registry.model.domain.fee.FeeQueryCommandExtensionItem;
 import google.registry.model.eppinput.EppInput.CommandExtension;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
+import java.time.Instant;
 import java.util.Optional;
 import org.joda.money.CurrencyUnit;
-import org.joda.time.DateTime;
 
 /** A fee extension that may be present on domain info commands. */
 @XmlRootElement(name = "info")
@@ -65,7 +65,7 @@ public class FeeInfoCommandExtensionV06
   }
 
   @Override
-  public Optional<DateTime> getEffectiveDate() {
+  public Optional<Instant> getEffectiveDate() {
     return Optional.empty();
   }
 }

--- a/core/src/main/java/google/registry/model/domain/fee11/FeeCheckCommandExtensionV11.java
+++ b/core/src/main/java/google/registry/model/domain/fee11/FeeCheckCommandExtensionV11.java
@@ -27,9 +27,9 @@ import google.registry.model.domain.fee11.FeeCheckCommandExtensionV11.FeeCheckCo
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
+import java.time.Instant;
 import java.util.Optional;
 import org.joda.money.CurrencyUnit;
-import org.joda.time.DateTime;
 
 /**
  * Version 0.11 of the fee extension that may be present on domain check commands. Unlike other
@@ -138,7 +138,7 @@ public class FeeCheckCommandExtensionV11 extends ImmutableObject
     }
 
     @Override
-    public Optional<DateTime> getEffectiveDate() {
+    public Optional<Instant> getEffectiveDate() {
       return Optional.empty();
     }
   }

--- a/core/src/main/java/google/registry/model/domain/fee12/FeeCheckCommandExtensionItemV12.java
+++ b/core/src/main/java/google/registry/model/domain/fee12/FeeCheckCommandExtensionItemV12.java
@@ -20,10 +20,10 @@ import google.registry.model.domain.fee.FeeCheckCommandExtensionItem;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
+import java.time.Instant;
 import java.util.Locale;
 import java.util.Optional;
 import org.joda.money.CurrencyUnit;
-import org.joda.time.DateTime;
 
 /**
  * An individual price check item in version 0.12 of the fee extension on domain check commands.
@@ -59,7 +59,7 @@ public class FeeCheckCommandExtensionItemV12 extends FeeCheckCommandExtensionIte
   String feeClass;
 
   @XmlElement(name = "date")
-  DateTime feeDate;
+  Instant feeDate;
 
   /** Version .12 does not support domain name or currency in fee extension items. */
   @Override
@@ -111,7 +111,7 @@ public class FeeCheckCommandExtensionItemV12 extends FeeCheckCommandExtensionIte
   }
 
   @Override
-  public Optional<DateTime> getEffectiveDate() {
+  public Optional<Instant> getEffectiveDate() {
     return Optional.ofNullable(feeDate);
   }
 }

--- a/core/src/main/java/google/registry/model/domain/fee12/FeeCheckResponseExtensionItemCommandV12.java
+++ b/core/src/main/java/google/registry/model/domain/fee12/FeeCheckResponseExtensionItemCommandV12.java
@@ -26,8 +26,8 @@ import google.registry.model.domain.fee.FeeQueryCommandExtensionItem.CommandName
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
+import java.time.Instant;
 import java.util.List;
-import org.joda.time.DateTime;
 
 /** The version 0.12 response command entity for a domain check on a single resource. */
 @XmlType(propOrder = {"period", "fee", "feeClass", "effectiveDate", "notAfterDate"})
@@ -65,12 +65,11 @@ public class FeeCheckResponseExtensionItemCommandV12 extends ImmutableObject {
 
   /** The effective date that the check is to be performed on (if specified in the query). */
   @XmlElement(name = "date")
-  DateTime effectiveDate;
+  Instant effectiveDate;
 
   /** The date after which the quoted fee is no longer valid (if applicable). */
   @XmlElement(name = "notAfter")
-  DateTime notAfterDate;
-
+  Instant notAfterDate;
 
   public String getFeeClass() {
     return feeClass;
@@ -99,12 +98,12 @@ public class FeeCheckResponseExtensionItemCommandV12 extends ImmutableObject {
       return this;
     }
 
-    public Builder setEffectiveDate(DateTime effectiveDate) {
+    public Builder setEffectiveDate(Instant effectiveDate) {
       getInstance().effectiveDate = effectiveDate;
       return this;
     }
 
-    public Builder setNotAfterDate(DateTime notAfterDate) {
+    public Builder setNotAfterDate(Instant notAfterDate) {
       getInstance().notAfterDate = notAfterDate;
       return this;
     }

--- a/core/src/main/java/google/registry/model/domain/fee12/FeeCheckResponseExtensionItemV12.java
+++ b/core/src/main/java/google/registry/model/domain/fee12/FeeCheckResponseExtensionItemV12.java
@@ -23,7 +23,7 @@ import google.registry.model.domain.fee.Fee;
 import google.registry.model.domain.fee.FeeCheckResponseExtensionItem;
 import google.registry.model.domain.fee.FeeQueryCommandExtensionItem.CommandName;
 import jakarta.xml.bind.annotation.XmlType;
-import org.joda.time.DateTime;
+import java.time.Instant;
 
 /**
  * The version 0.12 response for a domain check on a single resource.
@@ -110,13 +110,13 @@ public class FeeCheckResponseExtensionItemV12 extends FeeCheckResponseExtensionI
     }
 
     @Override
-    public Builder setEffectiveDateIfSupported(DateTime effectiveDate) {
+    public Builder setEffectiveDateIfSupported(Instant effectiveDate) {
       commandBuilder.setEffectiveDate(effectiveDate);
       return this;
     }
 
     @Override
-    public Builder setNotAfterDateIfSupported(DateTime notAfterDate) {
+    public Builder setNotAfterDateIfSupported(Instant notAfterDate) {
       commandBuilder.setNotAfterDate(notAfterDate);
       return this;
     }

--- a/core/src/main/java/google/registry/model/domain/fee12/package-info.java
+++ b/core/src/main/java/google/registry/model/domain/fee12/package-info.java
@@ -18,12 +18,13 @@
     elementFormDefault = XmlNsForm.QUALIFIED)
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlJavaTypeAdapters({
-    @XmlJavaTypeAdapter(CurrencyUnitAdapter.class),
-    @XmlJavaTypeAdapter(UtcDateTimeAdapter.class)})
+  @XmlJavaTypeAdapter(CurrencyUnitAdapter.class),
+  @XmlJavaTypeAdapter(UtcInstantAdapter.class)
+})
 package google.registry.model.domain.fee12;
 
 import google.registry.model.adapters.CurrencyUnitAdapter;
-import google.registry.xml.UtcDateTimeAdapter;
+import google.registry.xml.UtcInstantAdapter;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlNs;

--- a/core/src/main/java/google/registry/model/domain/feestdv1/FeeCheckCommandExtensionItemStdV1.java
+++ b/core/src/main/java/google/registry/model/domain/feestdv1/FeeCheckCommandExtensionItemStdV1.java
@@ -19,10 +19,10 @@ import google.registry.model.domain.Period;
 import google.registry.model.domain.fee.FeeCheckCommandExtensionItem;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlType;
+import java.time.Instant;
 import java.util.Locale;
 import java.util.Optional;
 import org.joda.money.CurrencyUnit;
-import org.joda.time.DateTime;
 
 /**
  * An individual price check item in version 1.0 of the fee extension on domain check commands.
@@ -100,7 +100,7 @@ public class FeeCheckCommandExtensionItemStdV1 extends FeeCheckCommandExtensionI
   }
 
   @Override
-  public Optional<DateTime> getEffectiveDate() {
+  public Optional<Instant> getEffectiveDate() {
     return Optional.empty();
   }
 }

--- a/core/src/main/java/google/registry/model/domain/feestdv1/package-info.java
+++ b/core/src/main/java/google/registry/model/domain/feestdv1/package-info.java
@@ -19,12 +19,12 @@
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlJavaTypeAdapters({
   @XmlJavaTypeAdapter(CurrencyUnitAdapter.class),
-  @XmlJavaTypeAdapter(UtcDateTimeAdapter.class)
+  @XmlJavaTypeAdapter(UtcInstantAdapter.class)
 })
 package google.registry.model.domain.feestdv1;
 
 import google.registry.model.adapters.CurrencyUnitAdapter;
-import google.registry.xml.UtcDateTimeAdapter;
+import google.registry.xml.UtcInstantAdapter;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlNs;

--- a/core/src/main/java/google/registry/model/eppoutput/CreateData.java
+++ b/core/src/main/java/google/registry/model/eppoutput/CreateData.java
@@ -19,14 +19,14 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-import org.joda.time.DateTime;
+import java.time.Instant;
 
 /** The {@link ResponseData} returned when creating a resource. */
 @XmlTransient
 public abstract class CreateData implements ResponseData {
 
   @XmlElement(name = "crDate")
-  protected DateTime creationDate;
+  protected Instant creationDate;
 
   /** An acknowledgment message indicating that a contact was created. */
   @XmlRootElement(name = "creData", namespace = "urn:ietf:params:xml:ns:contact-1.0")
@@ -35,7 +35,7 @@ public abstract class CreateData implements ResponseData {
 
     String id;
 
-    public static ContactCreateData create(String id, DateTime creationDate) {
+    public static ContactCreateData create(String id, Instant creationDate) {
       ContactCreateData instance = new ContactCreateData();
       instance.id = id;
       instance.creationDate = creationDate;
@@ -53,10 +53,10 @@ public abstract class CreateData implements ResponseData {
     String name;
 
     @XmlElement(name = "exDate")
-    DateTime expirationDate;
+    Instant expirationDate;
 
     public static DomainCreateData create(
-        String name, DateTime creationDate, DateTime expirationDate) {
+        String name, Instant creationDate, Instant expirationDate) {
       DomainCreateData instance = new DomainCreateData();
       instance.name = name;
       instance.creationDate = creationDate;
@@ -68,11 +68,11 @@ public abstract class CreateData implements ResponseData {
       return name;
     }
 
-    public DateTime creationDate() {
+    public Instant creationDate() {
       return creationDate;
     }
 
-    public DateTime expirationDate() {
+    public Instant expirationDate() {
       return expirationDate;
     }
   }
@@ -84,7 +84,7 @@ public abstract class CreateData implements ResponseData {
 
     String name;
 
-    public static HostCreateData create(String name, DateTime creationDate) {
+    public static HostCreateData create(String name, Instant creationDate) {
       HostCreateData instance = new HostCreateData();
       instance.name = name;
       instance.creationDate = creationDate;

--- a/core/src/main/java/google/registry/model/eppoutput/Greeting.java
+++ b/core/src/main/java/google/registry/model/eppoutput/Greeting.java
@@ -20,8 +20,8 @@ import google.registry.model.eppcommon.ProtocolDefinition;
 import google.registry.model.eppoutput.EppOutput.ResponseOrGreeting;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementWrapper;
+import java.time.Instant;
 import java.util.Set;
-import org.joda.time.DateTime;
 
 /**
  * A greeting, defined in <a href="http://tools.ietf.org/html/rfc5730">RFC5730</a>.
@@ -32,7 +32,7 @@ import org.joda.time.DateTime;
 public class Greeting extends ImmutableObject implements ResponseOrGreeting {
 
   String svID;
-  DateTime svDate;
+  Instant svDate;
 
   /** This is never changed, so it might as well be static for efficiency. */
   @XmlElement
@@ -42,7 +42,7 @@ public class Greeting extends ImmutableObject implements ResponseOrGreeting {
   @XmlElement
   static Dcp dcp = new Dcp();
 
-  public static Greeting create(DateTime svDate, String svID) {
+  public static Greeting create(Instant svDate, String svID) {
     Greeting instance = new Greeting();
     instance.svID = svID;
     instance.svDate = svDate;

--- a/core/src/main/java/google/registry/model/eppoutput/package-info.java
+++ b/core/src/main/java/google/registry/model/eppoutput/package-info.java
@@ -17,13 +17,18 @@
     xmlns = @XmlNs(prefix = "", namespaceURI = "urn:ietf:params:xml:ns:epp-1.0"),
     elementFormDefault = XmlNsForm.QUALIFIED)
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlJavaTypeAdapter(UtcDateTimeAdapter.class)
+@XmlJavaTypeAdapters({
+  @XmlJavaTypeAdapter(UtcDateTimeAdapter.class),
+  @XmlJavaTypeAdapter(UtcInstantAdapter.class)
+})
 package google.registry.model.eppoutput;
 
 import google.registry.xml.UtcDateTimeAdapter;
+import google.registry.xml.UtcInstantAdapter;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlNs;
 import jakarta.xml.bind.annotation.XmlNsForm;
 import jakarta.xml.bind.annotation.XmlSchema;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapters;

--- a/core/src/main/java/google/registry/model/host/HostInfoData.java
+++ b/core/src/main/java/google/registry/model/host/HostInfoData.java
@@ -23,8 +23,8 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
 import java.net.InetAddress;
+import java.time.Instant;
 import javax.annotation.Nullable;
-import org.joda.time.DateTime;
 
 /** The {@link ResponseData} returned for an EPP info flow on a host. */
 @XmlRootElement(name = "infData")
@@ -64,7 +64,7 @@ public abstract class HostInfoData implements ResponseData {
   abstract String getCreationRegistrarId();
 
   @XmlElement(name = "crDate")
-  abstract DateTime getCreationTime();
+  abstract Instant getCreationTime();
 
   @XmlElement(name = "upID")
   @Nullable
@@ -72,11 +72,11 @@ public abstract class HostInfoData implements ResponseData {
 
   @XmlElement(name = "upDate")
   @Nullable
-  abstract DateTime getLastEppUpdateTime();
+  abstract Instant getLastEppUpdateTime();
 
   @XmlElement(name = "trDate")
   @Nullable
-  abstract DateTime getLastTransferTime();
+  abstract Instant getLastTransferTime();
 
   /** Builder for {@link HostInfoData}. */
   @AutoValue.Builder
@@ -91,12 +91,14 @@ public abstract class HostInfoData implements ResponseData {
 
     public abstract Builder setCreationRegistrarId(String creationRegistrarId);
 
-    public abstract Builder setCreationTime(DateTime creationTime);
+    public abstract Builder setCreationTime(Instant creationTime);
 
     public abstract Builder setLastEppUpdateRegistrarId(@Nullable String lastEppUpdateRegistrarId);
 
-    public abstract Builder setLastEppUpdateTime(@Nullable DateTime lastEppUpdateTime);
-    public abstract Builder setLastTransferTime(@Nullable DateTime lastTransferTime);
+    public abstract Builder setLastEppUpdateTime(@Nullable Instant lastEppUpdateTime);
+
+    public abstract Builder setLastTransferTime(@Nullable Instant lastTransferTime);
+
     public abstract HostInfoData build();
   }
 

--- a/core/src/main/java/google/registry/model/mark/ProtectedMark.java
+++ b/core/src/main/java/google/registry/model/mark/ProtectedMark.java
@@ -16,14 +16,14 @@ package google.registry.model.mark;
 
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlTransient;
-import org.joda.time.DateTime;
+import java.time.Instant;
 
 /** Common fields for {@link CourtMark} and {@link TreatyOrStatuteMark}. */
 @XmlTransient
 public abstract class ProtectedMark extends CommonMarkFields {
   /** The date of protection of the mark. */
   @XmlElement(name = "proDate")
-  DateTime protectionDate;
+  Instant protectionDate;
 
   /**
    * The reference number of the court's opinion for a court mark, or the number of the mark of the
@@ -32,7 +32,7 @@ public abstract class ProtectedMark extends CommonMarkFields {
   @XmlElement(name = "refNum")
   String referenceNumber;
 
-  public DateTime getProtectionDate() {
+  public Instant getProtectionDate() {
     return protectionDate;
   }
 

--- a/core/src/main/java/google/registry/model/mark/Trademark.java
+++ b/core/src/main/java/google/registry/model/mark/Trademark.java
@@ -19,8 +19,8 @@ import static google.registry.util.CollectionUtils.nullToEmptyImmutableCopy;
 import com.google.common.collect.ImmutableList;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
+import java.time.Instant;
 import java.util.List;
-import org.joda.time.DateTime;
 
 /** Holds information about a registered trademark. */
 @XmlType(propOrder = {
@@ -52,7 +52,7 @@ public class Trademark extends CommonMarkFields {
 
   /** The date that the trademark was applied for. */
   @XmlElement(name = "apDate")
-  DateTime applicationDate;
+  Instant applicationDate;
 
   /** The trademark registration number registered in the trademark office. */
   @XmlElement(name = "regNum")
@@ -60,11 +60,11 @@ public class Trademark extends CommonMarkFields {
 
   /** The date the trademark was registered. */
   @XmlElement(name = "regDate")
-  DateTime registrationDate;
+  Instant registrationDate;
 
   /** Expiration date of the trademark. */
   @XmlElement(name = "exDate")
-  DateTime expirationDate;
+  Instant expirationDate;
 
   public String getJurisdiction() {
     return jurisdiction;
@@ -78,7 +78,7 @@ public class Trademark extends CommonMarkFields {
     return applicationId;
   }
 
-  public DateTime getApplicationDate() {
+  public Instant getApplicationDate() {
     return applicationDate;
   }
 
@@ -86,11 +86,11 @@ public class Trademark extends CommonMarkFields {
     return registrationNumber;
   }
 
-  public DateTime getRegistrationDate() {
+  public Instant getRegistrationDate() {
     return registrationDate;
   }
 
-  public DateTime getExpirationDate() {
+  public Instant getExpirationDate() {
     return expirationDate;
   }
 }

--- a/core/src/main/java/google/registry/model/mark/TreatyOrStatuteMark.java
+++ b/core/src/main/java/google/registry/model/mark/TreatyOrStatuteMark.java
@@ -19,8 +19,8 @@ import static google.registry.util.CollectionUtils.nullToEmptyImmutableCopy;
 import com.google.common.collect.ImmutableList;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlType;
+import java.time.Instant;
 import java.util.List;
-import org.joda.time.DateTime;
 
 /** Information about a mark derived from a treaty or statute. */
 @XmlType(propOrder = {
@@ -46,7 +46,7 @@ public class TreatyOrStatuteMark extends ProtectedMark {
 
   /** Execution date of the treaty or statute. */
   @XmlElement(name = "execDate")
-  DateTime executionDate;
+  Instant executionDate;
 
   public ImmutableList<MarkProtection> getMarkProtections() {
     return nullToEmptyImmutableCopy(markProtections);
@@ -56,7 +56,7 @@ public class TreatyOrStatuteMark extends ProtectedMark {
     return title;
   }
 
-  public DateTime getExecutionDate() {
+  public Instant getExecutionDate() {
     return executionDate;
   }
 }

--- a/core/src/main/java/google/registry/model/mark/package-info.java
+++ b/core/src/main/java/google/registry/model/mark/package-info.java
@@ -17,10 +17,10 @@
     xmlns = @XmlNs(prefix = "mark", namespaceURI = "urn:ietf:params:xml:ns:mark-1.0"),
     elementFormDefault = XmlNsForm.QUALIFIED)
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlJavaTypeAdapter(UtcDateTimeAdapter.class)
+@XmlJavaTypeAdapter(UtcInstantAdapter.class)
 package google.registry.model.mark;
 
-import google.registry.xml.UtcDateTimeAdapter;
+import google.registry.xml.UtcInstantAdapter;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlNs;

--- a/core/src/main/java/google/registry/model/poll/MessageQueueInfo.java
+++ b/core/src/main/java/google/registry/model/poll/MessageQueueInfo.java
@@ -21,14 +21,14 @@ import google.registry.model.Buildable;
 import google.registry.model.ImmutableObject;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
-import org.joda.time.DateTime;
+import java.time.Instant;
 
 /** Information about the message queue for the currently logged in registrar. */
 public class MessageQueueInfo extends ImmutableObject {
 
   /** The date and time that the current message was enqueued. */
   @XmlElement(name = "qDate")
-  DateTime queueDate;
+  Instant queueDate;
 
   /** A human-readable message. */
   String msg;
@@ -43,7 +43,7 @@ public class MessageQueueInfo extends ImmutableObject {
 
   /** A builder for constructing a {@link MessageQueueInfo}, since it's immutable. */
   public static class Builder extends Buildable.Builder<MessageQueueInfo> {
-    public Builder setQueueDate(DateTime queueDate) {
+    public Builder setQueueDate(Instant queueDate) {
       getInstance().queueDate = queueDate;
       return this;
     }

--- a/core/src/main/java/google/registry/model/pricing/PremiumPricingEngine.java
+++ b/core/src/main/java/google/registry/model/pricing/PremiumPricingEngine.java
@@ -14,8 +14,8 @@
 
 package google.registry.model.pricing;
 
+import java.time.Instant;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 
 /**
  * A plugin interface for premium pricing engines.
@@ -31,7 +31,7 @@ public interface PremiumPricingEngine {
    * <p>Note that the domainName must only contain a single part left of the TLD, i.e. subdomains
    * are not allowed, but multi-part TLDs are.
    */
-  DomainPrices getDomainPrices(String domainName, DateTime priceTime);
+  DomainPrices getDomainPrices(String domainName, Instant priceTime);
 
   /**
    * A class containing information on premium prices for a specific domain name.

--- a/core/src/main/java/google/registry/model/pricing/PremiumPricingEngine.java
+++ b/core/src/main/java/google/registry/model/pricing/PremiumPricingEngine.java
@@ -15,7 +15,7 @@
 package google.registry.model.pricing;
 
 import org.joda.money.Money;
-import org.joda.time.DateTime;
+import java.time.Instant;
 
 /**
  * A plugin interface for premium pricing engines.
@@ -31,7 +31,7 @@ public interface PremiumPricingEngine {
    * <p>Note that the domainName must only contain a single part left of the TLD, i.e. subdomains
    * are not allowed, but multi-part TLDs are.
    */
-  DomainPrices getDomainPrices(String domainName, DateTime priceTime);
+  DomainPrices getDomainPrices(String domainName, Instant priceTime);
 
   /**
    * A class containing information on premium prices for a specific domain name.

--- a/core/src/main/java/google/registry/model/pricing/StaticPremiumListPricingEngine.java
+++ b/core/src/main/java/google/registry/model/pricing/StaticPremiumListPricingEngine.java
@@ -21,9 +21,9 @@ import com.google.common.net.InternetDomainName;
 import google.registry.model.tld.Tld;
 import google.registry.model.tld.label.PremiumListDao;
 import jakarta.inject.Inject;
+import java.time.Instant;
 import java.util.Optional;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 
 /** A premium list pricing engine that stores static pricing information in database entities. */
 public final class StaticPremiumListPricingEngine implements PremiumPricingEngine {
@@ -34,7 +34,7 @@ public final class StaticPremiumListPricingEngine implements PremiumPricingEngin
   @Inject StaticPremiumListPricingEngine() {}
 
   @Override
-  public DomainPrices getDomainPrices(String domainName, DateTime priceTime) {
+  public DomainPrices getDomainPrices(String domainName, Instant priceTime) {
     String tldStr = getTldFromDomainName(domainName);
     String label = InternetDomainName.from(domainName).parts().get(0);
     Tld tld = Tld.get(checkNotNull(tldStr, "tld"));

--- a/core/src/main/java/google/registry/model/smd/SignedMark.java
+++ b/core/src/main/java/google/registry/model/smd/SignedMark.java
@@ -20,7 +20,7 @@ import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElementRef;
 import jakarta.xml.bind.annotation.XmlRootElement;
-import org.joda.time.DateTime;
+import java.time.Instant;
 
 /**
  * Represents an XML fragment that is digitally signed by the TMCH to prove ownership over a mark.
@@ -43,11 +43,11 @@ public class SignedMark extends ImmutableObject implements AbstractSignedMark {
 
   /** Creation time of this signed mark. */
   @XmlElement(name = "notBefore")
-  DateTime creationTime;
+  Instant creationTime;
 
   /** Expiration time of this signed mark. */
   @XmlElement(name = "notAfter")
-  DateTime expirationTime;
+  Instant expirationTime;
 
   /** Mark information. */
   @XmlElementRef(type = Mark.class)
@@ -66,11 +66,11 @@ public class SignedMark extends ImmutableObject implements AbstractSignedMark {
     return id;
   }
 
-  public DateTime getCreationTime() {
+  public Instant getCreationTime() {
     return creationTime;
   }
 
-  public DateTime getExpirationTime() {
+  public Instant getExpirationTime() {
     return expirationTime;
   }
 

--- a/core/src/main/java/google/registry/model/smd/SignedMarkRevocationList.java
+++ b/core/src/main/java/google/registry/model/smd/SignedMarkRevocationList.java
@@ -30,8 +30,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapKeyColumn;
+import java.time.Instant;
 import java.util.Map;
-import org.joda.time.DateTime;
 
 /**
  * Signed Mark Data Revocation List (SMDRL).
@@ -52,7 +52,7 @@ public class SignedMarkRevocationList extends ImmutableObject {
   Long revisionId;
 
   /** Time when this list was last updated, as specified in the first line of the CSV file. */
-  DateTime creationTime;
+  Instant creationTime;
 
   /** A map from SMD IDs to revocation time. */
   @ElementCollection
@@ -61,7 +61,7 @@ public class SignedMarkRevocationList extends ImmutableObject {
       joinColumns = @JoinColumn(name = "revisionId", referencedColumnName = "revisionId"))
   @MapKeyColumn(name = "smdId")
   @Column(name = "revocationTime", nullable = false)
-  Map</*@MatchesPattern("[0-9]+-[0-9]+")*/ String, DateTime> revokes;
+  Map</*@MatchesPattern("[0-9]+-[0-9]+")*/ String, Instant> revokes;
 
   /** A cached supplier that fetches the {@link SignedMarkRevocationList} object. */
   private static final Supplier<SignedMarkRevocationList> CACHE =
@@ -73,7 +73,7 @@ public class SignedMarkRevocationList extends ImmutableObject {
 
   /** Create a new {@link SignedMarkRevocationList} without saving it. */
   public static SignedMarkRevocationList create(
-      DateTime creationTime, ImmutableMap<String, DateTime> revokes) {
+      Instant creationTime, ImmutableMap<String, Instant> revokes) {
     SignedMarkRevocationList instance = new SignedMarkRevocationList();
     instance.creationTime = checkNotNull(creationTime, "creationTime");
     instance.revokes = checkNotNull(revokes, "revokes");
@@ -81,13 +81,13 @@ public class SignedMarkRevocationList extends ImmutableObject {
   }
 
   /** Returns {@code true} if the SMD ID has been revoked at the given point in time. */
-  public boolean isSmdRevoked(String smdId, DateTime now) {
-    DateTime revoked = revokes.get(checkNotNull(smdId, "smdId"));
+  public boolean isSmdRevoked(String smdId, Instant now) {
+    Instant revoked = revokes.get(checkNotNull(smdId, "smdId"));
     return revoked != null && isBeforeOrAt(revoked, now);
   }
 
   /** Returns the creation timestamp specified at the top of the SMDRL CSV file. */
-  public DateTime getCreationTime() {
+  public Instant getCreationTime() {
     return creationTime;
   }
 

--- a/core/src/main/java/google/registry/model/smd/SignedMarkRevocationListDao.java
+++ b/core/src/main/java/google/registry/model/smd/SignedMarkRevocationListDao.java
@@ -15,7 +15,7 @@
 package google.registry.model.smd;
 
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.flogger.FluentLogger;
@@ -41,7 +41,7 @@ public class SignedMarkRevocationListDao {
                       .getResultStream()
                       .findFirst();
                 });
-    return smdrl.orElseGet(() -> SignedMarkRevocationList.create(START_OF_TIME, ImmutableMap.of()));
+    return smdrl.orElseGet(() -> SignedMarkRevocationList.create(START_INSTANT, ImmutableMap.of()));
   }
 
   /**
@@ -51,7 +51,7 @@ public class SignedMarkRevocationListDao {
    * {@code revisionId} are needed.
    */
   public static SignedMarkRevocationList save(SignedMarkRevocationList signedMarkRevocationList) {
-    var persisted =
+    SignedMarkRevocationList persisted =
         tm().transact(
                 () -> {
                   var entity =

--- a/core/src/main/java/google/registry/model/smd/package-info.java
+++ b/core/src/main/java/google/registry/model/smd/package-info.java
@@ -17,10 +17,10 @@
     xmlns = @XmlNs(prefix = "smd", namespaceURI = "urn:ietf:params:xml:ns:signedMark-1.0"),
     elementFormDefault = XmlNsForm.QUALIFIED)
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlJavaTypeAdapter(UtcDateTimeAdapter.class)
+@XmlJavaTypeAdapter(UtcInstantAdapter.class)
 package google.registry.model.smd;
 
-import google.registry.xml.UtcDateTimeAdapter;
+import google.registry.xml.UtcInstantAdapter;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlNs;

--- a/core/src/main/java/google/registry/model/tld/Tld.java
+++ b/core/src/main/java/google/registry/model/tld/Tld.java
@@ -806,7 +806,7 @@ public class Tld extends ImmutableObject implements Buildable, UnsafeSerializabl
         Range.closedOpen(
             periodStart != null ? periodStart : START_INSTANT,
             periodEnd != null ? periodEnd : END_INSTANT);
-    return Fee.createInstant(
+    return Fee.create(
         eapFeeSchedule.getValueAtTime(now).getAmount(),
         FeeType.EAP,
         // An EAP fee does not count as premium -- it's a separate one-time fee, independent of

--- a/core/src/main/java/google/registry/model/tmch/ClaimsList.java
+++ b/core/src/main/java/google/registry/model/tmch/ClaimsList.java
@@ -19,8 +19,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static google.registry.persistence.transaction.QueryComposer.Comparator.EQ;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.util.DateTimeUtils.toDateTime;
-import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.annotations.VisibleForTesting;
@@ -43,7 +41,6 @@ import jakarta.persistence.Transient;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
-import org.joda.time.DateTime;
 
 /**
  * A list of TMCH claims labels and their associated claims keys.
@@ -141,31 +138,14 @@ public class ClaimsList extends ImmutableObject {
    *
    * @see <a href="https://tools.ietf.org/html/draft-lozano-tmch-func-spec-08#section-6.1">DNL List
    *     creation datetime</a>
-   * @deprecated Use {@link #getTmdbGenerationTimeInstant()}
    */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public DateTime getTmdbGenerationTime() {
-    return toDateTime(tmdbGenerationTime);
-  }
-
-  /** Returns the time when the external TMDB service generated this revision of the claims list. */
-  public Instant getTmdbGenerationTimeInstant() {
+  public Instant getTmdbGenerationTime() {
     return tmdbGenerationTime;
   }
 
   /** Returns the creation time of this claims list. */
   public Instant getCreationTime() {
     return creationTimestamp.getTimestamp();
-  }
-
-  /**
-   * @deprecated Use {@link #getCreationTime()}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public DateTime getCreationDateTime() {
-    return toDateTime(creationTimestamp.getTimestamp());
   }
 
   /**
@@ -239,15 +219,5 @@ public class ClaimsList extends ImmutableObject {
     instance.tmdbGenerationTime = checkNotNull(tmdbGenerationTime);
     instance.labelsToKeys = checkNotNull(labelsToKeys);
     return instance;
-  }
-
-  /**
-   * @deprecated Use {@link #create(Instant, ImmutableMap)}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public static ClaimsList create(
-      DateTime tmdbGenerationTime, ImmutableMap<String, String> labelsToKeys) {
-    return create(toInstant(tmdbGenerationTime), labelsToKeys);
   }
 }

--- a/core/src/main/java/google/registry/model/tmch/ClaimsListDao.java
+++ b/core/src/main/java/google/registry/model/tmch/ClaimsListDao.java
@@ -16,7 +16,7 @@ package google.registry.model.tmch;
 
 import static google.registry.config.RegistryConfig.getClaimsListCacheDuration;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
 
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.annotations.VisibleForTesting;
@@ -83,7 +83,7 @@ public class ClaimsListDao {
                     .setMaxResults(1)
                     .getResultStream()
                     .findFirst())
-        .orElse(ClaimsList.create(START_OF_TIME, ImmutableMap.of()));
+        .orElse(ClaimsList.create(START_INSTANT, ImmutableMap.of()));
   }
 
   private ClaimsListDao() {}

--- a/core/src/main/java/google/registry/model/tmch/TmchCrl.java
+++ b/core/src/main/java/google/registry/model/tmch/TmchCrl.java
@@ -19,9 +19,9 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 
 import google.registry.model.common.CrossTldSingleton;
 import jakarta.persistence.Column;
+import java.time.Instant;
 import java.util.Optional;
 import javax.annotation.concurrent.Immutable;
-import org.joda.time.DateTime;
 
 /** Singleton for ICANN's TMCH CA certificate revocation list (CRL). */
 @jakarta.persistence.Entity
@@ -32,7 +32,7 @@ public final class TmchCrl extends CrossTldSingleton {
   String crl;
 
   @Column(name = "updateTimestamp", nullable = false)
-  DateTime updated;
+  Instant updated;
 
   @Column(nullable = false)
   String url;
@@ -53,7 +53,7 @@ public final class TmchCrl extends CrossTldSingleton {
     tm().transact(
             () -> {
               TmchCrl tmchCrl = new TmchCrl();
-              tmchCrl.updated = tm().getTransactionTime();
+              tmchCrl.updated = tm().getTxTime();
               tmchCrl.crl = checkNotNull(crl, "crl");
               tmchCrl.url = checkNotNull(url, "url");
               tm().put(tmchCrl);
@@ -71,7 +71,7 @@ public final class TmchCrl extends CrossTldSingleton {
   }
 
   /** Time we last updated the Database with a newer ICANN CRL. */
-  public DateTime getUpdated() {
+  public Instant getUpdated() {
     return updated;
   }
 }

--- a/core/src/main/java/google/registry/module/ServletBase.java
+++ b/core/src/main/java/google/registry/module/ServletBase.java
@@ -24,6 +24,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.security.Security;
+import java.time.Duration;
 import java.util.concurrent.TimeoutException;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.joda.time.DateTime;
@@ -49,17 +50,14 @@ public class ServletBase extends HttpServlet {
     // credential, etc.), we log the error but keep the main thread running. Also, the shutdown hook
     // will only be registered if the metric reporter starts up correctly.
     try {
-      metricReporter.get().startAsync().awaitRunning(java.time.Duration.ofSeconds(10));
+      metricReporter.get().startAsync().awaitRunning(Duration.ofSeconds(10));
       logger.atInfo().log("Started up MetricReporter.");
       Runtime.getRuntime()
           .addShutdownHook(
               new Thread(
                   () -> {
                     try {
-                      metricReporter
-                          .get()
-                          .stopAsync()
-                          .awaitTerminated(java.time.Duration.ofSeconds(10));
+                      metricReporter.get().stopAsync().awaitTerminated(Duration.ofSeconds(10));
                       logger.atInfo().log("Shut down MetricReporter.");
                     } catch (TimeoutException e) {
                       logger.atSevere().withCause(e).log("Failed to stop MetricReporter.");

--- a/core/src/main/java/google/registry/pricing/PricingEngineProxy.java
+++ b/core/src/main/java/google/registry/pricing/PricingEngineProxy.java
@@ -21,9 +21,9 @@ import static google.registry.util.DomainNameUtils.getTldFromDomainName;
 import google.registry.model.pricing.PremiumPricingEngine;
 import google.registry.model.pricing.PremiumPricingEngine.DomainPrices;
 import google.registry.model.tld.Tld;
+import java.time.Instant;
 import java.util.Map;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 
 /**
  * A global proxy providing static methods for getting premium prices that dispatches requests
@@ -35,19 +35,19 @@ public final class PricingEngineProxy {
       premiumPricingEngines = DaggerPricingComponent.create().premiumPricingEngines();
 
   /** Returns the billing cost for registering the specified domain name for this many years. */
-  public static Money getDomainCreateCost(String domainName, DateTime priceTime, int years) {
+  public static Money getDomainCreateCost(String domainName, Instant priceTime, int years) {
     checkArgument(years > 0, "Number of years must be positive");
     return getPricesForDomainName(domainName, priceTime).getCreateCost().multipliedBy(years);
   }
 
   /** Returns the billing cost for renewing the specified domain name for this many years. */
-  public static Money getDomainRenewCost(String domainName, DateTime priceTime, int years) {
+  public static Money getDomainRenewCost(String domainName, Instant priceTime, int years) {
     checkArgument(years > 0, "Number of years must be positive");
     return getPricesForDomainName(domainName, priceTime).getRenewCost().multipliedBy(years);
   }
 
   /** Returns true if the specified domain name is premium. */
-  public static boolean isDomainPremium(String domainName, DateTime priceTime) {
+  public static boolean isDomainPremium(String domainName, Instant priceTime) {
     return getPricesForDomainName(domainName, priceTime).isPremium();
   }
 
@@ -56,7 +56,7 @@ public final class PricingEngineProxy {
    * appropriate {@link PremiumPricingEngine} based on what is configured for the TLD that the
    * domain is under.
    */
-  public static DomainPrices getPricesForDomainName(String domainName, DateTime priceTime) {
+  public static DomainPrices getPricesForDomainName(String domainName, Instant priceTime) {
     String tld = getTldFromDomainName(domainName);
     String clazz = Tld.get(tld).getPricingEngineClassName();
     PremiumPricingEngine engine = premiumPricingEngines.get(clazz);

--- a/core/src/main/java/google/registry/pricing/PricingEngineProxy.java
+++ b/core/src/main/java/google/registry/pricing/PricingEngineProxy.java
@@ -23,7 +23,7 @@ import google.registry.model.pricing.PremiumPricingEngine.DomainPrices;
 import google.registry.model.tld.Tld;
 import java.util.Map;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
+import java.time.Instant;
 
 /**
  * A global proxy providing static methods for getting premium prices that dispatches requests
@@ -35,19 +35,19 @@ public final class PricingEngineProxy {
       premiumPricingEngines = DaggerPricingComponent.create().premiumPricingEngines();
 
   /** Returns the billing cost for registering the specified domain name for this many years. */
-  public static Money getDomainCreateCost(String domainName, DateTime priceTime, int years) {
+  public static Money getDomainCreateCost(String domainName, Instant priceTime, int years) {
     checkArgument(years > 0, "Number of years must be positive");
     return getPricesForDomainName(domainName, priceTime).getCreateCost().multipliedBy(years);
   }
 
   /** Returns the billing cost for renewing the specified domain name for this many years. */
-  public static Money getDomainRenewCost(String domainName, DateTime priceTime, int years) {
+  public static Money getDomainRenewCost(String domainName, Instant priceTime, int years) {
     checkArgument(years > 0, "Number of years must be positive");
     return getPricesForDomainName(domainName, priceTime).getRenewCost().multipliedBy(years);
   }
 
   /** Returns true if the specified domain name is premium. */
-  public static boolean isDomainPremium(String domainName, DateTime priceTime) {
+  public static boolean isDomainPremium(String domainName, Instant priceTime) {
     return getPricesForDomainName(domainName, priceTime).isPremium();
   }
 
@@ -56,7 +56,7 @@ public final class PricingEngineProxy {
    * appropriate {@link PremiumPricingEngine} based on what is configured for the TLD that the
    * domain is under.
    */
-  public static DomainPrices getPricesForDomainName(String domainName, DateTime priceTime) {
+  public static DomainPrices getPricesForDomainName(String domainName, Instant priceTime) {
     String tld = getTldFromDomainName(domainName);
     String clazz = Tld.get(tld).getPricingEngineClassName();
     PremiumPricingEngine engine = premiumPricingEngines.get(clazz);

--- a/core/src/main/java/google/registry/tmch/ClaimsListParser.java
+++ b/core/src/main/java/google/registry/tmch/ClaimsListParser.java
@@ -18,15 +18,16 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.tmch.ClaimsList;
 import java.io.IOException;
 import java.io.StringReader;
+import java.time.Instant;
 import java.util.List;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
-import org.joda.time.DateTime;
 
 /**
  * Claims List (MarksDB DNL CSV) Parser.
@@ -35,6 +36,9 @@ import org.joda.time.DateTime;
  *     TMCH functional specifications - DNL List file</a>
  */
 public class ClaimsListParser {
+
+  private static final ImmutableList<String> EXPECTED_CSV_HEADERS =
+      ImmutableList.of("DNL", "lookup-key", "insertion-datetime");
 
   /**
    * Converts the lines from the DNL CSV file into a {@link ClaimsList} object.
@@ -50,7 +54,7 @@ public class ClaimsListParser {
         "Line 1: Expected 2 elements, found %d", firstLine.size()));
 
     int version = Integer.parseInt(firstLine.get(0));
-    DateTime creationTime = DateTime.parse(firstLine.get(1));
+    Instant creationTime = Instant.parse(firstLine.get(1));
     checkArgument(version == 1, String.format(
         "Line 1: Expected version 1, found %d", version));
 
@@ -61,9 +65,18 @@ public class ClaimsListParser {
             .setSkipHeaderRecord(true)
             .build()
             .parse(new StringReader(Joiner.on('\n').join(lines.subList(1, lines.size()))));
+
+    checkArgument(
+        csv.getHeaderNames().equals(EXPECTED_CSV_HEADERS),
+        "Expected CSV headers %s, found %s",
+        EXPECTED_CSV_HEADERS,
+        csv.getHeaderNames());
+
     for (CSVRecord record : csv) {
+      checkArgument(record.isConsistent(), "Inconsistent number of fields in record");
       String label = record.get("DNL");
       String lookupKey = record.get("lookup-key");
+      Instant.parse(record.get("insertion-datetime")); // Validate the format
       builder.put(label, lookupKey);
     }
 

--- a/core/src/main/java/google/registry/tmch/ClaimsListParser.java
+++ b/core/src/main/java/google/registry/tmch/ClaimsListParser.java
@@ -18,15 +18,16 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.tmch.ClaimsList;
 import java.io.IOException;
 import java.io.StringReader;
+import java.time.Instant;
 import java.util.List;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
-import org.joda.time.DateTime;
 
 /**
  * Claims List (MarksDB DNL CSV) Parser.
@@ -35,6 +36,9 @@ import org.joda.time.DateTime;
  *     TMCH functional specifications - DNL List file</a>
  */
 public class ClaimsListParser {
+
+  private static final ImmutableList<String> EXPECTED_CSV_HEADERS =
+      ImmutableList.of("DNL", "lookup-key", "insertion-datetime");
 
   /**
    * Converts the lines from the DNL CSV file into a {@link ClaimsList} object.
@@ -50,7 +54,7 @@ public class ClaimsListParser {
         "Line 1: Expected 2 elements, found %d", firstLine.size()));
 
     int version = Integer.parseInt(firstLine.get(0));
-    DateTime creationTime = DateTime.parse(firstLine.get(1));
+    Instant creationTime = Instant.parse(firstLine.get(1));
     checkArgument(version == 1, String.format(
         "Line 1: Expected version 1, found %d", version));
 
@@ -61,9 +65,17 @@ public class ClaimsListParser {
             .setSkipHeaderRecord(true)
             .build()
             .parse(new StringReader(Joiner.on('\n').join(lines.subList(1, lines.size()))));
+
+    checkArgument(
+        csv.getHeaderNames().equals(EXPECTED_CSV_HEADERS),
+        String.format(
+            "Expected CSV headers %s, found %s", EXPECTED_CSV_HEADERS, csv.getHeaderNames()));
+
     for (CSVRecord record : csv) {
+      checkArgument(record.isConsistent(), "Inconsistent number of fields in record");
       String label = record.get("DNL");
       String lookupKey = record.get("lookup-key");
+      Instant.parse(record.get("insertion-datetime")); // Validate the format
       builder.put(label, lookupKey);
     }
 

--- a/core/src/main/java/google/registry/tmch/SmdrlCsvParser.java
+++ b/core/src/main/java/google/registry/tmch/SmdrlCsvParser.java
@@ -15,7 +15,6 @@
 package google.registry.tmch;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static org.joda.time.DateTimeZone.UTC;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -23,11 +22,11 @@ import com.google.common.collect.ImmutableMap;
 import google.registry.model.smd.SignedMarkRevocationList;
 import java.io.IOException;
 import java.io.StringReader;
+import java.time.Instant;
 import java.util.List;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
-import org.joda.time.DateTime;
 
 /**
  * Signed Mark Data Revocation List (SMDRL) CSV Parser
@@ -39,7 +38,7 @@ public final class SmdrlCsvParser {
 
   /** Converts the lines from the DNL CSV file into a data structure. */
   public static SignedMarkRevocationList parse(List<String> lines) throws IOException {
-    ImmutableMap.Builder<String, DateTime> revokes = new ImmutableMap.Builder<>();
+    ImmutableMap.Builder<String, Instant> revokes = new ImmutableMap.Builder<>();
 
     // First line: <version>,<SMD Revocation List creation datetime>
     List<String> firstLine = Splitter.on(',').splitToList(lines.get(0));
@@ -48,7 +47,7 @@ public final class SmdrlCsvParser {
         String.format("Line 1: Expected 2 elements, found %d", firstLine.size()));
     int version = Integer.parseInt(firstLine.get(0));
     checkArgument(version == 1, String.format("Line 1: Expected version 1, found %d", version));
-    DateTime creationTime = DateTime.parse(firstLine.get(1)).withZone(UTC);
+    Instant creationTime = Instant.parse(firstLine.get(1));
 
     // Note: we have to skip the first line because it contains the version metadata
     CSVParser csv =
@@ -60,7 +59,7 @@ public final class SmdrlCsvParser {
 
     for (CSVRecord record : csv) {
       String smdId = record.get("smd-id");
-      DateTime revokedTime = DateTime.parse(record.get("insertion-datetime"));
+      Instant revokedTime = Instant.parse(record.get("insertion-datetime"));
       revokes.put(smdId, revokedTime);
     }
     return SignedMarkRevocationList.create(creationTime, revokes.build());

--- a/core/src/main/java/google/registry/tools/CreateAnchorTenantCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateAnchorTenantCommand.java
@@ -84,7 +84,7 @@ final class CreateAnchorTenantCommand extends MutatingEppToolCommand {
 
     Money cost = null;
     if (fee) {
-      cost = getDomainCreateCost(domainName, clock.nowUtc(), DEFAULT_ANCHOR_TENANT_PERIOD_YEARS);
+      cost = getDomainCreateCost(domainName, clock.now(), DEFAULT_ANCHOR_TENANT_PERIOD_YEARS);
     }
 
     setSoyTemplate(CreateAnchorTenantSoyInfo.getInstance(),

--- a/core/src/main/java/google/registry/tools/CreateDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateDomainCommand.java
@@ -62,7 +62,7 @@ final class CreateDomainCommand extends CreateOrUpdateDomainCommand {
     for (String domain : domains) {
       String currency = null;
       String cost = null;
-      DomainPrices prices = getPricesForDomainName(domain, clock.nowUtc());
+      DomainPrices prices = getPricesForDomainName(domain, clock.now());
 
       // Check if the domain is premium and set the fee on the create command if so.
       if (prices.isPremium()) {

--- a/core/src/main/java/google/registry/tools/GetHistoryEntriesCommand.java
+++ b/core/src/main/java/google/registry/tools/GetHistoryEntriesCommand.java
@@ -17,7 +17,6 @@ package google.registry.tools;
 import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.util.DateTimeUtils.END_INSTANT;
 import static google.registry.util.DateTimeUtils.START_INSTANT;
-import static google.registry.util.DateTimeUtils.toDateTime;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
@@ -65,7 +64,7 @@ final class GetHistoryEntriesCommand implements Command {
       checkArgument(
           type != null && uniqueId != null,
           "If either of 'type' or 'id' are set then both must be");
-      VKey<? extends EppResource> parentKey = type.getKey(uniqueId, toDateTime(clock.now()));
+      VKey<? extends EppResource> parentKey = type.getKey(uniqueId, clock.nowUtc());
       historyEntries = HistoryEntryDao.loadHistoryObjectsForResource(parentKey, after, before);
     } else {
       historyEntries = HistoryEntryDao.loadAllHistoryObjects(after, before);

--- a/core/src/test/java/google/registry/batch/DeleteProberDataActionTest.java
+++ b/core/src/test/java/google/registry/batch/DeleteProberDataActionTest.java
@@ -28,7 +28,6 @@ import static google.registry.testing.DatabaseHelper.persistDomainAsDeleted;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.END_INSTANT;
 import static google.registry.util.DateTimeUtils.minusYears;
-import static google.registry.util.DateTimeUtils.toDateTime;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableSet;
@@ -49,6 +48,7 @@ import google.registry.testing.DatabaseHelper;
 import google.registry.testing.FakeClock;
 import google.registry.testing.SystemPropertyExtension;
 import google.registry.util.RegistryEnvironment;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.Set;
@@ -238,7 +238,7 @@ class DeleteProberDataActionTest {
     persistResource(
         DatabaseHelper.newDomain("blah.ib-any.test")
             .asBuilder()
-            .setCreationTimeForTest(clock.now().minus(java.time.Duration.ofSeconds(1)))
+            .setCreationTimeForTest(clock.now().minus(Duration.ofSeconds(1)))
             .build());
     action.run();
     Optional<Domain> domain =
@@ -263,15 +263,14 @@ class DeleteProberDataActionTest {
   @Test
   void test_domainWithSubordinateHosts_isSkipped() throws Exception {
     persistActiveHost("ns1.blah.ib-any.test");
-    Domain nakedDomain =
-        persistDeletedDomain("todelete.ib-any.test", toDateTime(minusYears(clock.now(), 1)));
+    Domain nakedDomain = persistDeletedDomain("todelete.ib-any.test", clock.nowUtc().minusYears(1));
     Domain domainWithSubord =
         persistDomainAsDeleted(
             DatabaseHelper.newDomain("blah.ib-any.test")
                 .asBuilder()
                 .setSubordinateHosts(ImmutableSet.of("ns1.blah.ib-any.test"))
                 .build(),
-            toDateTime(minusYears(clock.now(), 1)));
+            clock.nowUtc().minusYears(1));
     action.run();
 
     assertAllExist(ImmutableSet.of(domainWithSubord));

--- a/core/src/test/java/google/registry/bsa/BsaValidateActionTest.java
+++ b/core/src/test/java/google/registry/bsa/BsaValidateActionTest.java
@@ -25,8 +25,7 @@ import static google.registry.bsa.persistence.BsaTestingUtils.persistUnblockable
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.util.DateTimeUtils.START_INSTANT;
-import static google.registry.util.DateTimeUtils.toDateTime;
+import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.startsWith;
@@ -238,7 +237,7 @@ public class BsaValidateActionTest {
   @Test
   void isStalenessAllowed_newDomain_allowed() {
     persistBsaLabel("label");
-    Domain domain = persistActiveDomain("label.app", toDateTime(fakeClock.now()));
+    Domain domain = persistActiveDomain("label.app", fakeClock.nowUtc());
     fakeClock.advanceBy(
         org.joda.time.Duration.millis(MAX_STALENESS.minus(Duration.ofSeconds(1)).toMillis()));
     assertThat(action.isStalenessAllowed(domain)).isTrue();
@@ -247,7 +246,7 @@ public class BsaValidateActionTest {
   @Test
   void isStalenessAllowed_newDomain_notAllowed() {
     persistBsaLabel("label");
-    Domain domain = persistActiveDomain("label.app", toDateTime(fakeClock.now()));
+    Domain domain = persistActiveDomain("label.app", fakeClock.nowUtc());
     fakeClock.advanceBy(org.joda.time.Duration.millis(MAX_STALENESS.toMillis()));
     assertThat(action.isStalenessAllowed(domain)).isFalse();
   }
@@ -278,15 +277,9 @@ public class BsaValidateActionTest {
   @Test
   void checkForMissingReservedUnblockables_success() {
     persistResource(
-        createTld("app")
-            .asBuilder()
-            .setBsaEnrollStartTime(Optional.of(toDateTime(START_INSTANT)))
-            .build());
+        createTld("app").asBuilder().setBsaEnrollStartTime(Optional.of(START_OF_TIME)).build());
     persistResource(
-        createTld("dev")
-            .asBuilder()
-            .setBsaEnrollStartTime(Optional.of(toDateTime(START_INSTANT)))
-            .build());
+        createTld("dev").asBuilder().setBsaEnrollStartTime(Optional.of(START_OF_TIME)).build());
     persistBsaLabel("registered-reserved");
     persistBsaLabel("reserved-only");
     persistBsaLabel("reserved-missing");
@@ -310,15 +303,9 @@ public class BsaValidateActionTest {
   @Test
   void checkForMissingReservedUnblockablesInOneTld_success() {
     persistResource(
-        createTld("app")
-            .asBuilder()
-            .setBsaEnrollStartTime(Optional.of(toDateTime(START_INSTANT)))
-            .build());
+        createTld("app").asBuilder().setBsaEnrollStartTime(Optional.of(START_OF_TIME)).build());
     persistResource(
-        createTld("dev")
-            .asBuilder()
-            .setBsaEnrollStartTime(Optional.of(toDateTime(START_INSTANT)))
-            .build());
+        createTld("dev").asBuilder().setBsaEnrollStartTime(Optional.of(START_OF_TIME)).build());
     persistBsaLabel("reserved-missing-in-app");
     persistUnblockableDomain(
         UnblockableDomain.of("reserved-missing-in-app", "dev", Reason.REGISTERED));
@@ -338,10 +325,7 @@ public class BsaValidateActionTest {
   @Test
   void checkForMissingReservedUnblockables_unblockedReservedNotReported() {
     persistResource(
-        createTld("app")
-            .asBuilder()
-            .setBsaEnrollStartTime(Optional.of(toDateTime(START_INSTANT)))
-            .build());
+        createTld("app").asBuilder().setBsaEnrollStartTime(Optional.of(START_OF_TIME)).build());
 
     createReservedList(
         "rl",
@@ -356,10 +340,7 @@ public class BsaValidateActionTest {
   @Test
   void checkForMissingRegisteredUnblockables_success() {
     persistResource(
-        createTld("app")
-            .asBuilder()
-            .setBsaEnrollStartTime(Optional.of(toDateTime(START_INSTANT)))
-            .build());
+        createTld("app").asBuilder().setBsaEnrollStartTime(Optional.of(START_OF_TIME)).build());
     persistBsaLabel("registered");
     persistBsaLabel("registered-missing");
     persistUnblockableDomain(UnblockableDomain.of("registered", "app", Reason.REGISTERED));

--- a/core/src/test/java/google/registry/bsa/persistence/QueriesTest.java
+++ b/core/src/test/java/google/registry/bsa/persistence/QueriesTest.java
@@ -44,6 +44,7 @@ import google.registry.bsa.persistence.Queries.DomainLifeSpan;
 import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationWithCoverageExtension;
 import google.registry.testing.FakeClock;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -208,14 +209,14 @@ class QueriesTest {
     createTlds("tld");
     persistNewRegistrar("TheRegistrar");
     // time 0:
-    persistActiveDomain("d1.tld", toDateTime(fakeClock.now()));
+    persistActiveDomain("d1.tld", fakeClock.nowUtc());
     // time 0, deletion time 1
     persistDomainAsDeleted(
         newDomain("will-delete.tld").asBuilder().setCreationTimeForTest(fakeClock.now()).build(),
-        toDateTime(fakeClock.now().plusMillis(1)));
+        fakeClock.now().plusMillis(1));
     fakeClock.advanceOneMilli();
     // time 1
-    persistActiveDomain("d2.tld", toDateTime(fakeClock.now()));
+    persistActiveDomain("d2.tld", fakeClock.nowUtc());
     fakeClock.advanceOneMilli();
     // Now is time 2
     assertThat(
@@ -232,14 +233,14 @@ class QueriesTest {
     createTlds("tld");
     persistNewRegistrar("TheRegistrar");
     // time 0:
-    persistActiveDomain("d1.tld", toDateTime(fakeClock.now()));
+    persistActiveDomain("d1.tld", fakeClock.nowUtc());
     // time 0, deletion time 1
     persistDomainAsDeleted(
         newDomain("will-delete.tld").asBuilder().setCreationTimeForTest(fakeClock.now()).build(),
-        toDateTime(fakeClock.now().plusMillis(1)));
+        fakeClock.now().plusMillis(1));
     fakeClock.advanceOneMilli();
     // time 1
-    persistActiveDomain("d2.tld", toDateTime(fakeClock.now()));
+    persistActiveDomain("d2.tld", fakeClock.nowUtc());
     fakeClock.advanceOneMilli();
     // Now is time 2, ask for domains created since time 1
     assertThat(
@@ -255,8 +256,8 @@ class QueriesTest {
     Instant testStartTime = fakeClock.now();
     createTlds("tld", "tld2");
     persistNewRegistrar("TheRegistrar");
-    persistActiveDomain("d1.tld", toDateTime(fakeClock.now()));
-    persistActiveDomain("d2.tld2", toDateTime(fakeClock.now()));
+    persistActiveDomain("d1.tld", fakeClock.nowUtc());
+    persistActiveDomain("d2.tld2", fakeClock.nowUtc());
     fakeClock.advanceOneMilli();
     assertThat(
             bsaQuery(
@@ -271,19 +272,19 @@ class QueriesTest {
     createTlds("tld", "tld2");
     persistNewRegistrar("TheRegistrar");
     Instant time1 = fakeClock.now();
-    persistActiveDomain("unblocked1.tld", toDateTime(fakeClock.now()));
-    persistActiveDomain("unblocked2.tld2", toDateTime(fakeClock.now()));
-    persistActiveDomain("label1.tld", toDateTime(fakeClock.now()));
-    persistActiveDomain("label2.tld2", toDateTime(fakeClock.now()));
+    persistActiveDomain("unblocked1.tld", fakeClock.nowUtc());
+    persistActiveDomain("unblocked2.tld2", fakeClock.nowUtc());
+    persistActiveDomain("label1.tld", fakeClock.nowUtc());
+    persistActiveDomain("label2.tld2", fakeClock.nowUtc());
     fakeClock.advanceOneMilli();
     Instant time2 = fakeClock.now();
     persistDomainAsDeleted(
         newDomain("label3.tld").asBuilder().setCreationTimeForTest(fakeClock.now()).build(),
-        toDateTime(fakeClock.now().plusMillis(1)));
+        fakeClock.now().plusMillis(1));
     // Deleted in the future
     persistDomainAsDeleted(
         newDomain("label3.tld2").asBuilder().setCreationTimeForTest(fakeClock.now()).build(),
-        toDateTime(fakeClock.now().plus(java.time.Duration.ofHours(1))));
+        toDateTime(fakeClock.now().plus(Duration.ofHours(1))));
     fakeClock.advanceOneMilli();
     assertThat(
             (ImmutableList<DomainLifeSpan>)
@@ -294,7 +295,7 @@ class QueriesTest {
                 bsaQuery(() -> queryMissedRegisteredUnblockables("tld2", fakeClock.now())))
         .containsExactly(
             new DomainLifeSpan("label2.tld2", time1, END_INSTANT),
-            new DomainLifeSpan("label3.tld2", time2, time2.plus(java.time.Duration.ofHours(1))));
+            new DomainLifeSpan("label3.tld2", time2, time2.plus(Duration.ofHours(1))));
 
     BsaTestingUtils.persistUnblockableDomain(
         UnblockableDomain.of("label2", "tld2", UnblockableDomain.Reason.REGISTERED));
@@ -303,8 +304,7 @@ class QueriesTest {
     assertThat(
             (ImmutableList<DomainLifeSpan>)
                 bsaQuery(() -> queryMissedRegisteredUnblockables("tld2", fakeClock.now())))
-        .containsExactly(
-            new DomainLifeSpan("label3.tld2", time2, time2.plus(java.time.Duration.ofHours(1))));
+        .containsExactly(new DomainLifeSpan("label3.tld2", time2, time2.plus(Duration.ofHours(1))));
   }
 
   @Test

--- a/core/src/test/java/google/registry/flows/ResourceFlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/ResourceFlowTestCase.java
@@ -101,7 +101,7 @@ public abstract class ResourceFlowTestCase<F extends Flow, R extends EppResource
 
   /** Persists a testing claims list to Cloud SQL. */
   protected void persistClaimsList(ImmutableMap<String, String> labelsToKeys) {
-    ClaimsListDao.save(ClaimsList.create(clock.nowUtc(), labelsToKeys));
+    ClaimsListDao.save(ClaimsList.create(clock.now(), labelsToKeys));
   }
 
   protected void assertClientIdFieldLogged(String registrarId) {

--- a/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
@@ -37,7 +37,9 @@ import static google.registry.testing.DatabaseHelper.persistPremiumList;
 import static google.registry.testing.DatabaseHelper.persistReservedList;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
-import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
+import static google.registry.util.DateTimeUtils.minusDays;
+import static google.registry.util.DateTimeUtils.plusDays;
 import static org.joda.money.CurrencyUnit.JPY;
 import static org.joda.money.CurrencyUnit.USD;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -93,9 +95,9 @@ import google.registry.model.tld.Tld.TldState;
 import google.registry.model.tld.label.ReservedList;
 import google.registry.testing.DatabaseHelper;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.Optional;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -105,7 +107,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
 
   DomainCheckFlowTest() {
     setEppInput("domain_check_one_tld.xml");
-    clock.setTo(DateTime.parse("2009-01-01T10:00:00Z"));
+    clock.setTo(Instant.parse("2009-01-01T10:00:00Z"));
   }
 
   static ReservedList createReservedList() {
@@ -158,7 +160,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
   @Test
   void testSuccess_bsaBlocked_otherwiseAvailable_blocked() throws Exception {
     persistResource(
-        Tld.get("tld").asBuilder().setBsaEnrollStartTime(Optional.of(START_OF_TIME)).build());
+        Tld.get("tld")
+            .asBuilder()
+            .setBsaEnrollStartTimeInstant(Optional.of(START_INSTANT))
+            .build());
     persistBsaLabel("example1");
     doCheckTest(
         create(false, "example1.tld", "Blocked by a GlobalBlock service"),
@@ -169,7 +174,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
   @Test
   void testSuccess_bsaBlocked_alsoRegistered_registered() throws Exception {
     persistResource(
-        Tld.get("tld").asBuilder().setBsaEnrollStartTime(Optional.of(START_OF_TIME)).build());
+        Tld.get("tld")
+            .asBuilder()
+            .setBsaEnrollStartTimeInstant(Optional.of(START_INSTANT))
+            .build());
     persistBsaLabel("example1");
     persistActiveDomain("example1.tld");
     doCheckTest(
@@ -181,7 +189,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
   @Test
   void testSuccess_bsaBlocked_alsoReserved_reserved() throws Exception {
     persistResource(
-        Tld.get("tld").asBuilder().setBsaEnrollStartTime(Optional.of(START_OF_TIME)).build());
+        Tld.get("tld")
+            .asBuilder()
+            .setBsaEnrollStartTimeInstant(Optional.of(START_INSTANT))
+            .build());
     persistBsaLabel("reserved");
     persistBsaLabel("allowedinsunrise");
     setEppInput("domain_check_one_tld_reserved.xml");
@@ -195,7 +206,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
   @Test
   void testSuccess_bsaBlocked_createAllowedWithToken() throws Exception {
     persistResource(
-        Tld.get("tld").asBuilder().setBsaEnrollStartTime(Optional.of(START_OF_TIME)).build());
+        Tld.get("tld")
+            .asBuilder()
+            .setBsaEnrollStartTimeInstant(Optional.of(START_INSTANT))
+            .build());
     persistBsaLabel("example1");
     setEppInput("domain_check_allocationtoken.xml");
     persistResource(
@@ -214,7 +228,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
   @Test
   void testSuccess_bsaBlocked_withIrrelevantTokenType() throws Exception {
     persistResource(
-        Tld.get("tld").asBuilder().setBsaEnrollStartTime(Optional.of(START_OF_TIME)).build());
+        Tld.get("tld")
+            .asBuilder()
+            .setBsaEnrollStartTimeInstant(Optional.of(START_INSTANT))
+            .build());
     persistBsaLabel("example1");
     setEppInput("domain_check_allocationtoken.xml");
     persistResource(
@@ -235,7 +252,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
     setEppInput("domain_check.xml");
     createTlds("com", "net", "org");
     persistResource(
-        Tld.get("com").asBuilder().setBsaEnrollStartTime(Optional.of(START_OF_TIME)).build());
+        Tld.get("com")
+            .asBuilder()
+            .setBsaEnrollStartTimeInstant(Optional.of(START_INSTANT))
+            .build());
     persistBsaLabel("example");
     doCheckTest(
         create(false, "example.com", "Blocked by a GlobalBlock service"),
@@ -326,11 +346,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setToken("abc123")
             .setTokenType(SINGLE_USE)
             .setDomainName("specificuse.tld")
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     doCheckTest(
@@ -350,11 +370,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE))
             .setDiscountFraction(0.5)
             .setDiscountYears(2)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_stdv1.xml");
@@ -373,11 +393,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountFraction(0.5)
             .setDiscountYears(2)
             .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE))
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_stdv1.xml");
@@ -395,11 +415,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountFraction(0.9)
             .setDiscountYears(3)
             .setDiscountPremiums(true)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput(
@@ -453,11 +473,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setToken("abc123")
             .setTokenType(SINGLE_USE)
             .setDomainName("specificuse.tld")
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(2), TokenStatus.VALID)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 2), TokenStatus.VALID)
+                    .put(minusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     doCheckTest(
@@ -515,11 +535,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDomainName("single.tld")
             .setDiscountFraction(0.444)
             .setDiscountYears(2)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput(
@@ -548,11 +568,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setToken("abc123")
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(60), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(plusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 60), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_stdv1.xml");
@@ -572,11 +592,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setAllowedTlds(ImmutableSet.of("example"))
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_stdv1.xml");
@@ -596,11 +616,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setAllowedRegistrarIds(ImmutableSet.of("someOtherClient"))
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_stdv1.xml");
@@ -781,11 +801,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
         Tld.get("tld")
             .asBuilder()
             .setCurrency(JPY)
-            .setCreateBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.ofMajor(JPY, 800)))
-            .setEapFeeSchedule(ImmutableSortedMap.of(START_OF_TIME, Money.ofMajor(JPY, 800)))
-            .setRenewBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.ofMajor(JPY, 800)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.ofMajor(JPY, 800)))
+            .setEapFeeScheduleInstant(ImmutableSortedMap.of(START_INSTANT, Money.ofMajor(JPY, 800)))
+            .setRenewBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.ofMajor(JPY, 800)))
             .setRegistryLockOrUnlockBillingCost(Money.ofMajor(JPY, 800))
             .setServerStatusChangeBillingCost(Money.ofMajor(JPY, 800))
             .setRestoreBillingCost(Money.ofMajor(JPY, 800))
@@ -1027,8 +1047,8 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setCreateBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.of(USD, 11.1)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.of(USD, 11.1)))
             .build());
     setEppInput("domain_check_fee_fractional_stdv1.xml");
     runFlowAssertResponse(loadFile("domain_check_fee_fractional_response_stdv1.xml"));
@@ -1130,11 +1150,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
         createTld("example")
             .asBuilder()
             .setCurrency(JPY)
-            .setCreateBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.ofMajor(JPY, 800)))
-            .setEapFeeSchedule(ImmutableSortedMap.of(START_OF_TIME, Money.ofMajor(JPY, 800)))
-            .setRenewBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.ofMajor(JPY, 800)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.ofMajor(JPY, 800)))
+            .setEapFeeScheduleInstant(ImmutableSortedMap.of(START_INSTANT, Money.ofMajor(JPY, 800)))
+            .setRenewBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.ofMajor(JPY, 800)))
             .setRegistryLockOrUnlockBillingCost(Money.ofMajor(JPY, 800))
             .setServerStatusChangeBillingCost(Money.ofMajor(JPY, 800))
             .setRestoreBillingCost(Money.ofMajor(JPY, 800))
@@ -1198,11 +1218,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
     persistResource(
         setUpDefaultToken("NewRegistrar")
             .asBuilder()
-            .setTokenStatusTransitions(
+            .setTokenStatusTransitionsInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     TokenStatus.NOT_STARTED,
-                    clock.nowUtc().plusDays(1),
+                    plusDays(clock.now(), 1),
                     TokenStatus.VALID))
             .build());
 
@@ -1303,16 +1323,16 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
   void testFeeExtension_premium_eap_v06() throws Exception {
     createTld("example");
     setEppInput("domain_check_fee_premium_v06.xml");
-    clock.setTo(DateTime.parse("2010-01-01T10:00:00Z"));
+    clock.setTo(Instant.parse("2010-01-01T10:00:00Z"));
     persistResource(
         Tld.get("example")
             .asBuilder()
-            .setEapFeeSchedule(
-                new ImmutableSortedMap.Builder<DateTime, Money>(Ordering.natural())
-                    .put(START_OF_TIME, Money.of(USD, 0))
-                    .put(clock.nowUtc().minusDays(1), Money.of(USD, 100))
-                    .put(clock.nowUtc().plusDays(1), Money.of(USD, 50))
-                    .put(clock.nowUtc().plusDays(2), Money.of(USD, 0))
+            .setEapFeeScheduleInstant(
+                new ImmutableSortedMap.Builder<Instant, Money>(Ordering.natural())
+                    .put(START_INSTANT, Money.of(USD, 0))
+                    .put(minusDays(clock.now(), 1), Money.of(USD, 100))
+                    .put(plusDays(clock.now(), 1), Money.of(USD, 50))
+                    .put(plusDays(clock.now(), 2), Money.of(USD, 0))
                     .build())
             .build());
 
@@ -1322,13 +1342,13 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
   @Test
   void testFeeExtension_premium_eap_v06_withRenewalOnRestore() throws Exception {
     createTld("example");
-    DateTime startTime = DateTime.parse("2010-01-01T10:00:00Z");
+    Instant startTime = Instant.parse("2010-01-01T10:00:00Z");
     clock.setTo(startTime);
     persistResource(
         persistActiveDomain("rich.example")
             .asBuilder()
-            .setDeletionTime(clock.nowUtc().plusDays(25))
-            .setRegistrationExpirationTime(clock.nowUtc().minusDays(1))
+            .setDeletionTime(plusDays(clock.now(), 25))
+            .setRegistrationExpirationTime(minusDays(clock.now(), 1))
             .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
             .build());
     persistPendingDeleteDomain("rich.example");
@@ -1336,12 +1356,12 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
     persistResource(
         Tld.get("example")
             .asBuilder()
-            .setEapFeeSchedule(
-                new ImmutableSortedMap.Builder<DateTime, Money>(Ordering.natural())
-                    .put(START_OF_TIME, Money.of(USD, 0))
-                    .put(startTime.minusDays(1), Money.of(USD, 100))
-                    .put(startTime.plusDays(1), Money.of(USD, 50))
-                    .put(startTime.plusDays(2), Money.of(USD, 0))
+            .setEapFeeScheduleInstant(
+                new ImmutableSortedMap.Builder<Instant, Money>(Ordering.natural())
+                    .put(START_INSTANT, Money.of(USD, 0))
+                    .put(minusDays(startTime, 1), Money.of(USD, 100))
+                    .put(plusDays(startTime, 1), Money.of(USD, 50))
+                    .put(plusDays(startTime, 2), Money.of(USD, 0))
                     .build())
             .build());
     runFlowAssertResponse(loadFile("domain_check_fee_premium_eap_response_v06_with_renewal.xml"));
@@ -2053,11 +2073,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
         createTld("example")
             .asBuilder()
             .setCurrency(JPY)
-            .setCreateBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.ofMajor(JPY, 800)))
-            .setEapFeeSchedule(ImmutableSortedMap.of(START_OF_TIME, Money.ofMajor(JPY, 800)))
-            .setRenewBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.ofMajor(JPY, 800)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.ofMajor(JPY, 800)))
+            .setEapFeeScheduleInstant(ImmutableSortedMap.of(START_INSTANT, Money.ofMajor(JPY, 800)))
+            .setRenewBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.ofMajor(JPY, 800)))
             .setRegistryLockOrUnlockBillingCost(Money.ofMajor(JPY, 800))
             .setServerStatusChangeBillingCost(Money.ofMajor(JPY, 800))
             .setRestoreBillingCost(Money.ofMajor(JPY, 800))
@@ -2097,11 +2117,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
     persistResource(
         setUpDefaultToken("NewRegistrar")
             .asBuilder()
-            .setTokenStatusTransitions(
+            .setTokenStatusTransitionsInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     TokenStatus.NOT_STARTED,
-                    clock.nowUtc().plusDays(1),
+                    plusDays(clock.now(), 1),
                     TokenStatus.VALID))
             .build());
 
@@ -2117,8 +2137,8 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setCreateBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.of(USD, 11.1)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.of(USD, 11.1)))
             .build());
     setEppInput("domain_check_fee_fractional_v06.xml");
     runFlowAssertResponse(loadFile("domain_check_fee_fractional_response_v06.xml"));
@@ -2136,11 +2156,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountFraction(0.5)
             .setDiscountYears(2)
             .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE))
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_v06.xml");
@@ -2170,11 +2190,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDomainName("single.tld")
             .setDiscountFraction(0.444)
             .setDiscountYears(2)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput(
@@ -2205,11 +2225,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountFraction(0.9)
             .setDiscountYears(3)
             .setDiscountPremiums(true)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput(
@@ -2254,11 +2274,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setToken("abc123")
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(60), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(plusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 60), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_v06.xml");
@@ -2283,11 +2303,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE))
             .setDiscountFraction(0.5)
             .setDiscountYears(2)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_v06.xml");
@@ -2303,11 +2323,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setAllowedTlds(ImmutableSet.of("example"))
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_v06.xml");
@@ -2331,11 +2351,11 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setAllowedRegistrarIds(ImmutableSet.of("someOtherClient"))
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_v06.xml");
@@ -2399,8 +2419,8 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
         persistResource(
             DatabaseHelper.newDomain(domainName)
                 .asBuilder()
-                .setDeletionTime(clock.nowUtc().plusDays(25))
-                .setRegistrationExpirationTime(clock.nowUtc().minusDays(1))
+                .setDeletionTime(plusDays(clock.now(), 25))
+                .setRegistrationExpirationTime(minusDays(clock.now(), 1))
                 .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
                 .build());
     DomainHistory historyEntry =
@@ -2419,7 +2439,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
                 .setTargetId(existingDomain.getDomainName())
                 .setRegistrarId("TheRegistrar")
                 .setEventTime(existingDomain.getCreationTime())
-                .setRecurrenceEndTime(clock.nowUtc())
+                .setRecurrenceEndTime(clock.now())
                 .setDomainHistory(historyEntry)
                 .build());
     return persistResource(
@@ -2428,17 +2448,17 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
 
   private void runEapFeeCheckTestWithXmlInputOutput(String inputXml, String outputXml)
       throws Exception {
-    clock.setTo(DateTime.parse("2010-01-01T10:00:00Z"));
+    clock.setTo(Instant.parse("2010-01-01T10:00:00Z"));
     persistActiveDomain("example1.tld");
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setEapFeeSchedule(
-                new ImmutableSortedMap.Builder<DateTime, Money>(Ordering.natural())
-                    .put(START_OF_TIME, Money.of(USD, 0))
-                    .put(clock.nowUtc().minusDays(1), Money.of(USD, 100))
-                    .put(clock.nowUtc().plusDays(1), Money.of(USD, 50))
-                    .put(clock.nowUtc().plusDays(2), Money.of(USD, 0))
+            .setEapFeeScheduleInstant(
+                new ImmutableSortedMap.Builder<Instant, Money>(Ordering.natural())
+                    .put(START_INSTANT, Money.of(USD, 0))
+                    .put(minusDays(clock.now(), 1), Money.of(USD, 100))
+                    .put(plusDays(clock.now(), 1), Money.of(USD, 50))
+                    .put(plusDays(clock.now(), 2), Money.of(USD, 0))
                     .build())
             .build());
     setEppInputXml(inputXml);

--- a/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
@@ -95,7 +95,7 @@ import google.registry.testing.DatabaseHelper;
 import java.math.BigDecimal;
 import java.util.Optional;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -105,7 +105,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
 
   DomainCheckFlowTest() {
     setEppInput("domain_check_one_tld.xml");
-    clock.setTo(DateTime.parse("2009-01-01T10:00:00Z"));
+    clock.setTo(Instant.parse("2009-01-01T10:00:00Z"));
   }
 
   static ReservedList createReservedList() {
@@ -327,10 +327,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setTokenType(SINGLE_USE)
             .setDomainName("specificuse.tld")
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     doCheckTest(
@@ -351,10 +351,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountFraction(0.5)
             .setDiscountYears(2)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_stdv1.xml");
@@ -374,10 +374,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountYears(2)
             .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE))
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_stdv1.xml");
@@ -396,10 +396,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountYears(3)
             .setDiscountPremiums(true)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput(
@@ -454,10 +454,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setTokenType(SINGLE_USE)
             .setDomainName("specificuse.tld")
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(2), TokenStatus.VALID)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(2), TokenStatus.VALID)
+                    .put(clock.now().minusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     doCheckTest(
@@ -516,10 +516,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountFraction(0.444)
             .setDiscountYears(2)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput(
@@ -549,10 +549,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(60), TokenStatus.ENDED)
+                    .put(clock.now().plusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(60), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_stdv1.xml");
@@ -573,10 +573,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountFraction(0.5)
             .setAllowedTlds(ImmutableSet.of("example"))
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_stdv1.xml");
@@ -597,10 +597,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountFraction(0.5)
             .setAllowedRegistrarIds(ImmutableSet.of("someOtherClient"))
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_stdv1.xml");
@@ -718,7 +718,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
 
   @Test
   void testSuccess_oneExistsButWasDeleted() throws Exception {
-    persistDeletedDomain("example1.tld", clock.nowUtc().minusDays(1));
+    persistDeletedDomain("example1.tld", clock.now().minusDays(1));
     doCheckTest(
         create(true, "example1.tld", null),
         create(true, "example2.tld", null),
@@ -1202,7 +1202,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
                 ImmutableSortedMap.of(
                     START_OF_TIME,
                     TokenStatus.NOT_STARTED,
-                    clock.nowUtc().plusDays(1),
+                    clock.now().plusDays(1),
                     TokenStatus.VALID))
             .build());
 
@@ -1303,16 +1303,16 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
   void testFeeExtension_premium_eap_v06() throws Exception {
     createTld("example");
     setEppInput("domain_check_fee_premium_v06.xml");
-    clock.setTo(DateTime.parse("2010-01-01T10:00:00Z"));
+    clock.setTo(Instant.parse("2010-01-01T10:00:00Z"));
     persistResource(
         Tld.get("example")
             .asBuilder()
             .setEapFeeSchedule(
-                new ImmutableSortedMap.Builder<DateTime, Money>(Ordering.natural())
+                new ImmutableSortedMap.Builder<Instant, Money>(Ordering.natural())
                     .put(START_OF_TIME, Money.of(USD, 0))
-                    .put(clock.nowUtc().minusDays(1), Money.of(USD, 100))
-                    .put(clock.nowUtc().plusDays(1), Money.of(USD, 50))
-                    .put(clock.nowUtc().plusDays(2), Money.of(USD, 0))
+                    .put(clock.now().minusDays(1), Money.of(USD, 100))
+                    .put(clock.now().plusDays(1), Money.of(USD, 50))
+                    .put(clock.now().plusDays(2), Money.of(USD, 0))
                     .build())
             .build());
 
@@ -1322,13 +1322,13 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
   @Test
   void testFeeExtension_premium_eap_v06_withRenewalOnRestore() throws Exception {
     createTld("example");
-    DateTime startTime = DateTime.parse("2010-01-01T10:00:00Z");
+    Instant startTime = Instant.parse("2010-01-01T10:00:00Z");
     clock.setTo(startTime);
     persistResource(
         persistActiveDomain("rich.example")
             .asBuilder()
-            .setDeletionTime(clock.nowUtc().plusDays(25))
-            .setRegistrationExpirationTime(clock.nowUtc().minusDays(1))
+            .setDeletionTime(clock.now().plusDays(25))
+            .setRegistrationExpirationTime(clock.now().minusDays(1))
             .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
             .build());
     persistPendingDeleteDomain("rich.example");
@@ -1337,7 +1337,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
         Tld.get("example")
             .asBuilder()
             .setEapFeeSchedule(
-                new ImmutableSortedMap.Builder<DateTime, Money>(Ordering.natural())
+                new ImmutableSortedMap.Builder<Instant, Money>(Ordering.natural())
                     .put(START_OF_TIME, Money.of(USD, 0))
                     .put(startTime.minusDays(1), Money.of(USD, 100))
                     .put(startTime.plusDays(1), Money.of(USD, 50))
@@ -2101,7 +2101,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
                 ImmutableSortedMap.of(
                     START_OF_TIME,
                     TokenStatus.NOT_STARTED,
-                    clock.nowUtc().plusDays(1),
+                    clock.now().plusDays(1),
                     TokenStatus.VALID))
             .build());
 
@@ -2137,10 +2137,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountYears(2)
             .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE))
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_v06.xml");
@@ -2171,10 +2171,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountFraction(0.444)
             .setDiscountYears(2)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput(
@@ -2206,10 +2206,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountYears(3)
             .setDiscountPremiums(true)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput(
@@ -2255,10 +2255,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(60), TokenStatus.ENDED)
+                    .put(clock.now().plusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(60), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_v06.xml");
@@ -2284,10 +2284,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountFraction(0.5)
             .setDiscountYears(2)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_v06.xml");
@@ -2304,10 +2304,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountFraction(0.5)
             .setAllowedTlds(ImmutableSet.of("example"))
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_v06.xml");
@@ -2332,10 +2332,10 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountFraction(0.5)
             .setAllowedRegistrarIds(ImmutableSet.of("someOtherClient"))
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_check_allocationtoken_fee_v06.xml");
@@ -2399,8 +2399,8 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
         persistResource(
             DatabaseHelper.newDomain(domainName)
                 .asBuilder()
-                .setDeletionTime(clock.nowUtc().plusDays(25))
-                .setRegistrationExpirationTime(clock.nowUtc().minusDays(1))
+                .setDeletionTime(clock.now().plusDays(25))
+                .setRegistrationExpirationTime(clock.now().minusDays(1))
                 .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
                 .build());
     DomainHistory historyEntry =
@@ -2419,7 +2419,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
                 .setTargetId(existingDomain.getDomainName())
                 .setRegistrarId("TheRegistrar")
                 .setEventTime(existingDomain.getCreationTime())
-                .setRecurrenceEndTime(clock.nowUtc())
+                .setRecurrenceEndTime(clock.now())
                 .setDomainHistory(historyEntry)
                 .build());
     return persistResource(
@@ -2428,17 +2428,17 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
 
   private void runEapFeeCheckTestWithXmlInputOutput(String inputXml, String outputXml)
       throws Exception {
-    clock.setTo(DateTime.parse("2010-01-01T10:00:00Z"));
+    clock.setTo(Instant.parse("2010-01-01T10:00:00Z"));
     persistActiveDomain("example1.tld");
     persistResource(
         Tld.get("tld")
             .asBuilder()
             .setEapFeeSchedule(
-                new ImmutableSortedMap.Builder<DateTime, Money>(Ordering.natural())
+                new ImmutableSortedMap.Builder<Instant, Money>(Ordering.natural())
                     .put(START_OF_TIME, Money.of(USD, 0))
-                    .put(clock.nowUtc().minusDays(1), Money.of(USD, 100))
-                    .put(clock.nowUtc().plusDays(1), Money.of(USD, 50))
-                    .put(clock.nowUtc().plusDays(2), Money.of(USD, 0))
+                    .put(clock.now().minusDays(1), Money.of(USD, 100))
+                    .put(clock.now().plusDays(1), Money.of(USD, 50))
+                    .put(clock.now().plusDays(2), Money.of(USD, 0))
                     .build())
             .build());
     setEppInputXml(inputXml);

--- a/core/src/test/java/google/registry/flows/domain/DomainClaimsCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainClaimsCheckFlowTest.java
@@ -181,7 +181,7 @@ public class DomainClaimsCheckFlowTest extends ResourceFlowTestCase<DomainClaims
   void testFailure_multipleTlds_oneHasEndedClaims() {
     createTlds("tld1", "tld2");
     persistResource(
-        Tld.get("tld2").asBuilder().setClaimsPeriodEnd(clock.nowUtc().minusMillis(1)).build());
+        Tld.get("tld2").asBuilder().setClaimsPeriodEndInstant(clock.now().minusMillis(1)).build());
     setEppInput("domain_check_claims_multiple_tlds.xml");
     EppException thrown = assertThrows(ClaimsPeriodEndedException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();

--- a/core/src/test/java/google/registry/flows/domain/DomainClaimsCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainClaimsCheckFlowTest.java
@@ -181,7 +181,7 @@ public class DomainClaimsCheckFlowTest extends ResourceFlowTestCase<DomainClaims
   void testFailure_multipleTlds_oneHasEndedClaims() {
     createTlds("tld1", "tld2");
     persistResource(
-        Tld.get("tld2").asBuilder().setClaimsPeriodEnd(clock.nowUtc().minusMillis(1)).build());
+        Tld.get("tld2").asBuilder().setClaimsPeriodEnd(clock.now().minusMillis(1)).build());
     setEppInput("domain_check_claims_multiple_tlds.xml");
     EppException thrown = assertThrows(ClaimsPeriodEndedException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -57,7 +57,12 @@ import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DomainSubject.assertAboutDomains;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
-import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
+import static google.registry.util.DateTimeUtils.minusDays;
+import static google.registry.util.DateTimeUtils.minusMonths;
+import static google.registry.util.DateTimeUtils.minusYears;
+import static google.registry.util.DateTimeUtils.plusDays;
+import static google.registry.util.DateTimeUtils.plusYears;
 import static org.joda.money.CurrencyUnit.JPY;
 import static org.joda.money.CurrencyUnit.USD;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -184,7 +189,6 @@ import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -197,12 +201,12 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   private static final String CLAIMS_KEY = "2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001";
   // This is a time when SMD itself is not valid, but its signing certificates are. It will
   // trigger a different exception than when any signing cert is not valid yet.
-  private static final DateTime SMD_NOT_YET_VALID_TIME = DateTime.parse("2022-11-20T12:34:56Z");
-  private static final DateTime SMD_VALID_TIME = DateTime.parse("2023-01-02T12:34:56Z");
+  private static final Instant SMD_NOT_YET_VALID_TIME = Instant.parse("2022-11-20T12:34:56Z");
+  private static final Instant SMD_VALID_TIME = Instant.parse("2023-01-02T12:34:56Z");
   // This is a time when the imtermediate certificate in the SMD signature chain has expired. The
   // SMD itself has not expired yet. It will trigger a different exception than when the SMD itself
   // has expired.
-  private static final DateTime SMD_CERT_EXPIRED_TIME = DateTime.parse("2027-11-02T12:34:56Z");
+  private static final Instant SMD_CERT_EXPIRED_TIME = Instant.parse("2027-11-02T12:34:56Z");
   private static final String SMD_ID = "000000851669081693741-65535";
   private static final String SMD_FILE_PATH = "smd/active.smd";
   private static final String ENCODED_SMD =
@@ -224,7 +228,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   DomainCreateFlowTest() {
     setEppInput("domain_create.xml", ImmutableMap.of("DOMAIN", "example.tld"));
-    clock.setTo(DateTime.parse("1999-04-03T22:00:00.0Z").minus(Duration.millis(2)));
+    clock.setTo(Instant.parse("1999-04-03T22:00:00.0Z").minusMillis(2));
   }
 
   @BeforeEach
@@ -257,7 +261,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setBsaEnrollStartTime(Optional.of(clock.nowUtc().minusSeconds(1)))
+            .setBsaEnrollStartTimeInstant(Optional.of(clock.now().minusSeconds(1)))
             .build());
   }
 
@@ -314,16 +318,18 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
     boolean isAnchorTenant = expectedBillingFlags.contains(ANCHOR_TENANT);
     // Set up the creation cost.
-    boolean isDomainPremium = isDomainPremium(getUniqueIdFromCommand(), clock.nowUtc());
+    boolean isDomainPremium = isDomainPremium(getUniqueIdFromCommand(), clock.now());
 
     Money eapFee =
         Money.of(
             Tld.get(domainTld).getCurrency(),
-            Tld.get(domainTld).getEapFeeFor(clock.nowUtc()).getCost());
-    DateTime billingTime =
+            Tld.get(domainTld).getEapFeeFor(clock.now()).getCost());
+    Instant billingTime =
         isAnchorTenant
-            ? clock.nowUtc().plus(Tld.get(domainTld).getAnchorTenantAddGracePeriodLength())
-            : clock.nowUtc().plus(Tld.get(domainTld).getAddGracePeriodLength());
+            ? clock
+                .now()
+                .plusMillis(Tld.get(domainTld).getAnchorTenantAddGracePeriodLength().getMillis())
+            : clock.now().plusMillis(Tld.get(domainTld).getAddGracePeriodLength().getMillis());
     assertLastHistoryContainsResource(domain);
     DomainHistory historyEntry = getHistoryEntries(domain, DomainHistory.class).get(0);
     VKey<BillingRecurrence> autorenewVKey = domain.getAutorenewBillingEvent();
@@ -351,7 +357,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setRegistrarId("TheRegistrar")
             .setCost(Money.of(USD, BigDecimal.valueOf(createCost)))
             .setPeriodYears(2)
-            .setEventTime(clock.nowUtc())
+            .setEventTime(clock.now())
             .setBillingTime(billingTime)
             .setFlags(expectedBillingFlags)
             .setDomainHistory(historyEntry)
@@ -387,7 +393,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
               .setRegistrarId("TheRegistrar")
               .setPeriodYears(1)
               .setCost(eapFee)
-              .setEventTime(clock.nowUtc())
+              .setEventTime(clock.now())
               .setBillingTime(billingTime)
               .setFlags(expectedBillingFlags)
               .setDomainHistory(historyEntry)
@@ -443,8 +449,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             LaunchNotice.create(
                 "370d0b7c9223372036854775807",
                 "tmch",
-                DateTime.parse("2010-08-16T09:00:00.0Z"),
-                DateTime.parse("2009-08-16T09:00:00.0Z")))
+                Instant.parse("2010-08-16T09:00:00.0Z"),
+                Instant.parse("2009-08-16T09:00:00.0Z")))
         .and()
         .hasLordnPhase(LordnPhase.CLAIMS);
   }
@@ -576,11 +582,11 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             new AllocationToken.Builder()
                 .setTokenType(UNLIMITED_USE)
                 .setToken("abc123")
-                .setTokenStatusTransitions(
-                    ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                        .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                        .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                        .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                .setTokenStatusTransitionsInstant(
+                    ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                        .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                        .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                        .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                         .build())
                 .build());
     clock.advanceOneMilli();
@@ -628,7 +634,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   @Test
   void testFailure_generalAvailability_withEncodedSignedMark() {
     createTld("tld", GENERAL_AVAILABILITY);
-    clock.setTo(DateTime.parse("2014-09-09T09:09:09Z"));
+    clock.setTo(Instant.parse("2014-09-09T09:09:09Z"));
     setEppInput(
         "domain_create_registration_encoded_signed_mark.xml",
         ImmutableMap.of("DOMAIN", "test-validate.tld", "PHASE", "open", "SMD", ENCODED_SMD));
@@ -726,13 +732,13 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("example")
             .asBuilder()
-            .setEapFeeSchedule(
+            .setEapFeeScheduleInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     Money.of(USD, 0),
-                    clock.nowUtc().minusDays(1),
+                    minusDays(clock.now(), 1),
                     Money.of(USD, 100),
-                    clock.nowUtc().plusDays(1),
+                    plusDays(clock.now(), 1),
                     Money.of(USD, 0)))
             .build());
     assertMutatingFlow(true);
@@ -829,7 +835,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         "epp.response.resData.creData.exDate"); // Ignore expiration date; we verify it below
     assertAboutDomains()
         .that(reloadResourceByForeignKey())
-        .hasRegistrationExpirationTime(clock.nowUtc().plusYears(1));
+        .hasRegistrationExpirationTime(plusYears(clock.now(), 1));
     assertDomainDnsRequests("example.tld");
   }
 
@@ -843,7 +849,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Test
   void testSuccess_claimsNotice() throws Exception {
-    clock.setTo(DateTime.parse("2009-08-16T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2009-08-16T09:00:00.0Z"));
     setEppInput("domain_create_claim_notice.xml");
     persistHosts();
     runFlowAssertResponse(loadFile("domain_create_response_claims.xml"));
@@ -864,15 +870,15 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setTldStateTransitions(
+            .setTldStateTransitionsInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     PREDELEGATION,
-                    DateTime.parse("1999-01-01T00:00:00Z"),
+                    Instant.parse("1999-01-01T00:00:00Z"),
                     QUIET_PERIOD))
             .setReservedLists(persistReservedList("res1", "example-one,RESERVED_FOR_SPECIFIC_USE"))
             .build());
-    clock.setTo(DateTime.parse("2009-08-16T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2009-08-16T09:00:00.0Z"));
     setEppInput("domain_create_allocationtoken_claims.xml");
     persistHosts();
     runFlowAssertResponse(loadFile("domain_create_response_claims.xml"));
@@ -886,7 +892,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   void testSuccess_noClaimsNotice_forClaimsListName_afterClaimsPeriodEnd() throws Exception {
     persistClaimsList(ImmutableMap.of("example", CLAIMS_KEY));
     persistHosts();
-    persistResource(Tld.get("tld").asBuilder().setClaimsPeriodEnd(clock.nowUtc()).build());
+    persistResource(Tld.get("tld").asBuilder().setClaimsPeriodEndInstant(clock.now()).build());
     runFlowAssertResponse(
         loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "example.tld")));
     assertSuccessfulCreate("tld", ImmutableSet.of());
@@ -915,7 +921,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     setEppInput("domain_create_claim_notice.xml");
     persistClaimsList(ImmutableMap.of("example-one", CLAIMS_KEY));
     persistHosts();
-    persistResource(Tld.get("tld").asBuilder().setClaimsPeriodEnd(clock.nowUtc()).build());
+    persistResource(Tld.get("tld").asBuilder().setClaimsPeriodEndInstant(clock.now()).build());
     EppException thrown = assertThrows(ClaimsPeriodEndedException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
@@ -974,8 +980,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setCreateBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.of(USD, 20)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.of(USD, 20)))
             .build());
     persistHosts();
     EppException thrown = assertThrows(FeesMismatchException.class, this::runFlow);
@@ -988,7 +994,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setCreateBillingCostTransitions(ImmutableSortedMap.of(START_OF_TIME, Money.of(USD, 8)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.of(USD, 8)))
             .build());
     // Expects fee of $24
     setEppInput("domain_create_fee.xml", FEE_STD_1_0_MAP);
@@ -1003,8 +1010,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setCreateBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.of(USD, 100)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.of(USD, 100)))
             .build());
     // Expects fee of $24
     setEppInput("domain_create_fee.xml", FEE_STD_1_0_MAP);
@@ -1139,7 +1146,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 persistReservedList("anchor-with-claims", "example-one,RESERVED_FOR_ANCHOR_TENANT"))
             .build());
     setEppInput("domain_create_allocationtoken_claims.xml");
-    clock.setTo(DateTime.parse("2009-08-16T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2009-08-16T09:00:00.0Z"));
     persistHosts();
     runFlowAssertResponse(loadFile("domain_create_response_claims.xml"));
     assertSuccessfulCreate("tld", ImmutableSet.of(ANCHOR_TENANT), allocationToken, 0);
@@ -1189,7 +1196,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 "CREATE_TIME",
                 SMD_VALID_TIME.toString(),
                 "EXPIRATION_TIME",
-                SMD_VALID_TIME.plusYears(2).toString())));
+                plusYears(SMD_VALID_TIME, 2).toString())));
     assertSuccessfulCreate("tld", ImmutableSet.of(SUNRISE, ANCHOR_TENANT), 0);
   }
 
@@ -1207,7 +1214,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .asBuilder()
             .setReservedLists(
                 persistReservedList("anchor_tenants", "test-validate,RESERVED_FOR_ANCHOR_TENANT"))
-            .setTldStateTransitions(ImmutableSortedMap.of(START_OF_TIME, START_DATE_SUNRISE))
+            .setTldStateTransitionsInstant(ImmutableSortedMap.of(START_INSTANT, START_DATE_SUNRISE))
             .build());
     setEppInput("domain_create_anchor_tenant_signed_mark.xml", ImmutableMap.of("SMD", ENCODED_SMD));
     clock.setTo(SMD_VALID_TIME);
@@ -1221,7 +1228,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 "CREATE_TIME",
                 SMD_VALID_TIME.toString(),
                 "EXPIRATION_TIME",
-                SMD_VALID_TIME.plusYears(2).toString())));
+                plusYears(SMD_VALID_TIME, 2).toString())));
     assertSuccessfulCreate("tld", ImmutableSet.of(ANCHOR_TENANT, SUNRISE), allocationToken, 0);
     assertDomainDnsRequests("test-validate.tld");
     assertSunriseLordn();
@@ -1233,12 +1240,12 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setTldStateTransitions(
-                new ImmutableSortedMap.Builder<DateTime, TldState>(Ordering.natural())
-                    .put(START_OF_TIME, PREDELEGATION)
-                    .put(DateTime.parse("1999-01-01T00:00:00Z"), QUIET_PERIOD)
-                    .put(DateTime.parse("1999-07-01T00:00:00Z"), START_DATE_SUNRISE)
-                    .put(DateTime.parse("2000-01-01T00:00:00Z"), GENERAL_AVAILABILITY)
+            .setTldStateTransitionsInstant(
+                new ImmutableSortedMap.Builder<Instant, TldState>(Ordering.natural())
+                    .put(START_INSTANT, PREDELEGATION)
+                    .put(Instant.parse("1999-01-01T00:00:00Z"), QUIET_PERIOD)
+                    .put(Instant.parse("1999-07-01T00:00:00Z"), START_DATE_SUNRISE)
+                    .put(Instant.parse("2000-01-01T00:00:00Z"), GENERAL_AVAILABILITY)
                     .build())
             .build());
     // The anchor tenant is created during the quiet period, on 1999-04-03.
@@ -1276,7 +1283,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setTldStateTransitions(ImmutableSortedMap.of(START_OF_TIME, QUIET_PERIOD))
+            .setTldStateTransitionsInstant(ImmutableSortedMap.of(START_INSTANT, QUIET_PERIOD))
             .build());
     allocationToken =
         persistResource(
@@ -1319,11 +1326,11 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setToken("abc123")
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusMillis(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusSeconds(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(clock.now().plusMillis(1), TokenStatus.VALID)
+                    .put(clock.now().plusSeconds(1), TokenStatus.ENDED)
                     .build())
             .build());
     clock.advanceOneMilli();
@@ -1363,11 +1370,11 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDiscountFraction(discountFraction)
             .setDiscountYears(discountYears)
             .setDiscountPremiums(discountPremiums)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusMillis(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusSeconds(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(clock.now().plusMillis(1), TokenStatus.VALID)
+                    .put(clock.now().plusSeconds(1), TokenStatus.ENDED)
                     .build())
             .build());
     clock.advanceOneMilli();
@@ -1400,11 +1407,11 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDiscountFraction(0.98)
             .setDiscountYears(2)
             .setDiscountPremiums(true)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusMillis(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusSeconds(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(clock.now().plusMillis(1), TokenStatus.VALID)
+                    .put(clock.now().plusSeconds(1), TokenStatus.ENDED)
                     .build())
             .build());
     clock.advanceOneMilli();
@@ -1439,11 +1446,11 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDomainName("rich.example")
             .setDiscountFraction(0.95555)
             .setDiscountPremiums(true)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusMillis(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusSeconds(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(clock.now().plusMillis(1), TokenStatus.VALID)
+                    .put(clock.now().plusSeconds(1), TokenStatus.ENDED)
                     .build())
             .build());
     clock.advanceOneMilli();
@@ -1496,11 +1503,11 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setToken("abc123")
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(60), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(plusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 60), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput(
@@ -1520,11 +1527,11 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setTokenType(UNLIMITED_USE)
             .setAllowedRegistrarIds(ImmutableSet.of("someClientId"))
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput(
@@ -1607,11 +1614,11 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         setupDefaultTokenWithDiscount()
             .asBuilder()
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(2), TokenStatus.VALID)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 2), TokenStatus.VALID)
+                    .put(minusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     doSuccessfulTest();
@@ -1672,7 +1679,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setTldStateTransitions(ImmutableSortedMap.of(START_OF_TIME, START_DATE_SUNRISE))
+            .setTldStateTransitionsInstant(ImmutableSortedMap.of(START_INSTANT, START_DATE_SUNRISE))
             .build());
     clock.setTo(SMD_VALID_TIME);
     setEppInput(
@@ -1688,7 +1695,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 "CREATE_TIME",
                 SMD_VALID_TIME.toString(),
                 "EXPIRATION_TIME",
-                SMD_VALID_TIME.plusYears(2).toString())));
+                plusYears(SMD_VALID_TIME, 2).toString())));
 
     assertSunriseLordn();
 
@@ -1735,7 +1742,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setResponseData(
                 ImmutableList.of(
                     DomainPendingActionNotificationResponse.create(
-                        domain.getDomainName(), true, historyEntry.getTrid(), clock.nowUtc())))
+                        domain.getDomainName(), true, historyEntry.getTrid(), clock.now())))
             .setId(1L)
             .build());
   }
@@ -1913,7 +1920,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Test
   void testFailure_expiredClaim() {
-    clock.setTo(DateTime.parse("2010-08-17T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2010-08-17T09:00:00.0Z"));
     setEppInput("domain_create_claim_notice.xml");
     persistHosts();
     EppException thrown = assertThrows(ExpiredClaimException.class, this::runFlow);
@@ -1922,7 +1929,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Test
   void testFailure_expiredAcceptance() {
-    clock.setTo(DateTime.parse("2009-09-16T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2009-09-16T09:00:00.0Z"));
     setEppInput("domain_create_claim_notice.xml");
     persistHosts();
     EppException thrown = assertThrows(AcceptedTooLongAgoException.class, this::runFlow);
@@ -1931,7 +1938,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Test
   void testFailure_malformedTcnIdWrongLength() {
-    clock.setTo(DateTime.parse("2009-08-16T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2009-08-16T09:00:00.0Z"));
     setEppInput("domain_create_malformed_claim_notice1.xml");
     persistHosts();
     EppException thrown = assertThrows(MalformedTcnIdException.class, this::runFlow);
@@ -1940,7 +1947,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Test
   void testFailure_malformedTcnIdBadChar() {
-    clock.setTo(DateTime.parse("2009-08-16T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2009-08-16T09:00:00.0Z"));
     setEppInput("domain_create_malformed_claim_notice2.xml");
     persistHosts();
     EppException thrown = assertThrows(MalformedTcnIdException.class, this::runFlow);
@@ -1949,7 +1956,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Test
   void testFailure_badTcnIdChecksum() {
-    clock.setTo(DateTime.parse("2009-08-16T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2009-08-16T09:00:00.0Z"));
     setEppInput("domain_create_bad_checksum_claim_notice.xml");
     persistHosts();
     EppException thrown = assertThrows(InvalidTcnIdChecksumException.class, this::runFlow);
@@ -2045,7 +2052,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setBsaEnrollStartTime(Optional.of(clock.nowUtc().plusSeconds(1)))
+            .setBsaEnrollStartTimeInstant(Optional.of(clock.now().plusSeconds(1)))
             .build());
     persistBsaLabel("example");
     persistHosts();
@@ -2111,7 +2118,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setTldStateTransitions(ImmutableSortedMap.of(START_OF_TIME, QUIET_PERIOD))
+            .setTldStateTransitionsInstant(ImmutableSortedMap.of(START_INSTANT, QUIET_PERIOD))
             .build());
     runFlow();
     assertSuccessfulCreate("tld", ImmutableSet.of(), token);
@@ -2296,7 +2303,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 "CREATE_TIME",
                 SMD_VALID_TIME.toString(),
                 "EXPIRATION_TIME",
-                SMD_VALID_TIME.plusYears(2).toString())));
+                plusYears(SMD_VALID_TIME, 2).toString())));
     assertSuccessfulCreate("tld", ImmutableSet.of(SUNRISE), 20.40);
     assertSunriseLordn();
   }
@@ -2319,7 +2326,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 "CREATE_TIME",
                 SMD_VALID_TIME.toString(),
                 "EXPIRATION_TIME",
-                SMD_VALID_TIME.plusYears(2).toString())));
+                plusYears(SMD_VALID_TIME, 2).toString())));
     assertSuccessfulCreate("tld", ImmutableSet.of(SUNRISE), 20.40);
     assertSunriseLordn();
   }
@@ -2409,7 +2416,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   @Test
   void testFailure_startDateSunriseRegistration_withClaimsNotice() {
     createTld("tld", START_DATE_SUNRISE);
-    clock.setTo(DateTime.parse("2009-08-16T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2009-08-16T09:00:00.0Z"));
     setEppInput("domain_create_registration_start_date_sunrise_claims_notice.xml");
     persistHosts();
     EppException thrown =
@@ -2437,11 +2444,11 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         Tld.get("tld")
             .asBuilder()
             .setCurrency(JPY)
-            .setCreateBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.ofMajor(JPY, 800)))
-            .setEapFeeSchedule(ImmutableSortedMap.of(START_OF_TIME, Money.ofMajor(JPY, 800)))
-            .setRenewBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.ofMajor(JPY, 800)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.ofMajor(JPY, 800)))
+            .setEapFeeScheduleInstant(ImmutableSortedMap.of(START_INSTANT, Money.ofMajor(JPY, 800)))
+            .setRenewBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.ofMajor(JPY, 800)))
             .setRegistryLockOrUnlockBillingCost(Money.ofMajor(JPY, 800))
             .setServerStatusChangeBillingCost(Money.ofMajor(JPY, 800))
             .setRestoreBillingCost(Money.ofMajor(JPY, 800))
@@ -2628,13 +2635,13 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get(tld)
             .asBuilder()
-            .setEapFeeSchedule(
+            .setEapFeeScheduleInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     Money.of(USD, 0),
-                    clock.nowUtc().minusDays(1),
+                    minusDays(clock.now(), 1),
                     Money.of(USD, 100),
-                    clock.nowUtc().plusDays(1),
+                    plusDays(clock.now(), 1),
                     Money.of(USD, 0)))
             .build());
   }
@@ -2645,13 +2652,13 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setEapFeeSchedule(
+            .setEapFeeScheduleInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     Money.of(USD, 0),
-                    clock.nowUtc().plusDays(1),
+                    plusDays(clock.now(), 1),
                     Money.of(USD, 10),
-                    clock.nowUtc().plusDays(2),
+                    plusDays(clock.now(), 2),
                     Money.of(USD, 0)))
             .build());
     doSuccessfulTest("tld", "domain_create_response.xml", ImmutableMap.of("DOMAIN", "example.tld"));
@@ -2663,13 +2670,13 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setEapFeeSchedule(
+            .setEapFeeScheduleInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     Money.of(USD, 0),
-                    clock.nowUtc().minusDays(2),
+                    minusDays(clock.now(), 2),
                     Money.of(USD, 100),
-                    clock.nowUtc().minusDays(1),
+                    minusDays(clock.now(), 1),
                     Money.of(USD, 0)))
             .build());
     doSuccessfulTest("tld", "domain_create_response.xml", ImmutableMap.of("DOMAIN", "example.tld"));
@@ -2804,7 +2811,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setTldStateTransitions(ImmutableSortedMap.of(START_OF_TIME, QUIET_PERIOD))
+            .setTldStateTransitionsInstant(ImmutableSortedMap.of(START_INSTANT, QUIET_PERIOD))
             .build());
     runFlow();
     assertSuccessfulCreate("tld", ImmutableSet.of(), token);
@@ -2826,7 +2833,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setTldStateTransitions(ImmutableSortedMap.of(START_OF_TIME, QUIET_PERIOD))
+            .setTldStateTransitionsInstant(ImmutableSortedMap.of(START_INSTANT, QUIET_PERIOD))
             .build());
     runFlow();
     assertSuccessfulCreate("tld", ImmutableSet.of(), token);
@@ -2860,7 +2867,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setTldStateTransitions(ImmutableSortedMap.of(START_OF_TIME, QUIET_PERIOD))
+            .setTldStateTransitionsInstant(ImmutableSortedMap.of(START_INSTANT, QUIET_PERIOD))
             .build());
     assertThrows(NoGeneralRegistrationsInCurrentPhaseException.class, this::runFlow);
   }
@@ -2879,9 +2886,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setTldStateTransitions(
+            .setTldStateTransitionsInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME, QUIET_PERIOD, clock.nowUtc().plusYears(1), START_DATE_SUNRISE))
+                    START_INSTANT, QUIET_PERIOD, plusYears(clock.now(), 1), START_DATE_SUNRISE))
             .build());
     persistHosts();
     setEppInput("domain_create_allocationtoken_claims.xml");
@@ -2902,13 +2909,13 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setTldStateTransitions(
+            .setTldStateTransitionsInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     QUIET_PERIOD,
-                    clock.nowUtc().minusYears(1),
+                    minusYears(clock.now(), 1),
                     START_DATE_SUNRISE,
-                    clock.nowUtc().minusMonths(1),
+                    minusMonths(clock.now(), 1),
                     QUIET_PERIOD))
             .build());
     persistHosts();
@@ -3050,13 +3057,13 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setTldStateTransitions(
+            .setTldStateTransitionsInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     QUIET_PERIOD,
-                    clock.nowUtc().minusYears(1),
+                    minusYears(clock.now(), 1),
                     START_DATE_SUNRISE,
-                    clock.nowUtc().minusMonths(1),
+                    minusMonths(clock.now(), 1),
                     QUIET_PERIOD))
             .build());
     AllocationToken token =
@@ -3081,13 +3088,13 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setTldStateTransitions(
+            .setTldStateTransitionsInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     QUIET_PERIOD,
-                    clock.nowUtc().minusYears(1),
+                    minusYears(clock.now(), 1),
                     START_DATE_SUNRISE,
-                    clock.nowUtc().minusMonths(1),
+                    minusMonths(clock.now(), 1),
                     QUIET_PERIOD))
             .build());
     persistResource(
@@ -3107,13 +3114,13 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setTldStateTransitions(
+            .setTldStateTransitionsInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     QUIET_PERIOD,
-                    clock.nowUtc().minusYears(1),
+                    minusYears(clock.now(), 1),
                     START_DATE_SUNRISE,
-                    clock.nowUtc().minusMonths(1),
+                    minusMonths(clock.now(), 1),
                     QUIET_PERIOD))
             .build());
     persistResource(
@@ -3279,11 +3286,11 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         setupDefaultTokenWithDiscount("NewRegistrar")
             .asBuilder()
-            .setTokenStatusTransitions(
+            .setTokenStatusTransitionsInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     TokenStatus.NOT_STARTED,
-                    clock.nowUtc().plusDays(1),
+                    plusDays(clock.now(), 1),
                     TokenStatus.VALID))
             .build());
 
@@ -3305,8 +3312,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setCreateBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.of(USD, 20)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.of(USD, 20)))
             .build());
     persistHosts();
     EppException thrown = assertThrows(FeesMismatchException.class, this::runFlow);
@@ -3319,8 +3326,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setCreateBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.of(USD, 20)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.of(USD, 20)))
             .build());
     persistHosts();
     EppException thrown = assertThrows(FeesMismatchException.class, this::runFlow);
@@ -3333,8 +3340,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setCreateBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.of(USD, 20)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.of(USD, 20)))
             .build());
     persistHosts();
     EppException thrown = assertThrows(FeesMismatchException.class, this::runFlow);
@@ -3347,7 +3354,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setCreateBillingCostTransitions(ImmutableSortedMap.of(START_OF_TIME, Money.of(USD, 8)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.of(USD, 8)))
             .build());
     // Expects fee of $24
     setEppInput("domain_create_fee.xml", FEE_06_MAP);
@@ -3362,7 +3370,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setCreateBillingCostTransitions(ImmutableSortedMap.of(START_OF_TIME, Money.of(USD, 8)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.of(USD, 8)))
             .build());
     // Expects fee of $24
     setEppInput("domain_create_fee.xml", FEE_11_MAP);
@@ -3377,7 +3386,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setCreateBillingCostTransitions(ImmutableSortedMap.of(START_OF_TIME, Money.of(USD, 8)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.of(USD, 8)))
             .build());
     // Expects fee of $24
     setEppInput("domain_create_fee.xml", FEE_12_MAP);
@@ -3518,8 +3528,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setCreateBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.of(USD, 100)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.of(USD, 100)))
             .build());
     // Expects fee of $24
     setEppInput("domain_create_fee.xml", FEE_06_MAP);
@@ -3534,8 +3544,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setCreateBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.of(USD, 100)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.of(USD, 100)))
             .build());
     // Expects fee of $24
     setEppInput("domain_create_fee.xml", FEE_11_MAP);
@@ -3550,8 +3560,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setCreateBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.of(USD, 100)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.of(USD, 100)))
             .build());
     // Expects fee of $24
     setEppInput("domain_create_fee.xml", FEE_12_MAP);
@@ -3868,11 +3878,11 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDiscountFraction(0.98)
             .setDiscountYears(2)
             .setDiscountPremiums(true)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusMillis(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusSeconds(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(clock.now().plusMillis(1), TokenStatus.VALID)
+                    .put(clock.now().plusSeconds(1), TokenStatus.ENDED)
                     .build())
             .build());
     clock.advanceOneMilli();
@@ -3937,13 +3947,13 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("example")
             .asBuilder()
-            .setEapFeeSchedule(
+            .setEapFeeScheduleInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     Money.of(USD, 0),
-                    clock.nowUtc().minusDays(1),
+                    minusDays(clock.now(), 1),
                     Money.of(USD, 100),
-                    clock.nowUtc().plusDays(1),
+                    plusDays(clock.now(), 1),
                     Money.of(USD, 0)))
             .build());
     assertMutatingFlow(true);
@@ -3977,11 +3987,11 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDomainName("rich.example")
             .setDiscountFraction(0.95555)
             .setDiscountPremiums(true)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusMillis(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusSeconds(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(clock.now().plusMillis(1), TokenStatus.VALID)
+                    .put(clock.now().plusSeconds(1), TokenStatus.ENDED)
                     .build())
             .build());
     clock.advanceOneMilli();
@@ -4008,11 +4018,11 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         setupDefaultTokenWithDiscount("NewRegistrar")
             .asBuilder()
-            .setTokenStatusTransitions(
+            .setTokenStatusTransitionsInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     TokenStatus.NOT_STARTED,
-                    clock.nowUtc().plusDays(1),
+                    plusDays(clock.now(), 1),
                     TokenStatus.VALID))
             .build());
 

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -184,7 +184,7 @@ import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -197,12 +197,12 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   private static final String CLAIMS_KEY = "2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001";
   // This is a time when SMD itself is not valid, but its signing certificates are. It will
   // trigger a different exception than when any signing cert is not valid yet.
-  private static final DateTime SMD_NOT_YET_VALID_TIME = DateTime.parse("2022-11-20T12:34:56Z");
-  private static final DateTime SMD_VALID_TIME = DateTime.parse("2023-01-02T12:34:56Z");
+  private static final Instant SMD_NOT_YET_VALID_TIME = Instant.parse("2022-11-20T12:34:56Z");
+  private static final Instant SMD_VALID_TIME = Instant.parse("2023-01-02T12:34:56Z");
   // This is a time when the imtermediate certificate in the SMD signature chain has expired. The
   // SMD itself has not expired yet. It will trigger a different exception than when the SMD itself
   // has expired.
-  private static final DateTime SMD_CERT_EXPIRED_TIME = DateTime.parse("2027-11-02T12:34:56Z");
+  private static final Instant SMD_CERT_EXPIRED_TIME = Instant.parse("2027-11-02T12:34:56Z");
   private static final String SMD_ID = "000000851669081693741-65535";
   private static final String SMD_FILE_PATH = "smd/active.smd";
   private static final String ENCODED_SMD =
@@ -224,7 +224,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   DomainCreateFlowTest() {
     setEppInput("domain_create.xml", ImmutableMap.of("DOMAIN", "example.tld"));
-    clock.setTo(DateTime.parse("1999-04-03T22:00:00.0Z").minus(Duration.millis(2)));
+    clock.setTo(Instant.parse("1999-04-03T22:00:00.0Z").minus(Duration.millis(2)));
   }
 
   @BeforeEach
@@ -257,7 +257,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setBsaEnrollStartTime(Optional.of(clock.nowUtc().minusSeconds(1)))
+            .setBsaEnrollStartTime(Optional.of(clock.now().minusSeconds(1)))
             .build());
   }
 
@@ -314,16 +314,16 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
     boolean isAnchorTenant = expectedBillingFlags.contains(ANCHOR_TENANT);
     // Set up the creation cost.
-    boolean isDomainPremium = isDomainPremium(getUniqueIdFromCommand(), clock.nowUtc());
+    boolean isDomainPremium = isDomainPremium(getUniqueIdFromCommand(), clock.now());
 
     Money eapFee =
         Money.of(
             Tld.get(domainTld).getCurrency(),
-            Tld.get(domainTld).getEapFeeFor(clock.nowUtc()).getCost());
-    DateTime billingTime =
+            Tld.get(domainTld).getEapFeeFor(clock.now()).getCost());
+    Instant billingTime =
         isAnchorTenant
-            ? clock.nowUtc().plus(Tld.get(domainTld).getAnchorTenantAddGracePeriodLength())
-            : clock.nowUtc().plus(Tld.get(domainTld).getAddGracePeriodLength());
+            ? clock.now().plus(Tld.get(domainTld).getAnchorTenantAddGracePeriodLength())
+            : clock.now().plus(Tld.get(domainTld).getAddGracePeriodLength());
     assertLastHistoryContainsResource(domain);
     DomainHistory historyEntry = getHistoryEntries(domain, DomainHistory.class).get(0);
     VKey<BillingRecurrence> autorenewVKey = domain.getAutorenewBillingEvent();
@@ -351,7 +351,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setRegistrarId("TheRegistrar")
             .setCost(Money.of(USD, BigDecimal.valueOf(createCost)))
             .setPeriodYears(2)
-            .setEventTime(clock.nowUtc())
+            .setEventTime(clock.now())
             .setBillingTime(billingTime)
             .setFlags(expectedBillingFlags)
             .setDomainHistory(historyEntry)
@@ -387,7 +387,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
               .setRegistrarId("TheRegistrar")
               .setPeriodYears(1)
               .setCost(eapFee)
-              .setEventTime(clock.nowUtc())
+              .setEventTime(clock.now())
               .setBillingTime(billingTime)
               .setFlags(expectedBillingFlags)
               .setDomainHistory(historyEntry)
@@ -443,8 +443,8 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             LaunchNotice.create(
                 "370d0b7c9223372036854775807",
                 "tmch",
-                DateTime.parse("2010-08-16T09:00:00.0Z"),
-                DateTime.parse("2009-08-16T09:00:00.0Z")))
+                Instant.parse("2010-08-16T09:00:00.0Z"),
+                Instant.parse("2009-08-16T09:00:00.0Z")))
         .and()
         .hasLordnPhase(LordnPhase.CLAIMS);
   }
@@ -577,10 +577,10 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 .setTokenType(UNLIMITED_USE)
                 .setToken("abc123")
                 .setTokenStatusTransitions(
-                    ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                    ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                         .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                        .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                        .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                        .put(clock.now().minusDays(1), TokenStatus.VALID)
+                        .put(clock.now().plusDays(1), TokenStatus.ENDED)
                         .build())
                 .build());
     clock.advanceOneMilli();
@@ -628,7 +628,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   @Test
   void testFailure_generalAvailability_withEncodedSignedMark() {
     createTld("tld", GENERAL_AVAILABILITY);
-    clock.setTo(DateTime.parse("2014-09-09T09:09:09Z"));
+    clock.setTo(Instant.parse("2014-09-09T09:09:09Z"));
     setEppInput(
         "domain_create_registration_encoded_signed_mark.xml",
         ImmutableMap.of("DOMAIN", "test-validate.tld", "PHASE", "open", "SMD", ENCODED_SMD));
@@ -730,9 +730,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 ImmutableSortedMap.of(
                     START_OF_TIME,
                     Money.of(USD, 0),
-                    clock.nowUtc().minusDays(1),
+                    clock.now().minusDays(1),
                     Money.of(USD, 100),
-                    clock.nowUtc().plusDays(1),
+                    clock.now().plusDays(1),
                     Money.of(USD, 0)))
             .build());
     assertMutatingFlow(true);
@@ -829,7 +829,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         "epp.response.resData.creData.exDate"); // Ignore expiration date; we verify it below
     assertAboutDomains()
         .that(reloadResourceByForeignKey())
-        .hasRegistrationExpirationTime(clock.nowUtc().plusYears(1));
+        .hasRegistrationExpirationTime(clock.now().plusYears(1));
     assertDomainDnsRequests("example.tld");
   }
 
@@ -843,7 +843,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Test
   void testSuccess_claimsNotice() throws Exception {
-    clock.setTo(DateTime.parse("2009-08-16T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2009-08-16T09:00:00.0Z"));
     setEppInput("domain_create_claim_notice.xml");
     persistHosts();
     runFlowAssertResponse(loadFile("domain_create_response_claims.xml"));
@@ -868,11 +868,11 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 ImmutableSortedMap.of(
                     START_OF_TIME,
                     PREDELEGATION,
-                    DateTime.parse("1999-01-01T00:00:00Z"),
+                    Instant.parse("1999-01-01T00:00:00Z"),
                     QUIET_PERIOD))
             .setReservedLists(persistReservedList("res1", "example-one,RESERVED_FOR_SPECIFIC_USE"))
             .build());
-    clock.setTo(DateTime.parse("2009-08-16T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2009-08-16T09:00:00.0Z"));
     setEppInput("domain_create_allocationtoken_claims.xml");
     persistHosts();
     runFlowAssertResponse(loadFile("domain_create_response_claims.xml"));
@@ -886,7 +886,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   void testSuccess_noClaimsNotice_forClaimsListName_afterClaimsPeriodEnd() throws Exception {
     persistClaimsList(ImmutableMap.of("example", CLAIMS_KEY));
     persistHosts();
-    persistResource(Tld.get("tld").asBuilder().setClaimsPeriodEnd(clock.nowUtc()).build());
+    persistResource(Tld.get("tld").asBuilder().setClaimsPeriodEnd(clock.now()).build());
     runFlowAssertResponse(
         loadFile("domain_create_response.xml", ImmutableMap.of("DOMAIN", "example.tld")));
     assertSuccessfulCreate("tld", ImmutableSet.of());
@@ -915,7 +915,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     setEppInput("domain_create_claim_notice.xml");
     persistClaimsList(ImmutableMap.of("example-one", CLAIMS_KEY));
     persistHosts();
-    persistResource(Tld.get("tld").asBuilder().setClaimsPeriodEnd(clock.nowUtc()).build());
+    persistResource(Tld.get("tld").asBuilder().setClaimsPeriodEnd(clock.now()).build());
     EppException thrown = assertThrows(ClaimsPeriodEndedException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
@@ -1139,7 +1139,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 persistReservedList("anchor-with-claims", "example-one,RESERVED_FOR_ANCHOR_TENANT"))
             .build());
     setEppInput("domain_create_allocationtoken_claims.xml");
-    clock.setTo(DateTime.parse("2009-08-16T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2009-08-16T09:00:00.0Z"));
     persistHosts();
     runFlowAssertResponse(loadFile("domain_create_response_claims.xml"));
     assertSuccessfulCreate("tld", ImmutableSet.of(ANCHOR_TENANT), allocationToken, 0);
@@ -1234,11 +1234,11 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         Tld.get("tld")
             .asBuilder()
             .setTldStateTransitions(
-                new ImmutableSortedMap.Builder<DateTime, TldState>(Ordering.natural())
+                new ImmutableSortedMap.Builder<Instant, TldState>(Ordering.natural())
                     .put(START_OF_TIME, PREDELEGATION)
-                    .put(DateTime.parse("1999-01-01T00:00:00Z"), QUIET_PERIOD)
-                    .put(DateTime.parse("1999-07-01T00:00:00Z"), START_DATE_SUNRISE)
-                    .put(DateTime.parse("2000-01-01T00:00:00Z"), GENERAL_AVAILABILITY)
+                    .put(Instant.parse("1999-01-01T00:00:00Z"), QUIET_PERIOD)
+                    .put(Instant.parse("1999-07-01T00:00:00Z"), START_DATE_SUNRISE)
+                    .put(Instant.parse("2000-01-01T00:00:00Z"), GENERAL_AVAILABILITY)
                     .build())
             .build());
     // The anchor tenant is created during the quiet period, on 1999-04-03.
@@ -1320,10 +1320,10 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusMillis(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusSeconds(1), TokenStatus.ENDED)
+                    .put(clock.now().plusMillis(1), TokenStatus.VALID)
+                    .put(clock.now().plusSeconds(1), TokenStatus.ENDED)
                     .build())
             .build());
     clock.advanceOneMilli();
@@ -1364,10 +1364,10 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDiscountYears(discountYears)
             .setDiscountPremiums(discountPremiums)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusMillis(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusSeconds(1), TokenStatus.ENDED)
+                    .put(clock.now().plusMillis(1), TokenStatus.VALID)
+                    .put(clock.now().plusSeconds(1), TokenStatus.ENDED)
                     .build())
             .build());
     clock.advanceOneMilli();
@@ -1401,10 +1401,10 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDiscountYears(2)
             .setDiscountPremiums(true)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusMillis(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusSeconds(1), TokenStatus.ENDED)
+                    .put(clock.now().plusMillis(1), TokenStatus.VALID)
+                    .put(clock.now().plusSeconds(1), TokenStatus.ENDED)
                     .build())
             .build());
     clock.advanceOneMilli();
@@ -1440,10 +1440,10 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDiscountFraction(0.95555)
             .setDiscountPremiums(true)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusMillis(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusSeconds(1), TokenStatus.ENDED)
+                    .put(clock.now().plusMillis(1), TokenStatus.VALID)
+                    .put(clock.now().plusSeconds(1), TokenStatus.ENDED)
                     .build())
             .build());
     clock.advanceOneMilli();
@@ -1497,10 +1497,10 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(60), TokenStatus.ENDED)
+                    .put(clock.now().plusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(60), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput(
@@ -1521,10 +1521,10 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setAllowedRegistrarIds(ImmutableSet.of("someClientId"))
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput(
@@ -1608,10 +1608,10 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         setupDefaultTokenWithDiscount()
             .asBuilder()
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(2), TokenStatus.VALID)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(2), TokenStatus.VALID)
+                    .put(clock.now().minusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     doSuccessfulTest();
@@ -1735,7 +1735,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setResponseData(
                 ImmutableList.of(
                     DomainPendingActionNotificationResponse.create(
-                        domain.getDomainName(), true, historyEntry.getTrid(), clock.nowUtc())))
+                        domain.getDomainName(), true, historyEntry.getTrid(), clock.now())))
             .setId(1L)
             .build());
   }
@@ -1913,7 +1913,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Test
   void testFailure_expiredClaim() {
-    clock.setTo(DateTime.parse("2010-08-17T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2010-08-17T09:00:00.0Z"));
     setEppInput("domain_create_claim_notice.xml");
     persistHosts();
     EppException thrown = assertThrows(ExpiredClaimException.class, this::runFlow);
@@ -1922,7 +1922,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Test
   void testFailure_expiredAcceptance() {
-    clock.setTo(DateTime.parse("2009-09-16T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2009-09-16T09:00:00.0Z"));
     setEppInput("domain_create_claim_notice.xml");
     persistHosts();
     EppException thrown = assertThrows(AcceptedTooLongAgoException.class, this::runFlow);
@@ -1931,7 +1931,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Test
   void testFailure_malformedTcnIdWrongLength() {
-    clock.setTo(DateTime.parse("2009-08-16T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2009-08-16T09:00:00.0Z"));
     setEppInput("domain_create_malformed_claim_notice1.xml");
     persistHosts();
     EppException thrown = assertThrows(MalformedTcnIdException.class, this::runFlow);
@@ -1940,7 +1940,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Test
   void testFailure_malformedTcnIdBadChar() {
-    clock.setTo(DateTime.parse("2009-08-16T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2009-08-16T09:00:00.0Z"));
     setEppInput("domain_create_malformed_claim_notice2.xml");
     persistHosts();
     EppException thrown = assertThrows(MalformedTcnIdException.class, this::runFlow);
@@ -1949,7 +1949,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
 
   @Test
   void testFailure_badTcnIdChecksum() {
-    clock.setTo(DateTime.parse("2009-08-16T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2009-08-16T09:00:00.0Z"));
     setEppInput("domain_create_bad_checksum_claim_notice.xml");
     persistHosts();
     EppException thrown = assertThrows(InvalidTcnIdChecksumException.class, this::runFlow);
@@ -2045,7 +2045,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setBsaEnrollStartTime(Optional.of(clock.nowUtc().plusSeconds(1)))
+            .setBsaEnrollStartTime(Optional.of(clock.now().plusSeconds(1)))
             .build());
     persistBsaLabel("example");
     persistHosts();
@@ -2409,7 +2409,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   @Test
   void testFailure_startDateSunriseRegistration_withClaimsNotice() {
     createTld("tld", START_DATE_SUNRISE);
-    clock.setTo(DateTime.parse("2009-08-16T09:00:00.0Z"));
+    clock.setTo(Instant.parse("2009-08-16T09:00:00.0Z"));
     setEppInput("domain_create_registration_start_date_sunrise_claims_notice.xml");
     persistHosts();
     EppException thrown =
@@ -2632,9 +2632,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 ImmutableSortedMap.of(
                     START_OF_TIME,
                     Money.of(USD, 0),
-                    clock.nowUtc().minusDays(1),
+                    clock.now().minusDays(1),
                     Money.of(USD, 100),
-                    clock.nowUtc().plusDays(1),
+                    clock.now().plusDays(1),
                     Money.of(USD, 0)))
             .build());
   }
@@ -2649,9 +2649,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 ImmutableSortedMap.of(
                     START_OF_TIME,
                     Money.of(USD, 0),
-                    clock.nowUtc().plusDays(1),
+                    clock.now().plusDays(1),
                     Money.of(USD, 10),
-                    clock.nowUtc().plusDays(2),
+                    clock.now().plusDays(2),
                     Money.of(USD, 0)))
             .build());
     doSuccessfulTest("tld", "domain_create_response.xml", ImmutableMap.of("DOMAIN", "example.tld"));
@@ -2667,9 +2667,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 ImmutableSortedMap.of(
                     START_OF_TIME,
                     Money.of(USD, 0),
-                    clock.nowUtc().minusDays(2),
+                    clock.now().minusDays(2),
                     Money.of(USD, 100),
-                    clock.nowUtc().minusDays(1),
+                    clock.now().minusDays(1),
                     Money.of(USD, 0)))
             .build());
     doSuccessfulTest("tld", "domain_create_response.xml", ImmutableMap.of("DOMAIN", "example.tld"));
@@ -2881,7 +2881,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .asBuilder()
             .setTldStateTransitions(
                 ImmutableSortedMap.of(
-                    START_OF_TIME, QUIET_PERIOD, clock.nowUtc().plusYears(1), START_DATE_SUNRISE))
+                    START_OF_TIME, QUIET_PERIOD, clock.now().plusYears(1), START_DATE_SUNRISE))
             .build());
     persistHosts();
     setEppInput("domain_create_allocationtoken_claims.xml");
@@ -2906,9 +2906,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 ImmutableSortedMap.of(
                     START_OF_TIME,
                     QUIET_PERIOD,
-                    clock.nowUtc().minusYears(1),
+                    clock.now().minusYears(1),
                     START_DATE_SUNRISE,
-                    clock.nowUtc().minusMonths(1),
+                    clock.now().minusMonths(1),
                     QUIET_PERIOD))
             .build());
     persistHosts();
@@ -3054,9 +3054,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 ImmutableSortedMap.of(
                     START_OF_TIME,
                     QUIET_PERIOD,
-                    clock.nowUtc().minusYears(1),
+                    clock.now().minusYears(1),
                     START_DATE_SUNRISE,
-                    clock.nowUtc().minusMonths(1),
+                    clock.now().minusMonths(1),
                     QUIET_PERIOD))
             .build());
     AllocationToken token =
@@ -3085,9 +3085,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 ImmutableSortedMap.of(
                     START_OF_TIME,
                     QUIET_PERIOD,
-                    clock.nowUtc().minusYears(1),
+                    clock.now().minusYears(1),
                     START_DATE_SUNRISE,
-                    clock.nowUtc().minusMonths(1),
+                    clock.now().minusMonths(1),
                     QUIET_PERIOD))
             .build());
     persistResource(
@@ -3111,9 +3111,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 ImmutableSortedMap.of(
                     START_OF_TIME,
                     QUIET_PERIOD,
-                    clock.nowUtc().minusYears(1),
+                    clock.now().minusYears(1),
                     START_DATE_SUNRISE,
-                    clock.nowUtc().minusMonths(1),
+                    clock.now().minusMonths(1),
                     QUIET_PERIOD))
             .build());
     persistResource(
@@ -3283,7 +3283,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 ImmutableSortedMap.of(
                     START_OF_TIME,
                     TokenStatus.NOT_STARTED,
-                    clock.nowUtc().plusDays(1),
+                    clock.now().plusDays(1),
                     TokenStatus.VALID))
             .build());
 
@@ -3869,10 +3869,10 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDiscountYears(2)
             .setDiscountPremiums(true)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusMillis(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusSeconds(1), TokenStatus.ENDED)
+                    .put(clock.now().plusMillis(1), TokenStatus.VALID)
+                    .put(clock.now().plusSeconds(1), TokenStatus.ENDED)
                     .build())
             .build());
     clock.advanceOneMilli();
@@ -3941,9 +3941,9 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 ImmutableSortedMap.of(
                     START_OF_TIME,
                     Money.of(USD, 0),
-                    clock.nowUtc().minusDays(1),
+                    clock.now().minusDays(1),
                     Money.of(USD, 100),
-                    clock.nowUtc().plusDays(1),
+                    clock.now().plusDays(1),
                     Money.of(USD, 0)))
             .build());
     assertMutatingFlow(true);
@@ -3978,10 +3978,10 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDiscountFraction(0.95555)
             .setDiscountPremiums(true)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusMillis(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusSeconds(1), TokenStatus.ENDED)
+                    .put(clock.now().plusMillis(1), TokenStatus.VALID)
+                    .put(clock.now().plusSeconds(1), TokenStatus.ENDED)
                     .build())
             .build());
     clock.advanceOneMilli();
@@ -4012,7 +4012,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
                 ImmutableSortedMap.of(
                     START_OF_TIME,
                     TokenStatus.NOT_STARTED,
-                    clock.nowUtc().plusDays(1),
+                    clock.now().plusDays(1),
                     TokenStatus.VALID))
             .build());
 

--- a/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
@@ -51,7 +51,14 @@ import static google.registry.testing.DomainSubject.assertAboutDomains;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
 import static google.registry.testing.HistoryEntrySubject.assertAboutHistoryEntries;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
-import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
+import static google.registry.util.DateTimeUtils.minusDays;
+import static google.registry.util.DateTimeUtils.minusMonths;
+import static google.registry.util.DateTimeUtils.minusYears;
+import static google.registry.util.DateTimeUtils.plusDays;
+import static google.registry.util.DateTimeUtils.plusMonths;
+import static google.registry.util.DateTimeUtils.plusYears;
+import static google.registry.util.DateTimeUtils.toDateTime;
 import static org.joda.money.CurrencyUnit.USD;
 import static org.joda.time.Duration.standardDays;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -101,10 +108,10 @@ import google.registry.model.transfer.TransferStatus;
 import google.registry.testing.CloudTasksHelper.TaskMatcher;
 import google.registry.testing.DatabaseHelper;
 import google.registry.testing.LogsSubject;
+import java.time.Instant;
 import java.util.Map;
 import java.util.logging.Level;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -115,9 +122,9 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
   private Domain domain;
   private DomainHistory earlierHistoryEntry;
 
-  private static final DateTime TIME_BEFORE_FLOW = DateTime.parse("2000-06-06T22:00:00.0Z");
-  private static final DateTime A_MONTH_AGO = TIME_BEFORE_FLOW.minusMonths(1);
-  private static final DateTime A_MONTH_FROM_NOW = TIME_BEFORE_FLOW.plusMonths(1);
+  private static final Instant TIME_BEFORE_FLOW = Instant.parse("2000-06-06T22:00:00.0Z");
+  private static final Instant A_MONTH_AGO = minusMonths(TIME_BEFORE_FLOW, 1);
+  private static final Instant A_MONTH_FROM_NOW = plusMonths(TIME_BEFORE_FLOW, 1);
 
   private static final ImmutableMap<String, String> FEE_06_MAP =
       ImmutableMap.of("FEE_VERSION", "fee-0.6", "FEE_NS", "fee");
@@ -156,7 +163,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     assertMutatingFlow(true);
   }
 
-  private void createReferencedEntities(DateTime expirationTime) throws Exception {
+  private void createReferencedEntities(Instant expirationTime) throws Exception {
     domain =
         persistResource(
             DatabaseHelper.newDomain(getUniqueIdFromCommand())
@@ -169,7 +176,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             new DomainHistory.Builder()
                 .setType(DOMAIN_CREATE)
                 .setDomain(domain)
-                .setModificationTime(clock.nowUtc())
+                .setModificationTime(clock.now())
                 .setRegistrarId(domain.getCreationRegistrarId())
                 .build());
   }
@@ -193,7 +200,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
   }
 
   private void setUpAutorenewGracePeriod() throws Exception {
-    createReferencedEntities(A_MONTH_AGO.plusYears(1));
+    createReferencedEntities(plusYears(A_MONTH_AGO, 1));
     BillingRecurrence autorenewBillingEvent =
         persistResource(
             createAutorenewBillingEvent("TheRegistrar").setEventTime(A_MONTH_AGO).build());
@@ -209,7 +216,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
                         GracePeriod.createForRecurrence(
                             GracePeriodStatus.AUTO_RENEW,
                             domain.getRepoId(),
-                            A_MONTH_AGO.plusDays(45),
+                            plusDays(A_MONTH_AGO, 45),
                             "TheRegistrar",
                             autorenewBillingEvent.createVKey())))
                 .setAutorenewBillingEvent(autorenewBillingEvent.createVKey())
@@ -221,11 +228,11 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
   private void assertAutorenewClosedAndCancellationCreatedFor(
       BillingEvent graceBillingEvent, DomainHistory historyEntryDomainDelete) {
     assertAutorenewClosedAndCancellationCreatedFor(
-        graceBillingEvent, historyEntryDomainDelete, clock.nowUtc());
+        graceBillingEvent, historyEntryDomainDelete, clock.now());
   }
 
   private void assertAutorenewClosedAndCancellationCreatedFor(
-      BillingEvent graceBillingEvent, DomainHistory historyEntryDomainDelete, DateTime eventTime) {
+      BillingEvent graceBillingEvent, DomainHistory historyEntryDomainDelete, Instant eventTime) {
     assertBillingEvents(
         createAutorenewBillingEvent("TheRegistrar").setRecurrenceEndTime(eventTime).build(),
         graceBillingEvent,
@@ -234,7 +241,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             .setTargetId("example.tld")
             .setRegistrarId("TheRegistrar")
             .setEventTime(eventTime)
-            .setBillingTime(TIME_BEFORE_FLOW.plusDays(1))
+            .setBillingTime(toDateTime(plusDays(TIME_BEFORE_FLOW, 1)))
             .setBillingEvent(graceBillingEvent.createVKey())
             .setDomainHistory(historyEntryDomainDelete)
             .build());
@@ -244,7 +251,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     // There should be no billing events (even timed to when the transfer would have expired) except
     // for the now closed autorenew one.
     assertBillingEvents(
-        createAutorenewBillingEvent(registrarId).setRecurrenceEndTime(clock.nowUtc()).build());
+        createAutorenewBillingEvent(registrarId).setRecurrenceEndTime(clock.now()).build());
   }
 
   private BillingEvent createBillingEvent(Reason reason, Money cost) {
@@ -254,8 +261,8 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .setRegistrarId("TheRegistrar")
         .setCost(cost)
         .setPeriodYears(2)
-        .setEventTime(TIME_BEFORE_FLOW.minusDays(4))
-        .setBillingTime(TIME_BEFORE_FLOW.plusDays(1))
+        .setEventTime(minusDays(TIME_BEFORE_FLOW, 4))
+        .setBillingTime(toDateTime(plusDays(TIME_BEFORE_FLOW, 1)))
         .setDomainHistory(earlierHistoryEntry)
         .build();
   }
@@ -298,7 +305,6 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     setUpSuccessfulTest();
     clock.advanceOneMilli();
     runFlowAssertResponse(loadFile("domain_delete_response_pending.xml"));
-    Duration when = standardDays(3);
     cloudTasksHelper.assertTasksEnqueued(
         QUEUE_ASYNC_ACTIONS,
         new TaskMatcher()
@@ -307,9 +313,9 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             .service("backend")
             .header("content-type", "application/x-www-form-urlencoded")
             .param(PARAM_RESOURCE_KEY, domain.createVKey().stringify())
-            .param(PARAM_REQUESTED_TIME, clock.nowUtc().toString())
-            .param(PARAM_RESAVE_TIMES, clock.nowUtc().plusDays(5).toString())
-            .scheduleTime(clock.nowUtc().plus(when)));
+            .param(PARAM_REQUESTED_TIME, clock.now().toString())
+            .param(PARAM_RESAVE_TIMES, plusDays(clock.now(), 5).toString())
+            .scheduleTime(clock.nowUtc().plus(standardDays(3))));
   }
 
   @Test
@@ -319,7 +325,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         GracePeriod.create(
             GracePeriodStatus.ADD,
             domain.getRepoId(),
-            TIME_BEFORE_FLOW.plusDays(1),
+            plusDays(TIME_BEFORE_FLOW, 1),
             "TheRegistrar",
             null));
     dryRunFlowAssertResponse(loadFile("generic_success_response.xml"));
@@ -376,8 +382,8 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     runFlowAssertResponse(loadFile("domain_delete_response_pending.xml"));
 
     Domain domain = reloadResourceByForeignKey();
-    DateTime redemptionEndTime = domain.getLastEppUpdateDateTime().plusDays(3);
-    Domain domainAtRedemptionTime = domain.cloneProjectedAtTime(redemptionEndTime);
+    Instant redemptionEndTime = plusDays(domain.getLastEppUpdateTime(), 3);
+    Domain domainAtRedemptionTime = domain.cloneProjectedAtInstant(redemptionEndTime);
     assertAboutDomains()
         .that(domainAtRedemptionTime)
         .hasLastEppUpdateRegistrarId("TheRegistrar")
@@ -413,12 +419,12 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         GracePeriod.create(
             GracePeriodStatus.TRANSFER,
             domain.getRepoId(),
-            TIME_BEFORE_FLOW.plusDays(1),
+            plusDays(TIME_BEFORE_FLOW, 1),
             "NewRegistrar",
             null));
     // We should see exactly one poll message, which is for the autorenew 1 month in the future.
     assertPollMessages(createAutorenewPollMessage("TheRegistrar").build());
-    DateTime expectedExpirationTime = domain.getRegistrationExpirationDateTime().minusYears(2);
+    Instant expectedExpirationTime = minusYears(domain.getRegistrationExpirationTime(), 2);
     clock.advanceOneMilli();
     runFlowAssertResponse(loadFile(responseFilename, substitutions));
     Domain resource = reloadResourceByForeignKey();
@@ -428,10 +434,11 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .hasStatusValue(StatusValue.PENDING_DELETE)
         .and()
         .hasDeletionTime(
-            clock
-                .nowUtc()
-                .plus(Tld.get("tld").getRedemptionGracePeriodLength())
-                .plus(Tld.get("tld").getPendingDeleteLength()))
+            toDateTime(
+                clock
+                    .now()
+                    .plusMillis(Tld.get("tld").getRedemptionGracePeriodLength().getMillis())
+                    .plusMillis(Tld.get("tld").getPendingDeleteLength().getMillis())))
         .and()
         .hasExactlyStatusValues(StatusValue.INACTIVE, StatusValue.PENDING_DELETE)
         .and()
@@ -451,7 +458,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             GracePeriod.create(
                 GracePeriodStatus.REDEMPTION,
                 domain.getRepoId(),
-                clock.nowUtc().plus(Tld.get("tld").getRedemptionGracePeriodLength()),
+                clock.now().plusMillis(Tld.get("tld").getRedemptionGracePeriodLength().getMillis()),
                 "TheRegistrar",
                 null,
                 resource.getGracePeriods().iterator().next().getGracePeriodId()));
@@ -462,8 +469,9 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     // There should be a future poll message at the deletion time. The previous autorenew poll
     // message should now be deleted.
     assertAboutDomains().that(domain).hasDeletePollMessage();
-    DateTime deletionTime = domain.getDeletionDateTime();
-    assertThat(getPollMessages("TheRegistrar", deletionTime.minusMinutes(1))).isEmpty();
+    Instant deletionTime = domain.getDeletionTime();
+    assertThat(getPollMessages("TheRegistrar", deletionTime.minus(java.time.Duration.ofMinutes(1))))
+        .isEmpty();
     assertThat(getPollMessages("TheRegistrar", deletionTime)).hasSize(1);
     assertThat(domain.getDeletePollMessage())
         .isEqualTo(getOnlyPollMessage("TheRegistrar").createVKey());
@@ -490,14 +498,15 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     persistResource(
         loadByKey(reloadResourceByForeignKey().getAutorenewPollMessage())
             .asBuilder()
-            .setEventTime(A_MONTH_FROM_NOW.minusYears(3))
+            .setEventTime(minusYears(A_MONTH_FROM_NOW, 3))
             .build());
     clock.advanceOneMilli();
     runFlowAssertResponse(loadFile("domain_delete_response_pending.xml"));
     // There should now be two poll messages; one for the delete of the domain (in the future), and
     // another for the unacked autorenew messages.
-    DateTime deletionTime = reloadResourceByForeignKey().getDeletionDateTime();
-    assertThat(getPollMessages("TheRegistrar", deletionTime.minusMinutes(1))).hasSize(1);
+    Instant deletionTime = reloadResourceByForeignKey().getDeletionTime();
+    assertThat(getPollMessages("TheRegistrar", deletionTime.minus(java.time.Duration.ofMinutes(1))))
+        .hasSize(1);
     assertThat(getPollMessages("TheRegistrar", deletionTime)).hasSize(2);
   }
 
@@ -532,11 +541,11 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setRenewBillingCostTransitions(
+            .setRenewBillingCostTransitionsInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     Money.of(USD, 11),
-                    TIME_BEFORE_FLOW.minusDays(5),
+                    minusDays(TIME_BEFORE_FLOW, 5),
                     Money.of(USD, 20)))
             .build());
     setUpAutorenewGracePeriod();
@@ -571,10 +580,11 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .hasExactlyStatusValues(StatusValue.INACTIVE, StatusValue.PENDING_DELETE)
         .and()
         .hasDeletionTime(
-            clock
-                .nowUtc()
-                .plus(Tld.get("tld").getRedemptionGracePeriodLength())
-                .plus(Tld.get("tld").getPendingDeleteLength()))
+            toDateTime(
+                clock
+                    .now()
+                    .plusMillis(Tld.get("tld").getRedemptionGracePeriodLength().getMillis())
+                    .plusMillis(Tld.get("tld").getPendingDeleteLength().getMillis())))
         .and()
         .hasOneHistoryEntryEachOfTypes(DOMAIN_CREATE, DOMAIN_TRANSFER_REQUEST, DOMAIN_DELETE);
     // All existing grace periods should be gone, and a new REDEMPTION one should be added.
@@ -583,7 +593,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             GracePeriod.create(
                 GracePeriodStatus.REDEMPTION,
                 domain.getRepoId(),
-                clock.nowUtc().plus(Tld.get("tld").getRedemptionGracePeriodLength()),
+                clock.now().plusMillis(Tld.get("tld").getRedemptionGracePeriodLength().getMillis()),
                 "TheRegistrar",
                 null,
                 domain.getGracePeriods().iterator().next().getGracePeriodId()));
@@ -613,8 +623,9 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .isEqualTo(Trid.create("transferClient-trid", "transferServer-trid"));
     assertThat(panData.getActionResult()).isFalse();
     // There should be a future poll message to the losing registrar at the deletion time.
-    DateTime deletionTime = domain.getDeletionDateTime();
-    assertThat(getPollMessages("TheRegistrar", deletionTime.minusMinutes(1))).isEmpty();
+    Instant deletionTime = domain.getDeletionTime();
+    assertThat(getPollMessages("TheRegistrar", deletionTime.minus(java.time.Duration.ofMinutes(1))))
+        .isEmpty();
     assertThat(getPollMessages("TheRegistrar", deletionTime)).hasSize(1);
     assertOnlyBillingEventIsClosedAutorenew("TheRegistrar");
     // The domain TransferData should reflect the cancelled transfer as we expect, with
@@ -624,7 +635,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             oldTransferData
                 .copyConstantFieldsToBuilder()
                 .setTransferStatus(TransferStatus.SERVER_CANCELLED)
-                .setPendingTransferExpirationTime(clock.nowUtc())
+                .setPendingTransferExpirationTime(clock.now())
                 .build());
     // The server-approve entities should all be deleted.
     assertThat(loadByKeyIfPresent(oldTransferData.getServerApproveBillingEvent())).isEmpty();
@@ -648,7 +659,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     // Add a nameserver.
     Host host = persistResource(newHost("ns1.example.tld"));
     persistResource(
-        ForeignKeyUtils.loadResource(Domain.class, getUniqueIdFromCommand(), clock.nowUtc())
+        ForeignKeyUtils.loadResource(Domain.class, getUniqueIdFromCommand(), clock.now())
             .get()
             .asBuilder()
             .setNameservers(ImmutableSet.of(host.createVKey()))
@@ -658,9 +669,9 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         DatabaseHelper.newDomain("example1.tld")
             .asBuilder()
             .setNameservers(ImmutableSet.of(host.createVKey()))
-            .setDeletionTime(START_OF_TIME)
+            .setDeletionTime(START_INSTANT)
             .build());
-    DateTime eventTime = clock.nowUtc();
+    Instant eventTime = clock.now();
     runFlowAssertResponse(loadFile("generic_success_response.xml"));
     assertDomainDnsRequests("example.tld");
     assertAutorenewClosedAndCancellationCreatedFor(
@@ -676,7 +687,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         newHost("ns1." + getUniqueIdFromCommand())
             .asBuilder()
             .setSuperordinateDomain(reloadResourceByForeignKey().createVKey())
-            .setDeletionTime(clock.nowUtc().minusDays(1))
+            .setDeletionTime(minusDays(clock.now(), 1))
             .build());
     clock.advanceOneMilli();
     runFlowAssertResponse(loadFile("domain_delete_response_pending.xml"));
@@ -747,7 +758,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         CommitMode.LIVE, UserPrivileges.SUPERUSER, loadFile("domain_delete_response_pending.xml"));
 
     HistoryEntry deleteHistoryEntry = getOnlyHistoryEntryOfType(domain, DOMAIN_DELETE);
-    DateTime now = clock.nowUtc();
+    Instant now = clock.now();
     assertPollMessages(
         new PollMessage.OneTime.Builder()
             .setRegistrarId("TheRegistrar")
@@ -764,7 +775,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         new PollMessage.OneTime.Builder()
             .setRegistrarId("TheRegistrar")
             .setHistoryEntry(deleteHistoryEntry)
-            .setEventTime(DateTime.parse("2000-07-11T22:00:00.010Z"))
+            .setEventTime(Instant.parse("2000-07-11T22:00:00.010Z"))
             .setMsg("Deleted by registry administrator.")
             .setResponseData(
                 ImmutableList.of(
@@ -772,7 +783,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
                         "example.tld",
                         true,
                         deleteHistoryEntry.getTrid(),
-                        DateTime.parse("2000-07-11T22:00:00.010Z"))))
+                        Instant.parse("2000-07-11T22:00:00.010Z"))))
             .build());
   }
 
@@ -888,7 +899,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .that(reloadResourceByForeignKey())
         .hasOneHistoryEntryEachOfTypes(DOMAIN_CREATE, DOMAIN_DELETE)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("TheRegistrar");
     assertAboutHistoryEntries()
@@ -928,11 +939,11 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             earlierHistoryEntry
                 .asBuilder()
                 .setType(DOMAIN_CREATE)
-                .setModificationTime(TIME_BEFORE_FLOW.minusDays(2))
+                .setModificationTime(minusDays(TIME_BEFORE_FLOW, 2))
                 .setDomainTransactionRecords(
                     ImmutableSet.of(
                         DomainTransactionRecord.create(
-                            "tld", TIME_BEFORE_FLOW.plusDays(1), NET_ADDS_1_YR, 1)))
+                            "tld", plusDays(TIME_BEFORE_FLOW, 1), NET_ADDS_1_YR, 1)))
                 .build());
     runFlow();
     DomainHistory persistedEntry = (DomainHistory) getOnlyHistoryEntryOfType(domain, DOMAIN_DELETE);
@@ -950,11 +961,11 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             earlierHistoryEntry
                 .asBuilder()
                 .setType(DOMAIN_CREATE)
-                .setModificationTime(TIME_BEFORE_FLOW.minusDays(4))
+                .setModificationTime(minusDays(TIME_BEFORE_FLOW, 4))
                 .setDomainTransactionRecords(
                     ImmutableSet.of(
                         DomainTransactionRecord.create(
-                            "tld", TIME_BEFORE_FLOW.plusDays(1), NET_ADDS_1_YR, 1)))
+                            "tld", plusDays(TIME_BEFORE_FLOW, 1), NET_ADDS_1_YR, 1)))
                 .build());
     runFlow();
     DomainHistory persistedEntry = (DomainHistory) getOnlyHistoryEntryOfType(domain, DOMAIN_DELETE);
@@ -962,7 +973,10 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     assertThat(persistedEntry.getDomainTransactionRecords())
         .containsExactly(
             DomainTransactionRecord.create(
-                "tld", clock.nowUtc().plusHours(3), DELETED_DOMAINS_NOGRACE, 1));
+                "tld",
+                clock.now().plus(java.time.Duration.ofHours(3)),
+                DELETED_DOMAINS_NOGRACE,
+                1));
   }
 
   @Test
@@ -975,12 +989,12 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             earlierHistoryEntry
                 .asBuilder()
                 .setType(DOMAIN_CREATE)
-                .setModificationTime(TIME_BEFORE_FLOW.minusDays(2))
+                .setModificationTime(minusDays(TIME_BEFORE_FLOW, 2))
                 .setDomainTransactionRecords(
                     ImmutableSet.of(
                         // Only add or renew records counts should be cancelled
                         DomainTransactionRecord.create(
-                            "tld", TIME_BEFORE_FLOW.plusDays(1), RESTORED_DOMAINS, 1)))
+                            "tld", plusDays(TIME_BEFORE_FLOW, 1), RESTORED_DOMAINS, 1)))
                 .build());
     runFlow();
     DomainHistory persistedEntry = (DomainHistory) getOnlyHistoryEntryOfType(domain, DOMAIN_DELETE);
@@ -988,7 +1002,10 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     assertThat(persistedEntry.getDomainTransactionRecords())
         .containsExactly(
             DomainTransactionRecord.create(
-                "tld", clock.nowUtc().plusHours(3), DELETED_DOMAINS_NOGRACE, 1));
+                "tld",
+                clock.now().plus(java.time.Duration.ofHours(3)),
+                DELETED_DOMAINS_NOGRACE,
+                1));
   }
 
   /** Verifies that if there's no add grace period, we still cancel out valid renew records */
@@ -998,16 +1015,16 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     setUpGracePeriodDurations();
     clock.advanceOneMilli();
     DomainTransactionRecord renewRecord =
-        DomainTransactionRecord.create("tld", TIME_BEFORE_FLOW.plusDays(1), NET_RENEWS_3_YR, 1);
+        DomainTransactionRecord.create("tld", plusDays(TIME_BEFORE_FLOW, 1), NET_RENEWS_3_YR, 1);
     // We don't want to cancel non-add or renew records
     DomainTransactionRecord notCancellableRecord =
-        DomainTransactionRecord.create("tld", TIME_BEFORE_FLOW.plusDays(1), RESTORED_DOMAINS, 5);
+        DomainTransactionRecord.create("tld", plusDays(TIME_BEFORE_FLOW, 1), RESTORED_DOMAINS, 5);
     earlierHistoryEntry =
         persistResource(
             earlierHistoryEntry
                 .asBuilder()
                 .setType(DOMAIN_CREATE)
-                .setModificationTime(TIME_BEFORE_FLOW.minusDays(2))
+                .setModificationTime(minusDays(TIME_BEFORE_FLOW, 2))
                 .setDomainTransactionRecords(ImmutableSet.of(renewRecord, notCancellableRecord))
                 .build());
     runFlow();
@@ -1016,7 +1033,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     assertThat(persistedEntry.getDomainTransactionRecords())
         .containsExactly(
             DomainTransactionRecord.create(
-                "tld", clock.nowUtc().plusHours(3), DELETED_DOMAINS_NOGRACE, 1),
+                "tld", clock.now().plus(java.time.Duration.ofHours(3)), DELETED_DOMAINS_NOGRACE, 1),
             renewRecord.asBuilder().setReportAmount(-1).build());
   }
 
@@ -1027,7 +1044,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         GracePeriod.create(
             GracePeriodStatus.ADD,
             domain.getRepoId(),
-            TIME_BEFORE_FLOW.plusDays(1),
+            plusDays(TIME_BEFORE_FLOW, 1),
             "TheRegistrar",
             null));
     setUpGracePeriodDurations();
@@ -1037,7 +1054,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     // Transaction record should just be the grace period delete
     assertThat(persistedEntry.getDomainTransactionRecords())
         .containsExactly(
-            DomainTransactionRecord.create("tld", clock.nowUtc(), DELETED_DOMAINS_GRACE, 1));
+            DomainTransactionRecord.create("tld", clock.now(), DELETED_DOMAINS_GRACE, 1));
   }
 
   @Test
@@ -1047,7 +1064,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         GracePeriod.create(
             GracePeriodStatus.ADD,
             domain.getRepoId(),
-            TIME_BEFORE_FLOW.plusDays(1),
+            plusDays(TIME_BEFORE_FLOW, 1),
             "TheRegistrar",
             null));
     setUpGracePeriodDurations();
@@ -1057,20 +1074,20 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             earlierHistoryEntry
                 .asBuilder()
                 .setType(DOMAIN_CREATE)
-                .setModificationTime(TIME_BEFORE_FLOW.minusDays(2))
+                .setModificationTime(minusDays(TIME_BEFORE_FLOW, 2))
                 .setDomainTransactionRecords(
                     ImmutableSet.of(
                         DomainTransactionRecord.create(
-                            "tld", TIME_BEFORE_FLOW.plusDays(1), NET_ADDS_10_YR, 1)))
+                            "tld", plusDays(TIME_BEFORE_FLOW, 1), NET_ADDS_10_YR, 1)))
                 .build());
     DomainTransactionRecord existingRecord =
-        DomainTransactionRecord.create("tld", TIME_BEFORE_FLOW.plusDays(2), NET_ADDS_10_YR, 1);
+        DomainTransactionRecord.create("tld", plusDays(TIME_BEFORE_FLOW, 2), NET_ADDS_10_YR, 1);
     // Create a HistoryEntry with a later modification time
     persistResource(
         new DomainHistory.Builder()
             .setType(DOMAIN_CREATE)
             .setDomain(domain)
-            .setModificationTime(TIME_BEFORE_FLOW.minusDays(1))
+            .setModificationTime(minusDays(TIME_BEFORE_FLOW, 1))
             .setRegistrarId("TheRegistrar")
             .setDomainTransactionRecords(ImmutableSet.of(existingRecord))
             .build());
@@ -1079,7 +1096,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     // Transaction record should be the grace period delete, and the more recent cancellation record
     assertThat(persistedEntry.getDomainTransactionRecords())
         .containsExactly(
-            DomainTransactionRecord.create("tld", clock.nowUtc(), DELETED_DOMAINS_GRACE, 1),
+            DomainTransactionRecord.create("tld", clock.now(), DELETED_DOMAINS_GRACE, 1),
             // The cancellation record is the same as the original, except with a -1 counter
             existingRecord.asBuilder().setReportAmount(-1).build());
   }
@@ -1099,13 +1116,13 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .that(resource)
         .hasExactlyStatusValues(StatusValue.INACTIVE, StatusValue.PENDING_DELETE)
         .and()
-        .hasDeletionTime(clock.nowUtc().plus(standardDays(19)));
+        .hasDeletionTime(clock.now().plusMillis(standardDays(19).getMillis()));
     assertThat(resource.getGracePeriods())
         .containsExactly(
             GracePeriod.create(
                 GracePeriodStatus.REDEMPTION,
                 domain.getRepoId(),
-                clock.nowUtc().plus(standardDays(15)),
+                clock.now().plusMillis(standardDays(15).getMillis()),
                 "TheRegistrar",
                 null,
                 resource.getGracePeriods().iterator().next().getGracePeriodId()));
@@ -1127,7 +1144,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .that(resource)
         .hasExactlyStatusValues(StatusValue.INACTIVE, StatusValue.PENDING_DELETE)
         .and()
-        .hasDeletionTime(clock.nowUtc().plus(standardDays(4)));
+        .hasDeletionTime(clock.now().plusMillis(standardDays(4).getMillis()));
     assertThat(resource.getGracePeriods()).isEmpty();
     assertDeletionPollMessageFor(resource, "Deleted by registry administrator.");
   }
@@ -1147,13 +1164,13 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .that(resource)
         .hasExactlyStatusValues(StatusValue.INACTIVE, StatusValue.PENDING_DELETE)
         .and()
-        .hasDeletionTime(clock.nowUtc().plus(standardDays(15)));
+        .hasDeletionTime(clock.now().plusMillis(standardDays(15).getMillis()));
     assertThat(resource.getGracePeriods())
         .containsExactly(
             GracePeriod.create(
                 GracePeriodStatus.REDEMPTION,
                 domain.getRepoId(),
-                clock.nowUtc().plus(standardDays(15)),
+                clock.now().plusMillis(standardDays(15).getMillis()),
                 "TheRegistrar",
                 null,
                 resource.getGracePeriods().iterator().next().getGracePeriodId()));
@@ -1312,11 +1329,11 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setRenewBillingCostTransitions(
+            .setRenewBillingCostTransitionsInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     Money.of(USD, 11),
-                    TIME_BEFORE_FLOW.minusDays(5),
+                    minusDays(TIME_BEFORE_FLOW, 5),
                     Money.of(USD, 20)))
             .build());
     setUpAutorenewGracePeriod();
@@ -1331,11 +1348,11 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setRenewBillingCostTransitions(
+            .setRenewBillingCostTransitionsInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     Money.of(USD, 11),
-                    TIME_BEFORE_FLOW.minusDays(5),
+                    minusDays(TIME_BEFORE_FLOW, 5),
                     Money.of(USD, 20)))
             .build());
     setUpAutorenewGracePeriod();
@@ -1349,11 +1366,11 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setRenewBillingCostTransitions(
+            .setRenewBillingCostTransitionsInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME,
+                    START_INSTANT,
                     Money.of(USD, 11),
-                    TIME_BEFORE_FLOW.minusDays(5),
+                    minusDays(TIME_BEFORE_FLOW, 5),
                     Money.of(USD, 20)))
             .build());
     setUpAutorenewGracePeriod();

--- a/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
@@ -104,7 +104,7 @@ import google.registry.testing.LogsSubject;
 import java.util.Map;
 import java.util.logging.Level;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -115,9 +115,9 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
   private Domain domain;
   private DomainHistory earlierHistoryEntry;
 
-  private static final DateTime TIME_BEFORE_FLOW = DateTime.parse("2000-06-06T22:00:00.0Z");
-  private static final DateTime A_MONTH_AGO = TIME_BEFORE_FLOW.minusMonths(1);
-  private static final DateTime A_MONTH_FROM_NOW = TIME_BEFORE_FLOW.plusMonths(1);
+  private static final Instant TIME_BEFORE_FLOW = Instant.parse("2000-06-06T22:00:00.0Z");
+  private static final Instant A_MONTH_AGO = TIME_BEFORE_FLOW.minusMonths(1);
+  private static final Instant A_MONTH_FROM_NOW = TIME_BEFORE_FLOW.plusMonths(1);
 
   private static final ImmutableMap<String, String> FEE_06_MAP =
       ImmutableMap.of("FEE_VERSION", "fee-0.6", "FEE_NS", "fee");
@@ -156,7 +156,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     assertMutatingFlow(true);
   }
 
-  private void createReferencedEntities(DateTime expirationTime) throws Exception {
+  private void createReferencedEntities(Instant expirationTime) throws Exception {
     domain =
         persistResource(
             DatabaseHelper.newDomain(getUniqueIdFromCommand())
@@ -169,7 +169,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             new DomainHistory.Builder()
                 .setType(DOMAIN_CREATE)
                 .setDomain(domain)
-                .setModificationTime(clock.nowUtc())
+                .setModificationTime(clock.now())
                 .setRegistrarId(domain.getCreationRegistrarId())
                 .build());
   }
@@ -221,11 +221,11 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
   private void assertAutorenewClosedAndCancellationCreatedFor(
       BillingEvent graceBillingEvent, DomainHistory historyEntryDomainDelete) {
     assertAutorenewClosedAndCancellationCreatedFor(
-        graceBillingEvent, historyEntryDomainDelete, clock.nowUtc());
+        graceBillingEvent, historyEntryDomainDelete, clock.now());
   }
 
   private void assertAutorenewClosedAndCancellationCreatedFor(
-      BillingEvent graceBillingEvent, DomainHistory historyEntryDomainDelete, DateTime eventTime) {
+      BillingEvent graceBillingEvent, DomainHistory historyEntryDomainDelete, Instant eventTime) {
     assertBillingEvents(
         createAutorenewBillingEvent("TheRegistrar").setRecurrenceEndTime(eventTime).build(),
         graceBillingEvent,
@@ -244,7 +244,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     // There should be no billing events (even timed to when the transfer would have expired) except
     // for the now closed autorenew one.
     assertBillingEvents(
-        createAutorenewBillingEvent(registrarId).setRecurrenceEndTime(clock.nowUtc()).build());
+        createAutorenewBillingEvent(registrarId).setRecurrenceEndTime(clock.now()).build());
   }
 
   private BillingEvent createBillingEvent(Reason reason, Money cost) {
@@ -307,9 +307,9 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             .service("backend")
             .header("content-type", "application/x-www-form-urlencoded")
             .param(PARAM_RESOURCE_KEY, domain.createVKey().stringify())
-            .param(PARAM_REQUESTED_TIME, clock.nowUtc().toString())
-            .param(PARAM_RESAVE_TIMES, clock.nowUtc().plusDays(5).toString())
-            .scheduleTime(clock.nowUtc().plus(when)));
+            .param(PARAM_REQUESTED_TIME, clock.now().toString())
+            .param(PARAM_RESAVE_TIMES, clock.now().plusDays(5).toString())
+            .scheduleTime(clock.now().plus(when)));
   }
 
   @Test
@@ -376,7 +376,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     runFlowAssertResponse(loadFile("domain_delete_response_pending.xml"));
 
     Domain domain = reloadResourceByForeignKey();
-    DateTime redemptionEndTime = domain.getLastEppUpdateDateTime().plusDays(3);
+    Instant redemptionEndTime = domain.getLastEppUpdateDateTime().plusDays(3);
     Domain domainAtRedemptionTime = domain.cloneProjectedAtTime(redemptionEndTime);
     assertAboutDomains()
         .that(domainAtRedemptionTime)
@@ -418,7 +418,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             null));
     // We should see exactly one poll message, which is for the autorenew 1 month in the future.
     assertPollMessages(createAutorenewPollMessage("TheRegistrar").build());
-    DateTime expectedExpirationTime = domain.getRegistrationExpirationDateTime().minusYears(2);
+    Instant expectedExpirationTime = domain.getRegistrationExpirationDateTime().minusYears(2);
     clock.advanceOneMilli();
     runFlowAssertResponse(loadFile(responseFilename, substitutions));
     Domain resource = reloadResourceByForeignKey();
@@ -429,7 +429,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .and()
         .hasDeletionTime(
             clock
-                .nowUtc()
+                .now()
                 .plus(Tld.get("tld").getRedemptionGracePeriodLength())
                 .plus(Tld.get("tld").getPendingDeleteLength()))
         .and()
@@ -451,7 +451,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             GracePeriod.create(
                 GracePeriodStatus.REDEMPTION,
                 domain.getRepoId(),
-                clock.nowUtc().plus(Tld.get("tld").getRedemptionGracePeriodLength()),
+                clock.now().plus(Tld.get("tld").getRedemptionGracePeriodLength()),
                 "TheRegistrar",
                 null,
                 resource.getGracePeriods().iterator().next().getGracePeriodId()));
@@ -462,7 +462,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     // There should be a future poll message at the deletion time. The previous autorenew poll
     // message should now be deleted.
     assertAboutDomains().that(domain).hasDeletePollMessage();
-    DateTime deletionTime = domain.getDeletionDateTime();
+    Instant deletionTime = domain.getDeletionDateTime();
     assertThat(getPollMessages("TheRegistrar", deletionTime.minusMinutes(1))).isEmpty();
     assertThat(getPollMessages("TheRegistrar", deletionTime)).hasSize(1);
     assertThat(domain.getDeletePollMessage())
@@ -496,7 +496,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     runFlowAssertResponse(loadFile("domain_delete_response_pending.xml"));
     // There should now be two poll messages; one for the delete of the domain (in the future), and
     // another for the unacked autorenew messages.
-    DateTime deletionTime = reloadResourceByForeignKey().getDeletionDateTime();
+    Instant deletionTime = reloadResourceByForeignKey().getDeletionDateTime();
     assertThat(getPollMessages("TheRegistrar", deletionTime.minusMinutes(1))).hasSize(1);
     assertThat(getPollMessages("TheRegistrar", deletionTime)).hasSize(2);
   }
@@ -572,7 +572,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .and()
         .hasDeletionTime(
             clock
-                .nowUtc()
+                .now()
                 .plus(Tld.get("tld").getRedemptionGracePeriodLength())
                 .plus(Tld.get("tld").getPendingDeleteLength()))
         .and()
@@ -583,16 +583,16 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             GracePeriod.create(
                 GracePeriodStatus.REDEMPTION,
                 domain.getRepoId(),
-                clock.nowUtc().plus(Tld.get("tld").getRedemptionGracePeriodLength()),
+                clock.now().plus(Tld.get("tld").getRedemptionGracePeriodLength()),
                 "TheRegistrar",
                 null,
                 domain.getGracePeriods().iterator().next().getGracePeriodId()));
     // The poll message (in the future) to the losing registrar for implicit ack should be gone.
-    assertThat(getPollMessages("TheRegistrar", clock.nowUtc().plusMonths(1))).isEmpty();
+    assertThat(getPollMessages("TheRegistrar", clock.now().plusMonths(1))).isEmpty();
     // The poll message in the future to the gaining registrar should be gone too, but there
     // should be one at the current time to the gaining registrar.
     PollMessage gainingPollMessage = getOnlyPollMessage("NewRegistrar");
-    assertThat(gainingPollMessage.getEventTime()).isEqualTo(clock.nowUtc());
+    assertThat(gainingPollMessage.getEventTime()).isEqualTo(clock.now());
     assertThat(
             gainingPollMessage
                 .getResponseData()
@@ -613,7 +613,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .isEqualTo(Trid.create("transferClient-trid", "transferServer-trid"));
     assertThat(panData.getActionResult()).isFalse();
     // There should be a future poll message to the losing registrar at the deletion time.
-    DateTime deletionTime = domain.getDeletionDateTime();
+    Instant deletionTime = domain.getDeletionDateTime();
     assertThat(getPollMessages("TheRegistrar", deletionTime.minusMinutes(1))).isEmpty();
     assertThat(getPollMessages("TheRegistrar", deletionTime)).hasSize(1);
     assertOnlyBillingEventIsClosedAutorenew("TheRegistrar");
@@ -624,7 +624,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             oldTransferData
                 .copyConstantFieldsToBuilder()
                 .setTransferStatus(TransferStatus.SERVER_CANCELLED)
-                .setPendingTransferExpirationTime(clock.nowUtc())
+                .setPendingTransferExpirationTime(clock.now())
                 .build());
     // The server-approve entities should all be deleted.
     assertThat(loadByKeyIfPresent(oldTransferData.getServerApproveBillingEvent())).isEmpty();
@@ -648,7 +648,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     // Add a nameserver.
     Host host = persistResource(newHost("ns1.example.tld"));
     persistResource(
-        ForeignKeyUtils.loadResource(Domain.class, getUniqueIdFromCommand(), clock.nowUtc())
+        ForeignKeyUtils.loadResource(Domain.class, getUniqueIdFromCommand(), clock.now())
             .get()
             .asBuilder()
             .setNameservers(ImmutableSet.of(host.createVKey()))
@@ -660,7 +660,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
             .setNameservers(ImmutableSet.of(host.createVKey()))
             .setDeletionTime(START_OF_TIME)
             .build());
-    DateTime eventTime = clock.nowUtc();
+    Instant eventTime = clock.now();
     runFlowAssertResponse(loadFile("generic_success_response.xml"));
     assertDomainDnsRequests("example.tld");
     assertAutorenewClosedAndCancellationCreatedFor(
@@ -676,7 +676,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         newHost("ns1." + getUniqueIdFromCommand())
             .asBuilder()
             .setSuperordinateDomain(reloadResourceByForeignKey().createVKey())
-            .setDeletionTime(clock.nowUtc().minusDays(1))
+            .setDeletionTime(clock.now().minusDays(1))
             .build());
     clock.advanceOneMilli();
     runFlowAssertResponse(loadFile("domain_delete_response_pending.xml"));
@@ -710,7 +710,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
 
   @Test
   void testFailure_existedButWasDeleted() throws Exception {
-    persistDeletedDomain(getUniqueIdFromCommand(), clock.nowUtc().minusDays(1));
+    persistDeletedDomain(getUniqueIdFromCommand(), clock.now().minusDays(1));
     ResourceDoesNotExistException thrown =
         assertThrows(ResourceDoesNotExistException.class, this::runFlow);
     assertThat(thrown).hasMessageThat().contains(String.format("(%s)", getUniqueIdFromCommand()));
@@ -747,7 +747,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         CommitMode.LIVE, UserPrivileges.SUPERUSER, loadFile("domain_delete_response_pending.xml"));
 
     HistoryEntry deleteHistoryEntry = getOnlyHistoryEntryOfType(domain, DOMAIN_DELETE);
-    DateTime now = clock.nowUtc();
+    Instant now = clock.now();
     assertPollMessages(
         new PollMessage.OneTime.Builder()
             .setRegistrarId("TheRegistrar")
@@ -764,7 +764,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         new PollMessage.OneTime.Builder()
             .setRegistrarId("TheRegistrar")
             .setHistoryEntry(deleteHistoryEntry)
-            .setEventTime(DateTime.parse("2000-07-11T22:00:00.010Z"))
+            .setEventTime(Instant.parse("2000-07-11T22:00:00.010Z"))
             .setMsg("Deleted by registry administrator.")
             .setResponseData(
                 ImmutableList.of(
@@ -772,7 +772,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
                         "example.tld",
                         true,
                         deleteHistoryEntry.getTrid(),
-                        DateTime.parse("2000-07-11T22:00:00.010Z"))))
+                        Instant.parse("2000-07-11T22:00:00.010Z"))))
             .build());
   }
 
@@ -888,7 +888,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .that(reloadResourceByForeignKey())
         .hasOneHistoryEntryEachOfTypes(DOMAIN_CREATE, DOMAIN_DELETE)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("TheRegistrar");
     assertAboutHistoryEntries()
@@ -962,7 +962,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     assertThat(persistedEntry.getDomainTransactionRecords())
         .containsExactly(
             DomainTransactionRecord.create(
-                "tld", clock.nowUtc().plusHours(3), DELETED_DOMAINS_NOGRACE, 1));
+                "tld", clock.now().plusHours(3), DELETED_DOMAINS_NOGRACE, 1));
   }
 
   @Test
@@ -988,7 +988,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     assertThat(persistedEntry.getDomainTransactionRecords())
         .containsExactly(
             DomainTransactionRecord.create(
-                "tld", clock.nowUtc().plusHours(3), DELETED_DOMAINS_NOGRACE, 1));
+                "tld", clock.now().plusHours(3), DELETED_DOMAINS_NOGRACE, 1));
   }
 
   /** Verifies that if there's no add grace period, we still cancel out valid renew records */
@@ -1016,7 +1016,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     assertThat(persistedEntry.getDomainTransactionRecords())
         .containsExactly(
             DomainTransactionRecord.create(
-                "tld", clock.nowUtc().plusHours(3), DELETED_DOMAINS_NOGRACE, 1),
+                "tld", clock.now().plusHours(3), DELETED_DOMAINS_NOGRACE, 1),
             renewRecord.asBuilder().setReportAmount(-1).build());
   }
 
@@ -1037,7 +1037,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     // Transaction record should just be the grace period delete
     assertThat(persistedEntry.getDomainTransactionRecords())
         .containsExactly(
-            DomainTransactionRecord.create("tld", clock.nowUtc(), DELETED_DOMAINS_GRACE, 1));
+            DomainTransactionRecord.create("tld", clock.now(), DELETED_DOMAINS_GRACE, 1));
   }
 
   @Test
@@ -1079,7 +1079,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
     // Transaction record should be the grace period delete, and the more recent cancellation record
     assertThat(persistedEntry.getDomainTransactionRecords())
         .containsExactly(
-            DomainTransactionRecord.create("tld", clock.nowUtc(), DELETED_DOMAINS_GRACE, 1),
+            DomainTransactionRecord.create("tld", clock.now(), DELETED_DOMAINS_GRACE, 1),
             // The cancellation record is the same as the original, except with a -1 counter
             existingRecord.asBuilder().setReportAmount(-1).build());
   }
@@ -1099,13 +1099,13 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .that(resource)
         .hasExactlyStatusValues(StatusValue.INACTIVE, StatusValue.PENDING_DELETE)
         .and()
-        .hasDeletionTime(clock.nowUtc().plus(standardDays(19)));
+        .hasDeletionTime(clock.now().plus(standardDays(19)));
     assertThat(resource.getGracePeriods())
         .containsExactly(
             GracePeriod.create(
                 GracePeriodStatus.REDEMPTION,
                 domain.getRepoId(),
-                clock.nowUtc().plus(standardDays(15)),
+                clock.now().plus(standardDays(15)),
                 "TheRegistrar",
                 null,
                 resource.getGracePeriods().iterator().next().getGracePeriodId()));
@@ -1127,7 +1127,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .that(resource)
         .hasExactlyStatusValues(StatusValue.INACTIVE, StatusValue.PENDING_DELETE)
         .and()
-        .hasDeletionTime(clock.nowUtc().plus(standardDays(4)));
+        .hasDeletionTime(clock.now().plus(standardDays(4)));
     assertThat(resource.getGracePeriods()).isEmpty();
     assertDeletionPollMessageFor(resource, "Deleted by registry administrator.");
   }
@@ -1147,13 +1147,13 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
         .that(resource)
         .hasExactlyStatusValues(StatusValue.INACTIVE, StatusValue.PENDING_DELETE)
         .and()
-        .hasDeletionTime(clock.nowUtc().plus(standardDays(15)));
+        .hasDeletionTime(clock.now().plus(standardDays(15)));
     assertThat(resource.getGracePeriods())
         .containsExactly(
             GracePeriod.create(
                 GracePeriodStatus.REDEMPTION,
                 domain.getRepoId(),
-                clock.nowUtc().plus(standardDays(15)),
+                clock.now().plus(standardDays(15)),
                 "TheRegistrar",
                 null,
                 resource.getGracePeriods().iterator().next().getGracePeriodId()));

--- a/core/src/test/java/google/registry/flows/domain/DomainDeletionTimeCacheTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainDeletionTimeCacheTest.java
@@ -19,11 +19,13 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistDomainAsDeleted;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
+import static google.registry.util.DateTimeUtils.toDateTime;
 
 import google.registry.model.domain.Domain;
 import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.testing.DatabaseHelper;
 import google.registry.testing.FakeClock;
+import java.time.Instant;
 import java.util.Optional;
 import org.joda.time.DateTime;
 import org.joda.time.Duration;
@@ -34,7 +36,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 /** Tests for {@link DomainDeletionTimeCache}. */
 public class DomainDeletionTimeCacheTest {
 
-  private final FakeClock clock = new FakeClock(DateTime.parse("2025-10-01T00:00:00.000Z"));
+  private final FakeClock clock = new FakeClock(Instant.parse("2025-10-01T00:00:00.000Z"));
   private final DomainDeletionTimeCache cache = DomainDeletionTimeCache.create();
 
   @RegisterExtension
@@ -85,10 +87,10 @@ public class DomainDeletionTimeCacheTest {
   void testCache_expires() {
     Domain domain = persistActiveDomain("domain.tld");
     assertThat(getDeletionTimeFromCache("domain.tld")).hasValue(END_OF_TIME);
-    DateTime elevenMinutesFromNow = clock.nowUtc().plusMinutes(11);
-    persistDomainAsDeleted(domain, elevenMinutesFromNow);
+    Instant elevenMinutesFromNow = clock.now().plus(java.time.Duration.ofMinutes(11));
+    persistDomainAsDeleted(domain, toDateTime(elevenMinutesFromNow));
     clock.advanceBy(Duration.standardMinutes(30));
-    assertThat(getDeletionTimeFromCache("domain.tld")).hasValue(elevenMinutesFromNow);
+    assertThat(getDeletionTimeFromCache("domain.tld")).hasValue(toDateTime(elevenMinutesFromNow));
   }
 
   private Optional<DateTime> getDeletionTimeFromCache(String domainName) {

--- a/core/src/test/java/google/registry/flows/domain/DomainDeletionTimeCacheTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainDeletionTimeCacheTest.java
@@ -25,7 +25,7 @@ import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.testing.DatabaseHelper;
 import google.registry.testing.FakeClock;
 import java.util.Optional;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 /** Tests for {@link DomainDeletionTimeCache}. */
 public class DomainDeletionTimeCacheTest {
 
-  private final FakeClock clock = new FakeClock(DateTime.parse("2025-10-01T00:00:00.000Z"));
+  private final FakeClock clock = new FakeClock(Instant.parse("2025-10-01T00:00:00.000Z"));
   private final DomainDeletionTimeCache cache = DomainDeletionTimeCache.create();
 
   @RegisterExtension
@@ -59,15 +59,15 @@ public class DomainDeletionTimeCacheTest {
 
   @Test
   void testDomainAvailable_deletedInFuture() {
-    persistDomainAsDeleted(persistActiveDomain("domain.tld"), clock.nowUtc().plusDays(1));
-    assertThat(getDeletionTimeFromCache("domain.tld")).hasValue(clock.nowUtc().plusDays(1));
+    persistDomainAsDeleted(persistActiveDomain("domain.tld"), clock.now().plusDays(1));
+    assertThat(getDeletionTimeFromCache("domain.tld")).hasValue(clock.now().plusDays(1));
   }
 
   @Test
   void testCache_returnsOldData() {
     Domain domain = persistActiveDomain("domain.tld");
     assertThat(getDeletionTimeFromCache("domain.tld")).hasValue(END_OF_TIME);
-    persistDomainAsDeleted(domain, clock.nowUtc().plusDays(1));
+    persistDomainAsDeleted(domain, clock.now().plusDays(1));
     // Without intervention, the cache should have the old data, even if a few minutes have passed
     clock.advanceBy(Duration.standardMinutes(5));
     assertThat(getDeletionTimeFromCache("domain.tld")).hasValue(END_OF_TIME);
@@ -77,21 +77,21 @@ public class DomainDeletionTimeCacheTest {
   void testCache_returnsNewDataAfterDomainCreate() {
     // Null deletion dates (meaning an avilable domain) shouldn't be cached
     assertThat(getDeletionTimeFromCache("domain.tld")).isEmpty();
-    persistDomainAsDeleted(persistActiveDomain("domain.tld"), clock.nowUtc().plusDays(1));
-    assertThat(getDeletionTimeFromCache("domain.tld")).hasValue(clock.nowUtc().plusDays(1));
+    persistDomainAsDeleted(persistActiveDomain("domain.tld"), clock.now().plusDays(1));
+    assertThat(getDeletionTimeFromCache("domain.tld")).hasValue(clock.now().plusDays(1));
   }
 
   @Test
   void testCache_expires() {
     Domain domain = persistActiveDomain("domain.tld");
     assertThat(getDeletionTimeFromCache("domain.tld")).hasValue(END_OF_TIME);
-    DateTime elevenMinutesFromNow = clock.nowUtc().plusMinutes(11);
+    Instant elevenMinutesFromNow = clock.now().plusMinutes(11);
     persistDomainAsDeleted(domain, elevenMinutesFromNow);
     clock.advanceBy(Duration.standardMinutes(30));
     assertThat(getDeletionTimeFromCache("domain.tld")).hasValue(elevenMinutesFromNow);
   }
 
-  private Optional<DateTime> getDeletionTimeFromCache(String domainName) {
+  private Optional<Instant> getDeletionTimeFromCache(String domainName) {
     return tm().transact(() -> cache.getDeletionTimeForDomain(domainName));
   }
 }

--- a/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
@@ -31,6 +31,8 @@ import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptio
 import static google.registry.testing.TestDataHelper.updateSubstitutions;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.minusDays;
+import static google.registry.util.DateTimeUtils.plusDays;
 import static google.registry.xml.XmlTestUtils.assertXmlEquals;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.joda.money.CurrencyUnit.USD;
@@ -77,7 +79,6 @@ import java.time.Instant;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -106,7 +107,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
   @BeforeEach
   void setup() {
     setEppInput("domain_info.xml");
-    clock.setTo(DateTime.parse("2005-03-03T22:00:00.000Z"));
+    clock.setTo(Instant.parse("2005-03-03T22:00:00.000Z"));
     sessionMetadata.setRegistrarId("NewRegistrar");
     createTld("tld");
     persistResource(
@@ -127,10 +128,10 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 .setPersistedCurrentSponsorRegistrarId("NewRegistrar")
                 .setCreationRegistrarId("TheRegistrar")
                 .setLastEppUpdateRegistrarId("NewRegistrar")
-                .setCreationTimeForTest(DateTime.parse("1999-04-03T22:00:00.0Z"))
-                .setLastEppUpdateTime(DateTime.parse("1999-12-03T09:00:00.0Z"))
-                .setLastTransferTime(DateTime.parse("2000-04-08T09:00:00.0Z"))
-                .setRegistrationExpirationTime(DateTime.parse("2005-04-03T22:00:00.0Z"))
+                .setCreationTimeForTest(Instant.parse("1999-04-03T22:00:00.0Z"))
+                .setLastEppUpdateTime(Instant.parse("1999-12-03T09:00:00.0Z"))
+                .setLastTransferTime(Instant.parse("2000-04-08T09:00:00.0Z"))
+                .setRegistrationExpirationTime(Instant.parse("2005-04-03T22:00:00.0Z"))
                 .setNameservers(
                     inactive ? null : ImmutableSet.of(host1.createVKey(), host2.createVKey()))
                 .setAuthInfo(DomainAuthInfo.create(PasswordAuth.create("2fooBAR")))
@@ -331,12 +332,12 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 GracePeriod.create(
                     gracePeriodStatus,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(1),
+                    plusDays(clock.now(), 1),
                     "TheRegistrar",
                     null))
             .setCreationRegistrarId("NewRegistrar")
-            .setCreationTimeForTest(DateTime.parse("2003-11-26T22:00:00.0Z"))
-            .setRegistrationExpirationTime(DateTime.parse("2005-11-26T22:00:00.0Z"))
+            .setCreationTimeForTest(Instant.parse("2003-11-26T22:00:00.0Z"))
+            .setRegistrationExpirationTime(Instant.parse("2005-11-26T22:00:00.0Z"))
             .setLastTransferTime((Instant) null)
             .setLastEppUpdateTime((Instant) null)
             .setLastEppUpdateRegistrarId(null)
@@ -357,7 +358,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
             new DomainHistory.Builder()
                 .setDomain(domain)
                 .setType(HistoryEntry.Type.DOMAIN_CREATE)
-                .setModificationTime(clock.nowUtc())
+                .setModificationTime(clock.now())
                 .setRegistrarId(domain.getCreationRegistrarId())
                 .build());
     BillingRecurrence renewEvent =
@@ -367,7 +368,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
                 .setTargetId(getUniqueIdFromCommand())
                 .setRegistrarId("TheRegistrar")
-                .setEventTime(clock.nowUtc())
+                .setEventTime(clock.now())
                 .setRecurrenceEndTime(END_OF_TIME)
                 .setDomainHistory(historyEntry)
                 .build());
@@ -380,7 +381,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 GracePeriod.createForRecurrence(
                     GracePeriodStatus.AUTO_RENEW,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(1),
+                    plusDays(clock.now(), 1),
                     "TheRegistrar",
                     recurrenceVKey))
             .build());
@@ -399,7 +400,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 GracePeriod.create(
                     GracePeriodStatus.REDEMPTION,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(1),
+                    plusDays(clock.now(), 1),
                     "TheRegistrar",
                     null))
             .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
@@ -418,7 +419,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 GracePeriod.create(
                     GracePeriodStatus.RENEW,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(1),
+                    plusDays(clock.now(), 1),
                     "TheRegistrar",
                     null))
             .build());
@@ -436,14 +437,14 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 GracePeriod.create(
                     GracePeriodStatus.RENEW,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(1),
+                    plusDays(clock.now(), 1),
                     "TheRegistrar",
                     null))
             .addGracePeriod(
                 GracePeriod.create(
                     GracePeriodStatus.RENEW,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(2),
+                    plusDays(clock.now(), 2),
                     "TheRegistrar",
                     null))
             .build());
@@ -461,7 +462,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 GracePeriod.create(
                     GracePeriodStatus.TRANSFER,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(1),
+                    plusDays(clock.now(), 1),
                     "TheRegistrar",
                     null))
             .build());
@@ -489,14 +490,14 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 GracePeriod.create(
                     GracePeriodStatus.ADD,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(1),
+                    plusDays(clock.now(), 1),
                     "TheRegistrar",
                     null))
             .addGracePeriod(
                 GracePeriod.create(
                     GracePeriodStatus.RENEW,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(2),
+                    plusDays(clock.now(), 2),
                     "TheRegistrar",
                     null))
             .build());
@@ -514,7 +515,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 GracePeriod.create(
                     GracePeriodStatus.ADD,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(1),
+                    plusDays(clock.now(), 1),
                     "TheRegistrar",
                     null))
             .setDsData(
@@ -536,7 +537,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
     persistResource(
         DatabaseHelper.newDomain("example.tld")
             .asBuilder()
-            .setDeletionTime(clock.nowUtc().minusDays(1))
+            .setDeletionTime(minusDays(clock.now(), 1))
             .build());
     ResourceDoesNotExistException thrown =
         assertThrows(ResourceDoesNotExistException.class, this::runFlow);
@@ -588,7 +589,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
             new AllocationToken.Builder()
                 .setToken("abc123")
                 .setTokenType(TokenType.BULK_PRICING)
-                .setCreationTimeForTest(DateTime.parse("2010-11-12T05:00:00Z"))
+                .setCreationTimeForTest(Instant.parse("2010-11-12T05:00:00Z"))
                 .setAllowedTlds(ImmutableSet.of("foo"))
                 .setAllowedRegistrarIds(ImmutableSet.of("NewRegistrar"))
                 .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
@@ -610,7 +611,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
             new AllocationToken.Builder()
                 .setToken("abc123")
                 .setTokenType(TokenType.BULK_PRICING)
-                .setCreationTimeForTest(DateTime.parse("2010-11-12T05:00:00Z"))
+                .setCreationTimeForTest(Instant.parse("2010-11-12T05:00:00Z"))
                 .setAllowedTlds(ImmutableSet.of("foo"))
                 .setAllowedRegistrarIds(ImmutableSet.of("NewRegistrar"))
                 .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
@@ -644,7 +645,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
             new AllocationToken.Builder()
                 .setToken("abc123")
                 .setTokenType(TokenType.BULK_PRICING)
-                .setCreationTimeForTest(DateTime.parse("2010-11-12T05:00:00Z"))
+                .setCreationTimeForTest(Instant.parse("2010-11-12T05:00:00Z"))
                 .setAllowedTlds(ImmutableSet.of("foo"))
                 .setAllowedRegistrarIds(ImmutableSet.of("NewRegistrar"))
                 .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
@@ -673,8 +674,8 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
     persistResource(
         domain
             .asBuilder()
-            .setDeletionTime(clock.nowUtc().plusDays(25))
-            .setRegistrationExpirationTime(clock.nowUtc().minusDays(1))
+            .setDeletionTime(plusDays(clock.now(), 25))
+            .setRegistrationExpirationTime(minusDays(clock.now(), 1))
             .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
             .build());
     doSuccessfulTest(
@@ -762,7 +763,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
     persistResource(
         domain
             .asBuilder()
-            .setDeletionTime(clock.nowUtc().plusDays(25))
+            .setDeletionTime(plusDays(clock.now(), 25))
             .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
             .build());
     doSuccessfulTest(

--- a/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
@@ -77,7 +77,7 @@ import java.time.Instant;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -106,7 +106,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
   @BeforeEach
   void setup() {
     setEppInput("domain_info.xml");
-    clock.setTo(DateTime.parse("2005-03-03T22:00:00.000Z"));
+    clock.setTo(Instant.parse("2005-03-03T22:00:00.000Z"));
     sessionMetadata.setRegistrarId("NewRegistrar");
     createTld("tld");
     persistResource(
@@ -127,10 +127,10 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 .setPersistedCurrentSponsorRegistrarId("NewRegistrar")
                 .setCreationRegistrarId("TheRegistrar")
                 .setLastEppUpdateRegistrarId("NewRegistrar")
-                .setCreationTimeForTest(DateTime.parse("1999-04-03T22:00:00.0Z"))
-                .setLastEppUpdateTime(DateTime.parse("1999-12-03T09:00:00.0Z"))
-                .setLastTransferTime(DateTime.parse("2000-04-08T09:00:00.0Z"))
-                .setRegistrationExpirationTime(DateTime.parse("2005-04-03T22:00:00.0Z"))
+                .setCreationTimeForTest(Instant.parse("1999-04-03T22:00:00.0Z"))
+                .setLastEppUpdateTime(Instant.parse("1999-12-03T09:00:00.0Z"))
+                .setLastTransferTime(Instant.parse("2000-04-08T09:00:00.0Z"))
+                .setRegistrationExpirationTime(Instant.parse("2005-04-03T22:00:00.0Z"))
                 .setNameservers(
                     inactive ? null : ImmutableSet.of(host1.createVKey(), host2.createVKey()))
                 .setAuthInfo(DomainAuthInfo.create(PasswordAuth.create("2fooBAR")))
@@ -331,12 +331,12 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 GracePeriod.create(
                     gracePeriodStatus,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(1),
+                    clock.now().plusDays(1),
                     "TheRegistrar",
                     null))
             .setCreationRegistrarId("NewRegistrar")
-            .setCreationTimeForTest(DateTime.parse("2003-11-26T22:00:00.0Z"))
-            .setRegistrationExpirationTime(DateTime.parse("2005-11-26T22:00:00.0Z"))
+            .setCreationTimeForTest(Instant.parse("2003-11-26T22:00:00.0Z"))
+            .setRegistrationExpirationTime(Instant.parse("2005-11-26T22:00:00.0Z"))
             .setLastTransferTime((Instant) null)
             .setLastEppUpdateTime((Instant) null)
             .setLastEppUpdateRegistrarId(null)
@@ -357,7 +357,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
             new DomainHistory.Builder()
                 .setDomain(domain)
                 .setType(HistoryEntry.Type.DOMAIN_CREATE)
-                .setModificationTime(clock.nowUtc())
+                .setModificationTime(clock.now())
                 .setRegistrarId(domain.getCreationRegistrarId())
                 .build());
     BillingRecurrence renewEvent =
@@ -367,7 +367,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
                 .setTargetId(getUniqueIdFromCommand())
                 .setRegistrarId("TheRegistrar")
-                .setEventTime(clock.nowUtc())
+                .setEventTime(clock.now())
                 .setRecurrenceEndTime(END_OF_TIME)
                 .setDomainHistory(historyEntry)
                 .build());
@@ -380,7 +380,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 GracePeriod.createForRecurrence(
                     GracePeriodStatus.AUTO_RENEW,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(1),
+                    clock.now().plusDays(1),
                     "TheRegistrar",
                     recurrenceVKey))
             .build());
@@ -399,7 +399,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 GracePeriod.create(
                     GracePeriodStatus.REDEMPTION,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(1),
+                    clock.now().plusDays(1),
                     "TheRegistrar",
                     null))
             .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
@@ -418,7 +418,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 GracePeriod.create(
                     GracePeriodStatus.RENEW,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(1),
+                    clock.now().plusDays(1),
                     "TheRegistrar",
                     null))
             .build());
@@ -436,14 +436,14 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 GracePeriod.create(
                     GracePeriodStatus.RENEW,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(1),
+                    clock.now().plusDays(1),
                     "TheRegistrar",
                     null))
             .addGracePeriod(
                 GracePeriod.create(
                     GracePeriodStatus.RENEW,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(2),
+                    clock.now().plusDays(2),
                     "TheRegistrar",
                     null))
             .build());
@@ -461,7 +461,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 GracePeriod.create(
                     GracePeriodStatus.TRANSFER,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(1),
+                    clock.now().plusDays(1),
                     "TheRegistrar",
                     null))
             .build());
@@ -489,14 +489,14 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 GracePeriod.create(
                     GracePeriodStatus.ADD,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(1),
+                    clock.now().plusDays(1),
                     "TheRegistrar",
                     null))
             .addGracePeriod(
                 GracePeriod.create(
                     GracePeriodStatus.RENEW,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(2),
+                    clock.now().plusDays(2),
                     "TheRegistrar",
                     null))
             .build());
@@ -514,7 +514,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                 GracePeriod.create(
                     GracePeriodStatus.ADD,
                     domain.getRepoId(),
-                    clock.nowUtc().plusDays(1),
+                    clock.now().plusDays(1),
                     "TheRegistrar",
                     null))
             .setDsData(
@@ -536,7 +536,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
     persistResource(
         DatabaseHelper.newDomain("example.tld")
             .asBuilder()
-            .setDeletionTime(clock.nowUtc().minusDays(1))
+            .setDeletionTime(clock.now().minusDays(1))
             .build());
     ResourceDoesNotExistException thrown =
         assertThrows(ResourceDoesNotExistException.class, this::runFlow);
@@ -588,7 +588,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
             new AllocationToken.Builder()
                 .setToken("abc123")
                 .setTokenType(TokenType.BULK_PRICING)
-                .setCreationTimeForTest(DateTime.parse("2010-11-12T05:00:00Z"))
+                .setCreationTimeForTest(Instant.parse("2010-11-12T05:00:00Z"))
                 .setAllowedTlds(ImmutableSet.of("foo"))
                 .setAllowedRegistrarIds(ImmutableSet.of("NewRegistrar"))
                 .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
@@ -610,7 +610,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
             new AllocationToken.Builder()
                 .setToken("abc123")
                 .setTokenType(TokenType.BULK_PRICING)
-                .setCreationTimeForTest(DateTime.parse("2010-11-12T05:00:00Z"))
+                .setCreationTimeForTest(Instant.parse("2010-11-12T05:00:00Z"))
                 .setAllowedTlds(ImmutableSet.of("foo"))
                 .setAllowedRegistrarIds(ImmutableSet.of("NewRegistrar"))
                 .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
@@ -644,7 +644,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
             new AllocationToken.Builder()
                 .setToken("abc123")
                 .setTokenType(TokenType.BULK_PRICING)
-                .setCreationTimeForTest(DateTime.parse("2010-11-12T05:00:00Z"))
+                .setCreationTimeForTest(Instant.parse("2010-11-12T05:00:00Z"))
                 .setAllowedTlds(ImmutableSet.of("foo"))
                 .setAllowedRegistrarIds(ImmutableSet.of("NewRegistrar"))
                 .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
@@ -673,8 +673,8 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
     persistResource(
         domain
             .asBuilder()
-            .setDeletionTime(clock.nowUtc().plusDays(25))
-            .setRegistrationExpirationTime(clock.nowUtc().minusDays(1))
+            .setDeletionTime(clock.now().plusDays(25))
+            .setRegistrationExpirationTime(clock.now().minusDays(1))
             .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
             .build());
     doSuccessfulTest(
@@ -762,7 +762,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
     persistResource(
         domain
             .asBuilder()
-            .setDeletionTime(clock.nowUtc().plusDays(25))
+            .setDeletionTime(clock.now().plusDays(25))
             .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
             .build());
     doSuccessfulTest(

--- a/core/src/test/java/google/registry/flows/domain/DomainPricingLogicTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainPricingLogicTest.java
@@ -27,7 +27,7 @@ import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistPremiumList;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
-import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static org.joda.money.CurrencyUnit.USD;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -56,9 +56,10 @@ import google.registry.testing.FakeClock;
 import google.registry.testing.FakeHttpSession;
 import google.registry.util.Clock;
 import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -72,7 +73,7 @@ public class DomainPricingLogicTest {
   final JpaIntegrationTestExtension jpa =
       new JpaTestExtensions.Builder().buildIntegrationTestExtension();
 
-  Clock clock = new FakeClock(DateTime.parse("2023-05-13T00:00:00.000Z"));
+  Clock clock = new FakeClock(Instant.parse("2023-05-13T00:00:00.000Z"));
   @Mock EppInput eppInput;
   SessionMetadata sessionMetadata;
   Tld tld;
@@ -88,9 +89,9 @@ public class DomainPricingLogicTest {
         persistResource(
             Tld.get("example")
                 .asBuilder()
-                .setRenewBillingCostTransitions(
+                .setRenewBillingCostTransitionsInstant(
                     ImmutableSortedMap.of(
-                        START_OF_TIME, Money.of(USD, 1), clock.nowUtc(), Money.of(USD, 10)))
+                        START_INSTANT, Money.of(USD, 1), clock.now(), Money.of(USD, 10)))
                 .setPremiumList(persistPremiumList("tld2", USD, "premium,USD 100"))
                 .build());
   }
@@ -102,14 +103,14 @@ public class DomainPricingLogicTest {
         persistResource(
             DatabaseHelper.newDomain(domainName)
                 .asBuilder()
-                .setCreationTimeForTest(DateTime.parse("1999-01-05T00:00:00Z"))
+                .setCreationTimeForTest(Instant.parse("1999-01-05T00:00:00Z"))
                 .build());
     DomainHistory historyEntry =
         persistResource(
             new DomainHistory.Builder()
                 .setRegistrarId(domain.getCreationRegistrarId())
                 .setType(DOMAIN_CREATE)
-                .setModificationTime(DateTime.parse("1999-01-05T00:00:00Z"))
+                .setModificationTime(Instant.parse("1999-01-05T00:00:00Z"))
                 .setDomain(domain)
                 .build());
     BillingRecurrence billingRecurrence =
@@ -117,7 +118,7 @@ public class DomainPricingLogicTest {
             new BillingRecurrence.Builder()
                 .setDomainHistory(historyEntry)
                 .setRegistrarId(domain.getCreationRegistrarId())
-                .setEventTime(DateTime.parse("1999-01-05T00:00:00Z"))
+                .setEventTime(Instant.parse("1999-01-05T00:00:00Z"))
                 .setFlags(ImmutableSet.of(AUTO_RENEW))
                 .setId(2L)
                 .setReason(Reason.RENEW)
@@ -133,16 +134,19 @@ public class DomainPricingLogicTest {
 
   @Test
   void testGetDomainCreatePrice_sunrise_appliesDiscount() throws EppException {
-    ImmutableSortedMap<DateTime, TldState> transitions =
-        ImmutableSortedMap.<DateTime, TldState>naturalOrder()
-            .put(START_OF_TIME, TldState.PREDELEGATION)
-            .put(clock.nowUtc().minusHours(1), TldState.START_DATE_SUNRISE)
-            .put(clock.nowUtc().plusHours(1), TldState.GENERAL_AVAILABILITY)
+    ImmutableSortedMap<Instant, TldState> transitions =
+        ImmutableSortedMap.<Instant, TldState>naturalOrder()
+            .put(START_INSTANT, TldState.PREDELEGATION)
+            .put(clock.now().minus(Duration.ofHours(1)), TldState.START_DATE_SUNRISE)
+            .put(clock.now().plus(Duration.ofHours(1)), TldState.GENERAL_AVAILABILITY)
             .build();
-    Tld sunriseTld = createTld("sunrise", transitions);
+    createTld("sunrise");
+    Tld sunriseTld =
+        persistResource(
+            Tld.get("sunrise").asBuilder().setTldStateTransitionsInstant(transitions).build());
     assertThat(
             domainPricingLogic.getCreatePrice(
-                sunriseTld, "domain.sunrise", clock.nowUtc(), 2, false, true, Optional.empty()))
+                sunriseTld, "domain.sunrise", clock.now(), 2, false, true, Optional.empty()))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -166,13 +170,7 @@ public class DomainPricingLogicTest {
                 .build());
     assertThat(
             domainPricingLogic.getCreatePrice(
-                tld,
-                "default.example",
-                clock.nowUtc(),
-                1,
-                false,
-                false,
-                Optional.of(allocationToken)))
+                tld, "default.example", clock.now(), 1, false, false, Optional.of(allocationToken)))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -197,13 +195,7 @@ public class DomainPricingLogicTest {
     // 3 year create should be 5 (discount price) + 10*2 (regular price) = 25.
     assertThat(
             domainPricingLogic.getCreatePrice(
-                tld,
-                "default.example",
-                clock.nowUtc(),
-                3,
-                false,
-                false,
-                Optional.of(allocationToken)))
+                tld, "default.example", clock.now(), 3, false, false, Optional.of(allocationToken)))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -216,7 +208,7 @@ public class DomainPricingLogicTest {
       throws EppException {
     assertThat(
             domainPricingLogic.getRenewPrice(
-                tld, "standard.example", clock.nowUtc(), 1, null, Optional.empty()))
+                tld, "standard.example", clock.now(), 1, null, Optional.empty()))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -229,7 +221,7 @@ public class DomainPricingLogicTest {
       throws EppException {
     assertThat(
             domainPricingLogic.getRenewPrice(
-                tld, "standard.example", clock.nowUtc(), 5, null, Optional.empty()))
+                tld, "standard.example", clock.now(), 5, null, Optional.empty()))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -242,7 +234,7 @@ public class DomainPricingLogicTest {
       throws EppException {
     assertThat(
             domainPricingLogic.getRenewPrice(
-                tld, "premium.example", clock.nowUtc(), 1, null, Optional.empty()))
+                tld, "premium.example", clock.now(), 1, null, Optional.empty()))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -255,7 +247,7 @@ public class DomainPricingLogicTest {
       throws EppException {
     assertThat(
             domainPricingLogic.getRenewPrice(
-                tld, "premium.example", clock.nowUtc(), 5, null, Optional.empty()))
+                tld, "premium.example", clock.now(), 5, null, Optional.empty()))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -269,7 +261,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("premium.example", DEFAULT, Optional.empty()),
                 Optional.empty()))
@@ -295,7 +287,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("premium.example", DEFAULT, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -312,7 +304,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence("premium.example", DEFAULT, Optional.empty()),
                 Optional.empty()))
@@ -339,7 +331,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence("premium.example", DEFAULT, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -357,7 +349,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("standard.example", DEFAULT, Optional.empty()),
                 Optional.empty()))
@@ -383,7 +375,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("standard.example", DEFAULT, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -410,7 +402,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("standard.example", DEFAULT, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -428,7 +420,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence("standard.example", DEFAULT, Optional.empty()),
                 Optional.empty()))
@@ -455,7 +447,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence("standard.example", DEFAULT, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -485,7 +477,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence("standard.example", DEFAULT, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -503,7 +495,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("premium.example", NONPREMIUM, Optional.empty()),
                 Optional.empty()))
@@ -530,7 +522,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("premium.example", NONPREMIUM, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -548,7 +540,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence("premium.example", NONPREMIUM, Optional.empty()),
                 Optional.empty()))
@@ -576,7 +568,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence("premium.example", NONPREMIUM, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -594,7 +586,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("standard.example", NONPREMIUM, Optional.empty()),
                 Optional.empty()))
@@ -612,7 +604,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence("standard.example", NONPREMIUM, Optional.empty()),
                 Optional.empty()))
@@ -630,7 +622,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence(
                     "standard.example", SPECIFIED, Optional.of(Money.of(USD, 1))),
@@ -658,7 +650,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence(
                     "standard.example", SPECIFIED, Optional.of(Money.of(USD, 1))),
@@ -688,7 +680,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence(
                     "standard.example", SPECIFIED, Optional.of(Money.of(USD, 1))),
@@ -719,7 +711,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence(
                     "standard.example", SPECIFIED, Optional.of(Money.of(USD, 1))),
@@ -744,7 +736,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence(
                     "standard.example", SPECIFIED, Optional.of(Money.of(USD, 1))),
@@ -772,7 +764,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence(
                     "standard.example", SPECIFIED, Optional.of(Money.of(USD, 1))),
@@ -800,7 +792,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence(
                     "standard.example", SPECIFIED, Optional.of(Money.of(USD, 1))),
@@ -819,7 +811,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence(
                     "premium.example", SPECIFIED, Optional.of(Money.of(USD, 17))),
@@ -838,7 +830,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence(
                     "premium.example", SPECIFIED, Optional.of(Money.of(USD, 17))),
@@ -857,14 +849,14 @@ public class DomainPricingLogicTest {
             IllegalArgumentException.class,
             () ->
                 domainPricingLogic.getRenewPrice(
-                    tld, "standard.example", clock.nowUtc(), -1, null, Optional.empty()));
+                    tld, "standard.example", clock.now(), -1, null, Optional.empty()));
     assertThat(thrown).hasMessageThat().isEqualTo("Number of years must be positive");
   }
 
   @Test
   void testGetDomainTransferPrice_standardDomain_default_noBilling_defaultRenewalPrice()
       throws EppException {
-    assertThat(domainPricingLogic.getTransferPrice(tld, "standard.example", clock.nowUtc(), null))
+    assertThat(domainPricingLogic.getTransferPrice(tld, "standard.example", clock.now(), null))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -875,7 +867,7 @@ public class DomainPricingLogicTest {
   @Test
   void testGetDomainTransferPrice_premiumDomain_default_noBilling_premiumRenewalPrice()
       throws EppException {
-    assertThat(domainPricingLogic.getTransferPrice(tld, "premium.example", clock.nowUtc(), null))
+    assertThat(domainPricingLogic.getTransferPrice(tld, "premium.example", clock.now(), null))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -889,7 +881,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getTransferPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 persistDomainAndSetRecurrence("standard.example", DEFAULT, Optional.empty())))
         .isEqualTo(
             new FeesAndCredits.Builder()
@@ -904,7 +896,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getTransferPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 persistDomainAndSetRecurrence("premium.example", DEFAULT, Optional.empty())))
         .isEqualTo(
             new FeesAndCredits.Builder()
@@ -920,7 +912,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getTransferPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 persistDomainAndSetRecurrence("standard.example", NONPREMIUM, Optional.empty())))
         .isEqualTo(
             new FeesAndCredits.Builder()
@@ -936,7 +928,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getTransferPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 persistDomainAndSetRecurrence("premium.example", NONPREMIUM, Optional.empty())))
         .isEqualTo(
             new FeesAndCredits.Builder()
@@ -952,7 +944,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getTransferPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 persistDomainAndSetRecurrence(
                     "standard.example", SPECIFIED, Optional.of(Money.of(USD, 1.23)))))
         .isEqualTo(
@@ -969,7 +961,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getTransferPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 persistDomainAndSetRecurrence(
                     "premium.example", SPECIFIED, Optional.of(Money.of(USD, 1.23)))))
         .isEqualTo(
@@ -991,13 +983,7 @@ public class DomainPricingLogicTest {
                 .build());
     assertThat(
             domainPricingLogic.getCreatePrice(
-                tld,
-                "premium.example",
-                clock.nowUtc(),
-                1,
-                false,
-                false,
-                Optional.of(allocationToken)))
+                tld, "premium.example", clock.now(), 1, false, false, Optional.of(allocationToken)))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -1006,13 +992,7 @@ public class DomainPricingLogicTest {
     // Two-year create should be 13 (standard price) + 100 (premium price), and it's premium
     assertThat(
             domainPricingLogic.getCreatePrice(
-                tld,
-                "premium.example",
-                clock.nowUtc(),
-                2,
-                false,
-                false,
-                Optional.of(allocationToken)))
+                tld, "premium.example", clock.now(), 2, false, false, Optional.of(allocationToken)))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -1022,7 +1002,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("premium.example", DEFAULT, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -1048,13 +1028,7 @@ public class DomainPricingLogicTest {
     // are standard
     assertThat(
             domainPricingLogic.getCreatePrice(
-                tld,
-                "premium.example",
-                clock.nowUtc(),
-                2,
-                false,
-                false,
-                Optional.of(allocationToken)))
+                tld, "premium.example", clock.now(), 2, false, false, Optional.of(allocationToken)))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -1063,13 +1037,7 @@ public class DomainPricingLogicTest {
     // Similarly, 3 years should be 13 + 10 + 10
     assertThat(
             domainPricingLogic.getCreatePrice(
-                tld,
-                "premium.example",
-                clock.nowUtc(),
-                3,
-                false,
-                false,
-                Optional.of(allocationToken)))
+                tld, "premium.example", clock.now(), 3, false, false, Optional.of(allocationToken)))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -1090,13 +1058,7 @@ public class DomainPricingLogicTest {
     // Two-year create should be 100 (premium 1st year) plus 10 (nonpremium 2nd year)
     assertThat(
             domainPricingLogic.getCreatePrice(
-                tld,
-                "premium.example",
-                clock.nowUtc(),
-                2,
-                false,
-                false,
-                Optional.of(allocationToken)))
+                tld, "premium.example", clock.now(), 2, false, false, Optional.of(allocationToken)))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -1105,13 +1067,7 @@ public class DomainPricingLogicTest {
     // Similarly, 3 years should be 100 + 10 + 10
     assertThat(
             domainPricingLogic.getCreatePrice(
-                tld,
-                "premium.example",
-                clock.nowUtc(),
-                3,
-                false,
-                false,
-                Optional.of(allocationToken)))
+                tld, "premium.example", clock.now(), 3, false, false, Optional.of(allocationToken)))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -1133,7 +1089,7 @@ public class DomainPricingLogicTest {
     assertThat(
             domainPricingLogic
                 .getRenewPrice(
-                    tld, "premium.example", clock.nowUtc(), 1, null, Optional.of(allocationToken))
+                    tld, "premium.example", clock.now(), 1, null, Optional.of(allocationToken))
                 .getRenewCost())
         .isEqualTo(Money.of(USD, 5));
   }

--- a/core/src/test/java/google/registry/flows/domain/DomainPricingLogicTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainPricingLogicTest.java
@@ -56,9 +56,9 @@ import google.registry.testing.FakeClock;
 import google.registry.testing.FakeHttpSession;
 import google.registry.util.Clock;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.Optional;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -72,7 +72,7 @@ public class DomainPricingLogicTest {
   final JpaIntegrationTestExtension jpa =
       new JpaTestExtensions.Builder().buildIntegrationTestExtension();
 
-  Clock clock = new FakeClock(DateTime.parse("2023-05-13T00:00:00.000Z"));
+  Clock clock = new FakeClock(Instant.parse("2023-05-13T00:00:00.000Z"));
   @Mock EppInput eppInput;
   SessionMetadata sessionMetadata;
   Tld tld;
@@ -90,7 +90,7 @@ public class DomainPricingLogicTest {
                 .asBuilder()
                 .setRenewBillingCostTransitions(
                     ImmutableSortedMap.of(
-                        START_OF_TIME, Money.of(USD, 1), clock.nowUtc(), Money.of(USD, 10)))
+                        START_OF_TIME, Money.of(USD, 1), clock.now(), Money.of(USD, 10)))
                 .setPremiumList(persistPremiumList("tld2", USD, "premium,USD 100"))
                 .build());
   }
@@ -102,14 +102,14 @@ public class DomainPricingLogicTest {
         persistResource(
             DatabaseHelper.newDomain(domainName)
                 .asBuilder()
-                .setCreationTimeForTest(DateTime.parse("1999-01-05T00:00:00Z"))
+                .setCreationTimeForTest(Instant.parse("1999-01-05T00:00:00Z"))
                 .build());
     DomainHistory historyEntry =
         persistResource(
             new DomainHistory.Builder()
                 .setRegistrarId(domain.getCreationRegistrarId())
                 .setType(DOMAIN_CREATE)
-                .setModificationTime(DateTime.parse("1999-01-05T00:00:00Z"))
+                .setModificationTime(Instant.parse("1999-01-05T00:00:00Z"))
                 .setDomain(domain)
                 .build());
     BillingRecurrence billingRecurrence =
@@ -117,7 +117,7 @@ public class DomainPricingLogicTest {
             new BillingRecurrence.Builder()
                 .setDomainHistory(historyEntry)
                 .setRegistrarId(domain.getCreationRegistrarId())
-                .setEventTime(DateTime.parse("1999-01-05T00:00:00Z"))
+                .setEventTime(Instant.parse("1999-01-05T00:00:00Z"))
                 .setFlags(ImmutableSet.of(AUTO_RENEW))
                 .setId(2L)
                 .setReason(Reason.RENEW)
@@ -133,16 +133,16 @@ public class DomainPricingLogicTest {
 
   @Test
   void testGetDomainCreatePrice_sunrise_appliesDiscount() throws EppException {
-    ImmutableSortedMap<DateTime, TldState> transitions =
-        ImmutableSortedMap.<DateTime, TldState>naturalOrder()
+    ImmutableSortedMap<Instant, TldState> transitions =
+        ImmutableSortedMap.<Instant, TldState>naturalOrder()
             .put(START_OF_TIME, TldState.PREDELEGATION)
-            .put(clock.nowUtc().minusHours(1), TldState.START_DATE_SUNRISE)
-            .put(clock.nowUtc().plusHours(1), TldState.GENERAL_AVAILABILITY)
+            .put(clock.now().minusHours(1), TldState.START_DATE_SUNRISE)
+            .put(clock.now().plusHours(1), TldState.GENERAL_AVAILABILITY)
             .build();
     Tld sunriseTld = createTld("sunrise", transitions);
     assertThat(
             domainPricingLogic.getCreatePrice(
-                sunriseTld, "domain.sunrise", clock.nowUtc(), 2, false, true, Optional.empty()))
+                sunriseTld, "domain.sunrise", clock.now(), 2, false, true, Optional.empty()))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -166,13 +166,7 @@ public class DomainPricingLogicTest {
                 .build());
     assertThat(
             domainPricingLogic.getCreatePrice(
-                tld,
-                "default.example",
-                clock.nowUtc(),
-                1,
-                false,
-                false,
-                Optional.of(allocationToken)))
+                tld, "default.example", clock.now(), 1, false, false, Optional.of(allocationToken)))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -197,13 +191,7 @@ public class DomainPricingLogicTest {
     // 3 year create should be 5 (discount price) + 10*2 (regular price) = 25.
     assertThat(
             domainPricingLogic.getCreatePrice(
-                tld,
-                "default.example",
-                clock.nowUtc(),
-                3,
-                false,
-                false,
-                Optional.of(allocationToken)))
+                tld, "default.example", clock.now(), 3, false, false, Optional.of(allocationToken)))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -216,7 +204,7 @@ public class DomainPricingLogicTest {
       throws EppException {
     assertThat(
             domainPricingLogic.getRenewPrice(
-                tld, "standard.example", clock.nowUtc(), 1, null, Optional.empty()))
+                tld, "standard.example", clock.now(), 1, null, Optional.empty()))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -229,7 +217,7 @@ public class DomainPricingLogicTest {
       throws EppException {
     assertThat(
             domainPricingLogic.getRenewPrice(
-                tld, "standard.example", clock.nowUtc(), 5, null, Optional.empty()))
+                tld, "standard.example", clock.now(), 5, null, Optional.empty()))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -242,7 +230,7 @@ public class DomainPricingLogicTest {
       throws EppException {
     assertThat(
             domainPricingLogic.getRenewPrice(
-                tld, "premium.example", clock.nowUtc(), 1, null, Optional.empty()))
+                tld, "premium.example", clock.now(), 1, null, Optional.empty()))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -255,7 +243,7 @@ public class DomainPricingLogicTest {
       throws EppException {
     assertThat(
             domainPricingLogic.getRenewPrice(
-                tld, "premium.example", clock.nowUtc(), 5, null, Optional.empty()))
+                tld, "premium.example", clock.now(), 5, null, Optional.empty()))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -269,7 +257,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("premium.example", DEFAULT, Optional.empty()),
                 Optional.empty()))
@@ -295,7 +283,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("premium.example", DEFAULT, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -312,7 +300,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence("premium.example", DEFAULT, Optional.empty()),
                 Optional.empty()))
@@ -339,7 +327,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence("premium.example", DEFAULT, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -357,7 +345,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("standard.example", DEFAULT, Optional.empty()),
                 Optional.empty()))
@@ -383,7 +371,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("standard.example", DEFAULT, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -410,7 +398,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("standard.example", DEFAULT, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -428,7 +416,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence("standard.example", DEFAULT, Optional.empty()),
                 Optional.empty()))
@@ -455,7 +443,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence("standard.example", DEFAULT, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -485,7 +473,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence("standard.example", DEFAULT, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -503,7 +491,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("premium.example", NONPREMIUM, Optional.empty()),
                 Optional.empty()))
@@ -530,7 +518,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("premium.example", NONPREMIUM, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -548,7 +536,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence("premium.example", NONPREMIUM, Optional.empty()),
                 Optional.empty()))
@@ -576,7 +564,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence("premium.example", NONPREMIUM, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -594,7 +582,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("standard.example", NONPREMIUM, Optional.empty()),
                 Optional.empty()))
@@ -612,7 +600,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence("standard.example", NONPREMIUM, Optional.empty()),
                 Optional.empty()))
@@ -630,7 +618,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence(
                     "standard.example", SPECIFIED, Optional.of(Money.of(USD, 1))),
@@ -658,7 +646,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence(
                     "standard.example", SPECIFIED, Optional.of(Money.of(USD, 1))),
@@ -688,7 +676,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence(
                     "standard.example", SPECIFIED, Optional.of(Money.of(USD, 1))),
@@ -719,7 +707,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence(
                     "standard.example", SPECIFIED, Optional.of(Money.of(USD, 1))),
@@ -744,7 +732,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence(
                     "standard.example", SPECIFIED, Optional.of(Money.of(USD, 1))),
@@ -772,7 +760,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence(
                     "standard.example", SPECIFIED, Optional.of(Money.of(USD, 1))),
@@ -800,7 +788,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence(
                     "standard.example", SPECIFIED, Optional.of(Money.of(USD, 1))),
@@ -819,7 +807,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence(
                     "premium.example", SPECIFIED, Optional.of(Money.of(USD, 17))),
@@ -838,7 +826,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 5,
                 persistDomainAndSetRecurrence(
                     "premium.example", SPECIFIED, Optional.of(Money.of(USD, 17))),
@@ -857,14 +845,14 @@ public class DomainPricingLogicTest {
             IllegalArgumentException.class,
             () ->
                 domainPricingLogic.getRenewPrice(
-                    tld, "standard.example", clock.nowUtc(), -1, null, Optional.empty()));
+                    tld, "standard.example", clock.now(), -1, null, Optional.empty()));
     assertThat(thrown).hasMessageThat().isEqualTo("Number of years must be positive");
   }
 
   @Test
   void testGetDomainTransferPrice_standardDomain_default_noBilling_defaultRenewalPrice()
       throws EppException {
-    assertThat(domainPricingLogic.getTransferPrice(tld, "standard.example", clock.nowUtc(), null))
+    assertThat(domainPricingLogic.getTransferPrice(tld, "standard.example", clock.now(), null))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -875,7 +863,7 @@ public class DomainPricingLogicTest {
   @Test
   void testGetDomainTransferPrice_premiumDomain_default_noBilling_premiumRenewalPrice()
       throws EppException {
-    assertThat(domainPricingLogic.getTransferPrice(tld, "premium.example", clock.nowUtc(), null))
+    assertThat(domainPricingLogic.getTransferPrice(tld, "premium.example", clock.now(), null))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -889,7 +877,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getTransferPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 persistDomainAndSetRecurrence("standard.example", DEFAULT, Optional.empty())))
         .isEqualTo(
             new FeesAndCredits.Builder()
@@ -904,7 +892,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getTransferPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 persistDomainAndSetRecurrence("premium.example", DEFAULT, Optional.empty())))
         .isEqualTo(
             new FeesAndCredits.Builder()
@@ -920,7 +908,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getTransferPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 persistDomainAndSetRecurrence("standard.example", NONPREMIUM, Optional.empty())))
         .isEqualTo(
             new FeesAndCredits.Builder()
@@ -936,7 +924,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getTransferPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 persistDomainAndSetRecurrence("premium.example", NONPREMIUM, Optional.empty())))
         .isEqualTo(
             new FeesAndCredits.Builder()
@@ -952,7 +940,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getTransferPrice(
                 tld,
                 "standard.example",
-                clock.nowUtc(),
+                clock.now(),
                 persistDomainAndSetRecurrence(
                     "standard.example", SPECIFIED, Optional.of(Money.of(USD, 1.23)))))
         .isEqualTo(
@@ -969,7 +957,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getTransferPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 persistDomainAndSetRecurrence(
                     "premium.example", SPECIFIED, Optional.of(Money.of(USD, 1.23)))))
         .isEqualTo(
@@ -991,13 +979,7 @@ public class DomainPricingLogicTest {
                 .build());
     assertThat(
             domainPricingLogic.getCreatePrice(
-                tld,
-                "premium.example",
-                clock.nowUtc(),
-                1,
-                false,
-                false,
-                Optional.of(allocationToken)))
+                tld, "premium.example", clock.now(), 1, false, false, Optional.of(allocationToken)))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -1006,13 +988,7 @@ public class DomainPricingLogicTest {
     // Two-year create should be 13 (standard price) + 100 (premium price), and it's premium
     assertThat(
             domainPricingLogic.getCreatePrice(
-                tld,
-                "premium.example",
-                clock.nowUtc(),
-                2,
-                false,
-                false,
-                Optional.of(allocationToken)))
+                tld, "premium.example", clock.now(), 2, false, false, Optional.of(allocationToken)))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -1022,7 +998,7 @@ public class DomainPricingLogicTest {
             domainPricingLogic.getRenewPrice(
                 tld,
                 "premium.example",
-                clock.nowUtc(),
+                clock.now(),
                 1,
                 persistDomainAndSetRecurrence("premium.example", DEFAULT, Optional.empty()),
                 Optional.of(allocationToken)))
@@ -1048,13 +1024,7 @@ public class DomainPricingLogicTest {
     // are standard
     assertThat(
             domainPricingLogic.getCreatePrice(
-                tld,
-                "premium.example",
-                clock.nowUtc(),
-                2,
-                false,
-                false,
-                Optional.of(allocationToken)))
+                tld, "premium.example", clock.now(), 2, false, false, Optional.of(allocationToken)))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -1063,13 +1033,7 @@ public class DomainPricingLogicTest {
     // Similarly, 3 years should be 13 + 10 + 10
     assertThat(
             domainPricingLogic.getCreatePrice(
-                tld,
-                "premium.example",
-                clock.nowUtc(),
-                3,
-                false,
-                false,
-                Optional.of(allocationToken)))
+                tld, "premium.example", clock.now(), 3, false, false, Optional.of(allocationToken)))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -1090,13 +1054,7 @@ public class DomainPricingLogicTest {
     // Two-year create should be 100 (premium 1st year) plus 10 (nonpremium 2nd year)
     assertThat(
             domainPricingLogic.getCreatePrice(
-                tld,
-                "premium.example",
-                clock.nowUtc(),
-                2,
-                false,
-                false,
-                Optional.of(allocationToken)))
+                tld, "premium.example", clock.now(), 2, false, false, Optional.of(allocationToken)))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -1105,13 +1063,7 @@ public class DomainPricingLogicTest {
     // Similarly, 3 years should be 100 + 10 + 10
     assertThat(
             domainPricingLogic.getCreatePrice(
-                tld,
-                "premium.example",
-                clock.nowUtc(),
-                3,
-                false,
-                false,
-                Optional.of(allocationToken)))
+                tld, "premium.example", clock.now(), 3, false, false, Optional.of(allocationToken)))
         .isEqualTo(
             new FeesAndCredits.Builder()
                 .setCurrency(USD)
@@ -1133,7 +1085,7 @@ public class DomainPricingLogicTest {
     assertThat(
             domainPricingLogic
                 .getRenewPrice(
-                    tld, "premium.example", clock.nowUtc(), 1, null, Optional.of(allocationToken))
+                    tld, "premium.example", clock.now(), 1, null, Optional.of(allocationToken))
                 .getRenewCost())
         .isEqualTo(Money.of(USD, 5));
   }

--- a/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
@@ -40,7 +40,13 @@ import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptio
 import static google.registry.testing.HistoryEntrySubject.assertAboutHistoryEntries;
 import static google.registry.testing.TestDataHelper.updateSubstitutions;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.minusDays;
+import static google.registry.util.DateTimeUtils.minusYears;
+import static google.registry.util.DateTimeUtils.plusDays;
+import static google.registry.util.DateTimeUtils.plusYears;
+import static google.registry.util.DateTimeUtils.toDateTime;
 import static org.joda.money.CurrencyUnit.EUR;
 import static org.joda.money.CurrencyUnit.JPY;
 import static org.joda.money.CurrencyUnit.USD;
@@ -100,10 +106,10 @@ import google.registry.model.reporting.HistoryEntry.HistoryEntryId;
 import google.registry.model.tld.Tld;
 import google.registry.persistence.VKey;
 import google.registry.testing.DatabaseHelper;
+import java.time.Instant;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -128,7 +134,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
   private static final ImmutableMap<String, String> FEE_STD_1_0_MAP =
       updateSubstitutions(FEE_BASE_MAP, "FEE_VERSION", "epp:fee-1.0", "FEE_NS", "fee1_00");
 
-  private final DateTime expirationTime = DateTime.parse("2000-04-03T22:00:00.0Z");
+  private final Instant expirationTime = Instant.parse("2000-04-03T22:00:00.0Z");
 
   @BeforeEach
   void initDomainTest() {
@@ -157,7 +163,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
           new DomainHistory.Builder()
               .setDomain(domain)
               .setType(HistoryEntry.Type.DOMAIN_CREATE)
-              .setModificationTime(clock.nowUtc())
+              .setModificationTime(clock.now())
               .setRegistrarId(domain.getCreationRegistrarId())
               .build();
       BillingRecurrence autorenewEvent =
@@ -247,8 +253,8 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
       @Nullable Money renewalPrice)
       throws Exception {
     assertMutatingFlow(true);
-    DateTime currentExpiration = reloadResourceByForeignKey().getRegistrationExpirationDateTime();
-    DateTime newExpiration = currentExpiration.plusYears(renewalYears);
+    Instant currentExpiration = reloadResourceByForeignKey().getRegistrationExpirationTime();
+    Instant newExpiration = plusYears(currentExpiration, renewalYears);
     runFlowAssertResponse(
         CommitMode.LIVE, userPrivileges, loadFile(responseFilename, substitutions));
     Domain domain = reloadResourceByForeignKey();
@@ -256,17 +262,17 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
     DomainHistory historyEntryDomainRenew =
         getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_RENEW, DomainHistory.class);
     assertThat(loadByKey(domain.getAutorenewBillingEvent()).getEventTime())
-        .isEqualTo(newExpiration);
+        .isEqualTo(toDateTime(newExpiration));
     assertAboutDomains()
         .that(domain)
-        .isActiveAt(clock.nowUtc())
+        .isActiveAt(clock.now())
         .and()
         .hasRegistrationExpirationTime(newExpiration)
         .and()
         .hasOneHistoryEntryEachOfTypes(
             HistoryEntry.Type.DOMAIN_CREATE, HistoryEntry.Type.DOMAIN_RENEW)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId(renewalClientId);
     assertAboutHistoryEntries().that(historyEntryDomainRenew).hasPeriodYears(renewalYears);
@@ -277,8 +283,10 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
             .setRegistrarId(renewalClientId)
             .setCost(totalRenewCost)
             .setPeriodYears(renewalYears)
-            .setEventTime(clock.nowUtc())
-            .setBillingTime(clock.nowUtc().plus(Tld.get("tld").getRenewGracePeriodLength()))
+            .setEventTime(clock.now())
+            .setBillingTime(
+                toDateTime(
+                    clock.now().plusMillis(Tld.get("tld").getRenewGracePeriodLength().getMillis())))
             .setDomainHistory(historyEntryDomainRenew)
             .build();
     assertBillingEvents(
@@ -291,7 +299,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
             .setTargetId(getUniqueIdFromCommand())
             .setRegistrarId("TheRegistrar")
             .setEventTime(expirationTime)
-            .setRecurrenceEndTime(clock.nowUtc())
+            .setRecurrenceEndTime(clock.now())
             .setDomainHistory(
                 getOnlyHistoryEntryOfType(
                     domain, HistoryEntry.Type.DOMAIN_CREATE, DomainHistory.class))
@@ -324,7 +332,8 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
             GracePeriod.create(
                 GracePeriodStatus.RENEW,
                 domain.getRepoId(),
-                clock.nowUtc().plus(Tld.get("tld").getRenewGracePeriodLength()),
+                toDateTime(
+                    clock.now().plusMillis(Tld.get("tld").getRenewGracePeriodLength().getMillis())),
                 renewalClientId,
                 null),
             renewBillingEvent));
@@ -659,11 +668,11 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
             .setToken("abc123")
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(60), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(plusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 60), TokenStatus.ENDED)
                     .build())
             .build());
     assertAboutEppExceptions()
@@ -683,11 +692,11 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
             .setTokenType(UNLIMITED_USE)
             .setAllowedRegistrarIds(ImmutableSet.of("someClientId"))
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     assertAboutEppExceptions()
@@ -708,11 +717,11 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
             .setTokenType(UNLIMITED_USE)
             .setAllowedTlds(ImmutableSet.of("example"))
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     runFlowAssertResponse(
@@ -795,7 +804,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
     persistResource(
         loadByKey(reloadResourceByForeignKey().getAutorenewPollMessage())
             .asBuilder()
-            .setEventTime(expirationTime.minusYears(1))
+            .setEventTime(minusYears(expirationTime, 1))
             .build());
     runFlowAssertResponse(
         loadFile(
@@ -807,8 +816,8 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
         new PollMessage.Autorenew.Builder()
             .setTargetId(getUniqueIdFromCommand())
             .setRegistrarId("TheRegistrar")
-            .setEventTime(expirationTime.minusYears(1))
-            .setAutorenewEndTime(clock.nowUtc())
+            .setEventTime(minusYears(expirationTime, 1))
+            .setAutorenewEndTime(clock.now())
             .setMsg("Domain was auto-renewed.")
             .setHistoryEntry(
                 getOnlyHistoryEntryOfType(
@@ -817,7 +826,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
         new PollMessage.Autorenew.Builder()
             .setTargetId(getUniqueIdFromCommand())
             .setRegistrarId("TheRegistrar")
-            .setEventTime(reloadResourceByForeignKey().getRegistrationExpirationDateTime())
+            .setEventTime(reloadResourceByForeignKey().getRegistrationExpirationTime())
             .setAutorenewEndTime(END_OF_TIME)
             .setMsg("Domain was auto-renewed.")
             .setHistoryEntry(historyEntryDomainRenew)
@@ -910,7 +919,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
         DatabaseHelper.newDomain(getUniqueIdFromCommand())
             .asBuilder()
             .setRegistrationExpirationTime(expirationTime)
-            .setDeletionTime(clock.nowUtc().plusDays(1))
+            .setDeletionTime(plusDays(clock.now(), 1))
             .addStatusValue(StatusValue.PENDING_DELETE)
             .build());
     ResourceStatusProhibitsOperationException thrown =
@@ -985,7 +994,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
     persistWithPendingTransfer(
         reloadResourceByForeignKey()
             .asBuilder()
-            .setRegistrationExpirationTime(DateTime.parse("2001-09-08T22:00:00.0Z"))
+            .setRegistrationExpirationTime(Instant.parse("2001-09-08T22:00:00.0Z"))
             .build());
     ResourceStatusProhibitsOperationException thrown =
         assertThrows(ResourceStatusProhibitsOperationException.class, this::runFlow);
@@ -1015,7 +1024,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
     persistResource(
         reloadResourceByForeignKey()
             .asBuilder()
-            .setRegistrationExpirationTime(DateTime.parse("2000-04-04T22:00:00.0Z"))
+            .setRegistrationExpirationTime(Instant.parse("2000-04-04T22:00:00.0Z"))
             .build());
     EppException thrown =
         assertThrows(IncorrectCurrentExpirationDateException.class, this::runFlow);

--- a/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
@@ -103,7 +103,7 @@ import google.registry.testing.DatabaseHelper;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -128,7 +128,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
   private static final ImmutableMap<String, String> FEE_STD_1_0_MAP =
       updateSubstitutions(FEE_BASE_MAP, "FEE_VERSION", "epp:fee-1.0", "FEE_NS", "fee1_00");
 
-  private final DateTime expirationTime = DateTime.parse("2000-04-03T22:00:00.0Z");
+  private final Instant expirationTime = Instant.parse("2000-04-03T22:00:00.0Z");
 
   @BeforeEach
   void initDomainTest() {
@@ -157,7 +157,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
           new DomainHistory.Builder()
               .setDomain(domain)
               .setType(HistoryEntry.Type.DOMAIN_CREATE)
-              .setModificationTime(clock.nowUtc())
+              .setModificationTime(clock.now())
               .setRegistrarId(domain.getCreationRegistrarId())
               .build();
       BillingRecurrence autorenewEvent =
@@ -247,8 +247,8 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
       @Nullable Money renewalPrice)
       throws Exception {
     assertMutatingFlow(true);
-    DateTime currentExpiration = reloadResourceByForeignKey().getRegistrationExpirationDateTime();
-    DateTime newExpiration = currentExpiration.plusYears(renewalYears);
+    Instant currentExpiration = reloadResourceByForeignKey().getRegistrationExpirationDateTime();
+    Instant newExpiration = currentExpiration.plusYears(renewalYears);
     runFlowAssertResponse(
         CommitMode.LIVE, userPrivileges, loadFile(responseFilename, substitutions));
     Domain domain = reloadResourceByForeignKey();
@@ -259,14 +259,14 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
         .isEqualTo(newExpiration);
     assertAboutDomains()
         .that(domain)
-        .isActiveAt(clock.nowUtc())
+        .isActiveAt(clock.now())
         .and()
         .hasRegistrationExpirationTime(newExpiration)
         .and()
         .hasOneHistoryEntryEachOfTypes(
             HistoryEntry.Type.DOMAIN_CREATE, HistoryEntry.Type.DOMAIN_RENEW)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId(renewalClientId);
     assertAboutHistoryEntries().that(historyEntryDomainRenew).hasPeriodYears(renewalYears);
@@ -277,8 +277,8 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
             .setRegistrarId(renewalClientId)
             .setCost(totalRenewCost)
             .setPeriodYears(renewalYears)
-            .setEventTime(clock.nowUtc())
-            .setBillingTime(clock.nowUtc().plus(Tld.get("tld").getRenewGracePeriodLength()))
+            .setEventTime(clock.now())
+            .setBillingTime(clock.now().plus(Tld.get("tld").getRenewGracePeriodLength()))
             .setDomainHistory(historyEntryDomainRenew)
             .build();
     assertBillingEvents(
@@ -291,7 +291,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
             .setTargetId(getUniqueIdFromCommand())
             .setRegistrarId("TheRegistrar")
             .setEventTime(expirationTime)
-            .setRecurrenceEndTime(clock.nowUtc())
+            .setRecurrenceEndTime(clock.now())
             .setDomainHistory(
                 getOnlyHistoryEntryOfType(
                     domain, HistoryEntry.Type.DOMAIN_CREATE, DomainHistory.class))
@@ -324,7 +324,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
             GracePeriod.create(
                 GracePeriodStatus.RENEW,
                 domain.getRepoId(),
-                clock.nowUtc().plus(Tld.get("tld").getRenewGracePeriodLength()),
+                clock.now().plus(Tld.get("tld").getRenewGracePeriodLength()),
                 renewalClientId,
                 null),
             renewBillingEvent));
@@ -660,10 +660,10 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(60), TokenStatus.ENDED)
+                    .put(clock.now().plusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(60), TokenStatus.ENDED)
                     .build())
             .build());
     assertAboutEppExceptions()
@@ -684,10 +684,10 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
             .setAllowedRegistrarIds(ImmutableSet.of("someClientId"))
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     assertAboutEppExceptions()
@@ -709,10 +709,10 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
             .setAllowedTlds(ImmutableSet.of("example"))
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     runFlowAssertResponse(
@@ -808,7 +808,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
             .setTargetId(getUniqueIdFromCommand())
             .setRegistrarId("TheRegistrar")
             .setEventTime(expirationTime.minusYears(1))
-            .setAutorenewEndTime(clock.nowUtc())
+            .setAutorenewEndTime(clock.now())
             .setMsg("Domain was auto-renewed.")
             .setHistoryEntry(
                 getOnlyHistoryEntryOfType(
@@ -882,7 +882,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
 
   @Test
   void testFailure_existedButWasDeleted() throws Exception {
-    persistDeletedDomain(getUniqueIdFromCommand(), clock.nowUtc().minusDays(1));
+    persistDeletedDomain(getUniqueIdFromCommand(), clock.now().minusDays(1));
     ResourceDoesNotExistException thrown =
         assertThrows(ResourceDoesNotExistException.class, this::runFlow);
     assertThat(thrown).hasMessageThat().contains(String.format("(%s)", getUniqueIdFromCommand()));
@@ -910,7 +910,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
         DatabaseHelper.newDomain(getUniqueIdFromCommand())
             .asBuilder()
             .setRegistrationExpirationTime(expirationTime)
-            .setDeletionTime(clock.nowUtc().plusDays(1))
+            .setDeletionTime(clock.now().plusDays(1))
             .addStatusValue(StatusValue.PENDING_DELETE)
             .build());
     ResourceStatusProhibitsOperationException thrown =
@@ -985,7 +985,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
     persistWithPendingTransfer(
         reloadResourceByForeignKey()
             .asBuilder()
-            .setRegistrationExpirationTime(DateTime.parse("2001-09-08T22:00:00.0Z"))
+            .setRegistrationExpirationTime(Instant.parse("2001-09-08T22:00:00.0Z"))
             .build());
     ResourceStatusProhibitsOperationException thrown =
         assertThrows(ResourceStatusProhibitsOperationException.class, this::runFlow);
@@ -1015,7 +1015,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
     persistResource(
         reloadResourceByForeignKey()
             .asBuilder()
-            .setRegistrationExpirationTime(DateTime.parse("2000-04-04T22:00:00.0Z"))
+            .setRegistrationExpirationTime(Instant.parse("2000-04-04T22:00:00.0Z"))
             .build());
     EppException thrown =
         assertThrows(IncorrectCurrentExpirationDateException.class, this::runFlow);

--- a/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
@@ -29,8 +29,14 @@ import static google.registry.testing.DatabaseHelper.persistReservedList;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DomainSubject.assertAboutDomains;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
+import static google.registry.util.DateTimeUtils.END_INSTANT;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
-import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
+import static google.registry.util.DateTimeUtils.minusDays;
+import static google.registry.util.DateTimeUtils.plusDays;
+import static google.registry.util.DateTimeUtils.plusMonths;
+import static google.registry.util.DateTimeUtils.plusYears;
+import static google.registry.util.DateTimeUtils.toDateTime;
 import static org.joda.money.CurrencyUnit.EUR;
 import static org.joda.money.CurrencyUnit.JPY;
 import static org.joda.money.CurrencyUnit.USD;
@@ -76,10 +82,11 @@ import google.registry.model.reporting.HistoryEntry;
 import google.registry.model.tld.Tld;
 import google.registry.persistence.VKey;
 import google.registry.testing.DatabaseHelper;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -108,16 +115,16 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
 
   Domain persistPendingDeleteDomain() throws Exception {
     // The domain is now past what had been its expiration date at the time of deletion.
-    return persistPendingDeleteDomain(clock.nowUtc().minusDays(5));
+    return persistPendingDeleteDomain(minusDays(clock.now(), 5));
   }
 
-  Domain persistPendingDeleteDomain(DateTime expirationTime) throws Exception {
+  Domain persistPendingDeleteDomain(Instant expirationTime) throws Exception {
     Domain domain = persistResource(DatabaseHelper.newDomain(getUniqueIdFromCommand()));
     HistoryEntry historyEntry =
         persistResource(
             new DomainHistory.Builder()
                 .setType(HistoryEntry.Type.DOMAIN_DELETE)
-                .setModificationTime(clock.nowUtc())
+                .setModificationTime(clock.now())
                 .setRegistrarId(domain.getCurrentSponsorRegistrarId())
                 .setDomain(domain)
                 .build());
@@ -126,12 +133,12 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
             domain
                 .asBuilder()
                 .setRegistrationExpirationTime(expirationTime)
-                .setDeletionTime(clock.nowUtc().plusDays(35))
+                .setDeletionTime(plusDays(clock.now(), 35))
                 .addGracePeriod(
                     GracePeriod.create(
                         GracePeriodStatus.REDEMPTION,
                         domain.getRepoId(),
-                        clock.nowUtc().plusDays(1),
+                        plusDays(clock.now(), 1),
                         "TheRegistrar",
                         null))
                 .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
@@ -139,7 +146,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
                     persistResource(
                             new PollMessage.OneTime.Builder()
                                 .setRegistrarId("TheRegistrar")
-                                .setEventTime(clock.nowUtc().plusDays(5))
+                                .setEventTime(plusDays(clock.now(), 5))
                                 .setHistoryEntry(historyEntry)
                                 .build())
                         .createVKey())
@@ -165,7 +172,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
   @Test
   void testSuccess_expiryStillInFuture_notExtended() throws Exception {
     setEppInput("domain_update_restore_request.xml", ImmutableMap.of("DOMAIN", "example.tld"));
-    DateTime expirationTime = clock.nowUtc().plusYears(5).plusDays(45);
+    Instant expirationTime = plusYears(clock.now(), 5).plus(Duration.ofDays(45));
     persistPendingDeleteDomain(expirationTime);
     assertMutatingFlow(true);
     // Double check that we see a poll message in the future for when the delete happens.
@@ -176,7 +183,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
         getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_RESTORE, DomainHistory.class);
     assertLastHistoryContainsResource(domain);
     assertThat(loadByKey(domain.getAutorenewBillingEvent()).getEventTime())
-        .isEqualTo(expirationTime);
+        .isEqualTo(toDateTime(expirationTime));
     assertAboutDomains()
         .that(domain)
         // New expiration time should be the same as from before the deletion.
@@ -184,12 +191,12 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
         .and()
         .doesNotHaveStatusValue(StatusValue.PENDING_DELETE)
         .and()
-        .hasDeletionTime(END_OF_TIME)
+        .hasDeletionTime(END_INSTANT)
         .and()
         .hasOneHistoryEntryEachOfTypes(
             HistoryEntry.Type.DOMAIN_DELETE, HistoryEntry.Type.DOMAIN_RESTORE)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("TheRegistrar");
     assertThat(domain.getGracePeriods()).isEmpty();
@@ -214,7 +221,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
             .setTargetId("example.tld")
             .setRegistrarId("TheRegistrar")
             .setEventTime(expirationTime)
-            .setRecurrenceEndTime(END_OF_TIME)
+            .setRecurrenceEndTime(END_INSTANT)
             .setDomainHistory(historyEntryDomainRestore)
             .build(),
         new BillingEvent.Builder()
@@ -223,8 +230,8 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
             .setRegistrarId("TheRegistrar")
             .setCost(Money.of(USD, 17))
             .setPeriodYears(1)
-            .setEventTime(clock.nowUtc())
-            .setBillingTime(clock.nowUtc())
+            .setEventTime(clock.now())
+            .setBillingTime(clock.now())
             .setDomainHistory(historyEntryDomainRestore)
             .build());
   }
@@ -232,8 +239,8 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
   @Test
   void testSuccess_expiryInPast_extendedByOneYear() throws Exception {
     setEppInput("domain_update_restore_request.xml", ImmutableMap.of("DOMAIN", "example.tld"));
-    DateTime expirationTime = clock.nowUtc().minusDays(20);
-    DateTime newExpirationTime = expirationTime.plusYears(1);
+    Instant expirationTime = minusDays(clock.now(), 20);
+    Instant newExpirationTime = plusYears(expirationTime, 1);
     persistPendingDeleteDomain(expirationTime);
     assertMutatingFlow(true);
     // Double check that we see a poll message in the future for when the delete happens.
@@ -244,7 +251,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
         getOnlyHistoryEntryOfType(domain, HistoryEntry.Type.DOMAIN_RESTORE, DomainHistory.class);
     assertLastHistoryContainsResource(domain);
     assertThat(loadByKey(domain.getAutorenewBillingEvent()).getEventTime())
-        .isEqualTo(newExpirationTime);
+        .isEqualTo(toDateTime(newExpirationTime));
     assertAboutDomains()
         .that(domain)
         // New expiration time should be exactly a year from now.
@@ -252,12 +259,12 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
         .and()
         .doesNotHaveStatusValue(StatusValue.PENDING_DELETE)
         .and()
-        .hasDeletionTime(END_OF_TIME)
+        .hasDeletionTime(END_INSTANT)
         .and()
         .hasOneHistoryEntryEachOfTypes(
             HistoryEntry.Type.DOMAIN_DELETE, HistoryEntry.Type.DOMAIN_RESTORE)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("TheRegistrar");
     assertThat(domain.getGracePeriods()).isEmpty();
@@ -283,7 +290,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
             .setTargetId("example.tld")
             .setRegistrarId("TheRegistrar")
             .setEventTime(newExpirationTime)
-            .setRecurrenceEndTime(END_OF_TIME)
+            .setRecurrenceEndTime(END_INSTANT)
             .setDomainHistory(historyEntryDomainRestore)
             .build(),
         new BillingEvent.Builder()
@@ -292,8 +299,8 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
             .setRegistrarId("TheRegistrar")
             .setCost(Money.of(USD, 17))
             .setPeriodYears(1)
-            .setEventTime(clock.nowUtc())
-            .setBillingTime(clock.nowUtc())
+            .setEventTime(clock.now())
+            .setBillingTime(clock.now())
             .setDomainHistory(historyEntryDomainRestore)
             .build(),
         new BillingEvent.Builder()
@@ -302,8 +309,8 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
             .setRegistrarId("TheRegistrar")
             .setCost(Money.of(USD, 11))
             .setPeriodYears(1)
-            .setEventTime(clock.nowUtc())
-            .setBillingTime(clock.nowUtc())
+            .setEventTime(clock.now())
+            .setBillingTime(clock.now())
             .setDomainHistory(historyEntryDomainRestore)
             .build());
   }
@@ -315,7 +322,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
     persistResource(
         reloadResourceByForeignKey()
             .asBuilder()
-            .setAutorenewEndTime(Optional.of(clock.nowUtc().plusYears(2)))
+            .setAutorenewEndTimeInstant(Optional.of(plusYears(clock.now(), 2)))
             .build());
     assertThat(reloadResourceByForeignKey().getAutorenewEndTime()).isPresent();
     runFlowAssertResponse(
@@ -386,7 +393,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
   void testSuccess_premiumNotBlocked_andNoRenewal_std_v1() throws Exception {
     createTld("example");
     setEppInput("domain_update_restore_request_premium_no_renewal.xml", FEE_STD_1_0_MAP);
-    persistPendingDeleteDomain(clock.nowUtc().plusYears(2));
+    persistPendingDeleteDomain(plusYears(clock.now(), 2));
     runFlowAssertResponse(
         loadFile("domain_update_restore_request_response_fee_no_renewal.xml", FEE_STD_1_0_MAP));
   }
@@ -475,11 +482,12 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
         Tld.get("tld")
             .asBuilder()
             .setCurrency(EUR)
-            .setCreateBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.of(EUR, 13)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.of(EUR, 13)))
             .setRestoreBillingCost(Money.of(EUR, 11))
-            .setRenewBillingCostTransitions(ImmutableSortedMap.of(START_OF_TIME, Money.of(EUR, 7)))
-            .setEapFeeSchedule(ImmutableSortedMap.of(START_OF_TIME, Money.zero(EUR)))
+            .setRenewBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.of(EUR, 7)))
+            .setEapFeeScheduleInstant(ImmutableSortedMap.of(START_INSTANT, Money.zero(EUR)))
             .setServerStatusChangeBillingCost(Money.of(EUR, 19))
             .setRegistryLockOrUnlockBillingCost(Money.of(EUR, 0))
             .build());
@@ -505,7 +513,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
     persistResource(
         DatabaseHelper.newDomain(getUniqueIdFromCommand())
             .asBuilder()
-            .setDeletionTime(clock.nowUtc().plusDays(4))
+            .setDeletionTime(plusDays(clock.now(), 4))
             .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
             .build());
     EppException thrown = assertThrows(DomainNotEligibleForRestoreException.class, this::runFlow);
@@ -593,11 +601,11 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
         Tld.get("tld")
             .asBuilder()
             .setCurrency(JPY)
-            .setCreateBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.ofMajor(JPY, 800)))
-            .setEapFeeSchedule(ImmutableSortedMap.of(START_OF_TIME, Money.ofMajor(JPY, 800)))
-            .setRenewBillingCostTransitions(
-                ImmutableSortedMap.of(START_OF_TIME, Money.ofMajor(JPY, 800)))
+            .setCreateBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.ofMajor(JPY, 800)))
+            .setEapFeeScheduleInstant(ImmutableSortedMap.of(START_INSTANT, Money.ofMajor(JPY, 800)))
+            .setRenewBillingCostTransitionsInstant(
+                ImmutableSortedMap.of(START_INSTANT, Money.ofMajor(JPY, 800)))
             .setRegistryLockOrUnlockBillingCost(Money.ofMajor(JPY, 800))
             .setServerStatusChangeBillingCost(Money.ofMajor(JPY, 800))
             .setRestoreBillingCost(Money.ofMajor(JPY, 800))
@@ -790,7 +798,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
   @Test
   void testSuccess_fee_v06_noRenewal() throws Exception {
     setEppInput("domain_update_restore_request_fee_no_renewal.xml", FEE_06_MAP);
-    persistPendingDeleteDomain(clock.nowUtc().plusMonths(6));
+    persistPendingDeleteDomain(plusMonths(clock.now(), 6));
     runFlowAssertResponse(
         loadFile("domain_update_restore_request_response_fee_no_renewal.xml", FEE_06_MAP));
   }
@@ -887,7 +895,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
   void testSuccess_premiumNotBlocked_andNoRenewal_v12() throws Exception {
     createTld("example");
     setEppInput("domain_update_restore_request_premium_no_renewal.xml", FEE_12_MAP);
-    persistPendingDeleteDomain(clock.nowUtc().plusYears(2));
+    persistPendingDeleteDomain(plusYears(clock.now(), 2));
     runFlowAssertResponse(
         loadFile("domain_update_restore_request_response_fee_no_renewal.xml", FEE_12_MAP));
   }

--- a/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
@@ -79,7 +79,7 @@ import google.registry.testing.DatabaseHelper;
 import java.util.Map;
 import java.util.Optional;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -108,16 +108,16 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
 
   Domain persistPendingDeleteDomain() throws Exception {
     // The domain is now past what had been its expiration date at the time of deletion.
-    return persistPendingDeleteDomain(clock.nowUtc().minusDays(5));
+    return persistPendingDeleteDomain(clock.now().minusDays(5));
   }
 
-  Domain persistPendingDeleteDomain(DateTime expirationTime) throws Exception {
+  Domain persistPendingDeleteDomain(Instant expirationTime) throws Exception {
     Domain domain = persistResource(DatabaseHelper.newDomain(getUniqueIdFromCommand()));
     HistoryEntry historyEntry =
         persistResource(
             new DomainHistory.Builder()
                 .setType(HistoryEntry.Type.DOMAIN_DELETE)
-                .setModificationTime(clock.nowUtc())
+                .setModificationTime(clock.now())
                 .setRegistrarId(domain.getCurrentSponsorRegistrarId())
                 .setDomain(domain)
                 .build());
@@ -126,12 +126,12 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
             domain
                 .asBuilder()
                 .setRegistrationExpirationTime(expirationTime)
-                .setDeletionTime(clock.nowUtc().plusDays(35))
+                .setDeletionTime(clock.now().plusDays(35))
                 .addGracePeriod(
                     GracePeriod.create(
                         GracePeriodStatus.REDEMPTION,
                         domain.getRepoId(),
-                        clock.nowUtc().plusDays(1),
+                        clock.now().plusDays(1),
                         "TheRegistrar",
                         null))
                 .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
@@ -139,7 +139,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
                     persistResource(
                             new PollMessage.OneTime.Builder()
                                 .setRegistrarId("TheRegistrar")
-                                .setEventTime(clock.nowUtc().plusDays(5))
+                                .setEventTime(clock.now().plusDays(5))
                                 .setHistoryEntry(historyEntry)
                                 .build())
                         .createVKey())
@@ -165,11 +165,11 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
   @Test
   void testSuccess_expiryStillInFuture_notExtended() throws Exception {
     setEppInput("domain_update_restore_request.xml", ImmutableMap.of("DOMAIN", "example.tld"));
-    DateTime expirationTime = clock.nowUtc().plusYears(5).plusDays(45);
+    Instant expirationTime = clock.now().plusYears(5).plusDays(45);
     persistPendingDeleteDomain(expirationTime);
     assertMutatingFlow(true);
     // Double check that we see a poll message in the future for when the delete happens.
-    assertThat(getPollMessages("TheRegistrar", clock.nowUtc().plusMonths(1))).hasSize(1);
+    assertThat(getPollMessages("TheRegistrar", clock.now().plusMonths(1))).hasSize(1);
     runFlowAssertResponse(loadFile("generic_success_response.xml"));
     Domain domain = reloadResourceByForeignKey();
     DomainHistory historyEntryDomainRestore =
@@ -189,7 +189,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
         .hasOneHistoryEntryEachOfTypes(
             HistoryEntry.Type.DOMAIN_DELETE, HistoryEntry.Type.DOMAIN_RESTORE)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("TheRegistrar");
     assertThat(domain.getGracePeriods()).isEmpty();
@@ -223,8 +223,8 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
             .setRegistrarId("TheRegistrar")
             .setCost(Money.of(USD, 17))
             .setPeriodYears(1)
-            .setEventTime(clock.nowUtc())
-            .setBillingTime(clock.nowUtc())
+            .setEventTime(clock.now())
+            .setBillingTime(clock.now())
             .setDomainHistory(historyEntryDomainRestore)
             .build());
   }
@@ -232,12 +232,12 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
   @Test
   void testSuccess_expiryInPast_extendedByOneYear() throws Exception {
     setEppInput("domain_update_restore_request.xml", ImmutableMap.of("DOMAIN", "example.tld"));
-    DateTime expirationTime = clock.nowUtc().minusDays(20);
-    DateTime newExpirationTime = expirationTime.plusYears(1);
+    Instant expirationTime = clock.now().minusDays(20);
+    Instant newExpirationTime = expirationTime.plusYears(1);
     persistPendingDeleteDomain(expirationTime);
     assertMutatingFlow(true);
     // Double check that we see a poll message in the future for when the delete happens.
-    assertThat(getPollMessages("TheRegistrar", clock.nowUtc().plusMonths(1))).hasSize(1);
+    assertThat(getPollMessages("TheRegistrar", clock.now().plusMonths(1))).hasSize(1);
     runFlowAssertResponse(loadFile("generic_success_response.xml"));
     Domain domain = reloadResourceByForeignKey();
     DomainHistory historyEntryDomainRestore =
@@ -257,7 +257,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
         .hasOneHistoryEntryEachOfTypes(
             HistoryEntry.Type.DOMAIN_DELETE, HistoryEntry.Type.DOMAIN_RESTORE)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("TheRegistrar");
     assertThat(domain.getGracePeriods()).isEmpty();
@@ -292,8 +292,8 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
             .setRegistrarId("TheRegistrar")
             .setCost(Money.of(USD, 17))
             .setPeriodYears(1)
-            .setEventTime(clock.nowUtc())
-            .setBillingTime(clock.nowUtc())
+            .setEventTime(clock.now())
+            .setBillingTime(clock.now())
             .setDomainHistory(historyEntryDomainRestore)
             .build(),
         new BillingEvent.Builder()
@@ -302,8 +302,8 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
             .setRegistrarId("TheRegistrar")
             .setCost(Money.of(USD, 11))
             .setPeriodYears(1)
-            .setEventTime(clock.nowUtc())
-            .setBillingTime(clock.nowUtc())
+            .setEventTime(clock.now())
+            .setBillingTime(clock.now())
             .setDomainHistory(historyEntryDomainRestore)
             .build());
   }
@@ -315,7 +315,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
     persistResource(
         reloadResourceByForeignKey()
             .asBuilder()
-            .setAutorenewEndTime(Optional.of(clock.nowUtc().plusYears(2)))
+            .setAutorenewEndTime(Optional.of(clock.now().plusYears(2)))
             .build());
     assertThat(reloadResourceByForeignKey().getAutorenewEndTime()).isPresent();
     runFlowAssertResponse(
@@ -386,7 +386,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
   void testSuccess_premiumNotBlocked_andNoRenewal_std_v1() throws Exception {
     createTld("example");
     setEppInput("domain_update_restore_request_premium_no_renewal.xml", FEE_STD_1_0_MAP);
-    persistPendingDeleteDomain(clock.nowUtc().plusYears(2));
+    persistPendingDeleteDomain(clock.now().plusYears(2));
     runFlowAssertResponse(
         loadFile("domain_update_restore_request_response_fee_no_renewal.xml", FEE_STD_1_0_MAP));
   }
@@ -505,7 +505,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
     persistResource(
         DatabaseHelper.newDomain(getUniqueIdFromCommand())
             .asBuilder()
-            .setDeletionTime(clock.nowUtc().plusDays(4))
+            .setDeletionTime(clock.now().plusDays(4))
             .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE))
             .build());
     EppException thrown = assertThrows(DomainNotEligibleForRestoreException.class, this::runFlow);
@@ -521,7 +521,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
 
   @Test
   void testFailure_fullyDeleted() throws Exception {
-    persistDeletedDomain(getUniqueIdFromCommand(), clock.nowUtc().minusDays(1));
+    persistDeletedDomain(getUniqueIdFromCommand(), clock.now().minusDays(1));
     EppException thrown = assertThrows(ResourceDoesNotExistException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
@@ -790,7 +790,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
   @Test
   void testSuccess_fee_v06_noRenewal() throws Exception {
     setEppInput("domain_update_restore_request_fee_no_renewal.xml", FEE_06_MAP);
-    persistPendingDeleteDomain(clock.nowUtc().plusMonths(6));
+    persistPendingDeleteDomain(clock.now().plusMonths(6));
     runFlowAssertResponse(
         loadFile("domain_update_restore_request_response_fee_no_renewal.xml", FEE_06_MAP));
   }
@@ -887,7 +887,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
   void testSuccess_premiumNotBlocked_andNoRenewal_v12() throws Exception {
     createTld("example");
     setEppInput("domain_update_restore_request_premium_no_renewal.xml", FEE_12_MAP);
-    persistPendingDeleteDomain(clock.nowUtc().plusYears(2));
+    persistPendingDeleteDomain(clock.now().plusYears(2));
     runFlowAssertResponse(
         loadFile("domain_update_restore_request_response_fee_no_renewal.xml", FEE_12_MAP));
   }

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
@@ -38,7 +38,12 @@ import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DomainSubject.assertAboutDomains;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
 import static google.registry.testing.HistoryEntrySubject.assertAboutHistoryEntries;
-import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
+import static google.registry.util.DateTimeUtils.minusDays;
+import static google.registry.util.DateTimeUtils.minusYears;
+import static google.registry.util.DateTimeUtils.plusDays;
+import static google.registry.util.DateTimeUtils.plusYears;
+import static google.registry.util.DateTimeUtils.toDateTime;
 import static org.joda.money.CurrencyUnit.USD;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -92,10 +97,10 @@ import google.registry.model.transfer.TransferStatus;
 import google.registry.persistence.VKey;
 import google.registry.testing.DatabaseHelper;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.stream.Stream;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -116,10 +121,10 @@ class DomainTransferApproveFlowTest
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setRenewBillingCostTransitions(
-                new ImmutableSortedMap.Builder<DateTime, Money>(Ordering.natural())
-                    .put(START_OF_TIME, Money.of(USD, 1))
-                    .put(clock.nowUtc().minusDays(1).plusMillis(1), Money.of(USD, 22))
+            .setRenewBillingCostTransitionsInstant(
+                new ImmutableSortedMap.Builder<Instant, Money>(Ordering.natural())
+                    .put(START_INSTANT, Money.of(USD, 1))
+                    .put(minusDays(clock.now(), 1).plusMillis(1), Money.of(USD, 22))
                     .put(TRANSFER_REQUEST_TIME.plusMillis(1), Money.of(USD, 333))
                     .build())
             .build());
@@ -134,11 +139,11 @@ class DomainTransferApproveFlowTest
         .that(domain)
         .hasCurrentSponsorRegistrarId("NewRegistrar")
         .and()
-        .hasLastTransferTime(clock.nowUtc())
+        .hasLastTransferTime(clock.now())
         .and()
         .doesNotHaveStatusValue(StatusValue.PENDING_TRANSFER)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("TheRegistrar");
     // The domain TransferData should reflect the approved transfer as we expect, with
@@ -148,9 +153,8 @@ class DomainTransferApproveFlowTest
             oldTransferData
                 .copyConstantFieldsToBuilder()
                 .setTransferStatus(TransferStatus.CLIENT_APPROVED)
-                .setPendingTransferExpirationTime(clock.nowUtc())
-                .setTransferredRegistrationExpirationTime(
-                    domain.getRegistrationExpirationDateTime())
+                .setPendingTransferExpirationTime(clock.now())
+                .setTransferredRegistrationExpirationTime(domain.getRegistrationExpirationTime())
                 .build());
   }
 
@@ -163,7 +167,7 @@ class DomainTransferApproveFlowTest
       String tld,
       String commandFilename,
       String expectedXmlFilename,
-      DateTime expectedExpirationTime,
+      Instant expectedExpirationTime,
       int expectedYearsToCharge,
       BillingCancellation.Builder... expectedCancellationBillingEvents)
       throws Exception {
@@ -177,7 +181,7 @@ class DomainTransferApproveFlowTest
       String tld,
       String commandFilename,
       String expectedXmlFilename,
-      DateTime expectedExpirationTime)
+      Instant expectedExpirationTime)
       throws Exception {
     setEppInput(commandFilename);
     Tld registry = Tld.get(tld);
@@ -210,7 +214,7 @@ class DomainTransferApproveFlowTest
     assertTransferApproved(domain, originalTransferData);
     assertAboutDomains().that(domain).hasRegistrationExpirationTime(expectedExpirationTime);
     assertThat(loadByKey(domain.getAutorenewBillingEvent()).getEventTime())
-        .isEqualTo(expectedExpirationTime);
+        .isEqualTo(toDateTime(expectedExpirationTime));
     // The poll message (in the future) to the losing registrar for implicit ack should be gone.
     assertThat(getPollMessages(domain, "TheRegistrar", clock.nowUtc().plusMonths(1))).isEmpty();
 
@@ -218,7 +222,9 @@ class DomainTransferApproveFlowTest
     // should be one at the current time to the gaining registrar, as well as one at the domain's
     // autorenew time.
     assertThat(getPollMessages(domain, "NewRegistrar", clock.nowUtc().plusMonths(1))).hasSize(1);
-    assertThat(getPollMessages(domain, "NewRegistrar", domain.getRegistrationExpirationDateTime()))
+    assertThat(
+            getPollMessages(
+                domain, "NewRegistrar", toDateTime(domain.getRegistrationExpirationTime())))
         .hasSize(2);
 
     PollMessage gainingTransferPollMessage =
@@ -227,11 +233,11 @@ class DomainTransferApproveFlowTest
         getOnlyPollMessage(
             domain,
             "NewRegistrar",
-            domain.getRegistrationExpirationDateTime(),
+            toDateTime(domain.getRegistrationExpirationTime()),
             PollMessage.Autorenew.class);
     assertThat(gainingTransferPollMessage.getEventTime()).isEqualTo(clock.nowUtc());
     assertThat(gainingAutorenewPollMessage.getEventTime())
-        .isEqualTo(domain.getRegistrationExpirationDateTime());
+        .isEqualTo(toDateTime(domain.getRegistrationExpirationTime()));
     DomainTransferResponse transferResponse =
         gainingTransferPollMessage
             .getResponseData()
@@ -256,7 +262,8 @@ class DomainTransferApproveFlowTest
     // After the expected grace time, the grace period should be gone.
     assertThat(
             domain
-                .cloneProjectedAtTime(clock.nowUtc().plus(registry.getTransferGracePeriodLength()))
+                .cloneProjectedAtInstant(
+                    clock.now().plusMillis(registry.getTransferGracePeriodLength().getMillis()))
                 .getGracePeriods())
         .isEmpty();
   }
@@ -276,8 +283,10 @@ class DomainTransferApproveFlowTest
         new BillingEvent.Builder()
             .setReason(Reason.TRANSFER)
             .setTargetId(domain.getDomainName())
-            .setEventTime(clock.nowUtc())
-            .setBillingTime(clock.nowUtc().plus(registry.getTransferGracePeriodLength()))
+            .setEventTime(clock.now())
+            .setBillingTime(
+                toDateTime(
+                    clock.now().plusMillis(registry.getTransferGracePeriodLength().getMillis())))
             .setRegistrarId("NewRegistrar")
             .setCost(Money.of(USD, 11).multipliedBy(expectedYearsToCharge))
             .setPeriodYears(expectedYearsToCharge)
@@ -292,13 +301,13 @@ class DomainTransferApproveFlowTest
                     transferBillingEvent,
                     getLosingClientAutorenewEvent()
                         .asBuilder()
-                        .setRecurrenceEndTime(clock.nowUtc())
+                        .setRecurrenceEndTime(clock.now())
                         .build(),
                     getGainingClientAutorenewEvent()
                         .asBuilder()
-                        .setEventTime(domain.getRegistrationExpirationDateTime())
+                        .setEventTime(domain.getRegistrationExpirationTime())
                         .setRecurrenceLastExpansion(
-                            domain.getRegistrationExpirationDateTime().minusYears(1))
+                            minusYears(domain.getRegistrationExpirationTime(), 1))
                         .setDomainHistory(historyEntryTransferApproved)
                         .build()))
             .toArray(BillingBase[]::new));
@@ -309,7 +318,8 @@ class DomainTransferApproveFlowTest
             GracePeriod.create(
                 GracePeriodStatus.TRANSFER,
                 domain.getRepoId(),
-                clock.nowUtc().plus(registry.getTransferGracePeriodLength()),
+                toDateTime(
+                    clock.now().plusMillis(registry.getTransferGracePeriodLength().getMillis())),
                 "NewRegistrar",
                 null),
             transferBillingEvent));
@@ -330,13 +340,13 @@ class DomainTransferApproveFlowTest
                 Stream.of(
                     getLosingClientAutorenewEvent()
                         .asBuilder()
-                        .setRecurrenceEndTime(clock.nowUtc())
+                        .setRecurrenceEndTime(clock.now())
                         .build(),
                     getGainingClientAutorenewEvent()
                         .asBuilder()
-                        .setEventTime(domain.getRegistrationExpirationDateTime())
+                        .setEventTime(domain.getRegistrationExpirationTime())
                         .setRecurrenceLastExpansion(
-                            domain.getRegistrationExpirationDateTime().minusYears(1))
+                            minusYears(domain.getRegistrationExpirationTime(), 1))
                         .setDomainHistory(historyEntryTransferApproved)
                         .build()))
             .toArray(BillingBase[]::new));
@@ -351,7 +361,7 @@ class DomainTransferApproveFlowTest
         tld,
         commandFilename,
         expectedXmlFilename,
-        domain.getRegistrationExpirationDateTime().plusYears(1),
+        plusYears(domain.getRegistrationExpirationTime(), 1),
         1);
   }
 
@@ -429,7 +439,7 @@ class DomainTransferApproveFlowTest
     persistResource(domain.asBuilder().setCurrentBulkToken(allocationToken.createVKey()).build());
     clock.advanceOneMilli();
     setEppInput("domain_transfer_approve_wildcard.xml", ImmutableMap.of("DOMAIN", "example.tld"));
-    DateTime now = clock.nowUtc();
+    Instant now = clock.now();
     runFlowAssertResponse(loadFile("domain_transfer_approve_response.xml"));
     domain = reloadResourceByForeignKey();
     DomainHistory acceptHistory =
@@ -437,7 +447,7 @@ class DomainTransferApproveFlowTest
     assertBillingEventsForResource(
         domain,
         new BillingEvent.Builder()
-            .setBillingTime(now.plusDays(5))
+            .setBillingTime(plusDays(now, 5))
             .setEventTime(now)
             .setRegistrarId("NewRegistrar")
             .setCost(Money.of(USD, new BigDecimal("11.00")))
@@ -490,7 +500,7 @@ class DomainTransferApproveFlowTest
   @Test
   void testSuccess_autorenewBeforeTransfer() throws Exception {
     domain = reloadResourceByForeignKey();
-    DateTime oldExpirationTime = clock.nowUtc().minusDays(1);
+    Instant oldExpirationTime = minusDays(clock.now(), 1);
     persistResource(domain.asBuilder().setRegistrationExpirationTime(oldExpirationTime).build());
     // The autorenew should be subsumed into the transfer resulting in 1 year of renewal in total.
     clock.advanceOneMilli();
@@ -498,15 +508,18 @@ class DomainTransferApproveFlowTest
         "tld",
         "domain_transfer_approve_domain_authinfo.xml",
         "domain_transfer_approve_response_autorenew.xml",
-        oldExpirationTime.plusYears(1),
+        plusYears(oldExpirationTime, 1),
         1,
         // Expect the grace period for autorenew to be cancelled.
         new BillingCancellation.Builder()
             .setReason(Reason.RENEW)
             .setTargetId("example.tld")
             .setRegistrarId("TheRegistrar")
-            .setEventTime(clock.nowUtc()) // The cancellation happens at the moment of transfer.
-            .setBillingTime(oldExpirationTime.plus(Tld.get("tld").getAutoRenewGracePeriodLength()))
+            .setEventTime(clock.now()) // The cancellation happens at the moment of transfer.
+            .setBillingTime(
+                toDateTime(
+                    oldExpirationTime.plusMillis(
+                        Tld.get("tld").getAutoRenewGracePeriodLength().getMillis())))
             .setBillingRecurrence(domain.getAutorenewBillingEvent()));
   }
 
@@ -529,7 +542,7 @@ class DomainTransferApproveFlowTest
             .setRenewalPriceBehavior(RenewalPriceBehavior.NONPREMIUM)
             .build());
     setEppInput("domain_transfer_approve_wildcard.xml", ImmutableMap.of("DOMAIN", "example.tld"));
-    DateTime now = clock.nowUtc();
+    Instant now = clock.now();
     runFlowAssertResponse(loadFile("domain_transfer_approve_response.xml"));
     domain = reloadResourceByForeignKey();
     DomainHistory acceptHistory =
@@ -537,7 +550,7 @@ class DomainTransferApproveFlowTest
     assertBillingEventsForResource(
         domain,
         new BillingEvent.Builder()
-            .setBillingTime(now.plusDays(5))
+            .setBillingTime(plusDays(now, 5))
             .setEventTime(now)
             .setRegistrarId("NewRegistrar")
             .setCost(Money.of(USD, new BigDecimal("11.00")))
@@ -578,7 +591,7 @@ class DomainTransferApproveFlowTest
             .setRenewalPrice(Money.of(USD, new BigDecimal("43.10")))
             .build());
     setEppInput("domain_transfer_approve_wildcard.xml", ImmutableMap.of("DOMAIN", "example.tld"));
-    DateTime now = clock.nowUtc();
+    Instant now = clock.now();
     runFlowAssertResponse(loadFile("domain_transfer_approve_response.xml"));
     domain = reloadResourceByForeignKey();
     DomainHistory acceptHistory =
@@ -586,7 +599,7 @@ class DomainTransferApproveFlowTest
     assertBillingEventsForResource(
         domain,
         new BillingEvent.Builder()
-            .setBillingTime(now.plusDays(5))
+            .setBillingTime(plusDays(now, 5))
             .setEventTime(now)
             .setRegistrarId("NewRegistrar")
             .setCost(Money.of(USD, new BigDecimal("43.10")))
@@ -708,7 +721,7 @@ class DomainTransferApproveFlowTest
 
   @Test
   void testFailure_deletedDomain() throws Exception {
-    persistResource(domain.asBuilder().setDeletionTime(clock.nowUtc().minusDays(1)).build());
+    persistResource(domain.asBuilder().setDeletionTime(minusDays(clock.now(), 1)).build());
     ResourceDoesNotExistException thrown =
         assertThrows(
             ResourceDoesNotExistException.class,
@@ -779,7 +792,7 @@ class DomainTransferApproveFlowTest
     assertThat(persistedEntry.getDomainTransactionRecords())
         .containsExactly(
             DomainTransactionRecord.create(
-                "tld", clock.nowUtc().plusDays(3), TRANSFER_SUCCESSFUL, 1));
+                "tld", plusDays(clock.now(), 3), TRANSFER_SUCCESSFUL, 1));
   }
 
   @Test
@@ -787,15 +800,15 @@ class DomainTransferApproveFlowTest
     clock.advanceOneMilli();
     setUpGracePeriodDurations();
     DomainTransactionRecord previousSuccessRecord =
-        DomainTransactionRecord.create("tld", clock.nowUtc().plusDays(1), TRANSFER_SUCCESSFUL, 1);
+        DomainTransactionRecord.create("tld", plusDays(clock.now(), 1), TRANSFER_SUCCESSFUL, 1);
     // We only want to cancel TRANSFER_SUCCESSFUL records
     DomainTransactionRecord notCancellableRecord =
-        DomainTransactionRecord.create("tld", clock.nowUtc().plusDays(1), NET_ADDS_4_YR, 5);
+        DomainTransactionRecord.create("tld", plusDays(clock.now(), 1), NET_ADDS_4_YR, 5);
     persistResource(
         new DomainHistory.Builder()
             .setType(DOMAIN_TRANSFER_REQUEST)
             .setDomain(domain)
-            .setModificationTime(clock.nowUtc().minusDays(4))
+            .setModificationTime(minusDays(clock.now(), 4))
             .setRegistrarId("TheRegistrar")
             .setDomainTransactionRecords(
                 ImmutableSet.of(previousSuccessRecord, notCancellableRecord))
@@ -809,7 +822,7 @@ class DomainTransferApproveFlowTest
         .containsExactly(
             previousSuccessRecord.asBuilder().setReportAmount(-1).build(),
             DomainTransactionRecord.create(
-                "tld", clock.nowUtc().plusDays(3), TRANSFER_SUCCESSFUL, 1));
+                "tld", plusDays(clock.now(), 3), TRANSFER_SUCCESSFUL, 1));
   }
 
   @Test
@@ -827,7 +840,7 @@ class DomainTransferApproveFlowTest
         "tld",
         "domain_transfer_approve.xml",
         "domain_transfer_approve_response_zero_period.xml",
-        domain.getRegistrationExpirationDateTime());
+        domain.getRegistrationExpirationTime());
     assertHistoryEntriesDoNotContainTransferBillingEventsOrGracePeriods();
   }
 
@@ -837,8 +850,8 @@ class DomainTransferApproveFlowTest
     VKey<BillingRecurrence> existingAutorenewEvent = domain.getAutorenewBillingEvent();
     // Set domain to have auto-renewed just before the transfer request, so that it will have an
     // active autorenew grace period spanning the entire transfer window.
-    DateTime autorenewTime = clock.nowUtc().minusDays(1);
-    DateTime expirationTime = autorenewTime.plusYears(1);
+    Instant autorenewTime = minusDays(clock.now(), 1);
+    Instant expirationTime = plusYears(autorenewTime, 1);
     DomainTransferData.Builder transferDataBuilder = domain.getTransferData().asBuilder();
     domain =
         persistResource(
@@ -851,7 +864,8 @@ class DomainTransferApproveFlowTest
                     GracePeriod.createForRecurrence(
                         GracePeriodStatus.AUTO_RENEW,
                         domain.getRepoId(),
-                        autorenewTime.plus(Tld.get("tld").getAutoRenewGracePeriodLength()),
+                        autorenewTime.plusMillis(
+                            Tld.get("tld").getAutoRenewGracePeriodLength().getMillis()),
                         "TheRegistrar",
                         existingAutorenewEvent))
                 .build());
@@ -860,7 +874,7 @@ class DomainTransferApproveFlowTest
         "tld",
         "domain_transfer_approve.xml",
         "domain_transfer_approve_response_zero_period_autorenew_grace.xml",
-        domain.getRegistrationExpirationDateTime());
+        domain.getRegistrationExpirationTime());
     assertHistoryEntriesDoNotContainTransferBillingEventsOrGracePeriods();
   }
 
@@ -909,11 +923,11 @@ class DomainTransferApproveFlowTest
             .setToken("abc123")
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(60), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(plusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 60), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_transfer_approve_allocation_token.xml");
@@ -929,11 +943,11 @@ class DomainTransferApproveFlowTest
             .setTokenType(UNLIMITED_USE)
             .setAllowedRegistrarIds(ImmutableSet.of("someClientId"))
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_transfer_approve_allocation_token.xml");
@@ -950,11 +964,11 @@ class DomainTransferApproveFlowTest
             .setTokenType(UNLIMITED_USE)
             .setAllowedTlds(ImmutableSet.of("example"))
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_transfer_approve_allocation_token.xml");

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
@@ -95,7 +95,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.stream.Stream;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -117,9 +117,9 @@ class DomainTransferApproveFlowTest
         Tld.get("tld")
             .asBuilder()
             .setRenewBillingCostTransitions(
-                new ImmutableSortedMap.Builder<DateTime, Money>(Ordering.natural())
+                new ImmutableSortedMap.Builder<Instant, Money>(Ordering.natural())
                     .put(START_OF_TIME, Money.of(USD, 1))
-                    .put(clock.nowUtc().minusDays(1).plusMillis(1), Money.of(USD, 22))
+                    .put(clock.now().minusDays(1).plusMillis(1), Money.of(USD, 22))
                     .put(TRANSFER_REQUEST_TIME.plusMillis(1), Money.of(USD, 333))
                     .build())
             .build());
@@ -134,11 +134,11 @@ class DomainTransferApproveFlowTest
         .that(domain)
         .hasCurrentSponsorRegistrarId("NewRegistrar")
         .and()
-        .hasLastTransferTime(clock.nowUtc())
+        .hasLastTransferTime(clock.now())
         .and()
         .doesNotHaveStatusValue(StatusValue.PENDING_TRANSFER)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("TheRegistrar");
     // The domain TransferData should reflect the approved transfer as we expect, with
@@ -148,7 +148,7 @@ class DomainTransferApproveFlowTest
             oldTransferData
                 .copyConstantFieldsToBuilder()
                 .setTransferStatus(TransferStatus.CLIENT_APPROVED)
-                .setPendingTransferExpirationTime(clock.nowUtc())
+                .setPendingTransferExpirationTime(clock.now())
                 .setTransferredRegistrationExpirationTime(
                     domain.getRegistrationExpirationDateTime())
                 .build());
@@ -163,7 +163,7 @@ class DomainTransferApproveFlowTest
       String tld,
       String commandFilename,
       String expectedXmlFilename,
-      DateTime expectedExpirationTime,
+      Instant expectedExpirationTime,
       int expectedYearsToCharge,
       BillingCancellation.Builder... expectedCancellationBillingEvents)
       throws Exception {
@@ -177,7 +177,7 @@ class DomainTransferApproveFlowTest
       String tld,
       String commandFilename,
       String expectedXmlFilename,
-      DateTime expectedExpirationTime)
+      Instant expectedExpirationTime)
       throws Exception {
     setEppInput(commandFilename);
     Tld registry = Tld.get(tld);
@@ -190,8 +190,8 @@ class DomainTransferApproveFlowTest
         getGainingClientAutorenewEvent(),
         getLosingClientAutorenewEvent());
     // Look in the future and make sure the poll messages for implicit ack are there.
-    assertThat(getPollMessages(domain, "NewRegistrar", clock.nowUtc().plusMonths(1))).hasSize(1);
-    assertThat(getPollMessages(domain, "TheRegistrar", clock.nowUtc().plusMonths(1))).hasSize(1);
+    assertThat(getPollMessages(domain, "NewRegistrar", clock.now().plusMonths(1))).hasSize(1);
+    assertThat(getPollMessages(domain, "TheRegistrar", clock.now().plusMonths(1))).hasSize(1);
     // Setup done; run the test.
     DomainTransferData originalTransferData = domain.getTransferData();
     assertMutatingFlow(true);
@@ -212,24 +212,24 @@ class DomainTransferApproveFlowTest
     assertThat(loadByKey(domain.getAutorenewBillingEvent()).getEventTime())
         .isEqualTo(expectedExpirationTime);
     // The poll message (in the future) to the losing registrar for implicit ack should be gone.
-    assertThat(getPollMessages(domain, "TheRegistrar", clock.nowUtc().plusMonths(1))).isEmpty();
+    assertThat(getPollMessages(domain, "TheRegistrar", clock.now().plusMonths(1))).isEmpty();
 
     // The poll message in the future to the gaining registrar should be gone too, but there
     // should be one at the current time to the gaining registrar, as well as one at the domain's
     // autorenew time.
-    assertThat(getPollMessages(domain, "NewRegistrar", clock.nowUtc().plusMonths(1))).hasSize(1);
+    assertThat(getPollMessages(domain, "NewRegistrar", clock.now().plusMonths(1))).hasSize(1);
     assertThat(getPollMessages(domain, "NewRegistrar", domain.getRegistrationExpirationDateTime()))
         .hasSize(2);
 
     PollMessage gainingTransferPollMessage =
-        getOnlyPollMessage(domain, "NewRegistrar", clock.nowUtc(), PollMessage.OneTime.class);
+        getOnlyPollMessage(domain, "NewRegistrar", clock.now(), PollMessage.OneTime.class);
     PollMessage gainingAutorenewPollMessage =
         getOnlyPollMessage(
             domain,
             "NewRegistrar",
             domain.getRegistrationExpirationDateTime(),
             PollMessage.Autorenew.class);
-    assertThat(gainingTransferPollMessage.getEventTime()).isEqualTo(clock.nowUtc());
+    assertThat(gainingTransferPollMessage.getEventTime()).isEqualTo(clock.now());
     assertThat(gainingAutorenewPollMessage.getEventTime())
         .isEqualTo(domain.getRegistrationExpirationDateTime());
     DomainTransferResponse transferResponse =
@@ -256,7 +256,7 @@ class DomainTransferApproveFlowTest
     // After the expected grace time, the grace period should be gone.
     assertThat(
             domain
-                .cloneProjectedAtTime(clock.nowUtc().plus(registry.getTransferGracePeriodLength()))
+                .cloneProjectedAtTime(clock.now().plus(registry.getTransferGracePeriodLength()))
                 .getGracePeriods())
         .isEmpty();
   }
@@ -276,8 +276,8 @@ class DomainTransferApproveFlowTest
         new BillingEvent.Builder()
             .setReason(Reason.TRANSFER)
             .setTargetId(domain.getDomainName())
-            .setEventTime(clock.nowUtc())
-            .setBillingTime(clock.nowUtc().plus(registry.getTransferGracePeriodLength()))
+            .setEventTime(clock.now())
+            .setBillingTime(clock.now().plus(registry.getTransferGracePeriodLength()))
             .setRegistrarId("NewRegistrar")
             .setCost(Money.of(USD, 11).multipliedBy(expectedYearsToCharge))
             .setPeriodYears(expectedYearsToCharge)
@@ -292,7 +292,7 @@ class DomainTransferApproveFlowTest
                     transferBillingEvent,
                     getLosingClientAutorenewEvent()
                         .asBuilder()
-                        .setRecurrenceEndTime(clock.nowUtc())
+                        .setRecurrenceEndTime(clock.now())
                         .build(),
                     getGainingClientAutorenewEvent()
                         .asBuilder()
@@ -309,7 +309,7 @@ class DomainTransferApproveFlowTest
             GracePeriod.create(
                 GracePeriodStatus.TRANSFER,
                 domain.getRepoId(),
-                clock.nowUtc().plus(registry.getTransferGracePeriodLength()),
+                clock.now().plus(registry.getTransferGracePeriodLength()),
                 "NewRegistrar",
                 null),
             transferBillingEvent));
@@ -330,7 +330,7 @@ class DomainTransferApproveFlowTest
                 Stream.of(
                     getLosingClientAutorenewEvent()
                         .asBuilder()
-                        .setRecurrenceEndTime(clock.nowUtc())
+                        .setRecurrenceEndTime(clock.now())
                         .build(),
                     getGainingClientAutorenewEvent()
                         .asBuilder()
@@ -429,7 +429,7 @@ class DomainTransferApproveFlowTest
     persistResource(domain.asBuilder().setCurrentBulkToken(allocationToken.createVKey()).build());
     clock.advanceOneMilli();
     setEppInput("domain_transfer_approve_wildcard.xml", ImmutableMap.of("DOMAIN", "example.tld"));
-    DateTime now = clock.nowUtc();
+    Instant now = clock.now();
     runFlowAssertResponse(loadFile("domain_transfer_approve_response.xml"));
     domain = reloadResourceByForeignKey();
     DomainHistory acceptHistory =
@@ -490,7 +490,7 @@ class DomainTransferApproveFlowTest
   @Test
   void testSuccess_autorenewBeforeTransfer() throws Exception {
     domain = reloadResourceByForeignKey();
-    DateTime oldExpirationTime = clock.nowUtc().minusDays(1);
+    Instant oldExpirationTime = clock.now().minusDays(1);
     persistResource(domain.asBuilder().setRegistrationExpirationTime(oldExpirationTime).build());
     // The autorenew should be subsumed into the transfer resulting in 1 year of renewal in total.
     clock.advanceOneMilli();
@@ -505,7 +505,7 @@ class DomainTransferApproveFlowTest
             .setReason(Reason.RENEW)
             .setTargetId("example.tld")
             .setRegistrarId("TheRegistrar")
-            .setEventTime(clock.nowUtc()) // The cancellation happens at the moment of transfer.
+            .setEventTime(clock.now()) // The cancellation happens at the moment of transfer.
             .setBillingTime(oldExpirationTime.plus(Tld.get("tld").getAutoRenewGracePeriodLength()))
             .setBillingRecurrence(domain.getAutorenewBillingEvent()));
   }
@@ -529,7 +529,7 @@ class DomainTransferApproveFlowTest
             .setRenewalPriceBehavior(RenewalPriceBehavior.NONPREMIUM)
             .build());
     setEppInput("domain_transfer_approve_wildcard.xml", ImmutableMap.of("DOMAIN", "example.tld"));
-    DateTime now = clock.nowUtc();
+    Instant now = clock.now();
     runFlowAssertResponse(loadFile("domain_transfer_approve_response.xml"));
     domain = reloadResourceByForeignKey();
     DomainHistory acceptHistory =
@@ -578,7 +578,7 @@ class DomainTransferApproveFlowTest
             .setRenewalPrice(Money.of(USD, new BigDecimal("43.10")))
             .build());
     setEppInput("domain_transfer_approve_wildcard.xml", ImmutableMap.of("DOMAIN", "example.tld"));
-    DateTime now = clock.nowUtc();
+    Instant now = clock.now();
     runFlowAssertResponse(loadFile("domain_transfer_approve_response.xml"));
     domain = reloadResourceByForeignKey();
     DomainHistory acceptHistory =
@@ -708,7 +708,7 @@ class DomainTransferApproveFlowTest
 
   @Test
   void testFailure_deletedDomain() throws Exception {
-    persistResource(domain.asBuilder().setDeletionTime(clock.nowUtc().minusDays(1)).build());
+    persistResource(domain.asBuilder().setDeletionTime(clock.now().minusDays(1)).build());
     ResourceDoesNotExistException thrown =
         assertThrows(
             ResourceDoesNotExistException.class,
@@ -718,7 +718,7 @@ class DomainTransferApproveFlowTest
 
   @Test
   void testFailure_nonexistentDomain() throws Exception {
-    deleteTestDomain(domain, clock.nowUtc());
+    deleteTestDomain(domain, clock.now());
     ResourceDoesNotExistException thrown =
         assertThrows(
             ResourceDoesNotExistException.class,
@@ -779,7 +779,7 @@ class DomainTransferApproveFlowTest
     assertThat(persistedEntry.getDomainTransactionRecords())
         .containsExactly(
             DomainTransactionRecord.create(
-                "tld", clock.nowUtc().plusDays(3), TRANSFER_SUCCESSFUL, 1));
+                "tld", clock.now().plusDays(3), TRANSFER_SUCCESSFUL, 1));
   }
 
   @Test
@@ -787,15 +787,15 @@ class DomainTransferApproveFlowTest
     clock.advanceOneMilli();
     setUpGracePeriodDurations();
     DomainTransactionRecord previousSuccessRecord =
-        DomainTransactionRecord.create("tld", clock.nowUtc().plusDays(1), TRANSFER_SUCCESSFUL, 1);
+        DomainTransactionRecord.create("tld", clock.now().plusDays(1), TRANSFER_SUCCESSFUL, 1);
     // We only want to cancel TRANSFER_SUCCESSFUL records
     DomainTransactionRecord notCancellableRecord =
-        DomainTransactionRecord.create("tld", clock.nowUtc().plusDays(1), NET_ADDS_4_YR, 5);
+        DomainTransactionRecord.create("tld", clock.now().plusDays(1), NET_ADDS_4_YR, 5);
     persistResource(
         new DomainHistory.Builder()
             .setType(DOMAIN_TRANSFER_REQUEST)
             .setDomain(domain)
-            .setModificationTime(clock.nowUtc().minusDays(4))
+            .setModificationTime(clock.now().minusDays(4))
             .setRegistrarId("TheRegistrar")
             .setDomainTransactionRecords(
                 ImmutableSet.of(previousSuccessRecord, notCancellableRecord))
@@ -809,7 +809,7 @@ class DomainTransferApproveFlowTest
         .containsExactly(
             previousSuccessRecord.asBuilder().setReportAmount(-1).build(),
             DomainTransactionRecord.create(
-                "tld", clock.nowUtc().plusDays(3), TRANSFER_SUCCESSFUL, 1));
+                "tld", clock.now().plusDays(3), TRANSFER_SUCCESSFUL, 1));
   }
 
   @Test
@@ -837,8 +837,8 @@ class DomainTransferApproveFlowTest
     VKey<BillingRecurrence> existingAutorenewEvent = domain.getAutorenewBillingEvent();
     // Set domain to have auto-renewed just before the transfer request, so that it will have an
     // active autorenew grace period spanning the entire transfer window.
-    DateTime autorenewTime = clock.nowUtc().minusDays(1);
-    DateTime expirationTime = autorenewTime.plusYears(1);
+    Instant autorenewTime = clock.now().minusDays(1);
+    Instant expirationTime = autorenewTime.plusYears(1);
     DomainTransferData.Builder transferDataBuilder = domain.getTransferData().asBuilder();
     domain =
         persistResource(
@@ -910,10 +910,10 @@ class DomainTransferApproveFlowTest
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(60), TokenStatus.ENDED)
+                    .put(clock.now().plusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(60), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_transfer_approve_allocation_token.xml");
@@ -930,10 +930,10 @@ class DomainTransferApproveFlowTest
             .setAllowedRegistrarIds(ImmutableSet.of("someClientId"))
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_transfer_approve_allocation_token.xml");
@@ -951,10 +951,10 @@ class DomainTransferApproveFlowTest
             .setAllowedTlds(ImmutableSet.of("example"))
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_transfer_approve_allocation_token.xml");

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferCancelFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferCancelFlowTest.java
@@ -32,6 +32,8 @@ import static google.registry.testing.DomainSubject.assertAboutDomains;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
 import static google.registry.testing.HistoryEntrySubject.assertAboutHistoryEntries;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
+import static google.registry.util.DateTimeUtils.minusDays;
+import static google.registry.util.DateTimeUtils.plusDays;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
@@ -55,7 +57,7 @@ import google.registry.model.tld.Tld;
 import google.registry.model.transfer.DomainTransferData;
 import google.registry.model.transfer.TransferResponse.DomainTransferResponse;
 import google.registry.model.transfer.TransferStatus;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -114,7 +116,7 @@ class DomainTransferCancelFlowTest
 
     // Setup done; run the test.
     assertMutatingFlow(true);
-    DateTime originalExpirationTime = domain.getRegistrationExpirationDateTime();
+    Instant originalExpirationTime = domain.getRegistrationExpirationTime();
     ImmutableSet<GracePeriod> originalGracePeriods = domain.getGracePeriods();
     DomainTransferData originalTransferData = domain.getTransferData();
     runFlowAssertResponse(loadFile("domain_transfer_cancel_response.xml"));
@@ -127,13 +129,13 @@ class DomainTransferCancelFlowTest
         .that(domain)
         .hasRegistrationExpirationTime(originalExpirationTime)
         .and()
-        .hasLastTransferTimeNotEqualTo(clock.nowUtc());
+        .hasLastTransferTimeNotEqualTo(clock.now());
     assertAboutDomains()
         .that(domain)
         .hasOneHistoryEntryEachOfTypes(
             DOMAIN_CREATE, DOMAIN_TRANSFER_REQUEST, DOMAIN_TRANSFER_CANCEL)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("NewRegistrar");
     final HistoryEntry historyEntryTransferCancel =
@@ -163,7 +165,7 @@ class DomainTransferCancelFlowTest
             .build(),
         new PollMessage.OneTime.Builder()
             .setRegistrarId("TheRegistrar")
-            .setEventTime(clock.nowUtc())
+            .setEventTime(clock.now())
             .setResponseData(
                 ImmutableList.of(
                     new DomainTransferResponse.Builder()
@@ -172,7 +174,7 @@ class DomainTransferCancelFlowTest
                         .setTransferRequestTime(TRANSFER_REQUEST_TIME)
                         .setGainingRegistrarId("NewRegistrar")
                         .setLosingRegistrarId("TheRegistrar")
-                        .setPendingTransferExpirationTime(clock.nowUtc())
+                        .setPendingTransferExpirationTime(clock.now())
                         .build()))
             .setMsg("Transfer cancelled.")
             .setHistoryEntry(getOnlyHistoryEntryOfType(domain, DOMAIN_TRANSFER_CANCEL))
@@ -312,8 +314,7 @@ class DomainTransferCancelFlowTest
 
   @Test
   void testFailure_deletedDomain() throws Exception {
-    domain =
-        persistResource(domain.asBuilder().setDeletionTime(clock.nowUtc().minusDays(1)).build());
+    domain = persistResource(domain.asBuilder().setDeletionTime(minusDays(clock.now(), 1)).build());
     ResourceDoesNotExistException thrown =
         assertThrows(
             ResourceDoesNotExistException.class, () -> doFailingTest("domain_transfer_cancel.xml"));
@@ -380,15 +381,15 @@ class DomainTransferCancelFlowTest
             .setTransferGracePeriodLength(Duration.standardDays(3))
             .build());
     DomainTransactionRecord previousSuccessRecord =
-        DomainTransactionRecord.create("tld", clock.nowUtc().plusDays(1), TRANSFER_SUCCESSFUL, 1);
+        DomainTransactionRecord.create("tld", plusDays(clock.now(), 1), TRANSFER_SUCCESSFUL, 1);
     // We only want to cancel TRANSFER_SUCCESSFUL records
     DomainTransactionRecord notCancellableRecord =
-        DomainTransactionRecord.create("tld", clock.nowUtc().plusDays(1), RESTORED_DOMAINS, 5);
+        DomainTransactionRecord.create("tld", plusDays(clock.now(), 1), RESTORED_DOMAINS, 5);
     persistResource(
         new DomainHistory.Builder()
             .setType(DOMAIN_TRANSFER_REQUEST)
             .setDomain(domain)
-            .setModificationTime(clock.nowUtc().minusDays(4))
+            .setModificationTime(minusDays(clock.now(), 4))
             .setRegistrarId("TheRegistrar")
             .setDomainTransactionRecords(
                 ImmutableSet.of(previousSuccessRecord, notCancellableRecord))

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferCancelFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferCancelFlowTest.java
@@ -55,7 +55,7 @@ import google.registry.model.tld.Tld;
 import google.registry.model.transfer.DomainTransferData;
 import google.registry.model.transfer.TransferResponse.DomainTransferResponse;
 import google.registry.model.transfer.TransferStatus;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -114,7 +114,7 @@ class DomainTransferCancelFlowTest
 
     // Setup done; run the test.
     assertMutatingFlow(true);
-    DateTime originalExpirationTime = domain.getRegistrationExpirationDateTime();
+    Instant originalExpirationTime = domain.getRegistrationExpirationDateTime();
     ImmutableSet<GracePeriod> originalGracePeriods = domain.getGracePeriods();
     DomainTransferData originalTransferData = domain.getTransferData();
     runFlowAssertResponse(loadFile("domain_transfer_cancel_response.xml"));
@@ -127,13 +127,13 @@ class DomainTransferCancelFlowTest
         .that(domain)
         .hasRegistrationExpirationTime(originalExpirationTime)
         .and()
-        .hasLastTransferTimeNotEqualTo(clock.nowUtc());
+        .hasLastTransferTimeNotEqualTo(clock.now());
     assertAboutDomains()
         .that(domain)
         .hasOneHistoryEntryEachOfTypes(
             DOMAIN_CREATE, DOMAIN_TRANSFER_REQUEST, DOMAIN_TRANSFER_CANCEL)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("NewRegistrar");
     final HistoryEntry historyEntryTransferCancel =
@@ -147,7 +147,7 @@ class DomainTransferCancelFlowTest
     assertBillingEvents(
         getLosingClientAutorenewEvent().asBuilder().setRecurrenceEndTime(END_OF_TIME).build());
     // The poll message (in the future) to the gaining registrar for implicit ack should be gone.
-    assertThat(getPollMessages("NewRegistrar", clock.nowUtc().plusMonths(1))).isEmpty();
+    assertThat(getPollMessages("NewRegistrar", clock.now().plusMonths(1))).isEmpty();
     // The poll message in the future to the losing registrar should be gone too, but there should
     // be two at the current time to the losing registrar - one for the original autorenew event,
     // and another for the transfer being cancelled.
@@ -163,7 +163,7 @@ class DomainTransferCancelFlowTest
             .build(),
         new PollMessage.OneTime.Builder()
             .setRegistrarId("TheRegistrar")
-            .setEventTime(clock.nowUtc())
+            .setEventTime(clock.now())
             .setResponseData(
                 ImmutableList.of(
                     new DomainTransferResponse.Builder()
@@ -172,7 +172,7 @@ class DomainTransferCancelFlowTest
                         .setTransferRequestTime(TRANSFER_REQUEST_TIME)
                         .setGainingRegistrarId("NewRegistrar")
                         .setLosingRegistrarId("TheRegistrar")
-                        .setPendingTransferExpirationTime(clock.nowUtc())
+                        .setPendingTransferExpirationTime(clock.now())
                         .build()))
             .setMsg("Transfer cancelled.")
             .setHistoryEntry(getOnlyHistoryEntryOfType(domain, DOMAIN_TRANSFER_CANCEL))
@@ -313,7 +313,7 @@ class DomainTransferCancelFlowTest
   @Test
   void testFailure_deletedDomain() throws Exception {
     domain =
-        persistResource(domain.asBuilder().setDeletionTime(clock.nowUtc().minusDays(1)).build());
+        persistResource(domain.asBuilder().setDeletionTime(clock.now().minusDays(1)).build());
     ResourceDoesNotExistException thrown =
         assertThrows(
             ResourceDoesNotExistException.class, () -> doFailingTest("domain_transfer_cancel.xml"));
@@ -322,7 +322,7 @@ class DomainTransferCancelFlowTest
 
   @Test
   void testFailure_nonexistentDomain() throws Exception {
-    deleteTestDomain(domain, clock.nowUtc());
+    deleteTestDomain(domain, clock.now());
     ResourceDoesNotExistException thrown =
         assertThrows(
             ResourceDoesNotExistException.class, () -> doFailingTest("domain_transfer_cancel.xml"));
@@ -380,15 +380,15 @@ class DomainTransferCancelFlowTest
             .setTransferGracePeriodLength(Duration.standardDays(3))
             .build());
     DomainTransactionRecord previousSuccessRecord =
-        DomainTransactionRecord.create("tld", clock.nowUtc().plusDays(1), TRANSFER_SUCCESSFUL, 1);
+        DomainTransactionRecord.create("tld", clock.now().plusDays(1), TRANSFER_SUCCESSFUL, 1);
     // We only want to cancel TRANSFER_SUCCESSFUL records
     DomainTransactionRecord notCancellableRecord =
-        DomainTransactionRecord.create("tld", clock.nowUtc().plusDays(1), RESTORED_DOMAINS, 5);
+        DomainTransactionRecord.create("tld", clock.now().plusDays(1), RESTORED_DOMAINS, 5);
     persistResource(
         new DomainHistory.Builder()
             .setType(DOMAIN_TRANSFER_REQUEST)
             .setDomain(domain)
-            .setModificationTime(clock.nowUtc().minusDays(4))
+            .setModificationTime(clock.now().minusDays(4))
             .setRegistrarId("TheRegistrar")
             .setDomainTransactionRecords(
                 ImmutableSet.of(previousSuccessRecord, notCancellableRecord))

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferFlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferFlowTestCase.java
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 package google.registry.flows.domain;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -25,6 +24,7 @@ import static google.registry.testing.DatabaseHelper.persistDomainWithPendingTra
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DomainSubject.assertAboutDomains;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
+import static google.registry.util.DateTimeUtils.plusYears;
 
 import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableSet;
@@ -44,7 +44,7 @@ import google.registry.model.tld.Tld;
 import google.registry.model.transfer.DomainTransferData;
 import google.registry.model.transfer.TransferStatus;
 import google.registry.persistence.transaction.JpaTransactionManagerExtension;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -60,15 +60,15 @@ abstract class DomainTransferFlowTestCase<F extends Flow, R extends EppResource>
   // Transfer is requested on the 6th and expires on the 11th.
   // The "now" of this flow is on the 9th, 3 days in.
 
-  static final DateTime TRANSFER_REQUEST_TIME = DateTime.parse("2000-06-06T22:00:00.0Z");
-  static final DateTime TRANSFER_EXPIRATION_TIME =
-      TRANSFER_REQUEST_TIME.plus(Tld.DEFAULT_AUTOMATIC_TRANSFER_LENGTH);
+  static final Instant TRANSFER_REQUEST_TIME = Instant.parse("2000-06-06T22:00:00.0Z");
+  static final Instant TRANSFER_EXPIRATION_TIME =
+      TRANSFER_REQUEST_TIME.plusMillis(Tld.DEFAULT_AUTOMATIC_TRANSFER_LENGTH.getMillis());
   private static final Duration TIME_SINCE_REQUEST = Duration.standardDays(3);
   private static final int EXTENDED_REGISTRATION_YEARS = 1;
-  private static final DateTime REGISTRATION_EXPIRATION_TIME =
-      DateTime.parse("2001-09-08T22:00:00.0Z");
-  static final DateTime EXTENDED_REGISTRATION_EXPIRATION_TIME =
-      REGISTRATION_EXPIRATION_TIME.plusYears(EXTENDED_REGISTRATION_YEARS);
+  private static final Instant REGISTRATION_EXPIRATION_TIME =
+      Instant.parse("2001-09-08T22:00:00.0Z");
+  static final Instant EXTENDED_REGISTRATION_EXPIRATION_TIME =
+      plusYears(REGISTRATION_EXPIRATION_TIME, EXTENDED_REGISTRATION_YEARS);
 
   protected Domain domain;
   Host subordinateHost;
@@ -76,7 +76,7 @@ abstract class DomainTransferFlowTestCase<F extends Flow, R extends EppResource>
 
   DomainTransferFlowTestCase() {
     checkState(!Tld.DEFAULT_TRANSFER_GRACE_PERIOD.isShorterThan(TIME_SINCE_REQUEST));
-    clock.setTo(TRANSFER_REQUEST_TIME.plus(TIME_SINCE_REQUEST));
+    clock.setTo(TRANSFER_REQUEST_TIME.plusMillis(TIME_SINCE_REQUEST.getMillis()));
   }
 
   @BeforeEach
@@ -105,8 +105,8 @@ abstract class DomainTransferFlowTestCase<F extends Flow, R extends EppResource>
         persistDomainWithDependentResources(
             label,
             tld,
-            clock.nowUtc(),
-            DateTime.parse("1999-04-03T22:00:00.0Z"),
+            clock.now(),
+            Instant.parse("1999-04-03T22:00:00.0Z"),
             REGISTRATION_EXPIRATION_TIME);
     subordinateHost =
         persistResource(
@@ -115,7 +115,7 @@ abstract class DomainTransferFlowTestCase<F extends Flow, R extends EppResource>
                 .setHostName("ns1." + label + "." + tld)
                 .setPersistedCurrentSponsorRegistrarId("TheRegistrar")
                 .setCreationRegistrarId("TheRegistrar")
-                .setCreationTimeForTest(DateTime.parse("1999-04-03T22:00:00.0Z"))
+                .setCreationTimeForTest(Instant.parse("1999-04-03T22:00:00.0Z"))
                 .setSuperordinateDomain(domain.createVKey())
                 .build());
     domain =
@@ -172,9 +172,10 @@ abstract class DomainTransferFlowTestCase<F extends Flow, R extends EppResource>
     // all the speculative server-approve fields nulled out.
     assertThat(domain.getTransferData())
         .isEqualTo(
-            oldTransferData.copyConstantFieldsToBuilder()
+            oldTransferData
+                .copyConstantFieldsToBuilder()
                 .setTransferStatus(status)
-                .setPendingTransferExpirationTime(clock.nowUtc())
+                .setPendingTransferExpirationTime(clock.now())
                 .build());
   }
 

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferFlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferFlowTestCase.java
@@ -44,7 +44,7 @@ import google.registry.model.tld.Tld;
 import google.registry.model.transfer.DomainTransferData;
 import google.registry.model.transfer.TransferStatus;
 import google.registry.persistence.transaction.JpaTransactionManagerExtension;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -60,14 +60,14 @@ abstract class DomainTransferFlowTestCase<F extends Flow, R extends EppResource>
   // Transfer is requested on the 6th and expires on the 11th.
   // The "now" of this flow is on the 9th, 3 days in.
 
-  static final DateTime TRANSFER_REQUEST_TIME = DateTime.parse("2000-06-06T22:00:00.0Z");
-  static final DateTime TRANSFER_EXPIRATION_TIME =
+  static final Instant TRANSFER_REQUEST_TIME = Instant.parse("2000-06-06T22:00:00.0Z");
+  static final Instant TRANSFER_EXPIRATION_TIME =
       TRANSFER_REQUEST_TIME.plus(Tld.DEFAULT_AUTOMATIC_TRANSFER_LENGTH);
   private static final Duration TIME_SINCE_REQUEST = Duration.standardDays(3);
   private static final int EXTENDED_REGISTRATION_YEARS = 1;
-  private static final DateTime REGISTRATION_EXPIRATION_TIME =
-      DateTime.parse("2001-09-08T22:00:00.0Z");
-  static final DateTime EXTENDED_REGISTRATION_EXPIRATION_TIME =
+  private static final Instant REGISTRATION_EXPIRATION_TIME =
+      Instant.parse("2001-09-08T22:00:00.0Z");
+  static final Instant EXTENDED_REGISTRATION_EXPIRATION_TIME =
       REGISTRATION_EXPIRATION_TIME.plusYears(EXTENDED_REGISTRATION_YEARS);
 
   protected Domain domain;
@@ -105,8 +105,8 @@ abstract class DomainTransferFlowTestCase<F extends Flow, R extends EppResource>
         persistDomainWithDependentResources(
             label,
             tld,
-            clock.nowUtc(),
-            DateTime.parse("1999-04-03T22:00:00.0Z"),
+            clock.now(),
+            Instant.parse("1999-04-03T22:00:00.0Z"),
             REGISTRATION_EXPIRATION_TIME);
     subordinateHost =
         persistResource(
@@ -115,7 +115,7 @@ abstract class DomainTransferFlowTestCase<F extends Flow, R extends EppResource>
                 .setHostName("ns1." + label + "." + tld)
                 .setPersistedCurrentSponsorRegistrarId("TheRegistrar")
                 .setCreationRegistrarId("TheRegistrar")
-                .setCreationTimeForTest(DateTime.parse("1999-04-03T22:00:00.0Z"))
+                .setCreationTimeForTest(Instant.parse("1999-04-03T22:00:00.0Z"))
                 .setSuperordinateDomain(domain.createVKey())
                 .build());
     domain =
@@ -174,7 +174,7 @@ abstract class DomainTransferFlowTestCase<F extends Flow, R extends EppResource>
         .isEqualTo(
             oldTransferData.copyConstantFieldsToBuilder()
                 .setTransferStatus(status)
-                .setPendingTransferExpirationTime(clock.nowUtc())
+                .setPendingTransferExpirationTime(clock.now())
                 .build());
   }
 

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferQueryFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferQueryFlowTest.java
@@ -21,6 +21,9 @@ import static google.registry.testing.DatabaseHelper.getPollMessages;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DomainSubject.assertAboutDomains;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
+import static google.registry.util.DateTimeUtils.minusDays;
+import static google.registry.util.DateTimeUtils.plusDays;
+import static google.registry.util.DateTimeUtils.plusYears;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import google.registry.flows.EppException;
@@ -152,8 +155,7 @@ class DomainTransferQueryFlowTest
   @Test
   void testFailure_pendingDeleteDomain() throws Exception {
     changeTransferStatus(TransferStatus.SERVER_CANCELLED);
-    domain =
-        persistResource(domain.asBuilder().setDeletionTime(clock.nowUtc().plusDays(1)).build());
+    domain = persistResource(domain.asBuilder().setDeletionTime(plusDays(clock.now(), 1)).build());
     doSuccessfulTest(
         "domain_transfer_query.xml", "domain_transfer_query_response_server_cancelled.xml", 1);
   }
@@ -205,8 +207,7 @@ class DomainTransferQueryFlowTest
 
   @Test
   void testFailure_deletedDomain() throws Exception {
-    domain =
-        persistResource(domain.asBuilder().setDeletionTime(clock.nowUtc().minusDays(1)).build());
+    domain = persistResource(domain.asBuilder().setDeletionTime(minusDays(clock.now(), 1)).build());
     ResourceDoesNotExistException thrown =
         assertThrows(
             ResourceDoesNotExistException.class, () -> doFailingTest("domain_transfer_query.xml"));
@@ -234,8 +235,8 @@ class DomainTransferQueryFlowTest
     // Set the clock to just past the extended registration time.  We'd expect the domain to have
     // auto-renewed once, but the transfer query response should be the same.
     clock.setTo(EXTENDED_REGISTRATION_EXPIRATION_TIME.plusMillis(1));
-    assertThat(domain.cloneProjectedAtTime(clock.nowUtc()).getRegistrationExpirationDateTime())
-        .isEqualTo(EXTENDED_REGISTRATION_EXPIRATION_TIME.plusYears(1));
+    assertThat(domain.cloneProjectedAtInstant(clock.now()).getRegistrationExpirationTime())
+        .isEqualTo(plusYears(EXTENDED_REGISTRATION_EXPIRATION_TIME, 1));
     doSuccessfulTest(
         "domain_transfer_query.xml", "domain_transfer_query_response_server_approved.xml", 2);
   }

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferQueryFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferQueryFlowTest.java
@@ -63,9 +63,9 @@ class DomainTransferQueryFlowTest
         getGainingClientAutorenewEvent(),
         getLosingClientAutorenewEvent());
     // Look in the future and make sure the poll messages for implicit ack are there.
-    assertThat(getPollMessages("NewRegistrar", clock.nowUtc().plusYears(1)))
+    assertThat(getPollMessages("NewRegistrar", clock.now().plusYears(1)))
         .hasSize(numPollMessages);
-    assertThat(getPollMessages("TheRegistrar", clock.nowUtc().plusYears(1))).hasSize(1);
+    assertThat(getPollMessages("TheRegistrar", clock.now().plusYears(1))).hasSize(1);
   }
 
   private void doFailingTest(String commandFilename) throws Exception {
@@ -153,7 +153,7 @@ class DomainTransferQueryFlowTest
   void testFailure_pendingDeleteDomain() throws Exception {
     changeTransferStatus(TransferStatus.SERVER_CANCELLED);
     domain =
-        persistResource(domain.asBuilder().setDeletionTime(clock.nowUtc().plusDays(1)).build());
+        persistResource(domain.asBuilder().setDeletionTime(clock.now().plusDays(1)).build());
     doSuccessfulTest(
         "domain_transfer_query.xml", "domain_transfer_query_response_server_cancelled.xml", 1);
   }
@@ -206,7 +206,7 @@ class DomainTransferQueryFlowTest
   @Test
   void testFailure_deletedDomain() throws Exception {
     domain =
-        persistResource(domain.asBuilder().setDeletionTime(clock.nowUtc().minusDays(1)).build());
+        persistResource(domain.asBuilder().setDeletionTime(clock.now().minusDays(1)).build());
     ResourceDoesNotExistException thrown =
         assertThrows(
             ResourceDoesNotExistException.class, () -> doFailingTest("domain_transfer_query.xml"));
@@ -215,7 +215,7 @@ class DomainTransferQueryFlowTest
 
   @Test
   void testFailure_nonexistentDomain() throws Exception {
-    deleteTestDomain(domain, clock.nowUtc());
+    deleteTestDomain(domain, clock.now());
     ResourceDoesNotExistException thrown =
         assertThrows(
             ResourceDoesNotExistException.class, () -> doFailingTest("domain_transfer_query.xml"));
@@ -234,7 +234,7 @@ class DomainTransferQueryFlowTest
     // Set the clock to just past the extended registration time.  We'd expect the domain to have
     // auto-renewed once, but the transfer query response should be the same.
     clock.setTo(EXTENDED_REGISTRATION_EXPIRATION_TIME.plusMillis(1));
-    assertThat(domain.cloneProjectedAtTime(clock.nowUtc()).getRegistrationExpirationDateTime())
+    assertThat(domain.cloneProjectedAtTime(clock.now()).getRegistrationExpirationDateTime())
         .isEqualTo(EXTENDED_REGISTRATION_EXPIRATION_TIME.plusYears(1));
     doSuccessfulTest(
         "domain_transfer_query.xml", "domain_transfer_query_response_server_approved.xml", 2);

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRejectFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRejectFlowTest.java
@@ -33,6 +33,8 @@ import static google.registry.testing.DomainSubject.assertAboutDomains;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
 import static google.registry.testing.HistoryEntrySubject.assertAboutHistoryEntries;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
+import static google.registry.util.DateTimeUtils.minusDays;
+import static google.registry.util.DateTimeUtils.plusDays;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableSet;
@@ -57,7 +59,7 @@ import google.registry.model.tld.Tld;
 import google.registry.model.transfer.DomainTransferData;
 import google.registry.model.transfer.TransferResponse;
 import google.registry.model.transfer.TransferStatus;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -88,7 +90,7 @@ class DomainTransferRejectFlowTest
     assertThat(getPollMessages("TheRegistrar", clock.nowUtc().plusMonths(1))).hasSize(1);
     // Setup done; run the test.
     assertMutatingFlow(true);
-    DateTime originalExpirationTime = domain.getRegistrationExpirationDateTime();
+    Instant originalExpirationTime = domain.getRegistrationExpirationTime();
     ImmutableSet<GracePeriod> originalGracePeriods = domain.getGracePeriods();
     DomainTransferData originalTransferData = domain.getTransferData();
     runFlowAssertResponse(loadFile(expectedXmlFilename));
@@ -99,12 +101,12 @@ class DomainTransferRejectFlowTest
         .that(domain)
         .hasRegistrationExpirationTime(originalExpirationTime)
         .and()
-        .hasLastTransferTimeNotEqualTo(clock.nowUtc())
+        .hasLastTransferTimeNotEqualTo(clock.now())
         .and()
         .hasOneHistoryEntryEachOfTypes(
             DOMAIN_CREATE, DOMAIN_TRANSFER_REQUEST, DOMAIN_TRANSFER_REJECT)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("TheRegistrar");
     final HistoryEntry historyEntryTransferRejected =
@@ -297,8 +299,7 @@ class DomainTransferRejectFlowTest
 
   @Test
   void testFailure_deletedDomain() throws Exception {
-    domain =
-        persistResource(domain.asBuilder().setDeletionTime(clock.nowUtc().minusDays(1)).build());
+    domain = persistResource(domain.asBuilder().setDeletionTime(minusDays(clock.now(), 1)).build());
     ResourceDoesNotExistException thrown =
         assertThrows(
             ResourceDoesNotExistException.class, () -> doFailingTest("domain_transfer_reject.xml"));
@@ -341,22 +342,22 @@ class DomainTransferRejectFlowTest
         (DomainHistory) getOnlyHistoryEntryOfType(domain, DOMAIN_TRANSFER_REJECT);
     // We should only produce transfer nacked records, reported now
     assertThat(persistedEntry.getDomainTransactionRecords())
-        .containsExactly(DomainTransactionRecord.create("tld", clock.nowUtc(), TRANSFER_NACKED, 1));
+        .containsExactly(DomainTransactionRecord.create("tld", clock.now(), TRANSFER_NACKED, 1));
   }
 
   @Test
   void testIcannTransactionRecord_cancelsPreviousRecords() throws Exception {
     setUpGracePeriodDurations();
     DomainTransactionRecord previousSuccessRecord =
-        DomainTransactionRecord.create("tld", clock.nowUtc().plusDays(1), TRANSFER_SUCCESSFUL, 1);
+        DomainTransactionRecord.create("tld", plusDays(clock.now(), 1), TRANSFER_SUCCESSFUL, 1);
     // We only want to cancel TRANSFER_SUCCESSFUL records
     DomainTransactionRecord notCancellableRecord =
-        DomainTransactionRecord.create("tld", clock.nowUtc().plusDays(1), NET_RENEWS_3_YR, 5);
+        DomainTransactionRecord.create("tld", plusDays(clock.now(), 1), NET_RENEWS_3_YR, 5);
     persistResource(
         new DomainHistory.Builder()
             .setType(DOMAIN_TRANSFER_REQUEST)
             .setDomain(domain)
-            .setModificationTime(clock.nowUtc().minusDays(4))
+            .setModificationTime(minusDays(clock.now(), 4))
             .setRegistrarId("TheRegistrar")
             .setDomainTransactionRecords(
                 ImmutableSet.of(previousSuccessRecord, notCancellableRecord))
@@ -368,6 +369,6 @@ class DomainTransferRejectFlowTest
     assertThat(persistedEntry.getDomainTransactionRecords())
         .containsExactly(
             previousSuccessRecord.asBuilder().setReportAmount(-1).build(),
-            DomainTransactionRecord.create("tld", clock.nowUtc(), TRANSFER_NACKED, 1));
+            DomainTransactionRecord.create("tld", clock.now(), TRANSFER_NACKED, 1));
   }
 }

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRejectFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRejectFlowTest.java
@@ -57,7 +57,7 @@ import google.registry.model.tld.Tld;
 import google.registry.model.transfer.DomainTransferData;
 import google.registry.model.transfer.TransferResponse;
 import google.registry.model.transfer.TransferStatus;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,11 +84,11 @@ class DomainTransferRejectFlowTest
         getGainingClientAutorenewEvent(),
         getLosingClientAutorenewEvent());
     // Look in the future and make sure the poll messages for implicit ack are there.
-    assertThat(getPollMessages("NewRegistrar", clock.nowUtc().plusMonths(1))).hasSize(1);
-    assertThat(getPollMessages("TheRegistrar", clock.nowUtc().plusMonths(1))).hasSize(1);
+    assertThat(getPollMessages("NewRegistrar", clock.now().plusMonths(1))).hasSize(1);
+    assertThat(getPollMessages("TheRegistrar", clock.now().plusMonths(1))).hasSize(1);
     // Setup done; run the test.
     assertMutatingFlow(true);
-    DateTime originalExpirationTime = domain.getRegistrationExpirationDateTime();
+    Instant originalExpirationTime = domain.getRegistrationExpirationDateTime();
     ImmutableSet<GracePeriod> originalGracePeriods = domain.getGracePeriods();
     DomainTransferData originalTransferData = domain.getTransferData();
     runFlowAssertResponse(loadFile(expectedXmlFilename));
@@ -99,12 +99,12 @@ class DomainTransferRejectFlowTest
         .that(domain)
         .hasRegistrationExpirationTime(originalExpirationTime)
         .and()
-        .hasLastTransferTimeNotEqualTo(clock.nowUtc())
+        .hasLastTransferTimeNotEqualTo(clock.now())
         .and()
         .hasOneHistoryEntryEachOfTypes(
             DOMAIN_CREATE, DOMAIN_TRANSFER_REQUEST, DOMAIN_TRANSFER_REJECT)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("TheRegistrar");
     final HistoryEntry historyEntryTransferRejected =
@@ -117,11 +117,11 @@ class DomainTransferRejectFlowTest
     assertBillingEvents(
         getLosingClientAutorenewEvent().asBuilder().setRecurrenceEndTime(END_OF_TIME).build());
     // The poll message (in the future) to the losing registrar for implicit ack should be gone.
-    assertThat(getPollMessages("TheRegistrar", clock.nowUtc().plusMonths(1))).isEmpty();
+    assertThat(getPollMessages("TheRegistrar", clock.now().plusMonths(1))).isEmpty();
     // The poll message in the future to the gaining registrar should be gone too, but there
     // should be one at the current time to the gaining registrar.
     PollMessage gainingPollMessage = getOnlyPollMessage("NewRegistrar");
-    assertThat(gainingPollMessage.getEventTime()).isEqualTo(clock.nowUtc());
+    assertThat(gainingPollMessage.getEventTime()).isEqualTo(clock.now());
     assertThat(
             gainingPollMessage
                 .getResponseData()
@@ -298,7 +298,7 @@ class DomainTransferRejectFlowTest
   @Test
   void testFailure_deletedDomain() throws Exception {
     domain =
-        persistResource(domain.asBuilder().setDeletionTime(clock.nowUtc().minusDays(1)).build());
+        persistResource(domain.asBuilder().setDeletionTime(clock.now().minusDays(1)).build());
     ResourceDoesNotExistException thrown =
         assertThrows(
             ResourceDoesNotExistException.class, () -> doFailingTest("domain_transfer_reject.xml"));
@@ -307,7 +307,7 @@ class DomainTransferRejectFlowTest
 
   @Test
   void testFailure_nonexistentDomain() throws Exception {
-    persistDomainAsDeleted(domain, clock.nowUtc());
+    persistDomainAsDeleted(domain, clock.now());
     ResourceDoesNotExistException thrown =
         assertThrows(
             ResourceDoesNotExistException.class, () -> doFailingTest("domain_transfer_reject.xml"));
@@ -341,22 +341,22 @@ class DomainTransferRejectFlowTest
         (DomainHistory) getOnlyHistoryEntryOfType(domain, DOMAIN_TRANSFER_REJECT);
     // We should only produce transfer nacked records, reported now
     assertThat(persistedEntry.getDomainTransactionRecords())
-        .containsExactly(DomainTransactionRecord.create("tld", clock.nowUtc(), TRANSFER_NACKED, 1));
+        .containsExactly(DomainTransactionRecord.create("tld", clock.now(), TRANSFER_NACKED, 1));
   }
 
   @Test
   void testIcannTransactionRecord_cancelsPreviousRecords() throws Exception {
     setUpGracePeriodDurations();
     DomainTransactionRecord previousSuccessRecord =
-        DomainTransactionRecord.create("tld", clock.nowUtc().plusDays(1), TRANSFER_SUCCESSFUL, 1);
+        DomainTransactionRecord.create("tld", clock.now().plusDays(1), TRANSFER_SUCCESSFUL, 1);
     // We only want to cancel TRANSFER_SUCCESSFUL records
     DomainTransactionRecord notCancellableRecord =
-        DomainTransactionRecord.create("tld", clock.nowUtc().plusDays(1), NET_RENEWS_3_YR, 5);
+        DomainTransactionRecord.create("tld", clock.now().plusDays(1), NET_RENEWS_3_YR, 5);
     persistResource(
         new DomainHistory.Builder()
             .setType(DOMAIN_TRANSFER_REQUEST)
             .setDomain(domain)
-            .setModificationTime(clock.nowUtc().minusDays(4))
+            .setModificationTime(clock.now().minusDays(4))
             .setRegistrarId("TheRegistrar")
             .setDomainTransactionRecords(
                 ImmutableSet.of(previousSuccessRecord, notCancellableRecord))
@@ -368,6 +368,6 @@ class DomainTransferRejectFlowTest
     assertThat(persistedEntry.getDomainTransactionRecords())
         .containsExactly(
             previousSuccessRecord.asBuilder().setReportAmount(-1).build(),
-            DomainTransactionRecord.create("tld", clock.nowUtc(), TRANSFER_NACKED, 1));
+            DomainTransactionRecord.create("tld", clock.now(), TRANSFER_NACKED, 1));
   }
 }

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
@@ -46,7 +46,13 @@ import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptio
 import static google.registry.testing.HistoryEntrySubject.assertAboutHistoryEntries;
 import static google.registry.testing.HostSubject.assertAboutHosts;
 import static google.registry.testing.TestDataHelper.updateSubstitutions;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.minusDays;
+import static google.registry.util.DateTimeUtils.minusYears;
+import static google.registry.util.DateTimeUtils.plusDays;
+import static google.registry.util.DateTimeUtils.plusYears;
+import static google.registry.util.DateTimeUtils.toDateTime;
 import static org.joda.money.CurrencyUnit.JPY;
 import static org.joda.money.CurrencyUnit.USD;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -125,11 +131,11 @@ import google.registry.persistence.VKey;
 import google.registry.testing.CloudTasksHelper.TaskMatcher;
 import google.registry.testing.DatabaseHelper;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -183,9 +189,9 @@ class DomainTransferRequestFlowTest
 
   private void assertTransferRequested(
       Domain domain,
-      DateTime automaticTransferTime,
+      Instant automaticTransferTime,
       Period expectedPeriod,
-      DateTime expectedExpirationTime)
+      Instant expectedExpirationTime)
       throws Exception {
     assertAboutDomains()
         .that(domain)
@@ -193,7 +199,7 @@ class DomainTransferRequestFlowTest
         .and()
         .hasStatusValue(StatusValue.PENDING_TRANSFER)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("NewRegistrar");
     Trid expectedTrid =
@@ -211,7 +217,7 @@ class DomainTransferRequestFlowTest
                 .setGainingRegistrarId("NewRegistrar")
                 .setLosingRegistrarId("TheRegistrar")
                 .setTransferRequestTrid(expectedTrid)
-                .setTransferRequestTime(clock.nowUtc())
+                .setTransferRequestTime(clock.now())
                 .setTransferPeriod(expectedPeriod)
                 .setTransferStatus(TransferStatus.PENDING)
                 .setPendingTransferExpirationTime(automaticTransferTime)
@@ -222,7 +228,7 @@ class DomainTransferRequestFlowTest
   }
 
   private void assertTransferApproved(
-      Domain domain, DateTime automaticTransferTime, Period expectedPeriod) throws Exception {
+      Domain domain, Instant automaticTransferTime, Period expectedPeriod) throws Exception {
     assertAboutDomains()
         .that(domain)
         .hasCurrentSponsorRegistrarId("NewRegistrar")
@@ -240,7 +246,7 @@ class DomainTransferRequestFlowTest
                 .setGainingRegistrarId("NewRegistrar")
                 .setLosingRegistrarId("TheRegistrar")
                 .setTransferRequestTrid(expectedTrid)
-                .setTransferRequestTime(clock.nowUtc())
+                .setTransferRequestTime(clock.now())
                 .setTransferPeriod(expectedPeriod)
                 .setTransferStatus(TransferStatus.SERVER_APPROVED)
                 .setPendingTransferExpirationTime(automaticTransferTime)
@@ -251,8 +257,8 @@ class DomainTransferRequestFlowTest
   }
 
   private void assertHistoryEntriesContainBillingEventsAndGracePeriods(
-      DateTime expectedExpirationTime,
-      DateTime implicitTransferTime,
+      Instant expectedExpirationTime,
+      Instant implicitTransferTime,
       Optional<Money> transferCost,
       ImmutableSet<GracePeriod> originalGracePeriods,
       boolean expectTransferBillingEvent,
@@ -274,7 +280,8 @@ class DomainTransferRequestFlowTest
                   .setTargetId(domain.getDomainName())
                   .setEventTime(implicitTransferTime)
                   .setBillingTime(
-                      implicitTransferTime.plus(registry.getTransferGracePeriodLength()))
+                      implicitTransferTime.plusMillis(
+                          registry.getTransferGracePeriodLength().getMillis()))
                   .setRegistrarId("NewRegistrar")
                   .setCost(transferCost.orElse(Money.of(USD, 11)))
                   .setPeriodYears(1)
@@ -297,7 +304,7 @@ class DomainTransferRequestFlowTest
         getGainingClientAutorenewEvent()
             .asBuilder()
             .setEventTime(expectedExpirationTime)
-            .setRecurrenceLastExpansion(expectedExpirationTime.minusYears(1))
+            .setRecurrenceLastExpansion(minusYears(expectedExpirationTime, 1))
             .build();
     // Construct extra billing events expected by the specific test.
     ImmutableSet<BillingBase> extraBillingBases =
@@ -334,12 +341,12 @@ class DomainTransferRequestFlowTest
     // The domain's autorenew billing event should still point to the losing client's event.
     BillingRecurrence domainAutorenewEvent = loadByKey(domain.getAutorenewBillingEvent());
     assertThat(domainAutorenewEvent.getRegistrarId()).isEqualTo("TheRegistrar");
-    assertThat(domainAutorenewEvent.getRecurrenceEndTime()).isEqualTo(implicitTransferTime);
+    assertThat(domainAutorenewEvent.getRecurrenceEndTimeInstant()).isEqualTo(implicitTransferTime);
     // The original grace periods should remain untouched.
     assertThat(domain.getGracePeriods()).containsExactlyElementsIn(originalGracePeriods);
     // If we fast forward AUTOMATIC_TRANSFER_DAYS, the transfer should have cleared out all other
     // grace periods, but expect a transfer grace period (if there was a transfer billing event).
-    Domain domainAfterAutomaticTransfer = domain.cloneProjectedAtTime(implicitTransferTime);
+    Domain domainAfterAutomaticTransfer = domain.cloneProjectedAtInstant(implicitTransferTime);
     if (expectTransferBillingEvent) {
       assertGracePeriods(
           domainAfterAutomaticTransfer.getGracePeriods(),
@@ -347,7 +354,8 @@ class DomainTransferRequestFlowTest
               GracePeriod.create(
                   GracePeriodStatus.TRANSFER,
                   domain.getRepoId(),
-                  implicitTransferTime.plus(registry.getTransferGracePeriodLength()),
+                  implicitTransferTime.plusMillis(
+                      registry.getTransferGracePeriodLength().getMillis()),
                   "NewRegistrar",
                   null),
               optionalTransferBillingEvent.get()));
@@ -357,12 +365,12 @@ class DomainTransferRequestFlowTest
   }
 
   private void assertPollMessagesEmitted(
-      DateTime expectedExpirationTime, DateTime implicitTransferTime) {
+      Instant expectedExpirationTime, Instant implicitTransferTime) {
     // Assert that there exists a poll message to notify the losing registrar that a transfer was
     // requested. If the implicit transfer time is now (i.e. the automatic transfer length is zero)
     // then also expect a server approved poll message.
     assertThat(getPollMessages("TheRegistrar", clock.nowUtc()))
-        .hasSize(implicitTransferTime.equals(clock.nowUtc()) ? 2 : 1);
+        .hasSize(implicitTransferTime.equals(clock.now()) ? 2 : 1);
 
     // Two poll messages on the gaining registrar's side at the expected expiration time: a
     // (OneTime) transfer approved message, and an Autorenew poll message.
@@ -371,8 +379,8 @@ class DomainTransferRequestFlowTest
         getOnlyPollMessage("NewRegistrar", implicitTransferTime, PollMessage.OneTime.class);
     PollMessage autorenewPollMessage =
         getOnlyPollMessage("NewRegistrar", expectedExpirationTime, PollMessage.Autorenew.class);
-    assertThat(transferApprovedPollMessage.getEventTime()).isEqualTo(implicitTransferTime);
-    assertThat(autorenewPollMessage.getEventTime()).isEqualTo(expectedExpirationTime);
+    assertThat(transferApprovedPollMessage.getEventTimeInstant()).isEqualTo(implicitTransferTime);
+    assertThat(autorenewPollMessage.getEventTimeInstant()).isEqualTo(expectedExpirationTime);
     assertThat(
             transferApprovedPollMessage.getResponseData().stream()
                 .filter(TransferResponse.class::isInstance)
@@ -399,8 +407,9 @@ class DomainTransferRequestFlowTest
         getPollMessages("TheRegistrar", implicitTransferTime).stream()
             .filter(Predicates.not(Predicates.equalTo(losingTransferPendingPollMessage)))
             .collect(onlyElement());
-    assertThat(losingTransferPendingPollMessage.getEventTime()).isEqualTo(clock.nowUtc());
-    assertThat(losingTransferApprovedPollMessage.getEventTime()).isEqualTo(implicitTransferTime);
+    assertThat(losingTransferPendingPollMessage.getEventTimeInstant()).isEqualTo(clock.now());
+    assertThat(losingTransferApprovedPollMessage.getEventTimeInstant())
+        .isEqualTo(implicitTransferTime);
     assertThat(
             losingTransferPendingPollMessage.getResponseData().stream()
                 .filter(TransferResponse.class::isInstance)
@@ -430,10 +439,10 @@ class DomainTransferRequestFlowTest
   }
 
   private void assertAboutDomainAfterAutomaticTransfer(
-      DateTime expectedExpirationTime, DateTime implicitTransferTime, Period expectedPeriod)
+      Instant expectedExpirationTime, Instant implicitTransferTime, Period expectedPeriod)
       throws Exception {
     Tld registry = Tld.get(domain.getTld());
-    Domain domainAfterAutomaticTransfer = domain.cloneProjectedAtTime(implicitTransferTime);
+    Domain domainAfterAutomaticTransfer = domain.cloneProjectedAtInstant(implicitTransferTime);
     assertTransferApproved(domainAfterAutomaticTransfer, implicitTransferTime, expectedPeriod);
     assertAboutDomains()
         .that(domainAfterAutomaticTransfer)
@@ -442,15 +451,17 @@ class DomainTransferRequestFlowTest
         .hasLastEppUpdateTime(implicitTransferTime)
         .and()
         .hasLastEppUpdateRegistrarId("NewRegistrar");
-    assertThat(loadByKey(domainAfterAutomaticTransfer.getAutorenewBillingEvent()).getEventTime())
+    assertThat(
+            loadByKey(domainAfterAutomaticTransfer.getAutorenewBillingEvent())
+                .getEventTimeInstant())
         .isEqualTo(expectedExpirationTime);
     // And after the expected grace time, the grace period should be gone.
     Domain afterGracePeriod =
-        domain.cloneProjectedAtTime(
+        domain.cloneProjectedAtInstant(
             clock
-                .nowUtc()
-                .plus(registry.getAutomaticTransferLength())
-                .plus(registry.getTransferGracePeriodLength()));
+                .now()
+                .plusMillis(registry.getAutomaticTransferLength().getMillis())
+                .plusMillis(registry.getTransferGracePeriodLength().getMillis()));
     assertThat(afterGracePeriod.getGracePeriods()).isEmpty();
   }
 
@@ -462,7 +473,7 @@ class DomainTransferRequestFlowTest
   private void doSuccessfulTest(
       String commandFilename,
       String expectedXmlFilename,
-      DateTime expectedExpirationTime,
+      Instant expectedExpirationTime,
       Map<String, String> substitutions,
       Optional<Money> transferCost,
       BillingCancellation.Builder... extraExpectedBillingEvents)
@@ -473,7 +484,8 @@ class DomainTransferRequestFlowTest
     // for the request test we want that same 'now' to be the initial request time, so we shift
     // the transfer timeline 3 days later by adjusting the implicit transfer time here.
     Tld registry = Tld.get(domain.getTld());
-    DateTime implicitTransferTime = clock.nowUtc().plus(registry.getAutomaticTransferLength());
+    Instant implicitTransferTime =
+        clock.now().plusMillis(registry.getAutomaticTransferLength().getMillis());
     // Setup done; run the test.
     assertMutatingFlow(true);
     runFlowAssertResponse(loadFile(expectedXmlFilename, substitutions));
@@ -517,14 +529,16 @@ class DomainTransferRequestFlowTest
             .service("backend")
             .header("content-type", "application/x-www-form-urlencoded")
             .param(PARAM_RESOURCE_KEY, domain.createVKey().stringify())
-            .param(PARAM_REQUESTED_TIME, clock.nowUtc().toString())
-            .scheduleTime(clock.nowUtc().plus(registry.getAutomaticTransferLength())));
+            .param(PARAM_REQUESTED_TIME, clock.now().toString())
+            .scheduleTime(
+                toDateTime(
+                    clock.now().plusMillis(registry.getAutomaticTransferLength().getMillis()))));
   }
 
   private void doSuccessfulTest(
       String commandFilename,
       String expectedXmlFilename,
-      DateTime expectedExpirationTime,
+      Instant expectedExpirationTime,
       BillingCancellation.Builder... extraExpectedBillingEvents)
       throws Exception {
     doSuccessfulTest(
@@ -543,7 +557,7 @@ class DomainTransferRequestFlowTest
     doSuccessfulTest(
         commandFilename,
         expectedXmlFilename,
-        domain.getRegistrationExpirationDateTime().plusYears(1),
+        plusYears(domain.getRegistrationExpirationTime(), 1),
         substitutions,
         Optional.empty());
   }
@@ -552,15 +566,13 @@ class DomainTransferRequestFlowTest
       throws Exception {
     clock.advanceOneMilli();
     doSuccessfulTest(
-        commandFilename,
-        expectedXmlFilename,
-        domain.getRegistrationExpirationDateTime().plusYears(1));
+        commandFilename, expectedXmlFilename, plusYears(domain.getRegistrationExpirationTime(), 1));
   }
 
   private void doSuccessfulSuperuserExtensionTest(
       String commandFilename,
       String expectedXmlFilename,
-      DateTime expectedExpirationTime,
+      Instant expectedExpirationTime,
       Map<String, String> substitutions,
       Optional<Money> transferCost,
       Period expectedPeriod,
@@ -573,7 +585,8 @@ class DomainTransferRequestFlowTest
     // For all of the other transfer flow tests, 'now' corresponds to day 3 of the transfer, but
     // for the request test we want that same 'now' to be the initial request time, so we shift
     // the transfer timeline 3 days later by adjusting the implicit transfer time here.
-    DateTime implicitTransferTime = clock.nowUtc().plus(expectedAutomaticTransferLength);
+    Instant implicitTransferTime =
+        clock.now().plusMillis(expectedAutomaticTransferLength.getMillis());
     // Setup done; run the test.
     assertMutatingFlow(true);
     runFlowAssertResponse(
@@ -815,7 +828,7 @@ class DomainTransferRequestFlowTest
     doSuccessfulSuperuserExtensionTest(
         "domain_transfer_request_superuser_extension.xml",
         "domain_transfer_request_response_su_ext_zero_period_nonzero_transfer_length.xml",
-        domain.getRegistrationExpirationDateTime().plusYears(0),
+        plusYears(domain.getRegistrationExpirationTime(), 0),
         ImmutableMap.of("PERIOD", "0", "AUTOMATIC_TRANSFER_LENGTH", "5"),
         Optional.empty(),
         Period.create(0, Unit.YEARS),
@@ -829,7 +842,7 @@ class DomainTransferRequestFlowTest
     doSuccessfulSuperuserExtensionTest(
         "domain_transfer_request_superuser_extension.xml",
         "domain_transfer_request_response_su_ext_zero_period_zero_transfer_length.xml",
-        domain.getRegistrationExpirationDateTime().plusYears(0),
+        plusYears(domain.getRegistrationExpirationTime(), 0),
         ImmutableMap.of("PERIOD", "0", "AUTOMATIC_TRANSFER_LENGTH", "0"),
         Optional.empty(),
         Period.create(0, Unit.YEARS),
@@ -844,7 +857,7 @@ class DomainTransferRequestFlowTest
     doSuccessfulSuperuserExtensionTest(
         "domain_transfer_request_superuser_extension.xml",
         "domain_transfer_request_response_su_ext_one_year_period_nonzero_transfer_length.xml",
-        domain.getRegistrationExpirationDateTime().plusYears(1),
+        plusYears(domain.getRegistrationExpirationTime(), 1),
         ImmutableMap.of("PERIOD", "1", "AUTOMATIC_TRANSFER_LENGTH", "5"),
         Optional.empty(),
         Period.create(1, Unit.YEARS),
@@ -857,8 +870,8 @@ class DomainTransferRequestFlowTest
     VKey<BillingRecurrence> existingAutorenewEvent = domain.getAutorenewBillingEvent();
     // Set domain to have auto-renewed just before the transfer request, so that it will have an
     // active autorenew grace period spanning the entire transfer window.
-    DateTime autorenewTime = clock.nowUtc().minusDays(1);
-    DateTime expirationTime = autorenewTime.plusYears(1);
+    Instant autorenewTime = minusDays(clock.now(), 1);
+    Instant expirationTime = plusYears(autorenewTime, 1);
     domain =
         persistResource(
             domain
@@ -868,7 +881,8 @@ class DomainTransferRequestFlowTest
                     GracePeriod.createForRecurrence(
                         GracePeriodStatus.AUTO_RENEW,
                         domain.getRepoId(),
-                        autorenewTime.plus(Tld.get("tld").getAutoRenewGracePeriodLength()),
+                        autorenewTime.plusMillis(
+                            Tld.get("tld").getAutoRenewGracePeriodLength().getMillis()),
                         "TheRegistrar",
                         existingAutorenewEvent))
                 .build());
@@ -876,7 +890,7 @@ class DomainTransferRequestFlowTest
     doSuccessfulSuperuserExtensionTest(
         "domain_transfer_request_superuser_extension.xml",
         "domain_transfer_request_response_su_ext_zero_period_autorenew_grace.xml",
-        domain.getRegistrationExpirationDateTime(),
+        domain.getRegistrationExpirationTime(),
         ImmutableMap.of("PERIOD", "0", "AUTOMATIC_TRANSFER_LENGTH", "0"),
         Optional.empty(),
         Period.create(0, Unit.YEARS),
@@ -925,7 +939,7 @@ class DomainTransferRequestFlowTest
     doSuccessfulSuperuserExtensionTest(
         "domain_transfer_request_superuser_extension.xml",
         "domain_transfer_request_response_su_ext_zero_period_zero_transfer_length.xml",
-        domain.getRegistrationExpirationDateTime().plusYears(0),
+        plusYears(domain.getRegistrationExpirationTime(), 0),
         ImmutableMap.of("PERIOD", "0", "AUTOMATIC_TRANSFER_LENGTH", "0"),
         Optional.empty(),
         Period.create(0, Unit.YEARS),
@@ -942,7 +956,7 @@ class DomainTransferRequestFlowTest
     doSuccessfulSuperuserExtensionTest(
         "domain_transfer_request_superuser_extension.xml",
         "domain_transfer_request_response_su_ext_zero_period_zero_transfer_length.xml",
-        domain.getRegistrationExpirationDateTime().plusYears(0),
+        plusYears(domain.getRegistrationExpirationTime(), 0),
         ImmutableMap.of("PERIOD", "0", "AUTOMATIC_TRANSFER_LENGTH", "0"),
         Optional.empty(),
         Period.create(0, Unit.YEARS),
@@ -955,7 +969,7 @@ class DomainTransferRequestFlowTest
     // Set the domain to expire 10 years from now (as if it were just created with a 10-year term).
     domain =
         persistResource(
-            domain.asBuilder().setRegistrationExpirationTime(clock.nowUtc().plusYears(10)).build());
+            domain.asBuilder().setRegistrationExpirationTime(plusYears(clock.now(), 10)).build());
     // New expiration time should be capped at exactly 10 years from the transfer server-approve
     // time, so the domain only ends up gaining the 5-day transfer window's worth of extra
     // registration time.
@@ -963,7 +977,8 @@ class DomainTransferRequestFlowTest
     doSuccessfulTest(
         "domain_transfer_request.xml",
         "domain_transfer_request_response_10_year_cap.xml",
-        clock.nowUtc().plus(Tld.get("tld").getAutomaticTransferLength()).plusYears(10));
+        plusYears(
+            clock.now().plusMillis(Tld.get("tld").getAutomaticTransferLength().getMillis()), 10));
   }
 
   @Test
@@ -980,7 +995,7 @@ class DomainTransferRequestFlowTest
     doSuccessfulTest(
         "domain_transfer_request_separate_fees.xml",
         "domain_transfer_request_response_fees.xml",
-        domain.getRegistrationExpirationDateTime().plusYears(1),
+        plusYears(domain.getRegistrationExpirationTime(), 1),
         new ImmutableMap.Builder<String, String>()
             .put("DOMAIN", "expensive-domain.foo")
             .put("YEARS", "1")
@@ -1046,9 +1061,12 @@ class DomainTransferRequestFlowTest
     setupDomain("example", "tld");
     // Set the domain to have auto-renewed long enough ago that it is still in the autorenew grace
     // period at the transfer request time, but will have exited it by the automatic transfer time.
-    DateTime autorenewTime =
-        clock.nowUtc().minus(Tld.get("tld").getAutoRenewGracePeriodLength()).plusDays(1);
-    DateTime expirationTime = autorenewTime.plusYears(1);
+    Instant autorenewTime =
+        clock
+            .now()
+            .minusMillis(Tld.get("tld").getAutoRenewGracePeriodLength().getMillis())
+            .plus(java.time.Duration.ofDays(1));
+    Instant expirationTime = plusYears(autorenewTime, 1);
     domain =
         persistResource(
             domain
@@ -1058,7 +1076,8 @@ class DomainTransferRequestFlowTest
                     GracePeriod.createForRecurrence(
                         GracePeriodStatus.AUTO_RENEW,
                         domain.getRepoId(),
-                        autorenewTime.plus(Tld.get("tld").getAutoRenewGracePeriodLength()),
+                        autorenewTime.plusMillis(
+                            Tld.get("tld").getAutoRenewGracePeriodLength().getMillis()),
                         "TheRegistrar",
                         domain.getAutorenewBillingEvent()))
                 .build());
@@ -1068,7 +1087,7 @@ class DomainTransferRequestFlowTest
     doSuccessfulTest(
         "domain_transfer_request.xml",
         "domain_transfer_request_response_autorenew_grace_at_request_only.xml",
-        expirationTime.plusYears(1));
+        plusYears(expirationTime, 1));
   }
 
   @Test
@@ -1077,8 +1096,8 @@ class DomainTransferRequestFlowTest
     VKey<BillingRecurrence> existingAutorenewEvent = domain.getAutorenewBillingEvent();
     // Set domain to have auto-renewed just before the transfer request, so that it will have an
     // active autorenew grace period spanning the entire transfer window.
-    DateTime autorenewTime = clock.nowUtc().minusDays(1);
-    DateTime expirationTime = autorenewTime.plusYears(1);
+    Instant autorenewTime = minusDays(clock.now(), 1);
+    Instant expirationTime = plusYears(autorenewTime, 1);
     domain =
         persistResource(
             domain
@@ -1088,7 +1107,8 @@ class DomainTransferRequestFlowTest
                     GracePeriod.createForRecurrence(
                         GracePeriodStatus.AUTO_RENEW,
                         domain.getRepoId(),
-                        autorenewTime.plus(Tld.get("tld").getAutoRenewGracePeriodLength()),
+                        autorenewTime.plusMillis(
+                            Tld.get("tld").getAutoRenewGracePeriodLength().getMillis()),
                         "TheRegistrar",
                         existingAutorenewEvent))
                 .build());
@@ -1104,8 +1124,15 @@ class DomainTransferRequestFlowTest
             .setTargetId("example.tld")
             .setRegistrarId("TheRegistrar")
             // The cancellation happens at the moment of transfer.
-            .setEventTime(clock.nowUtc().plus(Tld.get("tld").getAutomaticTransferLength()))
-            .setBillingTime(autorenewTime.plus(Tld.get("tld").getAutoRenewGracePeriodLength()))
+            .setEventTime(
+                toDateTime(
+                    clock
+                        .now()
+                        .plusMillis(Tld.get("tld").getAutomaticTransferLength().getMillis())))
+            .setBillingTime(
+                toDateTime(
+                    autorenewTime.plusMillis(
+                        Tld.get("tld").getAutoRenewGracePeriodLength().getMillis())))
             // The cancellation should refer to the old autorenew billing event.
             .setBillingRecurrence(existingAutorenewEvent));
   }
@@ -1116,7 +1143,7 @@ class DomainTransferRequestFlowTest
     VKey<BillingRecurrence> existingAutorenewEvent = domain.getAutorenewBillingEvent();
     // Set domain to expire in 1 day, so that it will be in the autorenew grace period by the
     // automatic transfer time, even though it isn't yet.
-    DateTime expirationTime = clock.nowUtc().plusDays(1);
+    Instant expirationTime = plusDays(clock.now(), 1);
     domain =
         persistResource(domain.asBuilder().setRegistrationExpirationTime(expirationTime).build());
     clock.advanceOneMilli();
@@ -1125,14 +1152,21 @@ class DomainTransferRequestFlowTest
     doSuccessfulTest(
         "domain_transfer_request.xml",
         "domain_transfer_request_response_autorenew_grace_at_transfer_only.xml",
-        expirationTime.plusYears(1),
+        plusYears(expirationTime, 1),
         new BillingCancellation.Builder()
             .setReason(Reason.RENEW)
             .setTargetId("example.tld")
             .setRegistrarId("TheRegistrar")
             // The cancellation happens at the moment of transfer.
-            .setEventTime(clock.nowUtc().plus(Tld.get("tld").getAutomaticTransferLength()))
-            .setBillingTime(expirationTime.plus(Tld.get("tld").getAutoRenewGracePeriodLength()))
+            .setEventTime(
+                toDateTime(
+                    clock
+                        .now()
+                        .plusMillis(Tld.get("tld").getAutomaticTransferLength().getMillis())))
+            .setBillingTime(
+                toDateTime(
+                    expirationTime.plusMillis(
+                        Tld.get("tld").getAutoRenewGracePeriodLength().getMillis())))
             // The cancellation should refer to the old autorenew billing event.
             .setBillingRecurrence(existingAutorenewEvent));
   }
@@ -1175,7 +1209,7 @@ class DomainTransferRequestFlowTest
             .asBuilder()
             .setRenewalPriceBehavior(RenewalPriceBehavior.NONPREMIUM)
             .build());
-    DateTime now = clock.nowUtc();
+    Instant now = clock.now();
 
     // This ensures that the transfer has non-premium cost, as otherwise, the fee extension would be
     // required to ack the premium price.
@@ -1190,8 +1224,10 @@ class DomainTransferRequestFlowTest
     assertBillingEventsForResource(
         domain,
         new BillingEvent.Builder()
-            .setBillingTime(now.plusDays(10)) // 5 day pending transfer + 5 day billing grace period
-            .setEventTime(now.plusDays(5))
+            .setBillingTime(
+                toDateTime(
+                    plusDays(now, 10))) // 5 day pending transfer + 5 day billing grace period
+            .setEventTime(plusDays(now, 5))
             .setRegistrarId("NewRegistrar")
             .setCost(Money.of(USD, new BigDecimal("11.00")))
             .setDomainHistory(requestHistory)
@@ -1206,7 +1242,7 @@ class DomainTransferRequestFlowTest
             .build(),
         getLosingClientAutorenewEvent()
             .asBuilder()
-            .setRecurrenceEndTime(now.plusDays(5))
+            .setRecurrenceEndTime(plusDays(now, 5))
             .setRenewalPriceBehavior(RenewalPriceBehavior.NONPREMIUM)
             .build());
   }
@@ -1232,7 +1268,7 @@ class DomainTransferRequestFlowTest
             .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
             .setRenewalPrice(Money.of(USD, new BigDecimal("18.79")))
             .build());
-    DateTime now = clock.nowUtc();
+    Instant now = clock.now();
 
     setEppInput("domain_transfer_request.xml");
     runFlowAssertResponse(loadFile("domain_transfer_request_response.xml"));
@@ -1245,8 +1281,10 @@ class DomainTransferRequestFlowTest
     assertBillingEventsForResource(
         domain,
         new BillingEvent.Builder()
-            .setBillingTime(now.plusDays(10)) // 5 day pending transfer + 5 day billing grace period
-            .setEventTime(now.plusDays(5))
+            .setBillingTime(
+                toDateTime(
+                    plusDays(now, 10))) // 5 day pending transfer + 5 day billing grace period
+            .setEventTime(plusDays(now, 5))
             .setRegistrarId("NewRegistrar")
             .setCost(Money.of(USD, new BigDecimal("18.79")))
             .setDomainHistory(requestHistory)
@@ -1262,7 +1300,7 @@ class DomainTransferRequestFlowTest
             .build(),
         getLosingClientAutorenewEvent()
             .asBuilder()
-            .setRecurrenceEndTime(now.plusDays(5))
+            .setRecurrenceEndTime(plusDays(now, 5))
             .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
             .setRenewalPrice(Money.of(USD, new BigDecimal("18.79")))
             .build());
@@ -1293,7 +1331,7 @@ class DomainTransferRequestFlowTest
     domain =
         persistResource(
             domain.asBuilder().setCurrentBulkToken(allocationToken.createVKey()).build());
-    DateTime now = clock.nowUtc();
+    Instant now = clock.now();
 
     setEppInput("domain_transfer_request.xml");
     runFlowAssertResponse(loadFile("domain_transfer_request_response.xml"));
@@ -1306,8 +1344,10 @@ class DomainTransferRequestFlowTest
     assertBillingEventsForResource(
         domain,
         new BillingEvent.Builder()
-            .setBillingTime(now.plusDays(10)) // 5 day pending transfer + 5 day billing grace period
-            .setEventTime(now.plusDays(5))
+            .setBillingTime(
+                toDateTime(
+                    plusDays(now, 10))) // 5 day pending transfer + 5 day billing grace period
+            .setEventTime(plusDays(now, 5))
             .setRegistrarId("NewRegistrar")
             .setCost(Money.of(USD, new BigDecimal("11.00")))
             .setDomainHistory(requestHistory)
@@ -1323,7 +1363,7 @@ class DomainTransferRequestFlowTest
             .build(),
         getLosingClientAutorenewEvent()
             .asBuilder()
-            .setRecurrenceEndTime(now.plusDays(5))
+            .setRecurrenceEndTime(plusDays(now, 5))
             .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
             .setRenewalPrice(Money.of(USD, new BigDecimal("18.79")))
             .build());
@@ -1353,7 +1393,7 @@ class DomainTransferRequestFlowTest
     domain =
         persistResource(
             domain.asBuilder().setCurrentBulkToken(allocationToken.createVKey()).build());
-    DateTime now = clock.nowUtc();
+    Instant now = clock.now();
 
     setEppInput("domain_transfer_request.xml");
     runFlowAssertResponse(loadFile("domain_transfer_request_response.xml"));
@@ -1366,8 +1406,10 @@ class DomainTransferRequestFlowTest
     assertBillingEventsForResource(
         domain,
         new BillingEvent.Builder()
-            .setBillingTime(now.plusDays(10)) // 5 day pending transfer + 5 day billing grace period
-            .setEventTime(now.plusDays(5))
+            .setBillingTime(
+                toDateTime(
+                    plusDays(now, 10))) // 5 day pending transfer + 5 day billing grace period
+            .setEventTime(plusDays(now, 5))
             .setRegistrarId("NewRegistrar")
             .setCost(Money.of(USD, new BigDecimal("11.00")))
             .setDomainHistory(requestHistory)
@@ -1383,7 +1425,7 @@ class DomainTransferRequestFlowTest
             .build(),
         getLosingClientAutorenewEvent()
             .asBuilder()
-            .setRecurrenceEndTime(now.plusDays(5))
+            .setRecurrenceEndTime(plusDays(now, 5))
             .setRenewalPriceBehavior(RenewalPriceBehavior.DEFAULT)
             .build());
   }
@@ -1416,7 +1458,7 @@ class DomainTransferRequestFlowTest
     doSuccessfulSuperuserExtensionTest(
         "domain_transfer_request_superuser_extension.xml",
         "domain_transfer_request_response_su_ext_zero_period_zero_transfer_length.xml",
-        domain.getRegistrationExpirationDateTime().plusYears(0),
+        plusYears(domain.getRegistrationExpirationTime(), 0),
         ImmutableMap.of("PERIOD", "0", "AUTOMATIC_TRANSFER_LENGTH", "0"),
         Optional.empty(),
         Period.create(0, Unit.YEARS),
@@ -1559,7 +1601,7 @@ class DomainTransferRequestFlowTest
                         .getTransferData()
                         .asBuilder()
                         .setTransferStatus(TransferStatus.PENDING)
-                        .setPendingTransferExpirationTime(clock.nowUtc().plusDays(1))
+                        .setPendingTransferExpirationTime(plusDays(clock.now(), 1))
                         .build())
                 .build());
     EppException thrown =
@@ -1600,8 +1642,7 @@ class DomainTransferRequestFlowTest
   @Test
   void testFailure_deletedDomain() throws Exception {
     setupDomain("example", "tld");
-    domain =
-        persistResource(domain.asBuilder().setDeletionTime(clock.nowUtc().minusDays(1)).build());
+    domain = persistResource(domain.asBuilder().setDeletionTime(minusDays(clock.now(), 1)).build());
     ResourceDoesNotExistException thrown =
         assertThrows(
             ResourceDoesNotExistException.class,
@@ -1738,7 +1779,7 @@ class DomainTransferRequestFlowTest
     assertThat(persistedEntry.getDomainTransactionRecords())
         .containsExactly(
             DomainTransactionRecord.create(
-                "tld", clock.nowUtc().plusDays(5), TRANSFER_SUCCESSFUL, 1));
+                "tld", plusDays(clock.now(), 5), TRANSFER_SUCCESSFUL, 1));
   }
 
   @Test
@@ -1772,11 +1813,11 @@ class DomainTransferRequestFlowTest
             .setToken("abc123")
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(60), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(plusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 60), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_transfer_request_allocation_token.xml", ImmutableMap.of("TOKEN", "abc123"));
@@ -1793,11 +1834,11 @@ class DomainTransferRequestFlowTest
             .setTokenType(UNLIMITED_USE)
             .setAllowedRegistrarIds(ImmutableSet.of("someClientId"))
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(minusDays(clock.now(), 1), TokenStatus.VALID)
+                    .put(plusDays(clock.now(), 1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_transfer_request_allocation_token.xml", ImmutableMap.of("TOKEN", "abc123"));
@@ -2031,7 +2072,7 @@ class DomainTransferRequestFlowTest
     doSuccessfulTest(
         "domain_transfer_request_separate_fees.xml",
         "domain_transfer_request_response_fees.xml",
-        domain.getRegistrationExpirationDateTime().plusYears(1),
+        plusYears(domain.getRegistrationExpirationTime(), 1),
         new ImmutableMap.Builder<String, String>()
             .put("DOMAIN", "expensive-domain.foo")
             .put("YEARS", "1")

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
@@ -129,7 +129,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.joda.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -183,9 +183,9 @@ class DomainTransferRequestFlowTest
 
   private void assertTransferRequested(
       Domain domain,
-      DateTime automaticTransferTime,
+      Instant automaticTransferTime,
       Period expectedPeriod,
-      DateTime expectedExpirationTime)
+      Instant expectedExpirationTime)
       throws Exception {
     assertAboutDomains()
         .that(domain)
@@ -193,7 +193,7 @@ class DomainTransferRequestFlowTest
         .and()
         .hasStatusValue(StatusValue.PENDING_TRANSFER)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("NewRegistrar");
     Trid expectedTrid =
@@ -211,7 +211,7 @@ class DomainTransferRequestFlowTest
                 .setGainingRegistrarId("NewRegistrar")
                 .setLosingRegistrarId("TheRegistrar")
                 .setTransferRequestTrid(expectedTrid)
-                .setTransferRequestTime(clock.nowUtc())
+                .setTransferRequestTime(clock.now())
                 .setTransferPeriod(expectedPeriod)
                 .setTransferStatus(TransferStatus.PENDING)
                 .setPendingTransferExpirationTime(automaticTransferTime)
@@ -222,7 +222,7 @@ class DomainTransferRequestFlowTest
   }
 
   private void assertTransferApproved(
-      Domain domain, DateTime automaticTransferTime, Period expectedPeriod) throws Exception {
+      Domain domain, Instant automaticTransferTime, Period expectedPeriod) throws Exception {
     assertAboutDomains()
         .that(domain)
         .hasCurrentSponsorRegistrarId("NewRegistrar")
@@ -240,7 +240,7 @@ class DomainTransferRequestFlowTest
                 .setGainingRegistrarId("NewRegistrar")
                 .setLosingRegistrarId("TheRegistrar")
                 .setTransferRequestTrid(expectedTrid)
-                .setTransferRequestTime(clock.nowUtc())
+                .setTransferRequestTime(clock.now())
                 .setTransferPeriod(expectedPeriod)
                 .setTransferStatus(TransferStatus.SERVER_APPROVED)
                 .setPendingTransferExpirationTime(automaticTransferTime)
@@ -251,8 +251,8 @@ class DomainTransferRequestFlowTest
   }
 
   private void assertHistoryEntriesContainBillingEventsAndGracePeriods(
-      DateTime expectedExpirationTime,
-      DateTime implicitTransferTime,
+      Instant expectedExpirationTime,
+      Instant implicitTransferTime,
       Optional<Money> transferCost,
       ImmutableSet<GracePeriod> originalGracePeriods,
       boolean expectTransferBillingEvent,
@@ -357,12 +357,12 @@ class DomainTransferRequestFlowTest
   }
 
   private void assertPollMessagesEmitted(
-      DateTime expectedExpirationTime, DateTime implicitTransferTime) {
+      Instant expectedExpirationTime, Instant implicitTransferTime) {
     // Assert that there exists a poll message to notify the losing registrar that a transfer was
     // requested. If the implicit transfer time is now (i.e. the automatic transfer length is zero)
     // then also expect a server approved poll message.
-    assertThat(getPollMessages("TheRegistrar", clock.nowUtc()))
-        .hasSize(implicitTransferTime.equals(clock.nowUtc()) ? 2 : 1);
+    assertThat(getPollMessages("TheRegistrar", clock.now()))
+        .hasSize(implicitTransferTime.equals(clock.now()) ? 2 : 1);
 
     // Two poll messages on the gaining registrar's side at the expected expiration time: a
     // (OneTime) transfer approved message, and an Autorenew poll message.
@@ -392,14 +392,14 @@ class DomainTransferRequestFlowTest
     // transfer pending message, and a transfer approved message (both OneTime messages).
     assertThat(getPollMessages("TheRegistrar", implicitTransferTime)).hasSize(2);
     PollMessage losingTransferPendingPollMessage =
-        getPollMessages("TheRegistrar", clock.nowUtc()).stream()
+        getPollMessages("TheRegistrar", clock.now()).stream()
             .filter(pollMessage -> TransferStatus.PENDING.getMessage().equals(pollMessage.getMsg()))
             .collect(onlyElement());
     PollMessage losingTransferApprovedPollMessage =
         getPollMessages("TheRegistrar", implicitTransferTime).stream()
             .filter(Predicates.not(Predicates.equalTo(losingTransferPendingPollMessage)))
             .collect(onlyElement());
-    assertThat(losingTransferPendingPollMessage.getEventTime()).isEqualTo(clock.nowUtc());
+    assertThat(losingTransferPendingPollMessage.getEventTime()).isEqualTo(clock.now());
     assertThat(losingTransferApprovedPollMessage.getEventTime()).isEqualTo(implicitTransferTime);
     assertThat(
             losingTransferPendingPollMessage.getResponseData().stream()
@@ -430,7 +430,7 @@ class DomainTransferRequestFlowTest
   }
 
   private void assertAboutDomainAfterAutomaticTransfer(
-      DateTime expectedExpirationTime, DateTime implicitTransferTime, Period expectedPeriod)
+      Instant expectedExpirationTime, Instant implicitTransferTime, Period expectedPeriod)
       throws Exception {
     Tld registry = Tld.get(domain.getTld());
     Domain domainAfterAutomaticTransfer = domain.cloneProjectedAtTime(implicitTransferTime);
@@ -448,7 +448,7 @@ class DomainTransferRequestFlowTest
     Domain afterGracePeriod =
         domain.cloneProjectedAtTime(
             clock
-                .nowUtc()
+                .now()
                 .plus(registry.getAutomaticTransferLength())
                 .plus(registry.getTransferGracePeriodLength()));
     assertThat(afterGracePeriod.getGracePeriods()).isEmpty();
@@ -462,7 +462,7 @@ class DomainTransferRequestFlowTest
   private void doSuccessfulTest(
       String commandFilename,
       String expectedXmlFilename,
-      DateTime expectedExpirationTime,
+      Instant expectedExpirationTime,
       Map<String, String> substitutions,
       Optional<Money> transferCost,
       BillingCancellation.Builder... extraExpectedBillingEvents)
@@ -473,7 +473,7 @@ class DomainTransferRequestFlowTest
     // for the request test we want that same 'now' to be the initial request time, so we shift
     // the transfer timeline 3 days later by adjusting the implicit transfer time here.
     Tld registry = Tld.get(domain.getTld());
-    DateTime implicitTransferTime = clock.nowUtc().plus(registry.getAutomaticTransferLength());
+    Instant implicitTransferTime = clock.now().plus(registry.getAutomaticTransferLength());
     // Setup done; run the test.
     assertMutatingFlow(true);
     runFlowAssertResponse(loadFile(expectedXmlFilename, substitutions));
@@ -495,7 +495,7 @@ class DomainTransferRequestFlowTest
     assertTransferRequested(
         domain, implicitTransferTime, Period.create(1, Unit.YEARS), expectedExpirationTime);
 
-    subordinateHost = reloadResourceAndCloneAtTime(subordinateHost, clock.nowUtc());
+    subordinateHost = reloadResourceAndCloneAtTime(subordinateHost, clock.now());
     assertAboutHosts().that(subordinateHost).hasNoHistoryEntries();
 
     assertHistoryEntriesContainBillingEventsAndGracePeriods(
@@ -517,14 +517,14 @@ class DomainTransferRequestFlowTest
             .service("backend")
             .header("content-type", "application/x-www-form-urlencoded")
             .param(PARAM_RESOURCE_KEY, domain.createVKey().stringify())
-            .param(PARAM_REQUESTED_TIME, clock.nowUtc().toString())
-            .scheduleTime(clock.nowUtc().plus(registry.getAutomaticTransferLength())));
+            .param(PARAM_REQUESTED_TIME, clock.now().toString())
+            .scheduleTime(clock.now().plus(registry.getAutomaticTransferLength())));
   }
 
   private void doSuccessfulTest(
       String commandFilename,
       String expectedXmlFilename,
-      DateTime expectedExpirationTime,
+      Instant expectedExpirationTime,
       BillingCancellation.Builder... extraExpectedBillingEvents)
       throws Exception {
     doSuccessfulTest(
@@ -560,7 +560,7 @@ class DomainTransferRequestFlowTest
   private void doSuccessfulSuperuserExtensionTest(
       String commandFilename,
       String expectedXmlFilename,
-      DateTime expectedExpirationTime,
+      Instant expectedExpirationTime,
       Map<String, String> substitutions,
       Optional<Money> transferCost,
       Period expectedPeriod,
@@ -573,7 +573,7 @@ class DomainTransferRequestFlowTest
     // For all of the other transfer flow tests, 'now' corresponds to day 3 of the transfer, but
     // for the request test we want that same 'now' to be the initial request time, so we shift
     // the transfer timeline 3 days later by adjusting the implicit transfer time here.
-    DateTime implicitTransferTime = clock.nowUtc().plus(expectedAutomaticTransferLength);
+    Instant implicitTransferTime = clock.now().plus(expectedAutomaticTransferLength);
     // Setup done; run the test.
     assertMutatingFlow(true);
     runFlowAssertResponse(
@@ -602,7 +602,7 @@ class DomainTransferRequestFlowTest
     // Verify correct fields were set.
     assertTransferRequested(domain, implicitTransferTime, expectedPeriod, expectedExpirationTime);
 
-    subordinateHost = reloadResourceAndCloneAtTime(subordinateHost, clock.nowUtc());
+    subordinateHost = reloadResourceAndCloneAtTime(subordinateHost, clock.now());
     assertAboutHosts().that(subordinateHost).hasNoHistoryEntries();
 
     boolean expectTransferBillingEvent = expectedPeriod.getValue() != 0;
@@ -857,8 +857,8 @@ class DomainTransferRequestFlowTest
     VKey<BillingRecurrence> existingAutorenewEvent = domain.getAutorenewBillingEvent();
     // Set domain to have auto-renewed just before the transfer request, so that it will have an
     // active autorenew grace period spanning the entire transfer window.
-    DateTime autorenewTime = clock.nowUtc().minusDays(1);
-    DateTime expirationTime = autorenewTime.plusYears(1);
+    Instant autorenewTime = clock.now().minusDays(1);
+    Instant expirationTime = autorenewTime.plusYears(1);
     domain =
         persistResource(
             domain
@@ -955,7 +955,7 @@ class DomainTransferRequestFlowTest
     // Set the domain to expire 10 years from now (as if it were just created with a 10-year term).
     domain =
         persistResource(
-            domain.asBuilder().setRegistrationExpirationTime(clock.nowUtc().plusYears(10)).build());
+            domain.asBuilder().setRegistrationExpirationTime(clock.now().plusYears(10)).build());
     // New expiration time should be capped at exactly 10 years from the transfer server-approve
     // time, so the domain only ends up gaining the 5-day transfer window's worth of extra
     // registration time.
@@ -963,7 +963,7 @@ class DomainTransferRequestFlowTest
     doSuccessfulTest(
         "domain_transfer_request.xml",
         "domain_transfer_request_response_10_year_cap.xml",
-        clock.nowUtc().plus(Tld.get("tld").getAutomaticTransferLength()).plusYears(10));
+        clock.now().plus(Tld.get("tld").getAutomaticTransferLength()).plusYears(10));
   }
 
   @Test
@@ -1046,9 +1046,9 @@ class DomainTransferRequestFlowTest
     setupDomain("example", "tld");
     // Set the domain to have auto-renewed long enough ago that it is still in the autorenew grace
     // period at the transfer request time, but will have exited it by the automatic transfer time.
-    DateTime autorenewTime =
-        clock.nowUtc().minus(Tld.get("tld").getAutoRenewGracePeriodLength()).plusDays(1);
-    DateTime expirationTime = autorenewTime.plusYears(1);
+    Instant autorenewTime =
+        clock.now().minus(Tld.get("tld").getAutoRenewGracePeriodLength()).plusDays(1);
+    Instant expirationTime = autorenewTime.plusYears(1);
     domain =
         persistResource(
             domain
@@ -1077,8 +1077,8 @@ class DomainTransferRequestFlowTest
     VKey<BillingRecurrence> existingAutorenewEvent = domain.getAutorenewBillingEvent();
     // Set domain to have auto-renewed just before the transfer request, so that it will have an
     // active autorenew grace period spanning the entire transfer window.
-    DateTime autorenewTime = clock.nowUtc().minusDays(1);
-    DateTime expirationTime = autorenewTime.plusYears(1);
+    Instant autorenewTime = clock.now().minusDays(1);
+    Instant expirationTime = autorenewTime.plusYears(1);
     domain =
         persistResource(
             domain
@@ -1104,7 +1104,7 @@ class DomainTransferRequestFlowTest
             .setTargetId("example.tld")
             .setRegistrarId("TheRegistrar")
             // The cancellation happens at the moment of transfer.
-            .setEventTime(clock.nowUtc().plus(Tld.get("tld").getAutomaticTransferLength()))
+            .setEventTime(clock.now().plus(Tld.get("tld").getAutomaticTransferLength()))
             .setBillingTime(autorenewTime.plus(Tld.get("tld").getAutoRenewGracePeriodLength()))
             // The cancellation should refer to the old autorenew billing event.
             .setBillingRecurrence(existingAutorenewEvent));
@@ -1116,7 +1116,7 @@ class DomainTransferRequestFlowTest
     VKey<BillingRecurrence> existingAutorenewEvent = domain.getAutorenewBillingEvent();
     // Set domain to expire in 1 day, so that it will be in the autorenew grace period by the
     // automatic transfer time, even though it isn't yet.
-    DateTime expirationTime = clock.nowUtc().plusDays(1);
+    Instant expirationTime = clock.now().plusDays(1);
     domain =
         persistResource(domain.asBuilder().setRegistrationExpirationTime(expirationTime).build());
     clock.advanceOneMilli();
@@ -1131,7 +1131,7 @@ class DomainTransferRequestFlowTest
             .setTargetId("example.tld")
             .setRegistrarId("TheRegistrar")
             // The cancellation happens at the moment of transfer.
-            .setEventTime(clock.nowUtc().plus(Tld.get("tld").getAutomaticTransferLength()))
+            .setEventTime(clock.now().plus(Tld.get("tld").getAutomaticTransferLength()))
             .setBillingTime(expirationTime.plus(Tld.get("tld").getAutoRenewGracePeriodLength()))
             // The cancellation should refer to the old autorenew billing event.
             .setBillingRecurrence(existingAutorenewEvent));
@@ -1175,7 +1175,7 @@ class DomainTransferRequestFlowTest
             .asBuilder()
             .setRenewalPriceBehavior(RenewalPriceBehavior.NONPREMIUM)
             .build());
-    DateTime now = clock.nowUtc();
+    Instant now = clock.now();
 
     // This ensures that the transfer has non-premium cost, as otherwise, the fee extension would be
     // required to ack the premium price.
@@ -1232,7 +1232,7 @@ class DomainTransferRequestFlowTest
             .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
             .setRenewalPrice(Money.of(USD, new BigDecimal("18.79")))
             .build());
-    DateTime now = clock.nowUtc();
+    Instant now = clock.now();
 
     setEppInput("domain_transfer_request.xml");
     runFlowAssertResponse(loadFile("domain_transfer_request_response.xml"));
@@ -1293,7 +1293,7 @@ class DomainTransferRequestFlowTest
     domain =
         persistResource(
             domain.asBuilder().setCurrentBulkToken(allocationToken.createVKey()).build());
-    DateTime now = clock.nowUtc();
+    Instant now = clock.now();
 
     setEppInput("domain_transfer_request.xml");
     runFlowAssertResponse(loadFile("domain_transfer_request_response.xml"));
@@ -1353,7 +1353,7 @@ class DomainTransferRequestFlowTest
     domain =
         persistResource(
             domain.asBuilder().setCurrentBulkToken(allocationToken.createVKey()).build());
-    DateTime now = clock.nowUtc();
+    Instant now = clock.now();
 
     setEppInput("domain_transfer_request.xml");
     runFlowAssertResponse(loadFile("domain_transfer_request_response.xml"));
@@ -1559,7 +1559,7 @@ class DomainTransferRequestFlowTest
                         .getTransferData()
                         .asBuilder()
                         .setTransferStatus(TransferStatus.PENDING)
-                        .setPendingTransferExpirationTime(clock.nowUtc().plusDays(1))
+                        .setPendingTransferExpirationTime(clock.now().plusDays(1))
                         .build())
                 .build());
     EppException thrown =
@@ -1601,7 +1601,7 @@ class DomainTransferRequestFlowTest
   void testFailure_deletedDomain() throws Exception {
     setupDomain("example", "tld");
     domain =
-        persistResource(domain.asBuilder().setDeletionTime(clock.nowUtc().minusDays(1)).build());
+        persistResource(domain.asBuilder().setDeletionTime(clock.now().minusDays(1)).build());
     ResourceDoesNotExistException thrown =
         assertThrows(
             ResourceDoesNotExistException.class,
@@ -1738,7 +1738,7 @@ class DomainTransferRequestFlowTest
     assertThat(persistedEntry.getDomainTransactionRecords())
         .containsExactly(
             DomainTransactionRecord.create(
-                "tld", clock.nowUtc().plusDays(5), TRANSFER_SUCCESSFUL, 1));
+                "tld", clock.now().plusDays(5), TRANSFER_SUCCESSFUL, 1));
   }
 
   @Test
@@ -1773,10 +1773,10 @@ class DomainTransferRequestFlowTest
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(60), TokenStatus.ENDED)
+                    .put(clock.now().plusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(60), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_transfer_request_allocation_token.xml", ImmutableMap.of("TOKEN", "abc123"));
@@ -1794,10 +1794,10 @@ class DomainTransferRequestFlowTest
             .setAllowedRegistrarIds(ImmutableSet.of("someClientId"))
             .setDiscountFraction(0.5)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(clock.nowUtc().minusDays(1), TokenStatus.VALID)
-                    .put(clock.nowUtc().plusDays(1), TokenStatus.ENDED)
+                    .put(clock.now().minusDays(1), TokenStatus.VALID)
+                    .put(clock.now().plusDays(1), TokenStatus.ENDED)
                     .build())
             .build());
     setEppInput("domain_transfer_request_allocation_token.xml", ImmutableMap.of("TOKEN", "abc123"));

--- a/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
@@ -51,6 +51,9 @@ import static google.registry.testing.DomainSubject.assertAboutDomains;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
 import static google.registry.testing.HistoryEntrySubject.assertAboutHistoryEntries;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.plusDays;
+import static google.registry.util.DateTimeUtils.plusYears;
+import static google.registry.util.DateTimeUtils.toDateTime;
 import static org.joda.money.CurrencyUnit.USD;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -103,9 +106,9 @@ import google.registry.model.poll.PollMessage;
 import google.registry.model.tld.Tld;
 import google.registry.persistence.VKey;
 import google.registry.testing.DatabaseHelper;
+import java.time.Instant;
 import java.util.Optional;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -138,7 +141,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
   }
 
   private Domain persistDomain() throws Exception {
-    Host host = loadResource(Host.class, "ns1.example.foo", clock.nowUtc()).get();
+    Host host = loadResource(Host.class, "ns1.example.foo", clock.now()).get();
     Domain domain =
         persistResource(
             DatabaseHelper.newDomain(getUniqueIdFromCommand())
@@ -148,7 +151,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     persistResource(
         new DomainHistory.Builder()
             .setType(DOMAIN_CREATE)
-            .setModificationTime(clock.nowUtc())
+            .setModificationTime(clock.now())
             .setRegistrarId(domain.getCreationRegistrarId())
             .setDomain(domain)
             .build());
@@ -173,7 +176,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
         .and()
         .hasOneHistoryEntryEachOfTypes(DOMAIN_CREATE, DOMAIN_UPDATE)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("TheRegistrar")
         .and()
@@ -234,7 +237,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
         .and()
         .hasOneHistoryEntryEachOfTypes(DOMAIN_CREATE, DOMAIN_UPDATE)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("TheRegistrar")
         .and()
@@ -286,7 +289,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     for (int i = 1; i < 15; i++) {
       if (i != 2) { // Skip 2 since that's the one that the tests will add.
         nameservers.add(
-            loadResource(Host.class, String.format("ns%d.example.foo", i), clock.nowUtc())
+            loadResource(Host.class, String.format("ns%d.example.foo", i), clock.now())
                 .get()
                 .createVKey());
       }
@@ -378,7 +381,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .addSubordinateHost("ns2.example.tld")
             .setNameservers(
                 ImmutableSet.of(
-                    loadResource(Host.class, "ns1.example.tld", clock.nowUtc()).get().createVKey()))
+                    loadResource(Host.class, "ns1.example.tld", clock.now()).get().createVKey()))
             .build());
     clock.advanceOneMilli();
     assertMutatingFlow(true);
@@ -386,8 +389,8 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     domain = reloadResourceByForeignKey();
     assertThat(domain.getNameservers()).containsExactly(addedHost.createVKey());
     assertThat(domain.getSubordinateHosts()).containsExactly("ns1.example.tld", "ns2.example.tld");
-    Host existingHost = loadResource(Host.class, "ns1.example.tld", clock.nowUtc()).get();
-    addedHost = loadResource(Host.class, "ns2.example.tld", clock.nowUtc()).get();
+    Host existingHost = loadResource(Host.class, "ns1.example.tld", clock.now()).get();
+    addedHost = loadResource(Host.class, "ns2.example.tld", clock.now()).get();
     assertThat(existingHost.getSuperordinateDomain()).isEqualTo(domain.createVKey());
     assertThat(addedHost.getSuperordinateDomain()).isEqualTo(domain.createVKey());
   }
@@ -797,8 +800,8 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
               .setTargetId("example.tld")
               .setRegistrarId("TheRegistrar")
               .setCost(Money.of(USD, 19))
-              .setEventTime(clock.nowUtc())
-              .setBillingTime(clock.nowUtc())
+              .setEventTime(clock.now())
+              .setBillingTime(clock.now())
               .setDomainHistory(
                   getOnlyHistoryEntryOfType(
                       reloadResourceByForeignKey(), DOMAIN_UPDATE, DomainHistory.class))
@@ -1095,17 +1098,14 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     assertPollMessagesForResource(
         updatedDomain,
         new PollMessage.OneTime.Builder()
-            .setEventTime(clock.nowUtc())
+            .setEventTime(clock.now())
             .setHistoryEntry(getOnlyHistoryEntryOfType(updatedDomain, DOMAIN_UPDATE))
             .setRegistrarId("NewRegistrar")
             .setMsg("The registry administrator has added the status(es) [serverHold].")
             .setResponseData(
                 ImmutableList.of(
                     DomainPendingActionNotificationResponse.create(
-                        "example.tld",
-                        true,
-                        Trid.create("ABC-12345", "server-trid"),
-                        clock.nowUtc())))
+                        "example.tld", true, Trid.create("ABC-12345", "server-trid"), clock.now())))
             .build());
   }
 
@@ -1134,7 +1134,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     assertPollMessagesForResource(
         updatedDomain,
         new PollMessage.OneTime.Builder()
-            .setEventTime(clock.nowUtc())
+            .setEventTime(clock.now())
             .setHistoryEntry(getOnlyHistoryEntryOfType(updatedDomain, DOMAIN_UPDATE))
             .setRegistrarId("NewRegistrar")
             .setMsg(
@@ -1143,10 +1143,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .setResponseData(
                 ImmutableList.of(
                     DomainPendingActionNotificationResponse.create(
-                        "example.tld",
-                        true,
-                        Trid.create("ABC-12345", "server-trid"),
-                        clock.nowUtc())))
+                        "example.tld", true, Trid.create("ABC-12345", "server-trid"), clock.now())))
             .build());
   }
 
@@ -1172,7 +1169,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     assertPollMessagesForResource(
         updatedDomain,
         new PollMessage.OneTime.Builder()
-            .setEventTime(clock.nowUtc())
+            .setEventTime(clock.now())
             .setHistoryEntry(getOnlyHistoryEntryOfType(updatedDomain, DOMAIN_UPDATE))
             .setRegistrarId("NewRegistrar")
             .setMsg(
@@ -1182,10 +1179,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .setResponseData(
                 ImmutableList.of(
                     DomainPendingActionNotificationResponse.create(
-                        "example.tld",
-                        true,
-                        Trid.create("ABC-12345", "server-trid"),
-                        clock.nowUtc())))
+                        "example.tld", true, Trid.create("ABC-12345", "server-trid"), clock.now())))
             .build());
   }
 
@@ -1262,7 +1256,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     persistResource(
         DatabaseHelper.newDomain(getUniqueIdFromCommand())
             .asBuilder()
-            .setDeletionTime(clock.nowUtc().plusDays(1))
+            .setDeletionTime(plusDays(clock.now(), 1))
             .addStatusValue(PENDING_DELETE)
             .build());
     ResourceStatusProhibitsOperationException thrown =
@@ -1319,7 +1313,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .asBuilder()
             .setNameservers(
                 ImmutableSet.of(
-                    loadResource(Host.class, "ns1.example.foo", clock.nowUtc()).get().createVKey()))
+                    loadResource(Host.class, "ns1.example.foo", clock.now()).get().createVKey()))
             .build());
     EppException thrown = assertThrows(AddRemoveSameValueException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
@@ -1387,7 +1381,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     persistReferencedEntities();
     persistDomain();
     persistResource(
-        loadResource(Host.class, "ns2.example.foo", clock.nowUtc())
+        loadResource(Host.class, "ns2.example.foo", clock.now())
             .get()
             .asBuilder()
             .addStatusValue(PENDING_DELETE)
@@ -1422,7 +1416,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
         reloadResourceByForeignKey()
             .asBuilder()
             .addNameserver(
-                loadResource(Host.class, "ns2.example.foo", clock.nowUtc()).get().createVKey())
+                loadResource(Host.class, "ns2.example.foo", clock.now()).get().createVKey())
             .build());
     persistResource(
         Tld.get("tld")
@@ -1431,12 +1425,12 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
                 ImmutableSet.of("ns1.example.foo", "ns2.example.foo"))
             .build());
     assertThat(reloadResourceByForeignKey().getNameservers())
-        .contains(loadResource(Host.class, "ns1.example.foo", clock.nowUtc()).get().createVKey());
+        .contains(loadResource(Host.class, "ns1.example.foo", clock.now()).get().createVKey());
     clock.advanceOneMilli();
     runFlow();
     assertThat(reloadResourceByForeignKey().getNameservers())
         .doesNotContain(
-            loadResource(Host.class, "ns1.example.foo", clock.nowUtc())
+            loadResource(Host.class, "ns1.example.foo", clock.now())
                 .map(ImmutableObject::createVKey)
                 .get());
   }
@@ -1491,7 +1485,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
   void testSuperuserExtension_turnsOffAutorenew() throws Exception {
     eppRequestSource = EppRequestSource.TOOL;
     setEppInput("domain_update_superuser_extension.xml", ImmutableMap.of("AUTORENEWS", "false"));
-    DateTime expirationTime = clock.nowUtc().plusYears(3);
+    Instant expirationTime = plusYears(clock.now(), 3);
     persistReferencedEntities();
     persistResource(
         persistDomain().asBuilder().setRegistrationExpirationTime(expirationTime).build());
@@ -1504,12 +1498,12 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
   void testSuperuserExtension_turnsOnAutorenew() throws Exception {
     eppRequestSource = EppRequestSource.TOOL;
     setEppInput("domain_update_superuser_extension.xml", ImmutableMap.of("AUTORENEWS", "true"));
-    DateTime expirationTime = clock.nowUtc().plusYears(3);
+    Instant expirationTime = plusYears(clock.now(), 3);
     persistReferencedEntities();
     persistResource(
         persistDomain()
             .asBuilder()
-            .setAutorenewEndTime(Optional.of(expirationTime))
+            .setAutorenewEndTime(Optional.of(toDateTime(expirationTime)))
             .setRegistrationExpirationTime(expirationTime)
             .build());
     clock.advanceOneMilli();

--- a/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
@@ -105,7 +105,7 @@ import google.registry.persistence.VKey;
 import google.registry.testing.DatabaseHelper;
 import java.util.Optional;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -138,7 +138,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
   }
 
   private Domain persistDomain() throws Exception {
-    Host host = loadResource(Host.class, "ns1.example.foo", clock.nowUtc()).get();
+    Host host = loadResource(Host.class, "ns1.example.foo", clock.now()).get();
     Domain domain =
         persistResource(
             DatabaseHelper.newDomain(getUniqueIdFromCommand())
@@ -148,7 +148,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     persistResource(
         new DomainHistory.Builder()
             .setType(DOMAIN_CREATE)
-            .setModificationTime(clock.nowUtc())
+            .setModificationTime(clock.now())
             .setRegistrarId(domain.getCreationRegistrarId())
             .setDomain(domain)
             .build());
@@ -173,7 +173,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
         .and()
         .hasOneHistoryEntryEachOfTypes(DOMAIN_CREATE, DOMAIN_UPDATE)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("TheRegistrar")
         .and()
@@ -234,7 +234,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
         .and()
         .hasOneHistoryEntryEachOfTypes(DOMAIN_CREATE, DOMAIN_UPDATE)
         .and()
-        .hasLastEppUpdateTime(clock.nowUtc())
+        .hasLastEppUpdateTime(clock.now())
         .and()
         .hasLastEppUpdateRegistrarId("TheRegistrar")
         .and()
@@ -286,7 +286,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     for (int i = 1; i < 15; i++) {
       if (i != 2) { // Skip 2 since that's the one that the tests will add.
         nameservers.add(
-            loadResource(Host.class, String.format("ns%d.example.foo", i), clock.nowUtc())
+            loadResource(Host.class, String.format("ns%d.example.foo", i), clock.now())
                 .get()
                 .createVKey());
       }
@@ -378,7 +378,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .addSubordinateHost("ns2.example.tld")
             .setNameservers(
                 ImmutableSet.of(
-                    loadResource(Host.class, "ns1.example.tld", clock.nowUtc()).get().createVKey()))
+                    loadResource(Host.class, "ns1.example.tld", clock.now()).get().createVKey()))
             .build());
     clock.advanceOneMilli();
     assertMutatingFlow(true);
@@ -386,8 +386,8 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     domain = reloadResourceByForeignKey();
     assertThat(domain.getNameservers()).containsExactly(addedHost.createVKey());
     assertThat(domain.getSubordinateHosts()).containsExactly("ns1.example.tld", "ns2.example.tld");
-    Host existingHost = loadResource(Host.class, "ns1.example.tld", clock.nowUtc()).get();
-    addedHost = loadResource(Host.class, "ns2.example.tld", clock.nowUtc()).get();
+    Host existingHost = loadResource(Host.class, "ns1.example.tld", clock.now()).get();
+    addedHost = loadResource(Host.class, "ns2.example.tld", clock.now()).get();
     assertThat(existingHost.getSuperordinateDomain()).isEqualTo(domain.createVKey());
     assertThat(addedHost.getSuperordinateDomain()).isEqualTo(domain.createVKey());
   }
@@ -797,8 +797,8 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
               .setTargetId("example.tld")
               .setRegistrarId("TheRegistrar")
               .setCost(Money.of(USD, 19))
-              .setEventTime(clock.nowUtc())
-              .setBillingTime(clock.nowUtc())
+              .setEventTime(clock.now())
+              .setBillingTime(clock.now())
               .setDomainHistory(
                   getOnlyHistoryEntryOfType(
                       reloadResourceByForeignKey(), DOMAIN_UPDATE, DomainHistory.class))
@@ -1044,7 +1044,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
   @Test
   void testFailure_existedButWasDeleted() throws Exception {
     persistReferencedEntities();
-    persistDeletedDomain(getUniqueIdFromCommand(), clock.nowUtc().minusDays(1));
+    persistDeletedDomain(getUniqueIdFromCommand(), clock.now().minusDays(1));
     ResourceDoesNotExistException thrown =
         assertThrows(ResourceDoesNotExistException.class, this::runFlow);
     assertThat(thrown).hasMessageThat().contains(String.format("(%s)", getUniqueIdFromCommand()));
@@ -1095,7 +1095,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     assertPollMessagesForResource(
         updatedDomain,
         new PollMessage.OneTime.Builder()
-            .setEventTime(clock.nowUtc())
+            .setEventTime(clock.now())
             .setHistoryEntry(getOnlyHistoryEntryOfType(updatedDomain, DOMAIN_UPDATE))
             .setRegistrarId("NewRegistrar")
             .setMsg("The registry administrator has added the status(es) [serverHold].")
@@ -1105,7 +1105,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
                         "example.tld",
                         true,
                         Trid.create("ABC-12345", "server-trid"),
-                        clock.nowUtc())))
+                        clock.now())))
             .build());
   }
 
@@ -1134,7 +1134,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     assertPollMessagesForResource(
         updatedDomain,
         new PollMessage.OneTime.Builder()
-            .setEventTime(clock.nowUtc())
+            .setEventTime(clock.now())
             .setHistoryEntry(getOnlyHistoryEntryOfType(updatedDomain, DOMAIN_UPDATE))
             .setRegistrarId("NewRegistrar")
             .setMsg(
@@ -1146,7 +1146,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
                         "example.tld",
                         true,
                         Trid.create("ABC-12345", "server-trid"),
-                        clock.nowUtc())))
+                        clock.now())))
             .build());
   }
 
@@ -1172,7 +1172,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     assertPollMessagesForResource(
         updatedDomain,
         new PollMessage.OneTime.Builder()
-            .setEventTime(clock.nowUtc())
+            .setEventTime(clock.now())
             .setHistoryEntry(getOnlyHistoryEntryOfType(updatedDomain, DOMAIN_UPDATE))
             .setRegistrarId("NewRegistrar")
             .setMsg(
@@ -1185,7 +1185,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
                         "example.tld",
                         true,
                         Trid.create("ABC-12345", "server-trid"),
-                        clock.nowUtc())))
+                        clock.now())))
             .build());
   }
 
@@ -1262,7 +1262,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     persistResource(
         DatabaseHelper.newDomain(getUniqueIdFromCommand())
             .asBuilder()
-            .setDeletionTime(clock.nowUtc().plusDays(1))
+            .setDeletionTime(clock.now().plusDays(1))
             .addStatusValue(PENDING_DELETE)
             .build());
     ResourceStatusProhibitsOperationException thrown =
@@ -1319,7 +1319,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .asBuilder()
             .setNameservers(
                 ImmutableSet.of(
-                    loadResource(Host.class, "ns1.example.foo", clock.nowUtc()).get().createVKey()))
+                    loadResource(Host.class, "ns1.example.foo", clock.now()).get().createVKey()))
             .build());
     EppException thrown = assertThrows(AddRemoveSameValueException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
@@ -1387,7 +1387,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     persistReferencedEntities();
     persistDomain();
     persistResource(
-        loadResource(Host.class, "ns2.example.foo", clock.nowUtc())
+        loadResource(Host.class, "ns2.example.foo", clock.now())
             .get()
             .asBuilder()
             .addStatusValue(PENDING_DELETE)
@@ -1422,7 +1422,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
         reloadResourceByForeignKey()
             .asBuilder()
             .addNameserver(
-                loadResource(Host.class, "ns2.example.foo", clock.nowUtc()).get().createVKey())
+                loadResource(Host.class, "ns2.example.foo", clock.now()).get().createVKey())
             .build());
     persistResource(
         Tld.get("tld")
@@ -1431,12 +1431,12 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
                 ImmutableSet.of("ns1.example.foo", "ns2.example.foo"))
             .build());
     assertThat(reloadResourceByForeignKey().getNameservers())
-        .contains(loadResource(Host.class, "ns1.example.foo", clock.nowUtc()).get().createVKey());
+        .contains(loadResource(Host.class, "ns1.example.foo", clock.now()).get().createVKey());
     clock.advanceOneMilli();
     runFlow();
     assertThat(reloadResourceByForeignKey().getNameservers())
         .doesNotContain(
-            loadResource(Host.class, "ns1.example.foo", clock.nowUtc())
+            loadResource(Host.class, "ns1.example.foo", clock.now())
                 .map(ImmutableObject::createVKey)
                 .get());
   }
@@ -1491,7 +1491,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
   void testSuperuserExtension_turnsOffAutorenew() throws Exception {
     eppRequestSource = EppRequestSource.TOOL;
     setEppInput("domain_update_superuser_extension.xml", ImmutableMap.of("AUTORENEWS", "false"));
-    DateTime expirationTime = clock.nowUtc().plusYears(3);
+    Instant expirationTime = clock.now().plusYears(3);
     persistReferencedEntities();
     persistResource(
         persistDomain().asBuilder().setRegistrationExpirationTime(expirationTime).build());
@@ -1504,7 +1504,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
   void testSuperuserExtension_turnsOnAutorenew() throws Exception {
     eppRequestSource = EppRequestSource.TOOL;
     setEppInput("domain_update_superuser_extension.xml", ImmutableMap.of("AUTORENEWS", "true"));
-    DateTime expirationTime = clock.nowUtc().plusYears(3);
+    Instant expirationTime = clock.now().plusYears(3);
     persistReferencedEntities();
     persistResource(
         persistDomain()

--- a/core/src/test/java/google/registry/flows/domain/ProductionSimulatingFeeExtensionsTest.java
+++ b/core/src/test/java/google/registry/flows/domain/ProductionSimulatingFeeExtensionsTest.java
@@ -86,7 +86,7 @@ public class ProductionSimulatingFeeExtensionsTest
         FEE_EXTENSION_1_DOT_0_IN_PROD.name(),
         "--force",
         "--status_map",
-        String.format("%s=INACTIVE,%s=ACTIVE", START_OF_TIME, fakeClock.nowUtc().plusMillis(1)));
+        String.format("%s=INACTIVE,%s=ACTIVE", START_OF_TIME, fakeClock.now().plusMillis(1)));
     RegistryEnvironment.PRODUCTION.setup();
     ProtocolDefinition.reloadServiceExtensionUris();
     // prod shouldn't have the fee extension version 1.0
@@ -107,7 +107,7 @@ public class ProductionSimulatingFeeExtensionsTest
         FEE_EXTENSION_1_DOT_0_IN_PROD.name(),
         "--force",
         "--status_map",
-        String.format("%s=INACTIVE,%s=ACTIVE", START_OF_TIME, fakeClock.nowUtc().minusMillis(1)));
+        String.format("%s=INACTIVE,%s=ACTIVE", START_OF_TIME, fakeClock.now().minusMillis(1)));
     RegistryEnvironment.PRODUCTION.setup();
     ProtocolDefinition.reloadServiceExtensionUris();
     // prod should have the fee extension version 1.0

--- a/core/src/test/java/google/registry/flows/domain/token/AllocationTokenFlowUtilsTest.java
+++ b/core/src/test/java/google/registry/flows/domain/token/AllocationTokenFlowUtilsTest.java
@@ -25,7 +25,11 @@ import static google.registry.model.domain.token.AllocationToken.TokenType.UNLIM
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
-import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
+import static google.registry.util.DateTimeUtils.minusDays;
+import static google.registry.util.DateTimeUtils.minusMonths;
+import static google.registry.util.DateTimeUtils.plusDays;
+import static google.registry.util.DateTimeUtils.plusMonths;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -49,8 +53,9 @@ import google.registry.model.tld.Tld;
 import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationTestExtension;
 import google.registry.testing.FakeClock;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -58,7 +63,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 /** Unit tests for {@link AllocationTokenFlowUtils}. */
 class AllocationTokenFlowUtilsTest {
 
-  private final FakeClock clock = new FakeClock(DateTime.parse("2025-01-10T01:00:00.000Z"));
+  private final FakeClock clock = new FakeClock(Instant.parse("2025-01-10T01:00:00.000Z"));
 
   @RegisterExtension
   final JpaIntegrationTestExtension jpa =
@@ -247,7 +252,7 @@ class AllocationTokenFlowUtilsTest {
         IllegalArgumentException.class,
         () ->
             AllocationTokenFlowUtils.redeemToken(
-                createOneMonthPromoTokenBuilder(clock.nowUtc()).build(),
+                createOneMonthPromoTokenBuilder(clock.now()).build(),
                 new HistoryEntryId("repoId", 10L)));
   }
 
@@ -265,7 +270,7 @@ class AllocationTokenFlowUtilsTest {
   @Test
   void testFailure_tokenInvalidForRegistrar() {
     persistResource(
-        createOneMonthPromoTokenBuilder(clock.nowUtc().minusDays(1))
+        createOneMonthPromoTokenBuilder(minusDays(clock.now(), 1))
             .setAllowedRegistrarIds(ImmutableSet.of("NewRegistrar"))
             .build());
     assertLoadTokenFromExtensionThrowsException(AllocationTokenNotValidForRegistrarException.class);
@@ -273,13 +278,13 @@ class AllocationTokenFlowUtilsTest {
 
   @Test
   void testFailure_beforePromoStart() {
-    persistResource(createOneMonthPromoTokenBuilder(clock.nowUtc().plusDays(1)).build());
+    persistResource(createOneMonthPromoTokenBuilder(plusDays(clock.now(), 1)).build());
     assertLoadTokenFromExtensionThrowsException(AllocationTokenNotInPromotionException.class);
   }
 
   @Test
   void testFailure_afterPromoEnd() {
-    persistResource(createOneMonthPromoTokenBuilder(clock.nowUtc().minusMonths(2)).build());
+    persistResource(createOneMonthPromoTokenBuilder(minusMonths(clock.now(), 2)).build());
     assertLoadTokenFromExtensionThrowsException(AllocationTokenNotInPromotionException.class);
   }
 
@@ -287,12 +292,12 @@ class AllocationTokenFlowUtilsTest {
   void testFailure_promoCancelled() {
     // the promo would be valid, but it was cancelled 12 hours ago
     persistResource(
-        createOneMonthPromoTokenBuilder(clock.nowUtc().minusDays(1))
-            .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, NOT_STARTED)
-                    .put(clock.nowUtc().minusMonths(1), VALID)
-                    .put(clock.nowUtc().minusHours(12), CANCELLED)
+        createOneMonthPromoTokenBuilder(minusDays(clock.now(), 1))
+            .setTokenStatusTransitionsInstant(
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, NOT_STARTED)
+                    .put(minusMonths(clock.now(), 1), VALID)
+                    .put(clock.now().minus(Duration.ofHours(12)), CANCELLED)
                     .build())
             .build());
     assertLoadTokenFromExtensionThrowsException(AllocationTokenNotInPromotionException.class);
@@ -475,16 +480,16 @@ class AllocationTokenFlowUtilsTest {
         .setAllowedRegistrarIds(ImmutableSet.of("TheRegistrar"));
   }
 
-  private AllocationToken.Builder createOneMonthPromoTokenBuilder(DateTime promoStart) {
+  private AllocationToken.Builder createOneMonthPromoTokenBuilder(Instant promoStart) {
     when(allocationTokenExtension.getAllocationToken()).thenReturn("tokeN");
     return new AllocationToken.Builder()
         .setToken("tokeN")
         .setTokenType(UNLIMITED_USE)
-        .setTokenStatusTransitions(
-            ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                .put(START_OF_TIME, NOT_STARTED)
+        .setTokenStatusTransitionsInstant(
+            ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                .put(START_INSTANT, NOT_STARTED)
                 .put(promoStart, VALID)
-                .put(promoStart.plusMonths(1), ENDED)
+                .put(plusMonths(promoStart, 1), ENDED)
                 .build());
   }
 }

--- a/core/src/test/java/google/registry/flows/domain/token/AllocationTokenFlowUtilsTest.java
+++ b/core/src/test/java/google/registry/flows/domain/token/AllocationTokenFlowUtilsTest.java
@@ -50,7 +50,7 @@ import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationTestExtension;
 import google.registry.testing.FakeClock;
 import java.util.Optional;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -58,7 +58,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 /** Unit tests for {@link AllocationTokenFlowUtils}. */
 class AllocationTokenFlowUtilsTest {
 
-  private final FakeClock clock = new FakeClock(DateTime.parse("2025-01-10T01:00:00.000Z"));
+  private final FakeClock clock = new FakeClock(Instant.parse("2025-01-10T01:00:00.000Z"));
 
   @RegisterExtension
   final JpaIntegrationTestExtension jpa =
@@ -122,7 +122,7 @@ class AllocationTokenFlowUtilsTest {
             AllocationTokenFlowUtils.loadAllocationTokenFromExtension(
                 "TheRegistrar",
                 "example.tld",
-                clock.nowUtc(),
+                clock.now(),
                 Optional.of(allocationTokenExtension)))
         .hasValue(token);
   }
@@ -141,7 +141,7 @@ class AllocationTokenFlowUtilsTest {
     assertThat(
             AllocationTokenFlowUtils.loadTokenFromExtensionOrGetDefault(
                 "TheRegistrar",
-                clock.nowUtc(),
+                clock.now(),
                 Optional.of(allocationTokenExtension),
                 tld,
                 "example.tld",
@@ -157,7 +157,7 @@ class AllocationTokenFlowUtilsTest {
     assertThat(
             AllocationTokenFlowUtils.loadTokenFromExtensionOrGetDefault(
                 "TheRegistrar",
-                clock.nowUtc(),
+                clock.now(),
                 Optional.empty(),
                 tld,
                 "example.tld",
@@ -181,7 +181,7 @@ class AllocationTokenFlowUtilsTest {
     assertThat(
             AllocationTokenFlowUtils.loadTokenFromExtensionOrGetDefault(
                 "TheRegistrar",
-                clock.nowUtc(),
+                clock.now(),
                 Optional.of(allocationTokenExtension),
                 tld,
                 "example.tld",
@@ -196,7 +196,7 @@ class AllocationTokenFlowUtilsTest {
     AllocationToken token = singleUseTokenBuilder().setDiscountPremiums(true).build();
     assertThat(
             AllocationTokenFlowUtils.tokenIsValidAgainstDomain(
-                InternetDomainName.from("rich.tld"), token, CommandName.CREATE, clock.nowUtc()))
+                InternetDomainName.from("rich.tld"), token, CommandName.CREATE, clock.now()))
         .isTrue();
   }
 
@@ -205,7 +205,7 @@ class AllocationTokenFlowUtilsTest {
     AllocationToken token = singleUseTokenBuilder().build();
     assertThat(
             AllocationTokenFlowUtils.tokenIsValidAgainstDomain(
-                InternetDomainName.from("rich.tld"), token, CommandName.CREATE, clock.nowUtc()))
+                InternetDomainName.from("rich.tld"), token, CommandName.CREATE, clock.now()))
         .isFalse();
   }
 
@@ -215,7 +215,7 @@ class AllocationTokenFlowUtilsTest {
         singleUseTokenBuilder().setAllowedEppActions(ImmutableSet.of(CommandName.RESTORE)).build();
     assertThat(
             AllocationTokenFlowUtils.tokenIsValidAgainstDomain(
-                InternetDomainName.from("domain.tld"), token, CommandName.CREATE, clock.nowUtc()))
+                InternetDomainName.from("domain.tld"), token, CommandName.CREATE, clock.now()))
         .isFalse();
   }
 
@@ -228,7 +228,7 @@ class AllocationTokenFlowUtilsTest {
                 InternetDomainName.from("domain.othertld"),
                 token,
                 CommandName.CREATE,
-                clock.nowUtc()))
+                clock.now()))
         .isFalse();
   }
 
@@ -237,7 +237,7 @@ class AllocationTokenFlowUtilsTest {
     AllocationToken token = singleUseTokenBuilder().setDomainName("anchor.tld").build();
     assertThat(
             AllocationTokenFlowUtils.tokenIsValidAgainstDomain(
-                InternetDomainName.from("domain.tld"), token, CommandName.CREATE, clock.nowUtc()))
+                InternetDomainName.from("domain.tld"), token, CommandName.CREATE, clock.now()))
         .isFalse();
   }
 
@@ -247,7 +247,7 @@ class AllocationTokenFlowUtilsTest {
         IllegalArgumentException.class,
         () ->
             AllocationTokenFlowUtils.redeemToken(
-                createOneMonthPromoTokenBuilder(clock.nowUtc()).build(),
+                createOneMonthPromoTokenBuilder(clock.now()).build(),
                 new HistoryEntryId("repoId", 10L)));
   }
 
@@ -265,7 +265,7 @@ class AllocationTokenFlowUtilsTest {
   @Test
   void testFailure_tokenInvalidForRegistrar() {
     persistResource(
-        createOneMonthPromoTokenBuilder(clock.nowUtc().minusDays(1))
+        createOneMonthPromoTokenBuilder(clock.now().minusDays(1))
             .setAllowedRegistrarIds(ImmutableSet.of("NewRegistrar"))
             .build());
     assertLoadTokenFromExtensionThrowsException(AllocationTokenNotValidForRegistrarException.class);
@@ -273,13 +273,13 @@ class AllocationTokenFlowUtilsTest {
 
   @Test
   void testFailure_beforePromoStart() {
-    persistResource(createOneMonthPromoTokenBuilder(clock.nowUtc().plusDays(1)).build());
+    persistResource(createOneMonthPromoTokenBuilder(clock.now().plusDays(1)).build());
     assertLoadTokenFromExtensionThrowsException(AllocationTokenNotInPromotionException.class);
   }
 
   @Test
   void testFailure_afterPromoEnd() {
-    persistResource(createOneMonthPromoTokenBuilder(clock.nowUtc().minusMonths(2)).build());
+    persistResource(createOneMonthPromoTokenBuilder(clock.now().minusMonths(2)).build());
     assertLoadTokenFromExtensionThrowsException(AllocationTokenNotInPromotionException.class);
   }
 
@@ -287,12 +287,12 @@ class AllocationTokenFlowUtilsTest {
   void testFailure_promoCancelled() {
     // the promo would be valid, but it was cancelled 12 hours ago
     persistResource(
-        createOneMonthPromoTokenBuilder(clock.nowUtc().minusDays(1))
+        createOneMonthPromoTokenBuilder(clock.now().minusDays(1))
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_OF_TIME, NOT_STARTED)
-                    .put(clock.nowUtc().minusMonths(1), VALID)
-                    .put(clock.nowUtc().minusHours(12), CANCELLED)
+                    .put(clock.now().minusMonths(1), VALID)
+                    .put(clock.now().minusHours(12), CANCELLED)
                     .build())
             .build());
     assertLoadTokenFromExtensionThrowsException(AllocationTokenNotInPromotionException.class);
@@ -306,7 +306,7 @@ class AllocationTokenFlowUtilsTest {
         () ->
             AllocationTokenFlowUtils.loadTokenFromExtensionOrGetDefault(
                 "TheRegistrar",
-                clock.nowUtc(),
+                clock.now(),
                 Optional.of(allocationTokenExtension),
                 tld,
                 "example.tld",
@@ -320,7 +320,7 @@ class AllocationTokenFlowUtilsTest {
     assertThat(
             AllocationTokenFlowUtils.loadTokenFromExtensionOrGetDefault(
                 "TheRegistrar",
-                clock.nowUtc(),
+                clock.now(),
                 Optional.empty(),
                 tld,
                 "example.tld",
@@ -340,7 +340,7 @@ class AllocationTokenFlowUtilsTest {
         () ->
             AllocationTokenFlowUtils.loadTokenFromExtensionOrGetDefault(
                 "TheRegistrar",
-                clock.nowUtc(),
+                clock.now(),
                 Optional.of(allocationTokenExtension),
                 tld,
                 "example.tld",
@@ -380,7 +380,7 @@ class AllocationTokenFlowUtilsTest {
     assertThat(
             AllocationTokenFlowUtils.loadTokenFromExtensionOrGetDefault(
                 "TheRegistrar",
-                clock.nowUtc(),
+                clock.now(),
                 Optional.empty(),
                 tld,
                 "example.tld",
@@ -423,7 +423,7 @@ class AllocationTokenFlowUtilsTest {
     assertThat(
             AllocationTokenFlowUtils.loadTokenFromExtensionOrGetDefault(
                 "TheRegistrar",
-                clock.nowUtc(),
+                clock.now(),
                 Optional.empty(),
                 tld,
                 "example.tld",
@@ -460,7 +460,7 @@ class AllocationTokenFlowUtilsTest {
                     AllocationTokenFlowUtils.loadAllocationTokenFromExtension(
                         "TheRegistrar",
                         "example.tld",
-                        clock.nowUtc(),
+                        clock.now(),
                         Optional.of(allocationTokenExtension))))
         .marshalsToXml();
   }
@@ -475,13 +475,13 @@ class AllocationTokenFlowUtilsTest {
         .setAllowedRegistrarIds(ImmutableSet.of("TheRegistrar"));
   }
 
-  private AllocationToken.Builder createOneMonthPromoTokenBuilder(DateTime promoStart) {
+  private AllocationToken.Builder createOneMonthPromoTokenBuilder(Instant promoStart) {
     when(allocationTokenExtension.getAllocationToken()).thenReturn("tokeN");
     return new AllocationToken.Builder()
         .setToken("tokeN")
         .setTokenType(UNLIMITED_USE)
         .setTokenStatusTransitions(
-            ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
+            ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                 .put(START_OF_TIME, NOT_STARTED)
                 .put(promoStart, VALID)
                 .put(promoStart.plusMonths(1), ENDED)

--- a/core/src/test/java/google/registry/flows/host/HostDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostDeleteFlowTest.java
@@ -345,7 +345,7 @@ class HostDeleteFlowTest extends ResourceFlowTestCase<HostDeleteFlow, Host> {
     Host deletedHost = reloadResourceByForeignKey(clock.nowUtc().minusMillis(1));
     assertAboutHosts()
         .that(deletedHost)
-        .isNotActiveAt(clock.nowUtc())
+        .isNotActiveAt(clock.now())
         .and()
         .hasExactlyStatusValues(StatusValue.OK)
         .and()

--- a/core/src/test/java/google/registry/flows/host/HostUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostUpdateFlowTest.java
@@ -408,7 +408,7 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
         .and()
         .hasLastSuperordinateChange(clock.nowUtc());
     assertThat(renamedHost.getLastTransferTime()).isEqualTo(oneDayAgo);
-    Domain reloadedDomain = loadByEntity(domain).cloneProjectedAtTime(clock.nowUtc());
+    Domain reloadedDomain = loadByEntity(domain).cloneProjectedAtInstant(clock.now());
     assertThat(reloadedDomain.getSubordinateHosts()).isEmpty();
     assertHostDnsRequests("ns1.example.foo");
   }

--- a/core/src/test/java/google/registry/model/CreateAutoTimestampTest.java
+++ b/core/src/test/java/google/registry/model/CreateAutoTimestampTest.java
@@ -17,6 +17,7 @@ package google.registry.model;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.loadByEntity;
+import static google.registry.util.DateTimeUtils.minusDays;
 
 import google.registry.model.common.CrossTldSingleton;
 import google.registry.persistence.transaction.JpaTestExtensions;
@@ -24,7 +25,6 @@ import google.registry.persistence.transaction.JpaTestExtensions.JpaUnitTestExte
 import google.registry.testing.FakeClock;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import java.time.Duration;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -67,7 +67,7 @@ public class CreateAutoTimestampTest {
 
   @Test
   void testResavingRespectsOriginalTime() {
-    final Instant oldCreateTime = clock.now().minus(Duration.ofDays(1));
+    final Instant oldCreateTime = minusDays(clock.now(), 1);
     tm().transact(
             () -> {
               CreateAutoTimestampTestObject object = new CreateAutoTimestampTestObject();

--- a/core/src/test/java/google/registry/model/UpdateAutoTimestampTest.java
+++ b/core/src/test/java/google/registry/model/UpdateAutoTimestampTest.java
@@ -17,6 +17,7 @@ package google.registry.model;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.START_INSTANT;
+import static google.registry.util.DateTimeUtils.minusDays;
 
 import google.registry.model.common.CrossTldSingleton;
 import google.registry.persistence.VKey;
@@ -25,7 +26,6 @@ import google.registry.persistence.transaction.JpaTestExtensions.JpaUnitTestExte
 import google.registry.testing.FakeClock;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import java.time.Duration;
 import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -75,8 +75,7 @@ public class UpdateAutoTimestampTest {
                 () -> {
                   clock.advanceOneMilli();
                   UpdateAutoTimestampTestObject object = new UpdateAutoTimestampTestObject();
-                  object.updateTime =
-                      UpdateAutoTimestamp.create(clock.now().minus(Duration.ofDays(1)));
+                  object.updateTime = UpdateAutoTimestamp.create(minusDays(clock.now(), 1));
                   tm().insert(object);
                   return tm().getTxTime();
                 });

--- a/core/src/test/java/google/registry/model/adapters/StatusValueAdapterTest.java
+++ b/core/src/test/java/google/registry/model/adapters/StatusValueAdapterTest.java
@@ -15,7 +15,7 @@
 package google.registry.model.adapters;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableMap;
@@ -46,7 +46,7 @@ public class StatusValueAdapterTest {
                         .setResData(
                             HostInfoData.newBuilder()
                                 .setCreationRegistrarId("")
-                                .setCreationTime(START_OF_TIME)
+                                .setCreationTime(START_INSTANT)
                                 .setCurrentSponsorRegistrarId("")
                                 .setHostName("")
                                 .setInetAddresses(ImmutableSet.of())

--- a/core/src/test/java/google/registry/model/domain/DomainSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainSqlTest.java
@@ -28,6 +28,7 @@ import static google.registry.testing.SqlHelper.assertThrowForeignKeyViolation;
 import static google.registry.testing.SqlHelper.saveRegistrar;
 import static google.registry.util.DateTimeUtils.END_INSTANT;
 import static google.registry.util.DateTimeUtils.START_INSTANT;
+import static google.registry.util.DateTimeUtils.plusDays;
 import static google.registry.util.DateTimeUtils.plusYears;
 
 import com.google.common.collect.ImmutableList;
@@ -131,7 +132,7 @@ public class DomainSqlTest {
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, NOT_STARTED)
                     .put(fakeClock.now(), TokenStatus.VALID)
-                    .put(fakeClock.now().plus(java.time.Duration.ofDays(56)), TokenStatus.ENDED)
+                    .put(plusDays(fakeClock.now(), 56), TokenStatus.ENDED)
                     .build())
             .build();
   }

--- a/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
+++ b/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
@@ -28,6 +28,7 @@ import static google.registry.testing.DatabaseHelper.loadByEntity;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_INSTANT;
+import static google.registry.util.DateTimeUtils.plusDays;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableSet;
@@ -77,7 +78,7 @@ public class AllocationTokenTest extends EntityTestCase {
                     ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                         .put(START_INSTANT, NOT_STARTED)
                         .put(fakeClock.now(), TokenStatus.VALID)
-                        .put(fakeClock.now().plus(java.time.Duration.ofDays(56)), TokenStatus.ENDED)
+                        .put(plusDays(fakeClock.now(), 56), TokenStatus.ENDED)
                         .build())
                 .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE, CommandName.RENEW))
                 .build());
@@ -114,7 +115,7 @@ public class AllocationTokenTest extends EntityTestCase {
                     ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                         .put(START_INSTANT, NOT_STARTED)
                         .put(fakeClock.now(), TokenStatus.VALID)
-                        .put(fakeClock.now().plus(java.time.Duration.ofDays(56)), TokenStatus.ENDED)
+                        .put(plusDays(fakeClock.now(), 56), TokenStatus.ENDED)
                         .build())
                 .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE, CommandName.RENEW))
                 .build());
@@ -422,12 +423,8 @@ public class AllocationTokenTest extends EntityTestCase {
                     .setTokenStatusTransitionsInstant(
                         ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                             .put(fakeClock.now(), NOT_STARTED)
-                            .put(
-                                fakeClock.now().plus(java.time.Duration.ofDays(1)),
-                                TokenStatus.VALID)
-                            .put(
-                                fakeClock.now().plus(java.time.Duration.ofDays(2)),
-                                TokenStatus.ENDED)
+                            .put(plusDays(fakeClock.now(), 1), TokenStatus.VALID)
+                            .put(plusDays(fakeClock.now(), 2), TokenStatus.ENDED)
                             .build()));
     assertThat(thrown)
         .hasMessageThat()
@@ -465,7 +462,7 @@ public class AllocationTokenTest extends EntityTestCase {
         ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
             .put(START_INSTANT, NOT_STARTED)
             .put(fakeClock.now(), VALID)
-            .put(fakeClock.now().plus(java.time.Duration.ofDays(1)), VALID)
+            .put(plusDays(fakeClock.now(), 1), VALID)
             .build(),
         VALID,
         VALID);
@@ -473,7 +470,7 @@ public class AllocationTokenTest extends EntityTestCase {
         ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
             .put(START_INSTANT, NOT_STARTED)
             .put(fakeClock.now(), VALID)
-            .put(fakeClock.now().plus(java.time.Duration.ofDays(1)), NOT_STARTED)
+            .put(plusDays(fakeClock.now(), 1), NOT_STARTED)
             .build(),
         VALID,
         NOT_STARTED);
@@ -741,8 +738,8 @@ public class AllocationTokenTest extends EntityTestCase {
                         ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                             .put(START_INSTANT, NOT_STARTED)
                             .put(fakeClock.now(), VALID)
-                            .put(fakeClock.now().plus(java.time.Duration.ofDays(1)), status)
-                            .put(fakeClock.now().plus(java.time.Duration.ofDays(2)), CANCELLED)
+                            .put(plusDays(fakeClock.now(), 1), status)
+                            .put(plusDays(fakeClock.now(), 2), CANCELLED)
                             .build()));
     assertThat(thrown)
         .hasMessageThat()

--- a/core/src/test/java/google/registry/model/smd/SignedMarkRevocationListDaoTest.java
+++ b/core/src/test/java/google/registry/model/smd/SignedMarkRevocationListDaoTest.java
@@ -21,6 +21,7 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.EntityTestCase;
 import jakarta.persistence.OptimisticLockException;
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +35,7 @@ public class SignedMarkRevocationListDaoTest extends EntityTestCase {
   void testSave_success() {
     SignedMarkRevocationList list =
         SignedMarkRevocationList.create(
-            fakeClock.nowUtc(), ImmutableMap.of("mark", fakeClock.nowUtc().minusHours(1)));
+            fakeClock.now(), ImmutableMap.of("mark", fakeClock.now().minus(Duration.ofHours(1))));
     list = SignedMarkRevocationListDao.save(list);
     SignedMarkRevocationList fromDb = SignedMarkRevocationListDao.load();
     assertAboutImmutableObjects().that(fromDb).isEqualExceptFields(list);
@@ -44,7 +45,7 @@ public class SignedMarkRevocationListDaoTest extends EntityTestCase {
   void testSave_retrySuccess() {
     SignedMarkRevocationList list =
         SignedMarkRevocationList.create(
-            fakeClock.nowUtc(), ImmutableMap.of("mark", fakeClock.nowUtc().minusHours(1)));
+            fakeClock.now(), ImmutableMap.of("mark", fakeClock.now().minus(Duration.ofHours(1))));
     AtomicBoolean isFirstAttempt = new AtomicBoolean(true);
     tm().transact(
             () -> {
@@ -61,7 +62,7 @@ public class SignedMarkRevocationListDaoTest extends EntityTestCase {
   @Test
   void testSaveAndLoad_emptyList() {
     SignedMarkRevocationList list =
-        SignedMarkRevocationList.create(fakeClock.nowUtc(), ImmutableMap.of());
+        SignedMarkRevocationList.create(fakeClock.now(), ImmutableMap.of());
     SignedMarkRevocationListDao.save(list);
     SignedMarkRevocationList fromDb = SignedMarkRevocationListDao.load();
     assertAboutImmutableObjects().that(fromDb).isEqualExceptFields(list, "revisionId");
@@ -71,17 +72,14 @@ public class SignedMarkRevocationListDaoTest extends EntityTestCase {
   void testSave_multipleVersions() {
     SignedMarkRevocationList list =
         SignedMarkRevocationList.create(
-            fakeClock.nowUtc(), ImmutableMap.of("mark", fakeClock.nowUtc().minusHours(1)));
+            fakeClock.now(), ImmutableMap.of("mark", fakeClock.now().minus(Duration.ofHours(1))));
     SignedMarkRevocationListDao.save(list);
-    assertThat(SignedMarkRevocationListDao.load().isSmdRevoked("mark", fakeClock.nowUtc()))
-        .isTrue();
+    assertThat(SignedMarkRevocationListDao.load().isSmdRevoked("mark", fakeClock.now())).isTrue();
 
     // Now remove the revocation
     SignedMarkRevocationList secondList =
-        SignedMarkRevocationList.create(fakeClock.nowUtc(), ImmutableMap.of());
+        SignedMarkRevocationList.create(fakeClock.now(), ImmutableMap.of());
     SignedMarkRevocationListDao.save(secondList);
-    assertThat(SignedMarkRevocationListDao.load().isSmdRevoked("mark", fakeClock.nowUtc()))
-        .isFalse();
+    assertThat(SignedMarkRevocationListDao.load().isSmdRevoked("mark", fakeClock.now())).isFalse();
   }
-
 }

--- a/core/src/test/java/google/registry/model/smd/SignedMarkRevocationListTest.java
+++ b/core/src/test/java/google/registry/model/smd/SignedMarkRevocationListTest.java
@@ -15,7 +15,7 @@
 package google.registry.model.smd;
 
 import static com.google.common.truth.Truth.assertThat;
-import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static org.joda.time.Duration.standardDays;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationTestExtension;
 import google.registry.testing.FakeClock;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -34,22 +34,21 @@ public class SignedMarkRevocationListTest {
   final JpaIntegrationTestExtension jpa =
       new JpaTestExtensions.Builder().buildIntegrationTestExtension();
 
-  private final FakeClock clock = new FakeClock(DateTime.parse("2013-01-01T00:00:00Z"));
+  private final FakeClock clock = new FakeClock(Instant.parse("2013-01-01T00:00:00Z"));
 
   @Test
   void testEmpty() {
     // When Cloud SQL is empty, it should give us an empty thing.
     assertThat(SignedMarkRevocationList.get())
-        .isEqualTo(SignedMarkRevocationList.create(START_OF_TIME, ImmutableMap.of()));
+        .isEqualTo(SignedMarkRevocationList.create(START_INSTANT, ImmutableMap.of()));
   }
 
   private SignedMarkRevocationList createSaveGetHelper(int rows) {
-    ImmutableMap.Builder<String, DateTime> revokes = new ImmutableMap.Builder<>();
+    ImmutableMap.Builder<String, Instant> revokes = new ImmutableMap.Builder<>();
     for (int i = 0; i < rows; i++) {
-      revokes.put(Integer.toString(i), clock.nowUtc());
+      revokes.put(Integer.toString(i), clock.now());
     }
-    SignedMarkRevocationListDao.save(
-        SignedMarkRevocationList.create(clock.nowUtc(), revokes.build()));
+    SignedMarkRevocationListDao.save(SignedMarkRevocationList.create(clock.now(), revokes.build()));
     SignedMarkRevocationList res = SignedMarkRevocationList.get();
     assertThat(res.size()).isEqualTo(rows);
     return res;
@@ -60,36 +59,36 @@ public class SignedMarkRevocationListTest {
     assertThrows(
         NullPointerException.class,
         () ->
-            SignedMarkRevocationList.create(START_OF_TIME, ImmutableMap.of())
-                .isSmdRevoked(null, clock.nowUtc()));
+            SignedMarkRevocationList.create(START_INSTANT, ImmutableMap.of())
+                .isSmdRevoked(null, clock.now()));
   }
 
   @Test
   void test_isSmdRevoked_garbage() {
     SignedMarkRevocationList smdrl = createSaveGetHelper(100);
-    assertThat(smdrl.getCreationTime()).isEqualTo(clock.nowUtc());
-    assertThat(smdrl.isSmdRevoked("rofl", clock.nowUtc())).isFalse();
-    assertThat(smdrl.isSmdRevoked("31337", clock.nowUtc())).isFalse();
+    assertThat(smdrl.getCreationTime()).isEqualTo(clock.now());
+    assertThat(smdrl.isSmdRevoked("rofl", clock.now())).isFalse();
+    assertThat(smdrl.isSmdRevoked("31337", clock.now())).isFalse();
   }
 
   @Test
   void test_getCreationTime() {
-    clock.setTo(DateTime.parse("2000-01-01T00:00:00Z"));
+    clock.setTo(Instant.parse("2000-01-01T00:00:00Z"));
     createSaveGetHelper(5);
     assertThat(SignedMarkRevocationList.get().getCreationTime())
-        .isEqualTo(DateTime.parse("2000-01-01T00:00:00Z"));
+        .isEqualTo(Instant.parse("2000-01-01T00:00:00Z"));
     clock.advanceBy(standardDays(1));
     assertThat(SignedMarkRevocationList.get().getCreationTime())
-        .isEqualTo(DateTime.parse("2000-01-01T00:00:00Z"));
+        .isEqualTo(Instant.parse("2000-01-01T00:00:00Z"));
   }
 
   @Test
   void test_isSmdRevoked_present() {
     final int rows = 100;
     SignedMarkRevocationList smdrl = createSaveGetHelper(rows);
-    assertThat(smdrl.isSmdRevoked("0", clock.nowUtc())).isTrue();
-    assertThat(smdrl.isSmdRevoked(Integer.toString(rows - 1), clock.nowUtc())).isTrue();
-    assertThat(smdrl.isSmdRevoked(Integer.toString(rows), clock.nowUtc())).isFalse();
+    assertThat(smdrl.isSmdRevoked("0", clock.now())).isTrue();
+    assertThat(smdrl.isSmdRevoked(Integer.toString(rows - 1), clock.now())).isTrue();
+    assertThat(smdrl.isSmdRevoked(Integer.toString(rows), clock.now())).isFalse();
   }
 
   @Test
@@ -97,18 +96,18 @@ public class SignedMarkRevocationListTest {
     final int rows = 100;
     SignedMarkRevocationList smdrl = createSaveGetHelper(rows);
     clock.advanceOneMilli();
-    assertThat(smdrl.isSmdRevoked("0", clock.nowUtc())).isTrue();
-    assertThat(smdrl.isSmdRevoked(Integer.toString(rows - 1), clock.nowUtc())).isTrue();
-    assertThat(smdrl.isSmdRevoked(Integer.toString(rows), clock.nowUtc())).isFalse();
+    assertThat(smdrl.isSmdRevoked("0", clock.now())).isTrue();
+    assertThat(smdrl.isSmdRevoked(Integer.toString(rows - 1), clock.now())).isTrue();
+    assertThat(smdrl.isSmdRevoked(Integer.toString(rows), clock.now())).isFalse();
   }
 
   @Test
   void test_isSmdRevoked_past() {
     final int rows = 100;
     SignedMarkRevocationList smdrl = createSaveGetHelper(rows);
-    clock.setTo(clock.nowUtc().minusMillis(1));
-    assertThat(smdrl.isSmdRevoked("0", clock.nowUtc())).isFalse();
-    assertThat(smdrl.isSmdRevoked(Integer.toString(rows - 1), clock.nowUtc())).isFalse();
-    assertThat(smdrl.isSmdRevoked(Integer.toString(rows), clock.nowUtc())).isFalse();
+    clock.setTo(clock.now().minusMillis(1));
+    assertThat(smdrl.isSmdRevoked("0", clock.now())).isFalse();
+    assertThat(smdrl.isSmdRevoked(Integer.toString(rows - 1), clock.now())).isFalse();
+    assertThat(smdrl.isSmdRevoked(Integer.toString(rows), clock.now())).isFalse();
   }
 }

--- a/core/src/test/java/google/registry/model/tmch/ClaimsListDaoTest.java
+++ b/core/src/test/java/google/registry/model/tmch/ClaimsListDaoTest.java
@@ -69,8 +69,8 @@ public class ClaimsListDaoTest {
               }
             });
     ClaimsList insertedClaimsList = ClaimsListDao.get();
-    assertThat(insertedClaimsList.getTmdbGenerationTimeInstant())
-        .isEqualTo(claimsList.getTmdbGenerationTimeInstant());
+    assertThat(insertedClaimsList.getTmdbGenerationTime())
+        .isEqualTo(claimsList.getTmdbGenerationTime());
     assertThat(insertedClaimsList.getLabelsToKeys()).isEqualTo(claimsList.getLabelsToKeys());
     assertThat(insertedClaimsList.getCreationTime()).isEqualTo(fakeClock.now());
   }
@@ -140,7 +140,7 @@ public class ClaimsListDaoTest {
 
   private void assertClaimsListEquals(ClaimsList left, ClaimsList right) {
     assertThat(left.getRevisionId()).isEqualTo(right.getRevisionId());
-    assertThat(left.getTmdbGenerationTimeInstant()).isEqualTo(right.getTmdbGenerationTimeInstant());
+    assertThat(left.getTmdbGenerationTime()).isEqualTo(right.getTmdbGenerationTime());
     assertThat(left.getLabelsToKeys()).isEqualTo(right.getLabelsToKeys());
   }
 }

--- a/core/src/test/java/google/registry/pricing/PricingEngineProxyTest.java
+++ b/core/src/test/java/google/registry/pricing/PricingEngineProxyTest.java
@@ -21,7 +21,7 @@ import static google.registry.pricing.PricingEngineProxy.isDomainPremium;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistPremiumList;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static org.joda.money.CurrencyUnit.USD;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -32,8 +32,8 @@ import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationTestExtension;
 import google.registry.testing.FakeClock;
 import google.registry.util.Clock;
+import java.time.Instant;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -54,39 +54,39 @@ public class PricingEngineProxyTest {
             "premium list", USD, "rich,USD 100", "richer,USD 999", "fraction,USD 20.50");
     createTld("moka");
     persistResource(Tld.get("moka").asBuilder().setPremiumList(premiumList).build());
-    clock = new FakeClock(DateTime.parse("2016-03-17T12:01:00Z"));
+    clock = new FakeClock(Instant.parse("2016-03-17T12:01:00Z"));
   }
 
   @Test
   void test_getDomainCreateCost_multipleYears() {
-    assertThat(getDomainCreateCost("espresso.moka", clock.nowUtc(), 1))
+    assertThat(getDomainCreateCost("espresso.moka", clock.now(), 1))
         .isEqualTo(Money.parse("USD 13"));
-    assertThat(getDomainCreateCost("espresso.moka", clock.nowUtc(), 5))
+    assertThat(getDomainCreateCost("espresso.moka", clock.now(), 5))
         .isEqualTo(Money.parse("USD 65"));
-    assertThat(getDomainCreateCost("fraction.moka", clock.nowUtc(), 1))
+    assertThat(getDomainCreateCost("fraction.moka", clock.now(), 1))
         .isEqualTo(Money.parse("USD 20.50"));
-    assertThat(getDomainCreateCost("fraction.moka", clock.nowUtc(), 3))
+    assertThat(getDomainCreateCost("fraction.moka", clock.now(), 3))
         .isEqualTo(Money.parse("USD 61.50"));
   }
 
   @Test
   void test_getDomainRenewCost_multipleYears() {
-    assertThat(getDomainRenewCost("espresso.moka", clock.nowUtc(), 1))
+    assertThat(getDomainRenewCost("espresso.moka", clock.now(), 1))
         .isEqualTo(Money.parse("USD 11"));
-    assertThat(getDomainRenewCost("espresso.moka", clock.nowUtc(), 5))
+    assertThat(getDomainRenewCost("espresso.moka", clock.now(), 5))
         .isEqualTo(Money.parse("USD 55"));
-    assertThat(getDomainRenewCost("fraction.moka", clock.nowUtc(), 1))
+    assertThat(getDomainRenewCost("fraction.moka", clock.now(), 1))
         .isEqualTo(Money.parse("USD 20.50"));
-    assertThat(getDomainRenewCost("fraction.moka", clock.nowUtc(), 3))
+    assertThat(getDomainRenewCost("fraction.moka", clock.now(), 3))
         .isEqualTo(Money.parse("USD 61.50"));
   }
 
   @Test
   void testIsPremiumDomain() {
     createTld("example");
-    assertThat(isDomainPremium("poor.example", clock.nowUtc())).isFalse();
-    assertThat(isDomainPremium("rich.example", clock.nowUtc())).isTrue();
-    assertThat(isDomainPremium("richer.example", clock.nowUtc())).isTrue();
+    assertThat(isDomainPremium("poor.example", clock.now())).isFalse();
+    assertThat(isDomainPremium("rich.example", clock.now())).isTrue();
+    assertThat(isDomainPremium("richer.example", clock.now())).isTrue();
   }
 
   @Test
@@ -94,12 +94,10 @@ public class PricingEngineProxyTest {
     // The example tld has a premium price for "rich".
     createTld("example");
     // The default value of 17 is set in createTld().
-    assertThat(getDomainCreateCost("poor.example", clock.nowUtc(), 1)).isEqualTo(Money.of(USD, 13));
-    assertThat(getDomainCreateCost("poor.example", clock.nowUtc(), 2)).isEqualTo(Money.of(USD, 26));
-    assertThat(getDomainCreateCost("rich.example", clock.nowUtc(), 1))
-        .isEqualTo(Money.of(USD, 100));
-    assertThat(getDomainCreateCost("rich.example", clock.nowUtc(), 2))
-        .isEqualTo(Money.of(USD, 200));
+    assertThat(getDomainCreateCost("poor.example", clock.now(), 1)).isEqualTo(Money.of(USD, 13));
+    assertThat(getDomainCreateCost("poor.example", clock.now(), 2)).isEqualTo(Money.of(USD, 26));
+    assertThat(getDomainCreateCost("rich.example", clock.now(), 1)).isEqualTo(Money.of(USD, 100));
+    assertThat(getDomainCreateCost("rich.example", clock.now(), 2)).isEqualTo(Money.of(USD, 200));
   }
 
   @Test
@@ -109,18 +107,18 @@ public class PricingEngineProxyTest {
     persistResource(
         Tld.get("example")
             .asBuilder()
-            .setRenewBillingCostTransitions(
+            .setRenewBillingCostTransitionsInstant(
                 ImmutableSortedMap.of(
-                    START_OF_TIME, Money.of(USD, 8), clock.nowUtc(), Money.of(USD, 10)))
+                    START_INSTANT, Money.of(USD, 8), clock.now(), Money.of(USD, 10)))
             .build());
-    assertThat(getDomainRenewCost("poor.example", START_OF_TIME, 1)).isEqualTo(Money.of(USD, 8));
-    assertThat(getDomainRenewCost("poor.example", START_OF_TIME, 2)).isEqualTo(Money.of(USD, 16));
-    assertThat(getDomainRenewCost("poor.example", clock.nowUtc(), 1)).isEqualTo(Money.of(USD, 10));
-    assertThat(getDomainRenewCost("poor.example", clock.nowUtc(), 2)).isEqualTo(Money.of(USD, 20));
-    assertThat(getDomainRenewCost("rich.example", START_OF_TIME, 1)).isEqualTo(Money.of(USD, 100));
-    assertThat(getDomainRenewCost("rich.example", START_OF_TIME, 2)).isEqualTo(Money.of(USD, 200));
-    assertThat(getDomainRenewCost("rich.example", clock.nowUtc(), 1)).isEqualTo(Money.of(USD, 100));
-    assertThat(getDomainRenewCost("rich.example", clock.nowUtc(), 2)).isEqualTo(Money.of(USD, 200));
+    assertThat(getDomainRenewCost("poor.example", START_INSTANT, 1)).isEqualTo(Money.of(USD, 8));
+    assertThat(getDomainRenewCost("poor.example", START_INSTANT, 2)).isEqualTo(Money.of(USD, 16));
+    assertThat(getDomainRenewCost("poor.example", clock.now(), 1)).isEqualTo(Money.of(USD, 10));
+    assertThat(getDomainRenewCost("poor.example", clock.now(), 2)).isEqualTo(Money.of(USD, 20));
+    assertThat(getDomainRenewCost("rich.example", START_INSTANT, 1)).isEqualTo(Money.of(USD, 100));
+    assertThat(getDomainRenewCost("rich.example", START_INSTANT, 2)).isEqualTo(Money.of(USD, 200));
+    assertThat(getDomainRenewCost("rich.example", clock.now(), 1)).isEqualTo(Money.of(USD, 100));
+    assertThat(getDomainRenewCost("rich.example", clock.now(), 2)).isEqualTo(Money.of(USD, 200));
   }
 
   @Test
@@ -129,8 +127,7 @@ public class PricingEngineProxyTest {
     persistResource(Tld.get("example").asBuilder().setPremiumPricingEngine("fake").build());
     IllegalStateException thrown =
         assertThrows(
-            IllegalStateException.class,
-            () -> getDomainCreateCost("bad.example", clock.nowUtc(), 1));
+            IllegalStateException.class, () -> getDomainCreateCost("bad.example", clock.now(), 1));
     assertThat(thrown)
         .hasMessageThat()
         .contains("Could not load pricing engine fake for TLD example");

--- a/core/src/test/java/google/registry/pricing/PricingEngineProxyTest.java
+++ b/core/src/test/java/google/registry/pricing/PricingEngineProxyTest.java
@@ -33,7 +33,7 @@ import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationT
 import google.registry.testing.FakeClock;
 import google.registry.util.Clock;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -54,39 +54,39 @@ public class PricingEngineProxyTest {
             "premium list", USD, "rich,USD 100", "richer,USD 999", "fraction,USD 20.50");
     createTld("moka");
     persistResource(Tld.get("moka").asBuilder().setPremiumList(premiumList).build());
-    clock = new FakeClock(DateTime.parse("2016-03-17T12:01:00Z"));
+    clock = new FakeClock(Instant.parse("2016-03-17T12:01:00Z"));
   }
 
   @Test
   void test_getDomainCreateCost_multipleYears() {
-    assertThat(getDomainCreateCost("espresso.moka", clock.nowUtc(), 1))
+    assertThat(getDomainCreateCost("espresso.moka", clock.now(), 1))
         .isEqualTo(Money.parse("USD 13"));
-    assertThat(getDomainCreateCost("espresso.moka", clock.nowUtc(), 5))
+    assertThat(getDomainCreateCost("espresso.moka", clock.now(), 5))
         .isEqualTo(Money.parse("USD 65"));
-    assertThat(getDomainCreateCost("fraction.moka", clock.nowUtc(), 1))
+    assertThat(getDomainCreateCost("fraction.moka", clock.now(), 1))
         .isEqualTo(Money.parse("USD 20.50"));
-    assertThat(getDomainCreateCost("fraction.moka", clock.nowUtc(), 3))
+    assertThat(getDomainCreateCost("fraction.moka", clock.now(), 3))
         .isEqualTo(Money.parse("USD 61.50"));
   }
 
   @Test
   void test_getDomainRenewCost_multipleYears() {
-    assertThat(getDomainRenewCost("espresso.moka", clock.nowUtc(), 1))
+    assertThat(getDomainRenewCost("espresso.moka", clock.now(), 1))
         .isEqualTo(Money.parse("USD 11"));
-    assertThat(getDomainRenewCost("espresso.moka", clock.nowUtc(), 5))
+    assertThat(getDomainRenewCost("espresso.moka", clock.now(), 5))
         .isEqualTo(Money.parse("USD 55"));
-    assertThat(getDomainRenewCost("fraction.moka", clock.nowUtc(), 1))
+    assertThat(getDomainRenewCost("fraction.moka", clock.now(), 1))
         .isEqualTo(Money.parse("USD 20.50"));
-    assertThat(getDomainRenewCost("fraction.moka", clock.nowUtc(), 3))
+    assertThat(getDomainRenewCost("fraction.moka", clock.now(), 3))
         .isEqualTo(Money.parse("USD 61.50"));
   }
 
   @Test
   void testIsPremiumDomain() {
     createTld("example");
-    assertThat(isDomainPremium("poor.example", clock.nowUtc())).isFalse();
-    assertThat(isDomainPremium("rich.example", clock.nowUtc())).isTrue();
-    assertThat(isDomainPremium("richer.example", clock.nowUtc())).isTrue();
+    assertThat(isDomainPremium("poor.example", clock.now())).isFalse();
+    assertThat(isDomainPremium("rich.example", clock.now())).isTrue();
+    assertThat(isDomainPremium("richer.example", clock.now())).isTrue();
   }
 
   @Test
@@ -94,11 +94,11 @@ public class PricingEngineProxyTest {
     // The example tld has a premium price for "rich".
     createTld("example");
     // The default value of 17 is set in createTld().
-    assertThat(getDomainCreateCost("poor.example", clock.nowUtc(), 1)).isEqualTo(Money.of(USD, 13));
-    assertThat(getDomainCreateCost("poor.example", clock.nowUtc(), 2)).isEqualTo(Money.of(USD, 26));
-    assertThat(getDomainCreateCost("rich.example", clock.nowUtc(), 1))
+    assertThat(getDomainCreateCost("poor.example", clock.now(), 1)).isEqualTo(Money.of(USD, 13));
+    assertThat(getDomainCreateCost("poor.example", clock.now(), 2)).isEqualTo(Money.of(USD, 26));
+    assertThat(getDomainCreateCost("rich.example", clock.now(), 1))
         .isEqualTo(Money.of(USD, 100));
-    assertThat(getDomainCreateCost("rich.example", clock.nowUtc(), 2))
+    assertThat(getDomainCreateCost("rich.example", clock.now(), 2))
         .isEqualTo(Money.of(USD, 200));
   }
 
@@ -111,16 +111,16 @@ public class PricingEngineProxyTest {
             .asBuilder()
             .setRenewBillingCostTransitions(
                 ImmutableSortedMap.of(
-                    START_OF_TIME, Money.of(USD, 8), clock.nowUtc(), Money.of(USD, 10)))
+                    START_OF_TIME, Money.of(USD, 8), clock.now(), Money.of(USD, 10)))
             .build());
     assertThat(getDomainRenewCost("poor.example", START_OF_TIME, 1)).isEqualTo(Money.of(USD, 8));
     assertThat(getDomainRenewCost("poor.example", START_OF_TIME, 2)).isEqualTo(Money.of(USD, 16));
-    assertThat(getDomainRenewCost("poor.example", clock.nowUtc(), 1)).isEqualTo(Money.of(USD, 10));
-    assertThat(getDomainRenewCost("poor.example", clock.nowUtc(), 2)).isEqualTo(Money.of(USD, 20));
+    assertThat(getDomainRenewCost("poor.example", clock.now(), 1)).isEqualTo(Money.of(USD, 10));
+    assertThat(getDomainRenewCost("poor.example", clock.now(), 2)).isEqualTo(Money.of(USD, 20));
     assertThat(getDomainRenewCost("rich.example", START_OF_TIME, 1)).isEqualTo(Money.of(USD, 100));
     assertThat(getDomainRenewCost("rich.example", START_OF_TIME, 2)).isEqualTo(Money.of(USD, 200));
-    assertThat(getDomainRenewCost("rich.example", clock.nowUtc(), 1)).isEqualTo(Money.of(USD, 100));
-    assertThat(getDomainRenewCost("rich.example", clock.nowUtc(), 2)).isEqualTo(Money.of(USD, 200));
+    assertThat(getDomainRenewCost("rich.example", clock.now(), 1)).isEqualTo(Money.of(USD, 100));
+    assertThat(getDomainRenewCost("rich.example", clock.now(), 2)).isEqualTo(Money.of(USD, 200));
   }
 
   @Test
@@ -130,7 +130,7 @@ public class PricingEngineProxyTest {
     IllegalStateException thrown =
         assertThrows(
             IllegalStateException.class,
-            () -> getDomainCreateCost("bad.example", clock.nowUtc(), 1));
+            () -> getDomainCreateCost("bad.example", clock.now(), 1));
     assertThat(thrown)
         .hasMessageThat()
         .contains("Could not load pricing engine fake for TLD example");

--- a/core/src/test/java/google/registry/rdap/RdapJsonFormatterTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapJsonFormatterTest.java
@@ -151,7 +151,7 @@ class RdapJsonFormatterTest {
             makeDomain("fish.みんな", null, null, registrar)
                 .asBuilder()
                 .setCreationTimeForTest(clock.nowUtc())
-                .setLastEppUpdateTime((java.time.Instant) null)
+                .setLastEppUpdateTime((Instant) null)
                 .build());
 
     // history entries

--- a/core/src/test/java/google/registry/testing/AbstractEppResourceSubject.java
+++ b/core/src/test/java/google/registry/testing/AbstractEppResourceSubject.java
@@ -32,6 +32,7 @@ import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.testing.TruthChainer.And;
 import google.registry.testing.TruthChainer.Which;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -153,12 +154,26 @@ abstract class AbstractEppResourceSubject<
     return hasValue(deletionTime, actual.getDeletionDateTime(), "getDeletionTime()");
   }
 
+  public And<S> hasDeletionTime(Instant deletionTime) {
+    return hasValue(deletionTime, actual.getDeletionTime(), "getDeletionTime()");
+  }
+
   public And<S> hasLastEppUpdateTime(DateTime lastUpdateTime) {
     return hasValue(lastUpdateTime, actual.getLastEppUpdateDateTime(), "has lastEppUpdateTime");
   }
 
+  public And<S> hasLastEppUpdateTime(Instant lastUpdateTime) {
+    return hasValue(lastUpdateTime, actual.getLastEppUpdateTime(), "has lastEppUpdateTime");
+  }
+
   public And<S> hasLastEppUpdateTimeAtLeast(DateTime before) {
     DateTime lastEppUpdateTime = actual.getLastEppUpdateDateTime();
+    check("getLastEppUpdateTime()").that(lastEppUpdateTime).isAtLeast(before);
+    return andChainer();
+  }
+
+  public And<S> hasLastEppUpdateTimeAtLeast(Instant before) {
+    Instant lastEppUpdateTime = actual.getLastEppUpdateTime();
     check("getLastEppUpdateTime()").that(lastEppUpdateTime).isAtLeast(before);
     return andChainer();
   }
@@ -182,9 +197,23 @@ abstract class AbstractEppResourceSubject<
     return andChainer();
   }
 
+  public And<S> isActiveAt(Instant time) {
+    if (!isActive(actual, DateTime.parse(time.toString()))) {
+      failWithActual("expected to be active at", time);
+    }
+    return andChainer();
+  }
+
   public And<S> isNotActiveAt(DateTime time) {
     if (isActive(actual, time)) {
-      failWithActual("expected not to be active at", time);
+      failWithActual("expected to not be active at", time);
+    }
+    return andChainer();
+  }
+
+  public And<S> isNotActiveAt(Instant time) {
+    if (isActive(actual, DateTime.parse(time.toString()))) {
+      failWithActual("expected to not be active at", time);
     }
     return andChainer();
   }

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -38,7 +38,8 @@ import static google.registry.util.CollectionUtils.difference;
 import static google.registry.util.CollectionUtils.union;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
-import static google.registry.util.DateTimeUtils.isBeforeOrAt;
+import static google.registry.util.DateTimeUtils.toDateTime;
+import static google.registry.util.DateTimeUtils.toInstant;
 import static google.registry.util.DomainNameUtils.ACE_PREFIX_REGEX;
 import static google.registry.util.DomainNameUtils.getTldFromDomainName;
 import static google.registry.util.PreconditionsUtils.checkArgumentPresent;
@@ -102,6 +103,7 @@ import google.registry.model.tld.label.ReservedListDao;
 import google.registry.model.transfer.DomainTransferData;
 import google.registry.model.transfer.TransferStatus;
 import google.registry.persistence.VKey;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -267,6 +269,10 @@ public final class DatabaseHelper {
    * Returns a persisted domain that is the passed-in domain modified to be deleted at the specified
    * time.
    */
+  public static Domain persistDomainAsDeleted(Domain domain, Instant deletionTime) {
+    return persistResource(domain.asBuilder().setDeletionTime(deletionTime).build());
+  }
+
   public static Domain persistDomainAsDeleted(Domain domain, DateTime deletionTime) {
     return persistResource(domain.asBuilder().setDeletionTime(deletionTime).build());
   }
@@ -450,6 +456,24 @@ public final class DatabaseHelper {
       Domain domain,
       HistoryEntry historyEntry,
       String registrarId,
+      Instant requestTime,
+      Instant expirationTime,
+      @Nullable Instant extendedRegistrationExpirationTime) {
+    return createPollMessageForImplicitTransfer(
+        domain,
+        historyEntry,
+        registrarId,
+        toDateTime(requestTime),
+        toDateTime(expirationTime),
+        extendedRegistrationExpirationTime != null
+            ? toDateTime(extendedRegistrationExpirationTime)
+            : null);
+  }
+
+  public static PollMessage.OneTime createPollMessageForImplicitTransfer(
+      Domain domain,
+      HistoryEntry historyEntry,
+      String registrarId,
       DateTime requestTime,
       DateTime expirationTime,
       @Nullable DateTime extendedRegistrationExpirationTime) {
@@ -467,6 +491,12 @@ public final class DatabaseHelper {
   }
 
   public static BillingEvent createBillingEventForTransfer(
+      Domain domain, DomainHistory historyEntry, Instant costLookupTime, Instant eventTime) {
+    return createBillingEventForTransfer(
+        domain, historyEntry, toDateTime(costLookupTime), toDateTime(eventTime));
+  }
+
+  public static BillingEvent createBillingEventForTransfer(
       Domain domain, DomainHistory historyEntry, DateTime costLookupTime, DateTime eventTime) {
     return new BillingEvent.Builder()
         .setReason(Reason.TRANSFER)
@@ -475,9 +505,15 @@ public final class DatabaseHelper {
         .setBillingTime(eventTime.plus(Tld.get(domain.getTld()).getTransferGracePeriodLength()))
         .setRegistrarId("NewRegistrar")
         .setPeriodYears(1)
-        .setCost(getDomainRenewCost(domain.getDomainName(), costLookupTime, 1))
+        .setCost(getDomainRenewCost(domain.getDomainName(), toInstant(costLookupTime), 1))
         .setDomainHistory(historyEntry)
         .build();
+  }
+
+  public static Domain persistDomainWithDependentResources(
+      String label, String tld, Instant now, Instant creationTime, Instant expirationTime) {
+    return persistDomainWithDependentResources(
+        label, tld, toDateTime(now), toDateTime(creationTime), toDateTime(expirationTime));
   }
 
   public static Domain persistDomainWithDependentResources(
@@ -543,6 +579,18 @@ public final class DatabaseHelper {
             .setAutorenewBillingEvent(autorenewEvent.createVKey())
             .setAutorenewPollMessage(autorenewPollMessage.createVKey())
             .build());
+  }
+
+  public static Domain persistDomainWithPendingTransfer(
+      Domain domain,
+      Instant requestTime,
+      Instant expirationTime,
+      Instant extendedRegistrationExpirationTime) {
+    return persistDomainWithPendingTransfer(
+        domain,
+        toDateTime(requestTime),
+        toDateTime(expirationTime),
+        toDateTime(extendedRegistrationExpirationTime));
   }
 
   public static Domain persistDomainWithPendingTransfer(
@@ -801,27 +849,33 @@ public final class DatabaseHelper {
 
   public static ImmutableList<PollMessage> getPollMessages(
       String registrarId, DateTime beforeOrAt) {
+    return getPollMessages(registrarId, toInstant(beforeOrAt));
+  }
+
+  public static ImmutableList<PollMessage> getPollMessages(String registrarId, Instant beforeOrAt) {
     return tm().transact(
             () ->
                 tm().loadAllOf(PollMessage.class).stream()
                     .filter(pollMessage -> pollMessage.getRegistrarId().equals(registrarId))
-                    .filter(pollMessage -> isBeforeOrAt(pollMessage.getEventTime(), beforeOrAt))
+                    .filter(pollMessage -> !pollMessage.getEventTimeInstant().isAfter(beforeOrAt))
                     .collect(toImmutableList()));
   }
 
   /** Gets all PollMessages associated with the given EppResource. */
   public static ImmutableList<PollMessage> getPollMessages(
       EppResource resource, String registrarId, DateTime now) {
+    return getPollMessages(resource, registrarId, toInstant(now));
+  }
+
+  public static ImmutableList<PollMessage> getPollMessages(
+      EppResource resource, String registrarId, Instant now) {
     return tm().transact(
             () ->
                 tm().loadAllOf(PollMessage.class).stream()
                     .filter(
                         pollMessage -> pollMessage.getDomainRepoId().equals(resource.getRepoId()))
                     .filter(pollMessage -> pollMessage.getRegistrarId().equals(registrarId))
-                    .filter(
-                        pollMessage ->
-                            pollMessage.getEventTime().isEqual(now)
-                                || pollMessage.getEventTime().isBefore(now))
+                    .filter(pollMessage -> !pollMessage.getEventTimeInstant().isAfter(now))
                     .collect(toImmutableList()));
   }
 
@@ -830,11 +884,20 @@ public final class DatabaseHelper {
   }
 
   public static PollMessage getOnlyPollMessage(String registrarId, DateTime now) {
+    return getOnlyPollMessage(registrarId, toInstant(now));
+  }
+
+  public static PollMessage getOnlyPollMessage(String registrarId, Instant now) {
     return Iterables.getOnlyElement(getPollMessages(registrarId, now));
   }
 
   public static PollMessage getOnlyPollMessage(
       String registrarId, DateTime now, Class<? extends PollMessage> subType) {
+    return getOnlyPollMessage(registrarId, toInstant(now), subType);
+  }
+
+  public static PollMessage getOnlyPollMessage(
+      String registrarId, Instant now, Class<? extends PollMessage> subType) {
     return getPollMessages(registrarId, now).stream()
         .filter(subType::isInstance)
         .map(subType::cast)
@@ -843,6 +906,11 @@ public final class DatabaseHelper {
 
   public static PollMessage getOnlyPollMessage(
       DomainBase domain, String registrarId, DateTime now, Class<? extends PollMessage> subType) {
+    return getOnlyPollMessage(domain, registrarId, toInstant(now), subType);
+  }
+
+  public static PollMessage getOnlyPollMessage(
+      DomainBase domain, String registrarId, Instant now, Class<? extends PollMessage> subType) {
     return getPollMessages(domain, registrarId, now).stream()
         .filter(subType::isInstance)
         .map(subType::cast)

--- a/core/src/test/java/google/registry/tmch/SmdrlCsvParserTest.java
+++ b/core/src/test/java/google/registry/tmch/SmdrlCsvParserTest.java
@@ -24,7 +24,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharSource;
 import google.registry.model.smd.SignedMarkRevocationList;
 import google.registry.testing.FakeClock;
-import org.joda.time.DateTime;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link SmdrlCsvParser}. */
@@ -39,38 +40,38 @@ class SmdrlCsvParserTest {
   void testParse() throws Exception {
     SignedMarkRevocationList smdrl = SmdrlCsvParser.parse(SMDRL_LATEST_CSV.readLines());
     assertThat(smdrl.size()).isEqualTo(150);
-    assertThat(smdrl.getCreationTime()).isEqualTo(DateTime.parse("2013-11-24T23:30:04.3Z"));
+    assertThat(smdrl.getCreationTime()).isEqualTo(Instant.parse("2013-11-24T23:30:04.3Z"));
   }
 
   @Test
   void testFirstRow() throws Exception {
     SignedMarkRevocationList smdrl = SmdrlCsvParser.parse(SMDRL_LATEST_CSV.readLines());
-    clock.setTo(DateTime.parse("2013-08-09T12:00:00.0Z"));
-    assertThat(smdrl.isSmdRevoked("0000001681375789102250-65535", clock.nowUtc())).isTrue();
-    clock.setTo(clock.nowUtc().minusMillis(1));
-    assertThat(smdrl.isSmdRevoked("0000001681375789102250-65535", clock.nowUtc())).isFalse();
+    clock.setTo(Instant.parse("2013-08-09T12:00:00.0Z"));
+    assertThat(smdrl.isSmdRevoked("0000001681375789102250-65535", clock.now())).isTrue();
+    clock.setTo(clock.now().minusMillis(1));
+    assertThat(smdrl.isSmdRevoked("0000001681375789102250-65535", clock.now())).isFalse();
     clock.advanceBy(millis(2));
-    assertThat(smdrl.isSmdRevoked("0000001681375789102250-65535", clock.nowUtc())).isTrue();
+    assertThat(smdrl.isSmdRevoked("0000001681375789102250-65535", clock.now())).isTrue();
   }
 
   @Test
   void testLastRow() throws Exception {
     SignedMarkRevocationList smdrl = SmdrlCsvParser.parse(SMDRL_LATEST_CSV.readLines());
-    clock.setTo(DateTime.parse("2013-08-09T12:00:00.0Z"));
-    assertThat(smdrl.isSmdRevoked("0000002211373633641407-65535", clock.nowUtc())).isTrue();
-    clock.setTo(clock.nowUtc().minusMillis(1));
-    assertThat(smdrl.isSmdRevoked("0000002211373633641407-65535", clock.nowUtc())).isFalse();
+    clock.setTo(Instant.parse("2013-08-09T12:00:00.0Z"));
+    assertThat(smdrl.isSmdRevoked("0000002211373633641407-65535", clock.now())).isTrue();
+    clock.setTo(clock.now().minusMillis(1));
+    assertThat(smdrl.isSmdRevoked("0000002211373633641407-65535", clock.now())).isFalse();
     clock.advanceBy(millis(2));
-    assertThat(smdrl.isSmdRevoked("0000002211373633641407-65535", clock.nowUtc())).isTrue();
+    assertThat(smdrl.isSmdRevoked("0000002211373633641407-65535", clock.now())).isTrue();
   }
 
   @Test
   void testRowWithDifferentDate() throws Exception {
     SignedMarkRevocationList smdrl = SmdrlCsvParser.parse(SMDRL_LATEST_CSV.readLines());
-    clock.setTo(DateTime.parse("2013-08-09T12:00:00.0Z"));
-    assertThat(smdrl.isSmdRevoked("0000002101376042766438-65535", clock.nowUtc())).isFalse();
+    clock.setTo(Instant.parse("2013-08-09T12:00:00.0Z"));
+    assertThat(smdrl.isSmdRevoked("0000002101376042766438-65535", clock.now())).isFalse();
     clock.advanceBy(standardDays(1));
-    assertThat(smdrl.isSmdRevoked("0000002101376042766438-65535", clock.nowUtc())).isTrue();
+    assertThat(smdrl.isSmdRevoked("0000002101376042766438-65535", clock.now())).isTrue();
   }
 
   @Test
@@ -82,9 +83,9 @@ class SmdrlCsvParserTest {
                 "smd-id,insertion-datetime",
                 "0000001681375789102250-65535,2013-08-09T12:00:00.0Z"));
     assertThat(smdrl.size()).isEqualTo(1);
-    assertThat(smdrl.getCreationTime()).isEqualTo(DateTime.parse("2013-11-24T23:30:04.3Z"));
-    clock.setTo(DateTime.parse("2020-08-09T12:00:00.0Z"));
-    assertThat(smdrl.isSmdRevoked("0000001681375789102250-65535", clock.nowUtc())).isTrue();
+    assertThat(smdrl.getCreationTime()).isEqualTo(Instant.parse("2013-11-24T23:30:04.3Z"));
+    clock.setTo(Instant.parse("2020-08-09T12:00:00.0Z"));
+    assertThat(smdrl.isSmdRevoked("0000001681375789102250-65535", clock.now())).isTrue();
   }
 
   @Test
@@ -93,9 +94,9 @@ class SmdrlCsvParserTest {
         SmdrlCsvParser.parse(
             ImmutableList.of("1,2014-11-24T23:30:04.3Z", "smd-id,insertion-datetime"));
     assertThat(smdrl.size()).isEqualTo(0);
-    assertThat(smdrl.getCreationTime()).isEqualTo(DateTime.parse("2014-11-24T23:30:04.3Z"));
-    clock.setTo(DateTime.parse("2020-08-09T12:00:00.0Z"));
-    assertThat(smdrl.isSmdRevoked("0000001681375789102250-65535", clock.nowUtc())).isFalse();
+    assertThat(smdrl.getCreationTime()).isEqualTo(Instant.parse("2014-11-24T23:30:04.3Z"));
+    clock.setTo(Instant.parse("2020-08-09T12:00:00.0Z"));
+    assertThat(smdrl.isSmdRevoked("0000001681375789102250-65535", clock.now())).isFalse();
   }
 
   @Test
@@ -130,15 +131,15 @@ class SmdrlCsvParserTest {
 
   @Test
   void testFail_tooManyColumns() {
-    IllegalArgumentException thrown =
+    DateTimeParseException thrown =
         assertThrows(
-            IllegalArgumentException.class,
+            DateTimeParseException.class,
             () ->
                 SmdrlCsvParser.parse(
                     ImmutableList.of(
                         "1,2013-11-24T23:30:04.3Z",
                         "smd-id,insertion-datetime",
                         "0000001681375789102250-65535,haha,2013-08-09T12:00:00.0Z")));
-    assertThat(thrown).hasMessageThat().isEqualTo("Invalid format: \"haha\"");
+    assertThat(thrown).hasMessageThat().contains("Text 'haha' could not be parsed at index 0");
   }
 }

--- a/core/src/test/java/google/registry/tmch/TmchDnlActionTest.java
+++ b/core/src/test/java/google/registry/tmch/TmchDnlActionTest.java
@@ -25,8 +25,8 @@ import google.registry.model.tmch.ClaimsList;
 import google.registry.model.tmch.ClaimsListDao;
 import java.io.ByteArrayInputStream;
 import java.net.URL;
+import java.time.Instant;
 import java.util.Optional;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link TmchDnlAction}. */
@@ -57,7 +57,7 @@ class TmchDnlActionTest extends TmchActionTestCase {
     // Make sure the contents of testdata/dnl-latest.csv got inserted into the database.
     ClaimsList claimsList = ClaimsListDao.get();
     assertThat(claimsList.getTmdbGenerationTime())
-        .isEqualTo(DateTime.parse("2013-11-24T23:15:37.4Z"));
+        .isEqualTo(Instant.parse("2013-11-24T23:15:37.4Z"));
     assertThat(tm().transact(() -> claimsList.getClaimKey("xn----7sbejwbn3axu3d")))
         .hasValue("2013112500/7/4/8/dIHW0DiuybvhdP8kIz");
     assertThat(tm().transact(() -> claimsList.getClaimKey("lolcat"))).isEmpty();

--- a/core/src/test/java/google/registry/tmch/TmchSmdrlActionTest.java
+++ b/core/src/test/java/google/registry/tmch/TmchSmdrlActionTest.java
@@ -24,14 +24,14 @@ import static org.mockito.Mockito.when;
 import google.registry.model.smd.SignedMarkRevocationList;
 import java.io.ByteArrayInputStream;
 import java.net.URL;
+import java.time.Instant;
 import java.util.Optional;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link TmchSmdrlAction}. */
 class TmchSmdrlActionTest extends TmchActionTestCase {
 
-  private static final DateTime now = DateTime.parse("2014-01-01T00:00:00Z");
+  private static final Instant now = Instant.parse("2014-01-01T00:00:00Z");
 
   private TmchSmdrlAction newTmchSmdrlAction() {
     TmchSmdrlAction action = new TmchSmdrlAction();

--- a/core/src/test/java/google/registry/tmch/TmchTestDataExpirationTest.java
+++ b/core/src/test/java/google/registry/tmch/TmchTestDataExpirationTest.java
@@ -15,7 +15,6 @@
 package google.registry.tmch;
 
 import static google.registry.testing.TestDataHelper.loadFile;
-import static org.joda.time.DateTimeZone.UTC;
 
 import google.registry.config.RegistryConfig.ConfigModule.TmchCaMode;
 import google.registry.flows.EppException;
@@ -24,7 +23,7 @@ import google.registry.model.smd.EncodedSignedMark;
 import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationTestExtension;
 import google.registry.util.SystemClock;
-import org.joda.time.DateTime;
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -57,7 +56,7 @@ class TmchTestDataExpirationTest {
     String tmchData = loadFile(TmchTestDataExpirationTest.class, filePath);
     EncodedSignedMark smd = TmchData.readEncodedSignedMark(tmchData);
     try {
-      tmchUtils.verifyEncodedSignedMark(smd, DateTime.now(UTC));
+      tmchUtils.verifyEncodedSignedMark(smd, Instant.now());
     } catch (EppException e) {
       throw new AssertionError("Error verifying signed mark " + filePath, e);
     }

--- a/core/src/test/java/google/registry/tools/CreateRegistrarCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateRegistrarCommandTest.java
@@ -23,7 +23,7 @@ import static google.registry.testing.DatabaseHelper.newTld;
 import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_INSTANT;
-import static google.registry.util.DateTimeUtils.toDateTime;
+import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.joda.money.CurrencyUnit.JPY;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
@@ -64,11 +64,7 @@ class CreateRegistrarCommandTest extends CommandTestCase<CreateRegistrarCommand>
     command.setConnection(connection);
     command.certificateChecker =
         new CertificateChecker(
-            ImmutableSortedMap.of(
-                toDateTime(START_INSTANT),
-                825,
-                toDateTime(Instant.parse("2020-09-01T00:00:00Z")),
-                398),
+            ImmutableSortedMap.of(START_OF_TIME, 825, DateTime.parse("2020-09-01T00:00:00Z"), 398),
             30,
             15,
             2048,

--- a/core/src/test/java/google/registry/tools/GetClaimsListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetClaimsListCommandTest.java
@@ -17,7 +17,6 @@ package google.registry.tools;
 import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.readAllLines;
-import static org.joda.time.DateTimeZone.UTC;
 
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.tmch.ClaimsList;
@@ -25,7 +24,7 @@ import google.registry.model.tmch.ClaimsListDao;
 import google.registry.testing.TestCacheExtension;
 import java.io.File;
 import java.nio.file.Files;
-import org.joda.time.DateTime;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -34,11 +33,11 @@ class GetClaimsListCommandTest extends CommandTestCase<GetClaimsListCommand> {
 
   @RegisterExtension
   public final TestCacheExtension testCacheExtension =
-      new TestCacheExtension.Builder().withClaimsListCache(java.time.Duration.ofHours(6)).build();
+      new TestCacheExtension.Builder().withClaimsListCache(Duration.ofHours(6)).build();
 
   @Test
   void testSuccess_getWorks() throws Exception {
-    ClaimsListDao.save(ClaimsList.create(DateTime.now(UTC), ImmutableMap.of("a", "1", "b", "2")));
+    ClaimsListDao.save(ClaimsList.create(fakeClock.now(), ImmutableMap.of("a", "1", "b", "2")));
     File output = tmpDir.resolve("claims.txt").toFile();
     runCommand("--output=" + output.getAbsolutePath());
     assertThat(readAllLines(output.toPath(), UTF_8)).containsExactly("a,1", "b,2");
@@ -46,7 +45,7 @@ class GetClaimsListCommandTest extends CommandTestCase<GetClaimsListCommand> {
 
   @Test
   void testSuccess_endsWithNewline() throws Exception {
-    ClaimsListDao.save(ClaimsList.create(DateTime.now(UTC), ImmutableMap.of("a", "1")));
+    ClaimsListDao.save(ClaimsList.create(fakeClock.now(), ImmutableMap.of("a", "1")));
     File output = tmpDir.resolve("claims.txt").toFile();
     runCommand("--output=" + output.getAbsolutePath());
     assertThat(Files.readString(output.toPath())).endsWith("\n");

--- a/core/src/test/java/google/registry/tools/GetClaimsListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetClaimsListCommandTest.java
@@ -17,7 +17,6 @@ package google.registry.tools;
 import static com.google.common.truth.Truth.assertThat;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.readAllLines;
-import static org.joda.time.DateTimeZone.UTC;
 
 import com.google.common.collect.ImmutableMap;
 import google.registry.model.tmch.ClaimsList;
@@ -25,7 +24,6 @@ import google.registry.model.tmch.ClaimsListDao;
 import google.registry.testing.TestCacheExtension;
 import java.io.File;
 import java.nio.file.Files;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -38,7 +36,7 @@ class GetClaimsListCommandTest extends CommandTestCase<GetClaimsListCommand> {
 
   @Test
   void testSuccess_getWorks() throws Exception {
-    ClaimsListDao.save(ClaimsList.create(DateTime.now(UTC), ImmutableMap.of("a", "1", "b", "2")));
+    ClaimsListDao.save(ClaimsList.create(fakeClock.now(), ImmutableMap.of("a", "1", "b", "2")));
     File output = tmpDir.resolve("claims.txt").toFile();
     runCommand("--output=" + output.getAbsolutePath());
     assertThat(readAllLines(output.toPath(), UTF_8)).containsExactly("a,1", "b,2");
@@ -46,7 +44,7 @@ class GetClaimsListCommandTest extends CommandTestCase<GetClaimsListCommand> {
 
   @Test
   void testSuccess_endsWithNewline() throws Exception {
-    ClaimsListDao.save(ClaimsList.create(DateTime.now(UTC), ImmutableMap.of("a", "1")));
+    ClaimsListDao.save(ClaimsList.create(fakeClock.now(), ImmutableMap.of("a", "1")));
     File output = tmpDir.resolve("claims.txt").toFile();
     runCommand("--output=" + output.getAbsolutePath());
     assertThat(Files.readString(output.toPath())).endsWith("\n");

--- a/core/src/test/java/google/registry/tools/UploadClaimsListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UploadClaimsListCommandTest.java
@@ -22,7 +22,9 @@ import google.registry.model.tmch.ClaimsList;
 import google.registry.model.tmch.ClaimsListDao;
 import google.registry.testing.TestCacheExtension;
 import java.io.FileNotFoundException;
-import org.joda.time.DateTime;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -31,7 +33,7 @@ class UploadClaimsListCommandTest extends CommandTestCase<UploadClaimsListComman
 
   @RegisterExtension
   public final TestCacheExtension testCacheExtension =
-      new TestCacheExtension.Builder().withClaimsListCache(java.time.Duration.ofHours(6)).build();
+      new TestCacheExtension.Builder().withClaimsListCache(Duration.ofHours(6)).build();
 
   @Test
   void testSuccess() throws Exception {
@@ -45,7 +47,7 @@ class UploadClaimsListCommandTest extends CommandTestCase<UploadClaimsListComman
 
     ClaimsList claimsList = ClaimsListDao.get();
     assertThat(claimsList.getTmdbGenerationTime())
-        .isEqualTo(DateTime.parse("2012-08-16T00:00:00.0Z"));
+        .isEqualTo(Instant.parse("2012-08-16T00:00:00.0Z"));
     assertThat(tm().transact(() -> claimsList.getClaimKey("example")))
         .hasValue("2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001");
     assertThat(tm().transact(() -> claimsList.getClaimKey("another-example")))
@@ -84,73 +86,79 @@ class UploadClaimsListCommandTest extends CommandTestCase<UploadClaimsListComman
       "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
       "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
       "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
-    assertThrows(IllegalArgumentException.class, () -> runCommand("--force", filename));
+    assertThrows(DateTimeParseException.class, () -> runCommand("--force", filename));
   }
 
   @Test
   void testFailure_badFirstHeader() throws Exception {
-    String filename = writeToTmpFile(
-      "1,foo",
-      "SNL,lookup-key,insertion-datetime",
-      "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
-      "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
-      "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
+    String filename =
+        writeToTmpFile(
+            "1,2010-01-01T00:00:00.0Z",
+            "SNL,lookup-key,insertion-datetime",
+            "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
+            "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
+            "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
     assertThrows(IllegalArgumentException.class, () -> runCommand("--force", filename));
   }
 
   @Test
   void testFailure_badSecondHeader() throws Exception {
-    String filename = writeToTmpFile(
-      "1,foo",
-      "DNL,lookup-keys,insertion-datetime",
-      "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
-      "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
-      "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
+    String filename =
+        writeToTmpFile(
+            "1,2010-01-01T00:00:00.0Z",
+            "DNL,lookup-keys,insertion-datetime",
+            "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
+            "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
+            "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
     assertThrows(IllegalArgumentException.class, () -> runCommand("--force", filename));
   }
 
   @Test
   void testFailure_badThirdHeader() throws Exception {
-    String filename = writeToTmpFile(
-      "1,foo",
-      "DNL,lookup-key,insertion-datetimes",
-      "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
-      "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
-      "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
+    String filename =
+        writeToTmpFile(
+            "1,2010-01-01T00:00:00.0Z",
+            "DNL,lookup-key,insertion-datetimes",
+            "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
+            "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
+            "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
     assertThrows(IllegalArgumentException.class, () -> runCommand("--force", filename));
   }
 
   @Test
   void testFailure_wrongNumberOfHeaders() throws Exception {
-    String filename = writeToTmpFile(
-      "1,foo",
-      "DNL,lookup-key,insertion-datetime,extra-field",
-      "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
-      "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
-      "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
+    String filename =
+        writeToTmpFile(
+            "1,2010-01-01T00:00:00.0Z",
+            "DNL,lookup-key,insertion-datetime,extra-field",
+            "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
+            "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
+            "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
     assertThrows(IllegalArgumentException.class, () -> runCommand("--force", filename));
   }
 
   @Test
   void testFailure_wrongNumberOfFields() throws Exception {
-    String filename = writeToTmpFile(
-      "1,foo",
-      "DNL,lookup-key,insertion-datetime",
-      "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z,extra",
-      "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
-      "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
+    String filename =
+        writeToTmpFile(
+            "1,2010-01-01T00:00:00.0Z",
+            "DNL,lookup-key,insertion-datetime",
+            "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z,extra",
+            "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
+            "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
     assertThrows(IllegalArgumentException.class, () -> runCommand("--force", filename));
   }
 
   @Test
   void testFailure_badInsertionTime() throws Exception {
-    String filename = writeToTmpFile(
-      "1,foo",
-      "DNL,lookup-key,insertion-datetime",
-      "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
-      "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,foo",
-      "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
-    assertThrows(IllegalArgumentException.class, () -> runCommand("--force", filename));
+    String filename =
+        writeToTmpFile(
+            "1,2010-01-01T00:00:00.0Z",
+            "DNL,lookup-key,insertion-datetime",
+            "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
+            "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,foo",
+            "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
+    assertThrows(DateTimeParseException.class, () -> runCommand("--force", filename));
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/UploadClaimsListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UploadClaimsListCommandTest.java
@@ -22,7 +22,8 @@ import google.registry.model.tmch.ClaimsList;
 import google.registry.model.tmch.ClaimsListDao;
 import google.registry.testing.TestCacheExtension;
 import java.io.FileNotFoundException;
-import org.joda.time.DateTime;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -45,7 +46,7 @@ class UploadClaimsListCommandTest extends CommandTestCase<UploadClaimsListComman
 
     ClaimsList claimsList = ClaimsListDao.get();
     assertThat(claimsList.getTmdbGenerationTime())
-        .isEqualTo(DateTime.parse("2012-08-16T00:00:00.0Z"));
+        .isEqualTo(Instant.parse("2012-08-16T00:00:00.0Z"));
     assertThat(tm().transact(() -> claimsList.getClaimKey("example")))
         .hasValue("2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001");
     assertThat(tm().transact(() -> claimsList.getClaimKey("another-example")))
@@ -84,73 +85,79 @@ class UploadClaimsListCommandTest extends CommandTestCase<UploadClaimsListComman
       "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
       "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
       "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
-    assertThrows(IllegalArgumentException.class, () -> runCommand("--force", filename));
+    assertThrows(DateTimeParseException.class, () -> runCommand("--force", filename));
   }
 
   @Test
   void testFailure_badFirstHeader() throws Exception {
-    String filename = writeToTmpFile(
-      "1,foo",
-      "SNL,lookup-key,insertion-datetime",
-      "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
-      "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
-      "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
+    String filename =
+        writeToTmpFile(
+            "1,2010-01-01T00:00:00.0Z",
+            "SNL,lookup-key,insertion-datetime",
+            "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
+            "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
+            "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
     assertThrows(IllegalArgumentException.class, () -> runCommand("--force", filename));
   }
 
   @Test
   void testFailure_badSecondHeader() throws Exception {
-    String filename = writeToTmpFile(
-      "1,foo",
-      "DNL,lookup-keys,insertion-datetime",
-      "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
-      "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
-      "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
+    String filename =
+        writeToTmpFile(
+            "1,2010-01-01T00:00:00.0Z",
+            "DNL,lookup-keys,insertion-datetime",
+            "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
+            "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
+            "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
     assertThrows(IllegalArgumentException.class, () -> runCommand("--force", filename));
   }
 
   @Test
   void testFailure_badThirdHeader() throws Exception {
-    String filename = writeToTmpFile(
-      "1,foo",
-      "DNL,lookup-key,insertion-datetimes",
-      "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
-      "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
-      "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
+    String filename =
+        writeToTmpFile(
+            "1,2010-01-01T00:00:00.0Z",
+            "DNL,lookup-key,insertion-datetimes",
+            "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
+            "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
+            "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
     assertThrows(IllegalArgumentException.class, () -> runCommand("--force", filename));
   }
 
   @Test
   void testFailure_wrongNumberOfHeaders() throws Exception {
-    String filename = writeToTmpFile(
-      "1,foo",
-      "DNL,lookup-key,insertion-datetime,extra-field",
-      "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
-      "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
-      "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
+    String filename =
+        writeToTmpFile(
+            "1,2010-01-01T00:00:00.0Z",
+            "DNL,lookup-key,insertion-datetime,extra-field",
+            "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
+            "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
+            "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
     assertThrows(IllegalArgumentException.class, () -> runCommand("--force", filename));
   }
 
   @Test
   void testFailure_wrongNumberOfFields() throws Exception {
-    String filename = writeToTmpFile(
-      "1,foo",
-      "DNL,lookup-key,insertion-datetime",
-      "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z,extra",
-      "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
-      "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
+    String filename =
+        writeToTmpFile(
+            "1,2010-01-01T00:00:00.0Z",
+            "DNL,lookup-key,insertion-datetime",
+            "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z,extra",
+            "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,2012-08-16T00:00:00.0Z",
+            "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
     assertThrows(IllegalArgumentException.class, () -> runCommand("--force", filename));
   }
 
   @Test
   void testFailure_badInsertionTime() throws Exception {
-    String filename = writeToTmpFile(
-      "1,foo",
-      "DNL,lookup-key,insertion-datetime",
-      "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
-      "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,foo",
-      "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
-    assertThrows(IllegalArgumentException.class, () -> runCommand("--force", filename));
+    String filename =
+        writeToTmpFile(
+            "1,2010-01-01T00:00:00.0Z",
+            "DNL,lookup-key,insertion-datetime",
+            "example,2013041500/2/6/9/rJ1NrDO92vDsAzf7EQzgjX4R0000000001,2010-07-14T00:00:00.0Z",
+            "another-example,2013041500/6/A/5/alJAqG2vI2BmCv5PfUvuDkf40000000002,foo",
+            "anotherexample,2013041500/A/C/7/rHdC4wnrWRvPY6nneCVtQhFj0000000003,2011-08-16T12:00:00.0Z");
+    assertThrows(DateTimeParseException.class, () -> runCommand("--force", filename));
   }
 
   @Test

--- a/proxy/src/main/java/google/registry/proxy/ProxyServer.java
+++ b/proxy/src/main/java/google/registry/proxy/ProxyServer.java
@@ -44,6 +44,7 @@ import io.netty.util.concurrent.Future;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 import io.netty.util.internal.logging.JdkLoggerFactory;
 import jakarta.inject.Provider;
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.Queue;
@@ -314,7 +315,7 @@ public class ProxyServer implements Runnable {
     if (proxyModule.provideEnvironment() != Environment.LOCAL) {
       MetricReporter metricReporter = proxyComponent.metricReporter();
       try {
-        metricReporter.startAsync().awaitRunning(java.time.Duration.ofSeconds(10));
+        metricReporter.startAsync().awaitRunning(Duration.ofSeconds(10));
         logger.atInfo().log("Started up MetricReporter.");
       } catch (TimeoutException timeoutException) {
         logger.atSevere().withCause(timeoutException).log(
@@ -325,7 +326,7 @@ public class ProxyServer implements Runnable {
               new Thread(
                   () -> {
                     try {
-                      metricReporter.stopAsync().awaitTerminated(java.time.Duration.ofSeconds(10));
+                      metricReporter.stopAsync().awaitTerminated(Duration.ofSeconds(10));
                       logger.atInfo().log("Shut down MetricReporter.");
                     } catch (TimeoutException timeoutException) {
                       logger.atWarning().withCause(timeoutException).log(

--- a/util/src/test/java/google/registry/util/DateTimeUtilsTest.java
+++ b/util/src/test/java/google/registry/util/DateTimeUtilsTest.java
@@ -23,7 +23,9 @@ import static google.registry.util.DateTimeUtils.earliestOf;
 import static google.registry.util.DateTimeUtils.isAtOrAfter;
 import static google.registry.util.DateTimeUtils.isBeforeOrAt;
 import static google.registry.util.DateTimeUtils.latestOf;
+import static google.registry.util.DateTimeUtils.minusMonths;
 import static google.registry.util.DateTimeUtils.minusYears;
+import static google.registry.util.DateTimeUtils.plusMonths;
 import static google.registry.util.DateTimeUtils.plusYears;
 import static google.registry.util.DateTimeUtils.toDateTime;
 import static google.registry.util.DateTimeUtils.toInstant;
@@ -106,6 +108,24 @@ class DateTimeUtilsTest {
   void test_minusYears_worksWithInstants() {
     Instant startDate = Instant.parse("2012-02-29T00:00:00Z");
     assertThat(minusYears(startDate, 4)).isEqualTo(Instant.parse("2008-02-28T00:00:00Z"));
+  }
+
+  @Test
+  void test_plusMonths_worksWithInstants() {
+    Instant startDate = Instant.parse("2012-02-29T00:00:00Z");
+    assertThat(plusMonths(startDate, 4)).isEqualTo(Instant.parse("2012-06-29T00:00:00Z"));
+
+    Instant startLeapYear = Instant.parse("2012-01-31T00:00:00Z");
+    assertThat(plusMonths(startLeapYear, 1)).isEqualTo(Instant.parse("2012-02-29T00:00:00Z"));
+  }
+
+  @Test
+  void test_minusMonths_worksWithInstants() {
+    Instant startDate = Instant.parse("2012-06-29T00:00:00Z");
+    assertThat(minusMonths(startDate, 4)).isEqualTo(Instant.parse("2012-02-29T00:00:00Z"));
+
+    Instant startLeapYear = Instant.parse("2012-03-31T00:00:00Z");
+    assertThat(minusMonths(startLeapYear, 1)).isEqualTo(Instant.parse("2012-02-29T00:00:00Z"));
   }
 
   @Test


### PR DESCRIPTION
This commit completes the java.time migration for the Trademark Clearinghouse (TMCH), Signed Mark Data (SMD), and Mark models, the EPP Response & InfoData Objects, and the Fee Extension ecosystem, transitioning them from Joda-Time's DateTime to java.time.Instant.

Changes made:
1. Core Models Migration:
   - `ClaimsList`, `TmchCrl`, `SignedMark`, `Trademark`, `BaseFee` and its extensions (`FeeCreateCommandExtension`, `FeeUpdateCommandExtension`, `FeeTransferCommandExtension`, `FeeRenewCommandExtension`, `FeeCheckResponseExtension` etc.) have all been migrated to natively store, parse, and return `Instant`.
   - Deprecated `toDateTime` bridge methods (e.g. `BaseFee`'s `getValidDateRangeInstant`) have been removed.

2. Flow Integrations & Utilities:
   - `DomainFlowUtils`, `DomainPricingLogic`, and `CheckApiAction` seamlessly integrate with `java.time.Instant` for fee requests, effective dates, pricing lookups, and premium checks.
   - `java.time.Duration` is natively utilized instead of Joda-Time's `Duration`.
   - Added `plusMonths(Instant, int)` and `minusMonths(Instant, int)` to `DateTimeUtils` to safely handle monthly temporal additions on `Instant` boundaries.

3. XML Binding and Serializers:
   - Extensively applied the updated `UtcInstantAdapter` in `package-info.java` definitions under `fee*`, `smd`, `mark`, `contact`, and `eppoutput` to securely marshal and unmarshal ISO-8601 strings into `Instant` representations.

4. Parsers:
   - Both `ClaimsListParser` and `SmdrlCsvParser` now strictly validate and build objects utilizing `Instant.parse()`.

5. Testing Ecosystem:
   - Resolved `[TruthIncompatibleType]` warnings where `DateTime` comparisons against `Instant` were previously triggering ErrorProne. Added `Instant` assertions and `toDateTime` wraps across test suites including `DomainSubject` and `AbstractEppResourceSubject`.
   - Simplified fully qualified imports (`java.time.Duration`, `START_INSTANT`, `END_OF_TIME`) and replaced `FakeClock.nowUtc()` with `FakeClock.now()`.
   - Replaced `toDateTime(clock.now())` with `clock.nowUtc()` and `toDateTime(END_INSTANT)` with `END_OF_TIME` across tests.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3019)
<!-- Reviewable:end -->
