### PR TITLE
Migrate Domain, Registrar, and Token models to java.time

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -135,7 +135,7 @@ This project treats Error Prone warnings as errors.
 ### 3. Build Strategy
 - **Surgical Changes**: In large-scale migrations, focus on "leaf" nodes first (Utilities -> Models -> Flows -> Actions).
 - **PR Size**: Minimize PR size by retaining Joda-Time bridge methods for high-level "Action" and "Flow" classes unless a full migration is requested. Reverting changes to DNS and Reporting logic while updating the underlying models is a valid strategy to keep PRs reviewable.
-- **Validation**: Always run `./gradlew build -x test` before attempting to run unit tests. Unit tests will not run if there are compilation errors in any part of the `core` module. Before finalizing a PR or declaring a task done, you MUST run the entire build using `./gradlew build` and verify that it succeeds completely without errors. Do not declare success if formatting checks (e.g., `spotlessCheck` or `javaIncrementalFormatCheck`) or tests fail. If formatting fails, run `./gradlew spotlessApply` and then re-run `./gradlew build` to verify everything passes.
+- **Validation**: Always run `./gradlew build -x test` before attempting to run unit tests. Unit tests will not run if there are compilation errors in any part of the `core` module. Before finalizing a PR or declaring a task done, you MUST verify your changes. **Prefer scoped builds** (e.g., `./gradlew :core:build`) if you are only modifying backend Java code. Running the global `./gradlew build` triggers the frontend `console-webapp` build, which unnecessarily runs `npmInstallDeps` and modifies `package-lock.json`. If you must run a global build, you must revert `console-webapp/package-lock.json` afterwards. Do not declare success if formatting checks (e.g., `spotlessCheck` or `javaIncrementalFormatCheck`) or tests fail. If formatting fails, run `./gradlew spotlessApply` and then re-run your build command to verify everything passes.
 
 ## 🚫 Common Pitfalls to Avoid
 
@@ -164,3 +164,4 @@ This protocol defines the standard for interacting with GitHub repositories and 
 ## 3. PR Lifecycle Management
 - **One Commit Per PR:** Ensure all changes are squashed into a single, clean commit. Use `git commit --amend --no-edit` for follow-up fixes.
 - **Clean Workspace:** Always run `git status` and verify the repository state before declaring a task complete.
+- **Package Lock:** The Gradle build automatically modifies `console-webapp/package-lock.json` via the `npmInstallDeps` task. ALWAYS revert this file (`git checkout console-webapp/package-lock.json`) before staging changes or finalizing a commit unless you explicitly modified NPM dependencies.

--- a/common/src/main/java/google/registry/util/DateTimeUtils.java
+++ b/common/src/main/java/google/registry/util/DateTimeUtils.java
@@ -170,7 +170,7 @@ public abstract class DateTimeUtils {
    * Adds years to a date, in the {@code Duration} sense of semantic years. Use this instead of
    * {@link java.time.ZonedDateTime#plusYears} to ensure that we never end up on February 29.
    */
-  public static Instant plusYears(Instant now, long years) {
+  public static Instant plusYears(Instant now, int years) {
     checkArgument(years >= 0);
     return (years == 0)
         ? now

--- a/config/presubmits.py
+++ b/config/presubmits.py
@@ -104,7 +104,7 @@ PRESUBMITS = {
 
     # System.(out|err).println should only appear in tools/ or load-testing/
     PresubmitCheck(
-        r".*\bSystem\.(out|err)\.print", "java", {
+        r".*\bSystem\s*\.\s*(?:out|err)\s*\.\s*print.*", "java", {
             "/tools/", "/example/", "/load-testing/",
             "RegistryTestServerMain.java", "TestServerExtension.java"
         }):
@@ -139,7 +139,7 @@ PRESUBMITS = {
     ):
         "All soy templates must use strict autoescaping",
     PresubmitCheck(
-        r".*\nimport (static )?.*\.shaded\..*",
+        r".*\nimport\s+(?:static\s+)?.*\.shaded\..*",
         "java",
         {"/node_modules/"},
     ):
@@ -163,7 +163,7 @@ PRESUBMITS = {
     ):
         "Use status code from jakarta.servlet.http.HttpServletResponse.",
     PresubmitCheck(
-        r".*mock\(Response\.class\).*",
+        r".*mock\(\s*Response\.class\s*\).*",
         "java",
         {"/node_modules/"},
     ):
@@ -181,13 +181,122 @@ PRESUBMITS = {
     ):
         "Do not use javax.inject.* Use jakarta.inject.* instead.",
     PresubmitCheck(
-        r".*import jakarta.persistence.(Pre|Post)(Persist|Load|Remove|Update);",
+        r".*import\s+jakarta\.persistence\.(?:Pre|Post)(?:Persist|Load|Remove|Update)\s*;",
         "java",
         {"EntityCallbacksListener.java"},
     ):
         "Hibernate lifecycle events aren't called for embedded entities, so it's "
         "usually best to avoid them. Instead, use the annotations defined in "
-        "EntityCallbacksListener.java"
+        "EntityCallbacksListener.java",
+    PresubmitCheck(
+        r".*\.isEqualTo\(\s*Optional\.of\(.*",
+        "java",
+        {},
+    ):
+        "Do not use .isEqualTo(Optional.of(...)). Use Truth's .hasValue(...) instead.",
+    # TODO: Remove the java.time migration presubmit checks below once the entire codebase has been migrated to java.time.
+    PresubmitCheck(
+        r".*toDateTime\(\s*toInstant\(.*",
+        "java",
+        {"DateTimeUtilsTest.java"},
+    ):
+        "Do not double-wrap toDateTime(toInstant(...)).",
+    PresubmitCheck(
+        r".*toInstant\(\s*toDateTime\(.*",
+        "java",
+        {"DateTimeUtilsTest.java"},
+    ):
+        "Do not double-wrap toInstant(toDateTime(...)).",
+    PresubmitCheck(
+        r".*toInstant\([^;]*[cC]lock\.nowUtc\(\).*",
+        "java",
+        {},
+    ):
+        "Do not use toInstant(clock.nowUtc()). Use clock.now() instead.",
+    PresubmitCheck(
+        r".*toDateTime\([^;]*[cC]lock\.now\(\).*",
+        "java",
+        {},
+    ):
+        "Do not use toDateTime(clock.now()). Use clock.nowUtc() instead.",
+    PresubmitCheck(
+        r".*toInstant\([^;]*tm\(\)\.getTransactionTime\(\).*",
+        "java",
+        {},
+    ):
+        "Do not use toInstant(tm().getTransactionTime()). Use tm().getTxTime() instead.",
+    PresubmitCheck(
+        r".*toDateTime\([^;]*tm\(\)\.getTxTime\(\).*",
+        "java",
+        {},
+    ):
+        "Do not use toDateTime(tm().getTxTime()). Use tm().getTransactionTime() instead.",
+    PresubmitCheck(
+        r".*\(\s*Instant\s*\)\s*(?:this\.)?(?:fakeClock|clock)\.now\(\s*\).*",
+        "java",
+        {},
+    ):
+        "Do not unnecessarily cast clock.now() to Instant.",
+    PresubmitCheck(
+        r".*toDateTime\(\s*Instant\.now\(.*",
+        "java",
+        {},
+    ):
+        "Do not wrap Instant.now() in toDateTime. Use DateTime.now(UTC) directly.",
+    PresubmitCheck(
+        r".*toInstant\(\s*DateTime\.now\(.*",
+        "java",
+        {},
+    ):
+        "Do not wrap DateTime.now() in toInstant. Use Instant.now().truncatedTo(ChronoUnit.MILLIS) directly.",
+    PresubmitCheck(
+        r".*toDateTime\(\s*Instant\.parse\(.*",
+        "java",
+        {"DateTimeUtilsTest.java"},
+    ):
+        "Do not wrap Instant.parse in toDateTime. Use DateTime.parse directly.",
+    PresubmitCheck(
+        r".*toInstant\(\s*DateTime\.parse\(.*",
+        "java",
+        {"DateTimeUtilsTest.java"},
+    ):
+        "Do not wrap DateTime.parse in toInstant. Use Instant.parse directly.",
+    PresubmitCheck(
+        r".*cloneProjectedAtTime\(\s*toDateTime\(.*",
+        "java",
+        {},
+    ):
+        "Do not use cloneProjectedAtTime(toDateTime(...)). Use cloneProjectedAtInstant(...) instead.",
+    PresubmitCheck(
+        r".*ZoneId\.of\(\s*\"UTC\"\s*\).*",
+        "java",
+        {},
+    ):
+        "Do not use ZoneId.of(\"UTC\"). Use java.time.ZoneOffset.UTC.",
+    PresubmitCheck(
+        r".*toDateTime\(\s*END_INSTANT\s*\).*",
+        "java",
+        {"DateTimeUtilsTest.java"},
+    ):
+        "Do not wrap END_INSTANT in toDateTime. Use END_OF_TIME.",
+    PresubmitCheck(
+        r".*toInstant\(\s*END_OF_TIME\s*\).*",
+        "java",
+        {"DateTimeUtilsTest.java"},
+    ):
+        "Do not wrap END_OF_TIME in toInstant. Use END_INSTANT.",
+    PresubmitCheck(
+        r".*toDateTime\(\s*START_INSTANT\s*\).*",
+        "java",
+        {"DateTimeUtilsTest.java"},
+    ):
+        "Do not wrap START_INSTANT in toDateTime. Use START_OF_TIME.",
+    PresubmitCheck(
+        r".*toInstant\(\s*START_OF_TIME\s*\).*",
+        "java",
+        {"DateTimeUtilsTest.java"},
+    ):
+        "Do not wrap START_OF_TIME in toInstant. Use START_INSTANT."
 }
 
 # Note that this regex only works for one kind of Flyway file.  If we want to

--- a/core/src/main/java/google/registry/batch/CheckBulkComplianceAction.java
+++ b/core/src/main/java/google/registry/batch/CheckBulkComplianceAction.java
@@ -32,8 +32,8 @@ import google.registry.request.auth.Auth;
 import google.registry.ui.server.SendEmailUtils;
 import google.registry.util.Clock;
 import jakarta.inject.Inject;
+import java.time.Duration;
 import java.util.Optional;
-import org.joda.time.Days;
 
 /**
  * An action that checks all {@link BulkPricingPackage} objects for compliance with their max create
@@ -111,8 +111,7 @@ public class CheckBulkComplianceAction implements Runnable {
                       + " 'DOMAIN_CREATE'",
                   Long.class)
               .setParameter("token", bulkPricingPackage.getToken())
-              .setParameter(
-                  "lastBilling", minusYears(bulkPricingPackage.getNextBillingDateInstant(), 1))
+              .setParameter("lastBilling", minusYears(bulkPricingPackage.getNextBillingDate(), 1))
               .getSingleResult();
       if (creates > bulkPricingPackage.getMaxCreates()) {
         long overage = creates - bulkPricingPackage.getMaxCreates();
@@ -186,7 +185,7 @@ public class CheckBulkComplianceAction implements Runnable {
       int daysSinceLastNotification =
           bulkPricingPackage
               .getLastNotificationSent()
-              .map(sentDate -> Days.daysBetween(sentDate, clock.nowUtc()).getDays())
+              .map(sentDate -> (int) Duration.between(sentDate, clock.now()).toDays())
               .orElse(Integer.MAX_VALUE);
       // Send a warning email if 30-39 days since last notification and an upgrade email if 40+ days
       if (daysSinceLastNotification >= THIRTY_DAYS) {
@@ -222,7 +221,7 @@ public class CheckBulkComplianceAction implements Runnable {
               bulkPricingPackage.getMaxDomains(),
               activeDomains);
       sendNotification(bulkToken, emailSubject, body, registrar.get());
-      tm().put(bulkPricingPackage.asBuilder().setLastNotificationSent(clock.nowUtc()).build());
+      tm().put(bulkPricingPackage.asBuilder().setLastNotificationSent(clock.now()).build());
     } else {
       throw new IllegalStateException(
           String.format("Could not find registrar for bulk token %s", bulkToken));

--- a/core/src/main/java/google/registry/batch/DeleteExpiredDomainsAction.java
+++ b/core/src/main/java/google/registry/batch/DeleteExpiredDomainsAction.java
@@ -172,7 +172,7 @@ public class DeleteExpiredDomainsAction implements Runnable {
                 () -> {
                   Domain transDomain = tm().loadByKey(domain.createVKey());
                   if (domain.getAutorenewEndTime().isEmpty()
-                      || domain.getAutorenewEndTime().get().isAfter(tm().getTransactionTime())) {
+                      || domain.getAutorenewEndTime().get().isAfter(tm().getTxTime())) {
                     logger.atSevere().log(
                         "Failed to delete domain %s because of its autorenew end time: %s.",
                         transDomain.getDomainName(), transDomain.getAutorenewEndTime());

--- a/core/src/main/java/google/registry/batch/RelockDomainAction.java
+++ b/core/src/main/java/google/registry/batch/RelockDomainAction.java
@@ -134,7 +134,7 @@ public class RelockDomainAction implements Runnable {
                           String.format("Unknown revision ID %d", oldUnlockRevisionId)));
       domain =
           tm().loadByKey(VKey.create(Domain.class, oldLock.getRepoId()))
-              .cloneProjectedAtTime(tm().getTransactionTime());
+              .cloneProjectedAtTime(tm().getTxTime());
     } catch (Throwable t) {
       handleTransientFailure(Optional.ofNullable(oldLock), t);
       return;

--- a/core/src/main/java/google/registry/batch/ResaveEntityAction.java
+++ b/core/src/main/java/google/registry/batch/ResaveEntityAction.java
@@ -83,7 +83,7 @@ public class ResaveEntityAction implements Runnable {
                     resourceKey);
                 return;
               }
-              tm().put(entity.get().cloneProjectedAtTime(tm().getTransactionTime()));
+              tm().put(entity.get().cloneProjectedAtTime(tm().getTxTime()));
               if (!resaveTimes.isEmpty()) {
                 asyncTaskEnqueuer.enqueueAsyncResave(
                     VKey.createEppVKeyFromString(resourceKey), requestedTime, resaveTimes);

--- a/core/src/main/java/google/registry/batch/SendExpiringCertificateNotificationEmailAction.java
+++ b/core/src/main/java/google/registry/batch/SendExpiringCertificateNotificationEmailAction.java
@@ -16,6 +16,8 @@ package google.registry.batch;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.util.DateTimeUtils.toDateTime;
+import static google.registry.util.DateTimeUtils.toInstant;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 import static org.apache.http.HttpStatus.SC_INTERNAL_SERVER_ERROR;
 import static org.apache.http.HttpStatus.SC_OK;
@@ -128,11 +130,11 @@ public class SendExpiringCertificateNotificationEmailAction implements Runnable 
                     registrar,
                     registrar.getClientCertificate().isPresent()
                         && certificateChecker.shouldReceiveExpiringNotification(
-                            registrar.getLastExpiringCertNotificationSentDate(),
+                            toDateTime(registrar.getLastExpiringCertNotificationSentDate()),
                             registrar.getClientCertificate().get()),
                     registrar.getFailoverClientCertificate().isPresent()
                         && certificateChecker.shouldReceiveExpiringNotification(
-                            registrar.getLastExpiringFailoverCertNotificationSentDate(),
+                            toDateTime(registrar.getLastExpiringFailoverCertNotificationSentDate()),
                             registrar.getFailoverClientCertificate().get())))
         .filter(
             registrarInfo ->
@@ -210,7 +212,7 @@ public class SendExpiringCertificateNotificationEmailAction implements Runnable 
                 Registrar.Builder newRegistrar = tm().loadByEntity(registrar).asBuilder();
                 switch (certificateType) {
                   case PRIMARY -> {
-                    newRegistrar.setLastExpiringCertNotificationSentDate(now);
+                    newRegistrar.setLastExpiringCertNotificationSentDate(toInstant(now));
                     tm().put(newRegistrar.build());
                     logger.atInfo().log(
                         "Updated last notification email sent date to %s for %s certificate of "
@@ -220,7 +222,7 @@ public class SendExpiringCertificateNotificationEmailAction implements Runnable 
                         registrar.getRegistrarName());
                   }
                   case FAILOVER -> {
-                    newRegistrar.setLastExpiringFailoverCertNotificationSentDate(now);
+                    newRegistrar.setLastExpiringFailoverCertNotificationSentDate(toInstant(now));
                     tm().put(newRegistrar.build());
                     logger.atInfo().log(
                         "Updated last notification email sent date to %s for %s certificate of "
@@ -255,7 +257,7 @@ public class SendExpiringCertificateNotificationEmailAction implements Runnable 
       if (registrarInfo.isCertExpiring()
           && sendNotificationEmail(
               registrar,
-              registrar.getLastExpiringCertNotificationSentDate(),
+              toDateTime(registrar.getLastExpiringCertNotificationSentDate()),
               CertificateType.PRIMARY,
               registrar.getClientCertificate())) {
         numEmailsSent++;
@@ -263,7 +265,7 @@ public class SendExpiringCertificateNotificationEmailAction implements Runnable 
       if (registrarInfo.isFailOverCertExpiring()
           && sendNotificationEmail(
               registrar,
-              registrar.getLastExpiringFailoverCertNotificationSentDate(),
+              toDateTime(registrar.getLastExpiringFailoverCertNotificationSentDate()),
               CertificateType.FAILOVER,
               registrar.getFailoverClientCertificate())) {
         numEmailsSent++;

--- a/core/src/main/java/google/registry/beam/rde/RdePipeline.java
+++ b/core/src/main/java/google/registry/beam/rde/RdePipeline.java
@@ -365,7 +365,7 @@ public class RdePipeline implements Serializable {
                 tm().loadByKey(
                         VKey.create(historyEntryClazz, new HistoryEntryId(repoId, revisionId))))
         .getResourceAtPointInTime()
-        .map(resource -> resource.cloneProjectedAtTime(watermark))
+        .map(resource -> resource.cloneProjectedAtTime(toInstant(watermark)))
         .get();
   }
 

--- a/core/src/main/java/google/registry/beam/resave/ResaveAllEppResourcesPipeline.java
+++ b/core/src/main/java/google/registry/beam/resave/ResaveAllEppResourcesPipeline.java
@@ -17,6 +17,7 @@ package google.registry.beam.resave;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.END_INSTANT;
+import static google.registry.util.DateTimeUtils.toInstant;
 import static org.apache.beam.sdk.values.TypeDescriptors.integers;
 
 import com.google.common.collect.ImmutableList;
@@ -164,7 +165,7 @@ public class ResaveAllEppResourcesPipeline implements Serializable {
                         .collect(toImmutableList());
                 ImmutableList<EppResource> mappedResources =
                     tm().loadByKeys(keys).values().stream()
-                        .map(r -> r.cloneProjectedAtTime(now))
+                        .map(r -> r.cloneProjectedAtTime(toInstant(now)))
                         .collect(toImmutableList());
                 tm().putAll(mappedResources);
               });

--- a/core/src/main/java/google/registry/cache/MultilayerDomainCache.java
+++ b/core/src/main/java/google/registry/cache/MultilayerDomainCache.java
@@ -52,7 +52,7 @@ public class MultilayerDomainCache extends MultilayerEppResourceCache<Domain>
     Instant now = clock.now();
     return possibleDomain
         .filter(domain -> now.isBefore(domain.getDeletionTime()))
-        .map(domain -> domain.cloneProjectedAtInstant(now));
+        .map(domain -> domain.cloneProjectedAtTime(now));
   }
 
   @Override

--- a/core/src/main/java/google/registry/export/sheet/SyncRegistrarsSheet.java
+++ b/core/src/main/java/google/registry/export/sheet/SyncRegistrarsSheet.java
@@ -25,7 +25,7 @@ import static google.registry.model.registrar.RegistrarPoc.Type.MARKETING;
 import static google.registry.model.registrar.RegistrarPoc.Type.TECH;
 import static google.registry.model.registrar.RegistrarPoc.Type.WHOIS;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
@@ -40,6 +40,7 @@ import google.registry.util.Clock;
 import google.registry.util.DateTimeUtils;
 import jakarta.inject.Inject;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
@@ -63,7 +64,7 @@ class SyncRegistrarsSheet {
   boolean wereRegistrarsModified() {
     Optional<Cursor> cursor =
         tm().transact(() -> tm().loadByKeyIfPresent(Cursor.createGlobalVKey(SYNC_REGISTRAR_SHEET)));
-    DateTime lastUpdateTime = cursor.isEmpty() ? START_OF_TIME : cursor.get().getCursorTime();
+    Instant lastUpdateTime = cursor.isEmpty() ? START_INSTANT : cursor.get().getCursorTimeInstant();
     for (Registrar registrar : Registrar.loadAllCached()) {
       if (DateTimeUtils.isAtOrAfter(registrar.getLastUpdateTime(), lastUpdateTime)) {
         return true;

--- a/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainCreateFlow.java
@@ -373,7 +373,7 @@ public final class DomainCreateFlow implements MutatingFlow {
             .setPersistedCurrentSponsorRegistrarId(registrarId)
             .setRepoId(repoId)
             .setIdnTableName(validateDomainNameWithIdnTables(domainName))
-            .setRegistrationExpirationTime(registrationExpirationTime)
+            .setRegistrationExpirationTime(toInstant(registrationExpirationTime))
             .setAutorenewBillingEvent(autorenewBillingEvent.createVKey())
             .setAutorenewPollMessage(autorenewPollMessage.createVKey())
             .setLaunchNotice(hasClaimsNotice ? launchCreate.get().getNotice() : null)

--- a/core/src/main/java/google/registry/flows/domain/DomainDeleteFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainDeleteFlow.java
@@ -238,7 +238,7 @@ public final class DomainDeleteFlow implements MutatingFlow, SqlStatementLogging
     }
 
     // Cancel any grace periods that were still active, and set the expiration time accordingly.
-    DateTime newExpirationTime = existingDomain.getRegistrationExpirationDateTime();
+    DateTime newExpirationTime = toDateTime(existingDomain.getRegistrationExpirationTime());
     for (GracePeriod gracePeriod : existingDomain.getGracePeriods()) {
       // No cancellation is written if the grace period was not for a billable event.
       if (gracePeriod.hasBillingEvent()) {
@@ -257,7 +257,7 @@ public final class DomainDeleteFlow implements MutatingFlow, SqlStatementLogging
         }
       }
     }
-    builder.setRegistrationExpirationTime(newExpirationTime);
+    builder.setRegistrationExpirationTime(toInstant(newExpirationTime));
 
     Domain newDomain = builder.build();
     DomainHistory domainHistory =

--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -489,7 +489,7 @@ public class DomainFlowUtils {
   static <T extends CreateOrUpdate<T>> T cloneAndLinkReferences(T command, DateTime now)
       throws EppException {
     try {
-      return command.cloneAndLinkReferences(now);
+      return command.cloneAndLinkReferences(toInstant(now));
     } catch (InvalidReferencesException e) {
       throw new LinkedResourcesDoNotExistException(e.getType(), e.getForeignKeys());
     }
@@ -980,11 +980,11 @@ public class DomainFlowUtils {
     }
     // Superuser can force domain creations regardless of the current date.
     if (!isSuperuser) {
-      if (notice.getExpirationTime().isBefore(now)) {
+      if (notice.getExpirationTime().isBefore(toInstant(now))) {
         throw new ExpiredClaimException();
       }
       // An acceptance within the past 48 hours is mandated by the TMCH Functional Spec.
-      if (notice.getAcceptedTime().isBefore(now.minusHours(48))) {
+      if (notice.getAcceptedTime().isBefore(toInstant(now.minusHours(48)))) {
         throw new AcceptedTooLongAgoException();
       }
     }

--- a/core/src/main/java/google/registry/flows/domain/DomainInfoFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainInfoFlow.java
@@ -124,7 +124,7 @@ public final class DomainInfoFlow implements MutatingFlow {
             .setCreationTime(domain.getCreationTime())
             .setLastEppUpdateTime(domain.getLastEppUpdateTime())
             .setRegistrationExpirationTime(domain.getRegistrationExpirationTime())
-            .setLastTransferTime(domain.getLastTransferTimeInstant());
+            .setLastTransferTime(domain.getLastTransferTime());
 
     // If authInfo is non-null, then the caller is authorized to see the full information since we
     // will have already verified the authInfo is valid.

--- a/core/src/main/java/google/registry/flows/domain/DomainRenewFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRenewFlow.java
@@ -35,6 +35,7 @@ import static google.registry.flows.domain.token.AllocationTokenFlowUtils.verify
 import static google.registry.model.reporting.HistoryEntry.Type.DOMAIN_RENEW;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.plusYears;
+import static google.registry.util.DateTimeUtils.toDateTime;
 import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.google.common.collect.ImmutableList;
@@ -192,7 +193,7 @@ public final class DomainRenewFlow implements MutatingFlow {
     existingDomain = maybeApplyBulkPricingRemovalToken(existingDomain, allocationToken);
 
     DateTime newExpirationTime =
-        plusYears(existingDomain.getRegistrationExpirationDateTime(), years); // Uncapped
+        toDateTime(plusYears(existingDomain.getRegistrationExpirationTime(), years)); // Uncapped
     validateRegistrationPeriod(now, newExpirationTime);
     Optional<FeeRenewCommandExtension> feeRenew =
         eppInput.getSingleExtension(FeeRenewCommandExtension.class);
@@ -240,7 +241,7 @@ public final class DomainRenewFlow implements MutatingFlow {
             .asBuilder()
             .setLastEppUpdateTime(toInstant(now))
             .setLastEppUpdateRegistrarId(registrarId)
-            .setRegistrationExpirationTime(newExpirationTime)
+            .setRegistrationExpirationTime(toInstant(newExpirationTime))
             .setAutorenewBillingEvent(newAutorenewEvent.createVKey())
             .setAutorenewPollMessage(newAutorenewPollMessage.createVKey())
             .addGracePeriod(
@@ -277,7 +278,7 @@ public final class DomainRenewFlow implements MutatingFlow {
         flowCustomLogic.beforeResponse(
             BeforeResponseParameters.newBuilder()
                 .setDomain(newDomain)
-                .setResData(DomainRenewData.create(targetId, newExpirationTime))
+                .setResData(DomainRenewData.create(targetId, toInstant(newExpirationTime)))
                 .setResponseExtensions(createResponseExtensions(feesAndCredits, feeRenew))
                 .build());
     persistEntityChanges(entityChanges);
@@ -331,7 +332,7 @@ public final class DomainRenewFlow implements MutatingFlow {
     // If the date they specify doesn't match the expiration, fail. (This is an idempotence check).
     if (!command
         .getCurrentExpirationDate()
-        .equals(existingDomain.getRegistrationExpirationDateTime().toLocalDate())) {
+        .equals(toDateTime(existingDomain.getRegistrationExpirationTime()).toLocalDate())) {
       throw new IncorrectCurrentExpirationDateException();
     }
   }

--- a/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainRestoreRequestFlow.java
@@ -31,6 +31,8 @@ import static google.registry.flows.domain.DomainFlowUtils.verifyRegistrarIsActi
 import static google.registry.model.reporting.HistoryEntry.Type.DOMAIN_RESTORE;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.END_INSTANT;
+import static google.registry.util.DateTimeUtils.plusYears;
+import static google.registry.util.DateTimeUtils.toDateTime;
 import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.google.common.collect.ImmutableList;
@@ -139,7 +141,7 @@ public final class DomainRestoreRequestFlow implements MutatingFlow {
     Update command = (Update) resourceCommand;
     DateTime now = tm().getTransactionTime();
     Domain existingDomain = loadAndVerifyExistence(Domain.class, targetId, now);
-    boolean isExpired = existingDomain.getRegistrationExpirationDateTime().isBefore(now);
+    boolean isExpired = existingDomain.getRegistrationExpirationTime().isBefore(toInstant(now));
     FeesAndCredits feesAndCredits =
         pricingLogic.getRestorePrice(
             Tld.get(existingDomain.getTld()), targetId, toInstant(now), isExpired);
@@ -151,7 +153,7 @@ public final class DomainRestoreRequestFlow implements MutatingFlow {
     ImmutableSet.Builder<ImmutableObject> entitiesToInsert = new ImmutableSet.Builder<>();
 
     DateTime newExpirationTime =
-        existingDomain.getRegistrationExpirationDateTime().plusYears(isExpired ? 1 : 0);
+        toDateTime(plusYears(existingDomain.getRegistrationExpirationTime(), isExpired ? 1 : 0));
     // Restore the expiration time on the deleted domain, except if that's already passed, then add
     // a year and bill for it immediately, with no grace period.
     if (isExpired) {
@@ -246,7 +248,7 @@ public final class DomainRestoreRequestFlow implements MutatingFlow {
       String registrarId) {
     return existingDomain
         .asBuilder()
-        .setRegistrationExpirationTime(newExpirationTime)
+        .setRegistrationExpirationTime(toInstant(newExpirationTime))
         .setDeletionTime(END_INSTANT)
         .setStatusValues(null)
         .setGracePeriods(null)

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferApproveFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferApproveFlow.java
@@ -240,7 +240,7 @@ public final class DomainTransferApproveFlow implements MutatingFlow {
                     .asBuilder()
                     .setTransferredRegistrationExpirationTime(toInstant(newExpirationTime))
                     .build())
-            .setRegistrationExpirationTime(newExpirationTime)
+            .setRegistrationExpirationTime(toInstant(newExpirationTime))
             .setAutorenewBillingEvent(autorenewEvent.createVKey())
             .setAutorenewPollMessage(gainingClientAutorenewPollMessage.createVKey())
             // Remove all the old grace periods and add a new one for the transfer.
@@ -278,7 +278,7 @@ public final class DomainTransferApproveFlow implements MutatingFlow {
             createTransferResponse(
                 targetId,
                 newDomain.getTransferData(),
-                newDomain.getRegistrationExpirationDateTime()))
+                toDateTime(newDomain.getRegistrationExpirationTime())))
         .build();
   }
 

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferRequestFlow.java
@@ -232,7 +232,8 @@ public final class DomainTransferRequestFlow implements MutatingFlow {
     //
     // See b/19430703#comment17 and https://www.icann.org/news/advisory-2002-06-06-en for the
     // policy documentation for transfers subsuming autorenews within the autorenew grace period.
-    Domain domainAtTransferTime = existingDomain.cloneProjectedAtTime(automaticTransferTime);
+    Domain domainAtTransferTime =
+        existingDomain.cloneProjectedAtTime(toInstant(automaticTransferTime));
     // The new expiration time if there is a server approval.
     DateTime serverApproveNewExpirationTime =
         toDateTime(

--- a/core/src/main/java/google/registry/flows/domain/DomainTransferUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainTransferUtils.java
@@ -289,7 +289,8 @@ public final class DomainTransferUtils {
       String targetId,
       Domain existingDomain,
       Optional<Money> transferCost) {
-    Domain domainAtTransferTime = existingDomain.cloneProjectedAtTime(automaticTransferTime);
+    Domain domainAtTransferTime =
+        existingDomain.cloneProjectedAtTime(toInstant(automaticTransferTime));
     GracePeriod autorenewGracePeriod =
         getOnlyElement(
             domainAtTransferTime.getGracePeriodsOfType(GracePeriodStatus.AUTO_RENEW), null);

--- a/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainUpdateFlow.java
@@ -282,7 +282,7 @@ public final class DomainUpdateFlow implements MutatingFlow {
       if (superuserExt.get().getAutorenews().isPresent()) {
         boolean autorenews = superuserExt.get().getAutorenews().get();
         domainBuilder.setAutorenewEndTime(
-            Optional.ofNullable(autorenews ? null : domain.getRegistrationExpirationDateTime()));
+            Optional.ofNullable(autorenews ? null : domain.getRegistrationExpirationTime()));
       }
     }
     return domainBuilder.build();

--- a/core/src/main/java/google/registry/flows/host/HostDeleteFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostDeleteFlow.java
@@ -94,7 +94,7 @@ public final class HostDeleteFlow implements MutatingFlow {
       // the client id, needs to be read off of it.
       EppResource owningResource =
           existingHost.isSubordinate()
-              ? tm().loadByKey(existingHost.getSuperordinateDomain()).cloneProjectedAtInstant(now)
+              ? tm().loadByKey(existingHost.getSuperordinateDomain()).cloneProjectedAtTime(now)
               : existingHost;
       verifyResourceOwnership(registrarId, owningResource);
     }

--- a/core/src/main/java/google/registry/flows/host/HostInfoFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostInfoFlow.java
@@ -77,7 +77,7 @@ public final class HostInfoFlow implements TransactionalFlow {
     // there is no superordinate domain, the host's own values for these fields will be correct.
     if (host.isSubordinate()) {
       Domain superordinateDomain =
-          tm().loadByKey(host.getSuperordinateDomain()).cloneProjectedAtInstant(now);
+          tm().loadByKey(host.getSuperordinateDomain()).cloneProjectedAtTime(now);
       hostInfoDataBuilder
           .setCurrentSponsorRegistrarId(superordinateDomain.getCurrentSponsorRegistrarId())
           .setLastTransferTime(host.computeLastTransferTime(superordinateDomain));

--- a/core/src/main/java/google/registry/flows/host/HostUpdateFlow.java
+++ b/core/src/main/java/google/registry/flows/host/HostUpdateFlow.java
@@ -145,7 +145,7 @@ public final class HostUpdateFlow implements MutatingFlow {
     String newHostName = firstNonNull(suppliedNewHostName, oldHostName);
     Domain oldSuperordinateDomain =
         existingHost.isSubordinate()
-            ? tm().loadByKey(existingHost.getSuperordinateDomain()).cloneProjectedAtInstant(now)
+            ? tm().loadByKey(existingHost.getSuperordinateDomain()).cloneProjectedAtTime(now)
             : null;
     // Note that lookupSuperordinateDomain calls cloneProjectedAtTime on the domain for us.
     Optional<Domain> newSuperordinateDomain =

--- a/core/src/main/java/google/registry/flows/poll/PollFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/poll/PollFlowUtils.java
@@ -63,7 +63,7 @@ public final class PollFlowUtils {
       // If the next event falls within the bounds of the end time, then just update the eventTime
       // and re-save it for future autorenew poll messages to be delivered. Otherwise, this
       // autorenew poll message has no more events to deliver and should be deleted.
-      if (nextEventTime.isBefore(autorenewPollMessage.getAutorenewEndTimeInstant())) {
+      if (nextEventTime.isBefore(autorenewPollMessage.getAutorenewEndTime())) {
         tm().put(autorenewPollMessage.asBuilder().setEventTime(nextEventTime).build());
       } else {
         tm().delete(autorenewPollMessage.createVKey());

--- a/core/src/main/java/google/registry/model/EppResource.java
+++ b/core/src/main/java/google/registry/model/EppResource.java
@@ -49,7 +49,6 @@ import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import org.joda.time.DateTime;
 
 /** An EPP entity object (i.e. a domain, contact, or host). */
 @MappedSuperclass
@@ -191,11 +190,7 @@ public abstract class EppResource extends UpdateAutoTimestampEntity implements B
   }
 
   /** Return a clone of the resource with timed status values modified using the given time. */
-  @Deprecated
-  public abstract EppResource cloneProjectedAtTime(DateTime now);
-
-  /** Return a clone of the resource with timed status values modified using the given time. */
-  public abstract EppResource cloneProjectedAtInstant(Instant now);
+  public abstract EppResource cloneProjectedAtTime(Instant now);
 
   /** Get the foreign key string for this resource. */
   public abstract String getForeignKey();

--- a/core/src/main/java/google/registry/model/EppResourceUtils.java
+++ b/core/src/main/java/google/registry/model/EppResourceUtils.java
@@ -20,7 +20,6 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static google.registry.util.DateTimeUtils.isAtOrAfter;
 import static google.registry.util.DateTimeUtils.isBeforeOrAt;
-import static google.registry.util.DateTimeUtils.toDateTime;
 import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.google.common.collect.ImmutableSet;
@@ -69,7 +68,7 @@ public final class EppResourceUtils {
   /** Helper to call {@link EppResource#cloneProjectedAtTime} without warnings. */
   @SuppressWarnings("unchecked")
   private static <T extends EppResource> T cloneProjectedAtTime(T resource, DateTime now) {
-    return (T) resource.cloneProjectedAtTime(now);
+    return (T) resource.cloneProjectedAtTime(toInstant(now));
   }
 
   /**
@@ -121,7 +120,7 @@ public final class EppResourceUtils {
     builder
         .removeStatusValue(StatusValue.PENDING_TRANSFER)
         .setTransferData(transferDataBuilder.build())
-        .setLastTransferTime(toDateTime(transferData.getPendingTransferExpirationTime()))
+        .setLastTransferTime(transferData.getPendingTransferExpirationTime())
         .setPersistedCurrentSponsorRegistrarId(transferData.getGainingRegistrarId());
   }
 
@@ -171,7 +170,7 @@ public final class EppResourceUtils {
     return (loadedResource == null)
         ? null
         : (isActive(loadedResource, timestamp)
-            ? (T) loadedResource.cloneProjectedAtInstant(timestamp)
+            ? (T) loadedResource.cloneProjectedAtTime(timestamp)
             : null);
   }
 

--- a/core/src/main/java/google/registry/model/ForeignKeyUtils.java
+++ b/core/src/main/java/google/registry/model/ForeignKeyUtils.java
@@ -185,7 +185,7 @@ public final class ForeignKeyUtils {
       Class<E> clazz, Collection<String> foreignKeys, Instant now) {
     return loadMostRecentResourceObjects(clazz, foreignKeys, false).entrySet().stream()
         .filter(e -> now.isBefore(e.getValue().getDeletionTime()))
-        .collect(toImmutableMap(Entry::getKey, e -> (E) e.getValue().cloneProjectedAtInstant(now)));
+        .collect(toImmutableMap(Entry::getKey, e -> (E) e.getValue().cloneProjectedAtTime(now)));
   }
 
   /**
@@ -543,6 +543,6 @@ public final class ForeignKeyUtils {
         foreignKeyToResourceCache
             .get(VKey.create(clazz, foreignKey))
             .filter(e -> now.isBefore(e.getDeletionTime()))
-            .map(e -> e.cloneProjectedAtInstant(now));
+            .map(e -> e.cloneProjectedAtTime(now));
   }
 }

--- a/core/src/main/java/google/registry/model/OteAccountBuilder.java
+++ b/core/src/main/java/google/registry/model/OteAccountBuilder.java
@@ -22,6 +22,7 @@ import static google.registry.model.tld.Tld.TldState.GENERAL_AVAILABILITY;
 import static google.registry.model.tld.Tld.TldState.START_DATE_SUNRISE;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -233,7 +234,7 @@ public final class OteAccountBuilder {
 
   /** Sets the client certificate to all the OT&amp;E Registrars. */
   public OteAccountBuilder setCertificate(String asciiCert, DateTime now) {
-    return transformRegistrars(builder -> builder.setClientCertificate(asciiCert, now));
+    return transformRegistrars(builder -> builder.setClientCertificate(asciiCert, toInstant(now)));
   }
 
   /** Sets the IP allowlist to all the OT&amp;E Registrars. */

--- a/core/src/main/java/google/registry/model/ResourceTransferUtils.java
+++ b/core/src/main/java/google/registry/model/ResourceTransferUtils.java
@@ -16,7 +16,6 @@ package google.registry.model;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.util.DateTimeUtils.toDateTime;
 import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.google.common.collect.ImmutableList;
@@ -161,7 +160,7 @@ public final class ResourceTransferUtils {
     checkArgument(transferStatus.isApproved(), "Not an approval transfer status");
     Domain.Builder builder = resolvePendingTransfer(domain, transferStatus, now);
     return builder
-        .setLastTransferTime(toDateTime(now))
+        .setLastTransferTime(now)
         .setPersistedCurrentSponsorRegistrarId(domain.getTransferData().getGainingRegistrarId())
         .build();
   }

--- a/core/src/main/java/google/registry/model/common/TimeOfYear.java
+++ b/core/src/main/java/google/registry/model/common/TimeOfYear.java
@@ -22,7 +22,6 @@ import static google.registry.util.DateTimeUtils.isAtOrAfter;
 import static google.registry.util.DateTimeUtils.isBeforeOrAt;
 import static google.registry.util.DateTimeUtils.minusYears;
 import static google.registry.util.DateTimeUtils.plusYears;
-import static java.time.ZoneOffset.UTC;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ContiguousSet;
@@ -33,6 +32,7 @@ import jakarta.persistence.Embeddable;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
 
@@ -63,7 +63,7 @@ public class TimeOfYear extends ImmutableObject implements UnsafeSerializable {
    * February 28. It is impossible to construct a {@link TimeOfYear} for February 29th.
    */
   public static TimeOfYear fromInstant(Instant instant) {
-    ZonedDateTime zdt = ZonedDateTime.ofInstant(instant, UTC);
+    ZonedDateTime zdt = ZonedDateTime.ofInstant(instant, ZoneOffset.UTC);
     int month = zdt.getMonthValue();
     int day = zdt.getDayOfMonth();
     if (month == 2 && day == 29) {
@@ -88,8 +88,8 @@ public class TimeOfYear extends ImmutableObject implements UnsafeSerializable {
     Range<Instant> normalizedRange = range.intersection(Range.closed(START_INSTANT, END_INSTANT));
     Range<Integer> yearRange =
         Range.closed(
-            ZonedDateTime.ofInstant(normalizedRange.lowerEndpoint(), UTC).getYear(),
-            ZonedDateTime.ofInstant(normalizedRange.upperEndpoint(), UTC).getYear());
+            ZonedDateTime.ofInstant(normalizedRange.lowerEndpoint(), ZoneOffset.UTC).getYear(),
+            ZonedDateTime.ofInstant(normalizedRange.upperEndpoint(), ZoneOffset.UTC).getYear());
     return ContiguousSet.create(yearRange, integers()).stream()
         .map(this::toInstantWithYear)
         .filter(normalizedRange)
@@ -107,18 +107,20 @@ public class TimeOfYear extends ImmutableObject implements UnsafeSerializable {
     int millis = Integer.parseInt(monthDayMillis.get(2));
     return LocalDate.of(year, month, day)
         .atTime(LocalTime.ofNanoOfDay(millis * 1000000L))
-        .toInstant(UTC);
+        .toInstant(ZoneOffset.UTC);
   }
 
   /** Get the first {@link Instant} with this month/day/millis that is at or after the start. */
   public Instant getNextInstanceAtOrAfter(Instant start) {
-    Instant withSameYear = toInstantWithYear(ZonedDateTime.ofInstant(start, UTC).getYear());
+    Instant withSameYear =
+        toInstantWithYear(ZonedDateTime.ofInstant(start, ZoneOffset.UTC).getYear());
     return isAtOrAfter(withSameYear, start) ? withSameYear : plusYears(withSameYear, 1);
   }
 
   /** Get the first {@link Instant} with this month/day/millis that is at or before the end. */
   public Instant getLastInstanceBeforeOrAt(Instant end) {
-    Instant withSameYear = toInstantWithYear(ZonedDateTime.ofInstant(end, UTC).getYear());
+    Instant withSameYear =
+        toInstantWithYear(ZonedDateTime.ofInstant(end, ZoneOffset.UTC).getYear());
     return isBeforeOrAt(withSameYear, end) ? withSameYear : minusYears(withSameYear, 1);
   }
 

--- a/core/src/main/java/google/registry/model/domain/Domain.java
+++ b/core/src/main/java/google/registry/model/domain/Domain.java
@@ -14,7 +14,6 @@
 
 package google.registry.model.domain;
 
-import static google.registry.util.DateTimeUtils.toInstant;
 
 import google.registry.model.EppResource;
 import google.registry.model.EppResource.ForeignKeyedEppResource;
@@ -42,7 +41,6 @@ import jakarta.persistence.Table;
 import java.time.Instant;
 import java.util.Set;
 import org.hibernate.Hibernate;
-import org.joda.time.DateTime;
 
 /**
  * A persistable domain resource including mutable and non-mutable fields.
@@ -155,12 +153,7 @@ public class Domain extends DomainBase implements ForeignKeyedEppResource {
   }
 
   @Override
-  public Domain cloneProjectedAtTime(final DateTime now) {
-    return cloneDomainProjectedAtTime(this, toInstant(now));
-  }
-
-  @Override
-  public Domain cloneProjectedAtInstant(final Instant now) {
+  public Domain cloneProjectedAtTime(Instant now) {
     return cloneDomainProjectedAtTime(this, now);
   }
 

--- a/core/src/main/java/google/registry/model/domain/DomainBase.java
+++ b/core/src/main/java/google/registry/model/domain/DomainBase.java
@@ -32,8 +32,6 @@ import static google.registry.util.DateTimeUtils.END_INSTANT;
 import static google.registry.util.DateTimeUtils.earliestOf;
 import static google.registry.util.DateTimeUtils.isBeforeOrAt;
 import static google.registry.util.DateTimeUtils.plusYears;
-import static google.registry.util.DateTimeUtils.toDateTime;
-import static google.registry.util.DateTimeUtils.toInstant;
 import static google.registry.util.DomainNameUtils.canonicalizeHostname;
 import static google.registry.util.DomainNameUtils.getTldFromDomainName;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
@@ -90,7 +88,6 @@ import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.hibernate.collection.spi.PersistentSet;
-import org.joda.time.DateTime;
 
 /**
  * A persistable domain resource including mutable and non-mutable fields.
@@ -290,15 +287,6 @@ public class DomainBase extends EppResource {
     return nullToEmptyImmutableCopy(subordinateHosts);
   }
 
-  /**
-   * @deprecated Use {@link #getRegistrationExpirationTime()}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public DateTime getRegistrationExpirationDateTime() {
-    return toDateTime(registrationExpirationTime);
-  }
-
   public Instant getRegistrationExpirationTime() {
     return registrationExpirationTime;
   }
@@ -333,17 +321,8 @@ public class DomainBase extends EppResource {
    * <p>Note that {@link DateTimeUtils#END_INSTANT} is used as a sentinel value in the database
    * representation to signify that autorenew doesn't end, and is mapped to empty here for the
    * purposes of more legible business logic.
-   *
-   * @deprecated Use {@link #getAutorenewEndTimeInstant()}
    */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public Optional<DateTime> getAutorenewEndTime() {
-    return getAutorenewEndTimeInstant().map(DateTimeUtils::toDateTime);
-  }
-
-  /** Returns the autorenew end time if there is one, otherwise empty. */
-  public Optional<Instant> getAutorenewEndTimeInstant() {
+  public Optional<Instant> getAutorenewEndTime() {
     return Optional.ofNullable(autorenewEndTime.equals(END_INSTANT) ? null : autorenewEndTime);
   }
 
@@ -351,16 +330,7 @@ public class DomainBase extends EppResource {
     return Optional.ofNullable(transferData).orElse(DomainTransferData.EMPTY);
   }
 
-  /**
-   * @deprecated Use {@link #getLastTransferTimeInstant()}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public DateTime getLastTransferTime() {
-    return toDateTime(lastTransferTime);
-  }
-
-  public Instant getLastTransferTimeInstant() {
+  public Instant getLastTransferTime() {
     return lastTransferTime;
   }
 
@@ -467,12 +437,7 @@ public class DomainBase extends EppResource {
   }
 
   @Override
-  public DomainBase cloneProjectedAtTime(final DateTime now) {
-    return cloneDomainProjectedAtTime(this, toInstant(now));
-  }
-
-  @Override
-  public DomainBase cloneProjectedAtInstant(final Instant now) {
+  public DomainBase cloneProjectedAtTime(Instant now) {
     return cloneDomainProjectedAtTime(this, now);
   }
 
@@ -515,7 +480,7 @@ public class DomainBase extends EppResource {
       Builder builder =
           domainAtTransferTime
               .asBuilder()
-              .setRegistrationExpirationTime(toDateTime(expirationDate))
+              .setRegistrationExpirationTime(expirationDate)
               // Set the speculatively-written new autorenew events as the domain's autorenew
               // events.
               .setAutorenewBillingEvent(transferData.getServerApproveAutorenewEvent())
@@ -544,7 +509,7 @@ public class DomainBase extends EppResource {
           .setLastEppUpdateTime(transferExpirationTime)
           .setLastEppUpdateRegistrarId(transferData.getGainingRegistrarId());
       // Finish projecting to now.
-      return (T) builder.build().cloneProjectedAtInstant(now);
+      return (T) builder.build().cloneProjectedAtTime(now);
     }
 
     Optional<Instant> newLastEppUpdateTime = Optional.empty();
@@ -558,11 +523,12 @@ public class DomainBase extends EppResource {
       Instant lastAutorenewTime =
           plusYears(
               domain.getRegistrationExpirationTime(),
-              ChronoUnit.YEARS.between(
-                  domain.getRegistrationExpirationTime().atZone(UTC), now.atZone(UTC)));
+              (int)
+                  ChronoUnit.YEARS.between(
+                      domain.getRegistrationExpirationTime().atZone(UTC), now.atZone(UTC)));
       Instant newExpirationTime = plusYears(lastAutorenewTime, 1);
       builder
-          .setRegistrationExpirationTime(toDateTime(newExpirationTime))
+          .setRegistrationExpirationTime(newExpirationTime)
           .addGracePeriod(
               GracePeriod.createForRecurrence(
                   GracePeriodStatus.AUTO_RENEW,
@@ -770,15 +736,6 @@ public class DomainBase extends EppResource {
       return thisCastToDerived();
     }
 
-    /**
-     * @deprecated Use {@link #setRegistrationExpirationTime(Instant)}
-     */
-    @Deprecated
-    @SuppressWarnings("InlineMeSuggester")
-    public B setRegistrationExpirationTime(DateTime registrationExpirationTime) {
-      return setRegistrationExpirationTime(toInstant(registrationExpirationTime));
-    }
-
     public B setDeletePollMessage(VKey<OneTime> deletePollMessage) {
       getInstance().deletePollMessage = deletePollMessage;
       return thisCastToDerived();
@@ -830,16 +787,7 @@ public class DomainBase extends EppResource {
      * representation to signify that autorenew doesn't end, and is mapped to empty here for the
      * purposes of more legible business logic.
      */
-    /**
-     * @deprecated Use {@link #setAutorenewEndTimeInstant(Optional)}
-     */
-    @Deprecated
-    @SuppressWarnings("InlineMeSuggester")
-    public B setAutorenewEndTime(Optional<DateTime> autorenewEndTime) {
-      return setAutorenewEndTimeInstant(autorenewEndTime.map(DateTimeUtils::toInstant));
-    }
-
-    public B setAutorenewEndTimeInstant(Optional<Instant> autorenewEndTime) {
+    public B setAutorenewEndTime(Optional<Instant> autorenewEndTime) {
       getInstance().autorenewEndTime = autorenewEndTime.orElse(END_INSTANT);
       return thisCastToDerived();
     }
@@ -852,15 +800,6 @@ public class DomainBase extends EppResource {
     public B setLastTransferTime(Instant lastTransferTime) {
       getInstance().lastTransferTime = lastTransferTime;
       return thisCastToDerived();
-    }
-
-    /**
-     * @deprecated Use {@link #setLastTransferTime(Instant)}
-     */
-    @Deprecated
-    @SuppressWarnings("InlineMeSuggester")
-    public B setLastTransferTime(DateTime lastTransferTime) {
-      return setLastTransferTime(toInstant(lastTransferTime));
     }
 
     public B setCurrentBulkToken(@Nullable VKey<AllocationToken> currentBulkToken) {
@@ -902,7 +841,7 @@ public class DomainBase extends EppResource {
           .setLastEppUpdateTime(domainBase.getLastEppUpdateTime())
           .setNameservers(domainBase.getNameservers())
           .setPersistedCurrentSponsorRegistrarId(domainBase.getPersistedCurrentSponsorRegistrarId())
-          .setRegistrationExpirationTime(domainBase.getRegistrationExpirationDateTime())
+          .setRegistrationExpirationTime(domainBase.getRegistrationExpirationTime())
           .setRepoId(domainBase.getRepoId())
           .setSmdId(domainBase.getSmdId())
           .setSubordinateHosts(domainBase.getSubordinateHosts())

--- a/core/src/main/java/google/registry/model/domain/DomainCommand.java
+++ b/core/src/main/java/google/registry/model/domain/DomainCommand.java
@@ -45,10 +45,10 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlValue;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 
 /** A collection of {@link Domain} commands. */
@@ -64,7 +64,7 @@ public class DomainCommand {
    */
   public interface CreateOrUpdate<T extends CreateOrUpdate<T>> extends SingleResourceCommand {
     /** Creates a copy of this command with hard links to hosts and contacts. */
-    T cloneAndLinkReferences(DateTime now)
+    T cloneAndLinkReferences(Instant now)
         throws InvalidReferencesException, ParameterValuePolicyErrorException;
   }
 
@@ -154,7 +154,7 @@ public class DomainCommand {
 
     /** Creates a copy of this {@link Create} with hard links to hosts and contacts. */
     @Override
-    public Create cloneAndLinkReferences(DateTime now)
+    public Create cloneAndLinkReferences(Instant now)
         throws InvalidReferencesException, ParameterValuePolicyErrorException {
       Create clone = clone(this);
       clone.nameservers = linkHosts(clone.nameserverHostNames, now);
@@ -333,7 +333,7 @@ public class DomainCommand {
       }
 
       /** Creates a copy of this {@link AddRemove} with hard links to hosts and contacts. */
-      private AddRemove cloneAndLinkReferences(DateTime now)
+      private AddRemove cloneAndLinkReferences(Instant now)
           throws InvalidReferencesException, ContactsProhibitedException {
         AddRemove clone = clone(this);
         clone.nameservers = linkHosts(clone.nameserverHostNames, now);
@@ -363,7 +363,7 @@ public class DomainCommand {
      * of those classes, which is harmless because the getters do that anyways.
      */
     @Override
-    public Update cloneAndLinkReferences(DateTime now)
+    public Update cloneAndLinkReferences(Instant now)
         throws InvalidReferencesException, ParameterValuePolicyErrorException {
       Update clone = clone(this);
       clone.innerAdd = clone.getInnerAdd().cloneAndLinkReferences(now);
@@ -373,7 +373,7 @@ public class DomainCommand {
     }
   }
 
-  private static Set<VKey<Host>> linkHosts(Set<String> hostNames, DateTime now)
+  private static Set<VKey<Host>> linkHosts(Set<String> hostNames, Instant now)
       throws InvalidReferencesException {
     if (hostNames == null) {
       return null;
@@ -383,7 +383,7 @@ public class DomainCommand {
 
   /** Loads host keys to cached EPP resources by their foreign keys. */
   private static ImmutableMap<String, VKey<Host>> loadByForeignKeysCached(
-      final Set<String> foreignKeys, final DateTime now) throws InvalidReferencesException {
+      Set<String> foreignKeys, Instant now) throws InvalidReferencesException {
     ImmutableMap<String, VKey<Host>> fks =
         ForeignKeyUtils.loadKeysByCacheIfEnabled(Host.class, foreignKeys, now);
     if (!fks.keySet().equals(foreignKeys)) {

--- a/core/src/main/java/google/registry/model/domain/DomainRenewData.java
+++ b/core/src/main/java/google/registry/model/domain/DomainRenewData.java
@@ -14,8 +14,6 @@
 
 package google.registry.model.domain;
 
-import static google.registry.util.DateTimeUtils.toDateTime;
-import static google.registry.util.DateTimeUtils.toInstant;
 
 import google.registry.model.eppoutput.EppResponse.ResponseData;
 import google.registry.xml.UtcInstantAdapter;
@@ -24,7 +22,6 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.time.Instant;
-import org.joda.time.DateTime;
 
 /** The {@link ResponseData} returned when renewing a domain. */
 @XmlRootElement(name = "renData")
@@ -44,26 +41,9 @@ public class DomainRenewData implements ResponseData {
     return instance;
   }
 
-  /**
-   * @deprecated Use {@link #create(String, Instant)}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public static DomainRenewData create(String name, DateTime expirationDate) {
-    return create(name, toInstant(expirationDate));
-  }
-
   /** Returns the expiration date. */
   public Instant getExpirationDate() {
     return expirationDate;
   }
 
-  /**
-   * @deprecated Use {@link #getExpirationDate()}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public DateTime getExpirationDateTime() {
-    return toDateTime(expirationDate);
-  }
 }

--- a/core/src/main/java/google/registry/model/domain/launch/LaunchNotice.java
+++ b/core/src/main/java/google/registry/model/domain/launch/LaunchNotice.java
@@ -17,8 +17,6 @@ package google.registry.model.domain.launch;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.hash.Hashing.crc32;
 import static com.google.common.io.BaseEncoding.base16;
-import static google.registry.util.DateTimeUtils.toDateTime;
-import static google.registry.util.DateTimeUtils.toInstant;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.base.Ascii;
@@ -34,7 +32,6 @@ import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlValue;
 import java.time.Instant;
 import java.util.Optional;
-import org.joda.time.DateTime;
 
 /** The claims notice id from the claims phase. */
 @XmlType(propOrder = {"noticeId", "expirationTime", "acceptedTime"})
@@ -82,29 +79,11 @@ public class LaunchNotice extends ImmutableObject implements UnsafeSerializable 
     return Optional.ofNullable(noticeId).orElse(EMPTY_NOTICE_ID);
   }
 
-  /**
-   * @deprecated Use {@link #getExpirationTimeInstant()}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public DateTime getExpirationTime() {
-    return toDateTime(expirationTime);
-  }
-
-  public Instant getExpirationTimeInstant() {
+  public Instant getExpirationTime() {
     return expirationTime;
   }
 
-  /**
-   * @deprecated Use {@link #getAcceptedTimeInstant()}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public DateTime getAcceptedTime() {
-    return toDateTime(acceptedTime);
-  }
-
-  public Instant getAcceptedTimeInstant() {
+  public Instant getAcceptedTime() {
     return acceptedTime;
   }
 
@@ -123,7 +102,7 @@ public class LaunchNotice extends ImmutableObject implements UnsafeSerializable 
     checkArgument(CharMatcher.inRange('0', '9').matchesAllOf(noticeId));
 
     // The checksum in the first 8 chars must match the crc32 of label + expiration + notice id.
-    String stringToHash = domainLabel + getExpirationTimeInstant().getEpochSecond() + noticeId;
+    String stringToHash = domainLabel + getExpirationTime().getEpochSecond() + noticeId;
     int computedChecksum = crc32().hashString(stringToHash, UTF_8).asInt();
     if (checksum != computedChecksum) {
       throw new InvalidChecksumException();
@@ -144,13 +123,4 @@ public class LaunchNotice extends ImmutableObject implements UnsafeSerializable 
     return instance;
   }
 
-  /**
-   * @deprecated Use {@link #create(String, String, Instant, Instant)}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public static LaunchNotice create(
-      String tcnId, String validatorId, DateTime expirationTime, DateTime acceptedTime) {
-    return create(tcnId, validatorId, toInstant(expirationTime), toInstant(acceptedTime));
   }
-}

--- a/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
+++ b/core/src/main/java/google/registry/model/domain/token/AllocationToken.java
@@ -26,8 +26,6 @@ import static google.registry.model.domain.token.AllocationToken.TokenType.REGIS
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.CollectionUtils.forceEmptyToNull;
 import static google.registry.util.CollectionUtils.nullToEmptyImmutableCopy;
-import static google.registry.util.DateTimeUtils.toDateTime;
-import static google.registry.util.DateTimeUtils.toInstant;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -40,7 +38,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Ordering;
 import com.google.common.collect.Range;
 import google.registry.flows.EppException;
 import google.registry.flows.domain.DomainFlowUtils;
@@ -71,7 +68,6 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.hibernate.annotations.Type;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 
 /** An entity representing an allocation token. */
 @Entity
@@ -339,23 +335,11 @@ public class AllocationToken extends UpdateAutoTimestampEntity implements Builda
     return tokenType;
   }
 
-  /**
-   * @deprecated Use {@link #getCreationTime()}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  @JsonIgnore
-  public Optional<DateTime> getCreationDateTime() {
-    return Optional.ofNullable(toDateTime(creationTime.getTimestamp()));
-  }
+
 
   @JsonIgnore
   public TimedTransitionProperty<TokenStatus> getTokenStatusTransitions() {
     return tokenStatusTransitions;
-  }
-
-  public ImmutableSortedMap<DateTime, TokenStatus> getTokenStatusTransitionsMap() {
-    return tokenStatusTransitions.toValueMap();
   }
 
   @JsonIgnore
@@ -538,11 +522,6 @@ public class AllocationToken extends UpdateAutoTimestampEntity implements Builda
     }
 
     @VisibleForTesting
-    public Builder setCreationTimeForTest(DateTime creationTime) {
-      return setCreationTimeForTest(toInstant(creationTime));
-    }
-
-    @VisibleForTesting
     public Builder setCreationTimeForTest(Instant creationTime) {
       checkState(
           getInstance().creationTime.getTimestamp() == null, "Creation time can only be set once");
@@ -587,17 +566,7 @@ public class AllocationToken extends UpdateAutoTimestampEntity implements Builda
       return this;
     }
 
-    public Builder setTokenStatusTransitions(
-        ImmutableSortedMap<DateTime, TokenStatus> transitions) {
-      return setTokenStatusTransitionsInstant(
-          transitions.entrySet().stream()
-              .collect(
-                  ImmutableSortedMap.toImmutableSortedMap(
-                      Ordering.natural(), e -> toInstant(e.getKey()), Map.Entry::getValue)));
-    }
-
-    public Builder setTokenStatusTransitionsInstant(
-        ImmutableSortedMap<Instant, TokenStatus> transitions) {
+    public Builder setTokenStatusTransitions(ImmutableSortedMap<Instant, TokenStatus> transitions) {
       getInstance().tokenStatusTransitions =
           TimedTransitionProperty.makeInstant(
               transitions,

--- a/core/src/main/java/google/registry/model/domain/token/BulkPricingPackage.java
+++ b/core/src/main/java/google/registry/model/domain/token/BulkPricingPackage.java
@@ -17,8 +17,6 @@ package google.registry.model.domain.token;
 import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.DateTimeUtils.END_INSTANT;
-import static google.registry.util.DateTimeUtils.toDateTime;
-import static google.registry.util.DateTimeUtils.toInstant;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
 import google.registry.model.Buildable;
@@ -38,7 +36,6 @@ import java.time.Instant;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 
 /**
  * An entity representing a bulk pricing promotion. Note that this table is still called
@@ -107,29 +104,11 @@ public class BulkPricingPackage extends ImmutableObject implements Buildable {
     return bulkPrice;
   }
 
-  /**
-   * @deprecated Use {@link #getNextBillingDateInstant()}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public DateTime getNextBillingDate() {
-    return toDateTime(nextBillingDate);
-  }
-
-  public Instant getNextBillingDateInstant() {
+  public Instant getNextBillingDate() {
     return nextBillingDate;
   }
 
-  /**
-   * @deprecated Use {@link #getLastNotificationSentInstant()}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public Optional<DateTime> getLastNotificationSent() {
-    return Optional.ofNullable(toDateTime(lastNotificationSent));
-  }
-
-  public Optional<Instant> getLastNotificationSentInstant() {
+  public Optional<Instant> getLastNotificationSent() {
     return Optional.ofNullable(lastNotificationSent);
   }
 
@@ -197,28 +176,10 @@ public class BulkPricingPackage extends ImmutableObject implements Buildable {
       return this;
     }
 
-    /**
-     * @deprecated Use {@link #setNextBillingDate(Instant)}
-     */
-    @Deprecated
-    @SuppressWarnings("InlineMeSuggester")
-    public Builder setNextBillingDate(DateTime nextBillingDate) {
-      return setNextBillingDate(toInstant(nextBillingDate));
-    }
-
     public Builder setNextBillingDate(Instant nextBillingDate) {
       checkArgumentNotNull(nextBillingDate, "Next billing date must not be null");
       getInstance().nextBillingDate = nextBillingDate;
       return this;
-    }
-
-    /**
-     * @deprecated Use {@link #setLastNotificationSent(Instant)}
-     */
-    @Deprecated
-    @SuppressWarnings("InlineMeSuggester")
-    public Builder setLastNotificationSent(@Nullable DateTime lastNotificationSent) {
-      return setLastNotificationSent(toInstant(lastNotificationSent));
     }
 
     public Builder setLastNotificationSent(@Nullable Instant lastNotificationSent) {

--- a/core/src/main/java/google/registry/model/host/HostBase.java
+++ b/core/src/main/java/google/registry/model/host/HostBase.java
@@ -27,7 +27,6 @@ import google.registry.model.domain.Domain;
 import google.registry.model.domain.VKeyConverter_Domain;
 import google.registry.persistence.VKey;
 import google.registry.persistence.converter.InetAddressSetUserType;
-import google.registry.util.DateTimeUtils;
 import jakarta.persistence.Access;
 import jakarta.persistence.AccessType;
 import jakarta.persistence.Column;
@@ -39,7 +38,6 @@ import java.util.Optional;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.hibernate.annotations.Type;
-import org.joda.time.DateTime;
 
 /**
  * A persistable Host resource including mutable and non-mutable fields.
@@ -127,15 +125,8 @@ public class HostBase extends EppResource {
         "HostBase is not an actual persisted entity you can create a key to; use Host instead");
   }
 
-  @Deprecated
   @Override
-  @SuppressWarnings("InlineMeSuggester")
-  public HostBase cloneProjectedAtTime(DateTime now) {
-    return this;
-  }
-
-  @Override
-  public EppResource cloneProjectedAtInstant(Instant now) {
+  public HostBase cloneProjectedAtTime(Instant now) {
     return this;
   }
 
@@ -170,9 +161,8 @@ public class HostBase extends EppResource {
     Instant lastSuperordinateChange =
         Optional.ofNullable(getLastSuperordinateChange()).orElse(getCreationTime());
     Instant lastTransferOfCurrentSuperordinate =
-        Optional.ofNullable(superordinateDomain.getLastTransferTime())
-            .map(DateTimeUtils::toInstant)
-            .orElse(START_INSTANT);
+        Optional.ofNullable(superordinateDomain.getLastTransferTime()).orElse(START_INSTANT);
+
     return lastSuperordinateChange.isBefore(lastTransferOfCurrentSuperordinate)
         ? lastTransferOfCurrentSuperordinate
         : lastTransferTime;

--- a/core/src/main/java/google/registry/model/poll/PollMessage.java
+++ b/core/src/main/java/google/registry/model/poll/PollMessage.java
@@ -549,16 +549,7 @@ public abstract class PollMessage extends ImmutableObject
       return targetId;
     }
 
-    /**
-     * @deprecated Use {@link #getAutorenewEndTimeInstant()}
-     */
-    @Deprecated
-    @SuppressWarnings("InlineMeSuggester")
-    public DateTime getAutorenewEndTime() {
-      return toDateTime(autorenewEndTime);
-    }
-
-    public Instant getAutorenewEndTimeInstant() {
+    public Instant getAutorenewEndTime() {
       return autorenewEndTime;
     }
 

--- a/core/src/main/java/google/registry/model/registrar/Registrar.java
+++ b/core/src/main/java/google/registry/model/registrar/Registrar.java
@@ -32,8 +32,6 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.util.CollectionUtils.nullToEmptyImmutableCopy;
 import static google.registry.util.CollectionUtils.nullToEmptyImmutableSortedCopy;
 import static google.registry.util.DateTimeUtils.START_INSTANT;
-import static google.registry.util.DateTimeUtils.toDateTime;
-import static google.registry.util.DateTimeUtils.toInstant;
 import static google.registry.util.PasswordUtils.SALT_SUPPLIER;
 import static google.registry.util.PasswordUtils.hashPassword;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
@@ -94,7 +92,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.joda.money.CurrencyUnit;
-import org.joda.time.DateTime;
 
 /** Information about a registrar. */
 @Entity
@@ -441,15 +438,6 @@ public class Registrar extends UpdateAutoTimestampEntity implements Buildable, J
     return creationTime.getTimestamp();
   }
 
-  /**
-   * @deprecated Use {@link #getCreationTime()}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public DateTime getCreationDateTime() {
-    return toDateTime(creationTime.getTimestamp());
-  }
-
   @Nullable
   public Long getIanaIdentifier() {
     return ianaIdentifier;
@@ -465,55 +453,19 @@ public class Registrar extends UpdateAutoTimestampEntity implements Buildable, J
         : ImmutableSortedMap.copyOf(billingAccountMap);
   }
 
-  /**
-   * @deprecated Use {@link #getLastUpdateTimeInstant()}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public DateTime getLastUpdateTime() {
-    return toDateTime(getUpdateTimestamp().getTimestamp());
-  }
-
-  public Instant getLastUpdateTimeInstant() {
+  public Instant getLastUpdateTime() {
     return getUpdateTimestamp().getTimestamp();
   }
 
-  /**
-   * @deprecated Use {@link #getLastCertificateUpdateTimeInstant()}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public DateTime getLastCertificateUpdateTime() {
-    return toDateTime(lastCertificateUpdateTime);
-  }
-
-  public Instant getLastCertificateUpdateTimeInstant() {
+  public Instant getLastCertificateUpdateTime() {
     return lastCertificateUpdateTime;
   }
 
-  /**
-   * @deprecated Use {@link #getLastExpiringCertNotificationSentDateInstant()}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public DateTime getLastExpiringCertNotificationSentDate() {
-    return toDateTime(lastExpiringCertNotificationSentDate);
-  }
-
-  public Instant getLastExpiringCertNotificationSentDateInstant() {
+  public Instant getLastExpiringCertNotificationSentDate() {
     return lastExpiringCertNotificationSentDate;
   }
 
-  /**
-   * @deprecated Use {@link #getLastExpiringFailoverCertNotificationSentDateInstant()}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public DateTime getLastExpiringFailoverCertNotificationSentDate() {
-    return toDateTime(lastExpiringFailoverCertNotificationSentDate);
-  }
-
-  public Instant getLastExpiringFailoverCertNotificationSentDateInstant() {
+  public Instant getLastExpiringFailoverCertNotificationSentDate() {
     return lastExpiringFailoverCertNotificationSentDate;
   }
 
@@ -521,16 +473,7 @@ public class Registrar extends UpdateAutoTimestampEntity implements Buildable, J
     return registrarName;
   }
 
-  /**
-   * @deprecated Use {@link #getLastPocVerificationDateInstant()}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  public DateTime getLastPocVerificationDate() {
-    return toDateTime(lastPocVerificationDate);
-  }
-
-  public Instant getLastPocVerificationDateInstant() {
+  public Instant getLastPocVerificationDate() {
     return lastPocVerificationDate;
   }
 
@@ -862,28 +805,10 @@ public class Registrar extends UpdateAutoTimestampEntity implements Buildable, J
       return this;
     }
 
-    /**
-     * @deprecated Use {@link #setClientCertificate(String, Instant)}
-     */
-    @Deprecated
-    @SuppressWarnings("InlineMeSuggester")
-    public Builder setClientCertificate(String clientCertificate, DateTime now) {
-      return setClientCertificate(clientCertificate, toInstant(now));
-    }
-
     public Builder setLastExpiringCertNotificationSentDate(Instant now) {
       checkArgumentNotNull(now, "Registrar lastExpiringCertNotificationSentDate cannot be null");
       getInstance().lastExpiringCertNotificationSentDate = now;
       return this;
-    }
-
-    /**
-     * @deprecated Use {@link #setLastExpiringCertNotificationSentDate(Instant)}
-     */
-    @Deprecated
-    @SuppressWarnings("InlineMeSuggester")
-    public Builder setLastExpiringCertNotificationSentDate(DateTime now) {
-      return setLastExpiringCertNotificationSentDate(toInstant(now));
     }
 
     public Builder setLastExpiringFailoverCertNotificationSentDate(Instant now) {
@@ -891,15 +816,6 @@ public class Registrar extends UpdateAutoTimestampEntity implements Buildable, J
           now, "Registrar lastExpiringFailoverCertNotificationSentDate cannot be null");
       getInstance().lastExpiringFailoverCertNotificationSentDate = now;
       return this;
-    }
-
-    /**
-     * @deprecated Use {@link #setLastExpiringFailoverCertNotificationSentDate(Instant)}
-     */
-    @Deprecated
-    @SuppressWarnings("InlineMeSuggester")
-    public Builder setLastExpiringFailoverCertNotificationSentDate(DateTime now) {
-      return setLastExpiringFailoverCertNotificationSentDate(toInstant(now));
     }
 
     public Builder setFailoverClientCertificate(String clientCertificate, Instant now) {
@@ -914,28 +830,10 @@ public class Registrar extends UpdateAutoTimestampEntity implements Buildable, J
       return this;
     }
 
-    /**
-     * @deprecated Use {@link #setFailoverClientCertificate(String, Instant)}
-     */
-    @Deprecated
-    @SuppressWarnings("InlineMeSuggester")
-    public Builder setFailoverClientCertificate(String clientCertificate, DateTime now) {
-      return setFailoverClientCertificate(clientCertificate, toInstant(now));
-    }
-
     public Builder setLastPocVerificationDate(Instant now) {
       checkArgumentNotNull(now, "Registrar lastPocVerificationDate cannot be null");
       getInstance().lastPocVerificationDate = now;
       return this;
-    }
-
-    /**
-     * @deprecated Use {@link #setLastPocVerificationDate(Instant)}
-     */
-    @Deprecated
-    @SuppressWarnings("InlineMeSuggester")
-    public Builder setLastPocVerificationDate(DateTime now) {
-      return setLastPocVerificationDate(toInstant(now));
     }
 
     private static String calculateHash(String clientCertificate) {
@@ -1073,16 +971,6 @@ public class Registrar extends UpdateAutoTimestampEntity implements Buildable, J
     public Builder setLastUpdateTime(Instant timestamp) {
       getInstance().setUpdateTimestamp(UpdateAutoTimestamp.create(timestamp));
       return this;
-    }
-
-    /**
-     * @deprecated Use {@link #setLastUpdateTime(Instant)}
-     */
-    @Deprecated
-    @SuppressWarnings("InlineMeSuggester")
-    @VisibleForTesting
-    public Builder setLastUpdateTime(DateTime timestamp) {
-      return setLastUpdateTime(toInstant(timestamp));
     }
 
     /** Build the registrar, nullifying empty fields. */

--- a/core/src/main/java/google/registry/model/tld/Tld.java
+++ b/core/src/main/java/google/registry/model/tld/Tld.java
@@ -649,16 +649,6 @@ public class Tld extends ImmutableObject implements Buildable, UnsafeSerializabl
     return creationTime.getTimestamp();
   }
 
-  /**
-   * @deprecated Use {@link #getCreationTime()}
-   */
-  @Deprecated
-  @SuppressWarnings("InlineMeSuggester")
-  @JsonIgnore
-  public DateTime getCreationDateTime() {
-    return toDateTime(creationTime.getTimestamp());
-  }
-
   public boolean getEscrowEnabled() {
     return escrowEnabled;
   }

--- a/core/src/main/java/google/registry/rde/DomainToXjcConverter.java
+++ b/core/src/main/java/google/registry/rde/DomainToXjcConverter.java
@@ -95,7 +95,7 @@ final class DomainToXjcConverter {
     //    identifying the end (expiration) of the domain name object's
     //    registration period.  This element MUST be present if the domain
     //    name has been allocated.
-    bean.setExDate(model.getRegistrationExpirationDateTime());
+    bean.setExDate(toDateTime(model.getRegistrationExpirationTime()));
 
     // o  An OPTIONAL <upDate> element that contains the date and time of
     //    the most recent domain-name-object modification.  This element
@@ -114,7 +114,7 @@ final class DomainToXjcConverter {
     //    the most recent domain object successful transfer.  This element
     //    MUST NOT be present if the domain name object has never been
     //    transferred.
-    bean.setTrDate(model.getLastTransferTime());
+    bean.setTrDate(toDateTime(model.getLastTransferTime()));
 
     // o  One or more <status> elements that contain the current status
     //    descriptors associated with the domain name.

--- a/core/src/main/java/google/registry/rde/RegistrarToXjcConverter.java
+++ b/core/src/main/java/google/registry/rde/RegistrarToXjcConverter.java
@@ -146,7 +146,7 @@ final class RegistrarToXjcConverter {
     //    the most recent RDE registrar-object modification.  This element
     //    MUST NOT be present if the rdeRegistrar object has never been
     //    modified.
-    bean.setUpDate(model.getLastUpdateTime());
+    bean.setUpDate(toDateTime(model.getLastUpdateTime()));
 
     return bean;
   }

--- a/core/src/main/java/google/registry/tmch/LordnTaskUtils.java
+++ b/core/src/main/java/google/registry/tmch/LordnTaskUtils.java
@@ -16,7 +16,6 @@ package google.registry.tmch;
 
 import static com.google.common.base.Preconditions.checkState;
 import static google.registry.util.DateTimeUtils.ISO_8601_FORMATTER;
-import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.google.common.base.Joiner;
 import google.registry.model.domain.Domain;
@@ -58,7 +57,7 @@ public final class LordnTaskUtils {
             domain.getLaunchNotice().getNoticeId().getTcnId(),
             getIanaIdentifier(domain.getCreationRegistrarId()),
             ISO_8601_FORMATTER.format(domain.getCreationTime()), // Used as creation time.
-            ISO_8601_FORMATTER.format(toInstant(domain.getLaunchNotice().getAcceptedTime())));
+            ISO_8601_FORMATTER.format(domain.getLaunchNotice().getAcceptedTime()));
   }
 
   /** Retrieves the IANA identifier for a registrar by its ID. */

--- a/core/src/main/java/google/registry/tools/CreateOrUpdateBulkPricingPackageCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdateBulkPricingPackageCommand.java
@@ -16,6 +16,7 @@ package google.registry.tools;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.beust.jcommander.Parameter;
 import google.registry.model.domain.token.AllocationToken;
@@ -107,7 +108,8 @@ abstract class CreateOrUpdateBulkPricingPackageCommand extends MutatingCommand {
                 Optional.ofNullable(maxCreates).ifPresent(builder::setMaxCreates);
                 Optional.ofNullable(price).ifPresent(builder::setBulkPrice);
                 Optional.ofNullable(nextBillingDate)
-                    .ifPresent(nextBillingDate -> builder.setNextBillingDate(nextBillingDate));
+                    .ifPresent(
+                        nextBillingDate -> builder.setNextBillingDate(toInstant(nextBillingDate)));
                 if (clearLastNotificationSent()) {
                   builder.setLastNotificationSent((Instant) null);
                 }

--- a/core/src/main/java/google/registry/tools/CreateOrUpdateRegistrarCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdateRegistrarCommand.java
@@ -19,6 +19,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static google.registry.util.DateTimeUtils.toInstant;
 import static google.registry.util.RegistrarUtils.normalizeRegistrarName;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 
@@ -338,9 +339,10 @@ abstract class CreateOrUpdateRegistrarCommand extends MutatingCommand {
           verify(
               oldRegistrar.getClientCertificate().isPresent(),
               "Primary cert is absent. Rotation may remove a failover certificate still in use.");
-          builder.setFailoverClientCertificate(oldRegistrar.getClientCertificate().get(), now);
+          builder.setFailoverClientCertificate(
+              oldRegistrar.getClientCertificate().get(), toInstant(now));
         }
-        builder.setClientCertificate(asciiCert, now);
+        builder.setClientCertificate(asciiCert, toInstant(now));
       }
       if (rotatePrimaryCert && clientCertificateFilename == null) {
         throw new IllegalArgumentException("--rotate_primary_cert must be used with --cert_file.");
@@ -351,7 +353,7 @@ abstract class CreateOrUpdateRegistrarCommand extends MutatingCommand {
         if (!asciiCert.equals("")) {
           certificateChecker.validateCertificate(asciiCert);
         }
-        builder.setFailoverClientCertificate(asciiCert, now);
+        builder.setFailoverClientCertificate(asciiCert, toInstant(now));
       }
       Optional.ofNullable(ianaId).ifPresent(i -> builder.setIanaIdentifier(i.orElse(null)));
       Optional.ofNullable(poNumber).ifPresent(builder::setPoNumber);

--- a/core/src/main/java/google/registry/tools/GenerateAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/GenerateAllocationTokensCommand.java
@@ -252,7 +252,7 @@ class GenerateAllocationTokensCommand implements Command {
                     Optional.ofNullable(discountPrice).ifPresent(token::setDiscountPrice);
                     Optional.ofNullable(discountYears).ifPresent(token::setDiscountYears);
                     Optional.ofNullable(tokenStatusTransitions)
-                        .ifPresent(token::setTokenStatusTransitionsInstant);
+                        .ifPresent(token::setTokenStatusTransitions);
                     Optional.ofNullable(renewalPrice).ifPresent(token::setRenewalPrice);
                     Optional.ofNullable(domainNames)
                         .ifPresent(d -> token.setDomainName(d.removeFirst()));

--- a/core/src/main/java/google/registry/tools/RenewDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/RenewDomainCommand.java
@@ -17,6 +17,7 @@ package google.registry.tools;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static google.registry.util.CollectionUtils.findDuplicates;
+import static google.registry.util.DateTimeUtils.toDateTime;
 import static google.registry.util.PreconditionsUtils.checkArgumentNotNull;
 
 import com.beust.jcommander.Parameter;
@@ -76,7 +77,8 @@ final class RenewDomainCommand extends MutatingEppToolCommand {
       SoyMapData soyMapData =
           new SoyMapData(
               "domainName", domain.getDomainName(),
-              "expirationDate", domain.getRegistrationExpirationDateTime().toString(DATE_FORMATTER),
+              "expirationDate",
+                  DATE_FORMATTER.print(toDateTime(domain.getRegistrationExpirationTime())),
               "period", String.valueOf(period));
 
       if (requestedByRegistrar != null) {

--- a/core/src/main/java/google/registry/tools/UniformRapidSuspensionCommand.java
+++ b/core/src/main/java/google/registry/tools/UniformRapidSuspensionCommand.java
@@ -38,12 +38,13 @@ import google.registry.tools.params.NameserversParameter;
 import google.registry.tools.soy.DomainRenewSoyInfo;
 import google.registry.tools.soy.UniformRapidSuspensionSoyInfo;
 import jakarta.xml.bind.annotation.adapters.HexBinaryAdapter;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.joda.time.DateTime;
-import org.joda.time.format.DateTimeFormat;
 
 /** A command to suspend a domain for the Uniform Rapid Suspension process. */
 @Parameters(separators = " =",
@@ -158,9 +159,9 @@ final class UniformRapidSuspensionCommand extends MutatingEppToolCommand {
               "domainName",
               domain.getDomainName(),
               "expirationDate",
-              domain
-                  .getRegistrationExpirationDateTime()
-                  .toString(DateTimeFormat.forPattern("YYYY-MM-dd")),
+              DateTimeFormatter.ofPattern("yyyy-MM-dd")
+                  .withZone(ZoneOffset.UTC)
+                  .format(domain.getRegistrationExpirationTime()),
               // period is the number of years to renew the registration for
               "period",
               String.valueOf(1),

--- a/core/src/main/java/google/registry/tools/UnrenewDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/UnrenewDomainCommand.java
@@ -20,9 +20,11 @@ import static google.registry.flows.domain.DomainFlowUtils.newAutorenewBillingEv
 import static google.registry.flows.domain.DomainFlowUtils.newAutorenewPollMessage;
 import static google.registry.flows.domain.DomainFlowUtils.updateAutorenewRecurrenceEndTime;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
+import static google.registry.util.DateTimeUtils.ISO_8601_FORMATTER;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static google.registry.util.DateTimeUtils.isBeforeOrAt;
 import static google.registry.util.DateTimeUtils.minusYears;
+import static google.registry.util.DateTimeUtils.toDateTime;
 import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.beust.jcommander.Parameter;
@@ -44,6 +46,7 @@ import google.registry.util.Clock;
 import google.registry.util.NonFinalForTesting;
 import jakarta.inject.Inject;
 import java.io.UnsupportedEncodingException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.joda.time.DateTime;
@@ -99,9 +102,10 @@ class UnrenewDomainCommand extends ConfirmingCommand {
       }
       domainsWithDisallowedStatusesBuilder.putAll(
           domainName, Sets.intersection(domain.get().getStatusValues(), DISALLOWED_STATUSES));
-      if (isBeforeOrAt(minusYears(domain.get().getRegistrationExpirationDateTime(), period), now)) {
+      if (isBeforeOrAt(
+          toDateTime(minusYears(domain.get().getRegistrationExpirationTime(), period)), now)) {
         domainsExpiringTooSoonBuilder.put(
-            domainName, domain.get().getRegistrationExpirationDateTime());
+            domainName, toDateTime(domain.get().getRegistrationExpirationTime()));
       }
     }
 
@@ -144,8 +148,8 @@ class UnrenewDomainCommand extends ConfirmingCommand {
     DateTime now = clock.nowUtc();
     for (String domainName : mainParameters) {
       Domain domain = ForeignKeyUtils.loadResource(Domain.class, domainName, now).get();
-      DateTime previousTime = domain.getRegistrationExpirationDateTime();
-      DateTime newTime = minusYears(previousTime, period);
+      Instant previousTime = domain.getRegistrationExpirationTime();
+      Instant newTime = minusYears(previousTime, period);
       resultBuilder.append(
           String.format(
               "%s expiration time changed from %s to %s\n", domainName, previousTime, newTime));
@@ -180,11 +184,11 @@ class UnrenewDomainCommand extends ConfirmingCommand {
         "Domain %s has prohibited status values",
         domainName);
     checkState(
-        minusYears(domain.getRegistrationExpirationDateTime(), period).isAfter(now),
+        minusYears(domain.getRegistrationExpirationTime(), period).isAfter(toInstant(now)),
         "Domain %s expires too soon",
         domainName);
 
-    DateTime newExpirationTime = minusYears(domain.getRegistrationExpirationDateTime(), period);
+    Instant newExpirationTime = minusYears(domain.getRegistrationExpirationTime(), period);
     DomainHistory domainHistory =
         new DomainHistory.Builder()
             .setDomain(domain)
@@ -202,19 +206,19 @@ class UnrenewDomainCommand extends ConfirmingCommand {
             .setMsg(
                 String.format(
                     "Domain %s was unrenewed by %d years; now expires at %s.",
-                    domainName, period, newExpirationTime))
+                    domainName, period, ISO_8601_FORMATTER.format(newExpirationTime)))
             .setHistoryEntry(domainHistory)
             .setEventTime(now)
             .build();
     // Create a new autorenew billing event and poll message starting at the new expiration time.
     BillingRecurrence newAutorenewEvent =
         newAutorenewBillingEvent(domain)
-            .setEventTime(toInstant(newExpirationTime))
+            .setEventTime(newExpirationTime)
             .setDomainHistory(domainHistory)
             .build();
     PollMessage.Autorenew newAutorenewPollMessage =
         newAutorenewPollMessage(domain)
-            .setEventTime(toInstant(newExpirationTime))
+            .setEventTime(newExpirationTime)
             .setHistoryEntry(domainHistory)
             .build();
     // End the old autorenew billing event and poll message now.

--- a/core/src/main/java/google/registry/tools/UpdateAllocationTokensCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdateAllocationTokensCommand.java
@@ -220,8 +220,7 @@ final class UpdateAllocationTokensCommand extends UpdateOrDeleteAllocationTokens
     Optional.ofNullable(discountPremiums).ifPresent(builder::setDiscountPremiums);
     Optional.ofNullable(discountPrice).ifPresent(builder::setDiscountPrice);
     Optional.ofNullable(discountYears).ifPresent(builder::setDiscountYears);
-    Optional.ofNullable(tokenStatusTransitions)
-        .ifPresent(builder::setTokenStatusTransitionsInstant);
+    Optional.ofNullable(tokenStatusTransitions).ifPresent(builder::setTokenStatusTransitions);
 
     if (renewalPriceBehavior != null
         && renewalPriceBehavior != original.getRenewalPriceBehavior()) {

--- a/core/src/main/java/google/registry/tools/UpdateRecurrenceCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdateRecurrenceCommand.java
@@ -180,7 +180,7 @@ public class UpdateRecurrenceCommand extends ConfirmingCommand {
           "Domain %s has a pending transfer: %s",
           domainName,
           domain.getTransferData());
-      Optional<Instant> domainAutorenewEndTime = domain.getAutorenewEndTimeInstant();
+      Optional<Instant> domainAutorenewEndTime = domain.getAutorenewEndTime();
       domainAutorenewEndTime.ifPresent(
           endTime ->
               checkArgument(

--- a/core/src/main/java/google/registry/ui/server/console/ConsoleUpdateRegistrarAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleUpdateRegistrarAction.java
@@ -17,7 +17,8 @@ package google.registry.ui.server.console;
 import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.request.Action.Method.POST;
-import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
+import static google.registry.util.DateTimeUtils.toInstant;
 import static google.registry.util.PreconditionsUtils.checkArgumentPresent;
 import static org.apache.http.HttpStatus.SC_OK;
 
@@ -36,6 +37,7 @@ import google.registry.request.auth.Auth;
 import google.registry.util.DomainNameUtils;
 import google.registry.util.RegistryEnvironment;
 import jakarta.inject.Inject;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.joda.time.DateTime;
@@ -92,13 +94,13 @@ public class ConsoleUpdateRegistrarAction extends ConsoleApiAction {
               }
 
               DateTime now = tm().getTransactionTime();
-              DateTime newLastPocVerificationDate =
+              Instant newLastPocVerificationDate =
                   registrarParam.getLastPocVerificationDate() == null
-                      ? START_OF_TIME
+                      ? START_INSTANT
                       : registrarParam.getLastPocVerificationDate();
 
               checkArgument(
-                  newLastPocVerificationDate.isBefore(now),
+                  newLastPocVerificationDate.isBefore(toInstant(now)),
                   "Invalid value of LastPocVerificationDate - value is in the future");
 
               var updatedRegistrarBuilder =

--- a/core/src/main/java/google/registry/ui/server/console/settings/SecurityAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/settings/SecurityAction.java
@@ -102,7 +102,7 @@ public class SecurityAction extends ConsoleApiAction {
         if (registrarParameter.getClientCertificate().isPresent()) {
           String newClientCert = registrarParameter.getClientCertificate().get();
           certificateChecker.validateCertificate(newClientCert);
-          updatedRegistrarBuilder.setClientCertificate(newClientCert, tm().getTransactionTime());
+          updatedRegistrarBuilder.setClientCertificate(newClientCert, tm().getTxTime());
           updates.add("PRIMARY_SSL_CERT_CHANGE");
         }
       }
@@ -112,8 +112,7 @@ public class SecurityAction extends ConsoleApiAction {
         if (registrarParameter.getFailoverClientCertificate().isPresent()) {
           String newFailoverCert = registrarParameter.getFailoverClientCertificate().get();
           certificateChecker.validateCertificate(newFailoverCert);
-          updatedRegistrarBuilder.setFailoverClientCertificate(
-              newFailoverCert, tm().getTransactionTime());
+          updatedRegistrarBuilder.setFailoverClientCertificate(newFailoverCert, tm().getTxTime());
           updates.add("FAILOVER_SSL_CERT_CHANGE");
         }
       }

--- a/core/src/test/java/google/registry/batch/BulkDomainTransferActionTest.java
+++ b/core/src/test/java/google/registry/batch/BulkDomainTransferActionTest.java
@@ -106,23 +106,23 @@ public class BulkDomainTransferActionTest {
     // The cloneProjectedAtTime calls are necessary to resolve the transfers, even though the
     // transfers have a time period of 0
     activeDomain = loadByEntity(activeDomain);
-    assertThat(activeDomain.cloneProjectedAtInstant(now).getCurrentSponsorRegistrarId())
+    assertThat(activeDomain.cloneProjectedAtTime(now).getCurrentSponsorRegistrarId())
         .isEqualTo("NewRegistrar");
     assertThat(activeDomain.getUpdateTimestamp().getTimestamp()).isEqualTo(runTime);
 
     // The other three domains shouldn't change
     alreadyTransferredDomain = loadByEntity(alreadyTransferredDomain);
-    assertThat(alreadyTransferredDomain.cloneProjectedAtInstant(now).getCurrentSponsorRegistrarId())
+    assertThat(alreadyTransferredDomain.cloneProjectedAtTime(now).getCurrentSponsorRegistrarId())
         .isEqualTo("NewRegistrar");
     assertThat(alreadyTransferredDomain.getUpdateTimestamp().getTimestamp()).isEqualTo(preRunTime);
 
     pendingDeleteDomain = loadByEntity(pendingDeleteDomain);
-    assertThat(pendingDeleteDomain.cloneProjectedAtInstant(now).getCurrentSponsorRegistrarId())
+    assertThat(pendingDeleteDomain.cloneProjectedAtTime(now).getCurrentSponsorRegistrarId())
         .isEqualTo("TheRegistrar");
     assertThat(pendingDeleteDomain.getUpdateTimestamp().getTimestamp()).isEqualTo(preRunTime);
 
     deletedDomain = loadByEntity(deletedDomain);
-    assertThat(deletedDomain.cloneProjectedAtInstant(now).getCurrentSponsorRegistrarId())
+    assertThat(deletedDomain.cloneProjectedAtTime(now).getCurrentSponsorRegistrarId())
         .isEqualTo("TheRegistrar");
     assertThat(deletedDomain.getUpdateTimestamp().getTimestamp()).isEqualTo(preRunTime);
   }

--- a/core/src/test/java/google/registry/batch/CheckBulkComplianceActionTest.java
+++ b/core/src/test/java/google/registry/batch/CheckBulkComplianceActionTest.java
@@ -19,6 +19,7 @@ import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistEppResource;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.LogsSubject.assertAboutLogs;
+import static google.registry.util.DateTimeUtils.minusDays;
 import static org.joda.money.CurrencyUnit.USD;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -376,7 +377,7 @@ public class CheckBulkComplianceActionTest {
             String.format(DOMAIN_LIMIT_WARNING_EMAIL_BODY, 1, "abc123", "The Registrar", 1, 2));
     BulkPricingPackage packageAfterCheck =
         tm().transact(() -> BulkPricingPackage.loadByTokenString(token.getToken()).get());
-    assertThat(packageAfterCheck.getLastNotificationSent().get()).isEqualTo(clock.nowUtc());
+    assertThat(packageAfterCheck.getLastNotificationSent().get()).isEqualTo(clock.now());
   }
 
   @Test
@@ -458,7 +459,7 @@ public class CheckBulkComplianceActionTest {
             .asBuilder()
             .setMaxCreates(4)
             .setMaxDomains(1)
-            .setLastNotificationSent(clock.nowUtc().minusDays(5))
+            .setLastNotificationSent(minusDays(clock.now(), 5))
             .build();
     tm().transact(() -> tm().put(bulkPricingPackage));
     // Domains limit is 1, creating 2 domains to go over the limit
@@ -488,7 +489,7 @@ public class CheckBulkComplianceActionTest {
     BulkPricingPackage packageAfterCheck =
         tm().transact(() -> BulkPricingPackage.loadByTokenString(token.getToken()).get());
     assertThat(packageAfterCheck.getLastNotificationSent().get())
-        .isEqualTo(clock.nowUtc().minusDays(5));
+        .isEqualTo(minusDays(clock.now(), 5));
   }
 
   @Test
@@ -499,7 +500,7 @@ public class CheckBulkComplianceActionTest {
             .asBuilder()
             .setMaxCreates(4)
             .setMaxDomains(1)
-            .setLastNotificationSent(clock.nowUtc().minusDays(45))
+            .setLastNotificationSent(minusDays(clock.now(), 45))
             .build();
     tm().transact(() -> tm().put(bulkPricingPackage));
     // Domains limit is 1, creating 2 domains to go over the limit
@@ -533,7 +534,7 @@ public class CheckBulkComplianceActionTest {
             String.format(DOMAIN_LIMIT_WARNING_EMAIL_BODY, 1, "abc123", "The Registrar", 1, 2));
     BulkPricingPackage packageAfterCheck =
         tm().transact(() -> BulkPricingPackage.loadByTokenString(token.getToken()).get());
-    assertThat(packageAfterCheck.getLastNotificationSent().get()).isEqualTo(clock.nowUtc());
+    assertThat(packageAfterCheck.getLastNotificationSent().get()).isEqualTo(clock.now());
   }
 
   @Test
@@ -544,7 +545,7 @@ public class CheckBulkComplianceActionTest {
             .asBuilder()
             .setMaxCreates(4)
             .setMaxDomains(1)
-            .setLastNotificationSent(clock.nowUtc().minusDays(31))
+            .setLastNotificationSent(minusDays(clock.now(), 31))
             .build();
     tm().transact(() -> tm().put(bulkPricingPackage));
     // Domains limit is 1, creating 2 domains to go over the limit
@@ -578,6 +579,6 @@ public class CheckBulkComplianceActionTest {
             String.format(DOMAIN_LIMIT_UPGRADE_EMAIL_BODY, 1, "abc123", "The Registrar", 1, 2));
     BulkPricingPackage packageAfterCheck =
         tm().transact(() -> BulkPricingPackage.loadByTokenString(token.getToken()).get());
-    assertThat(packageAfterCheck.getLastNotificationSent().get()).isEqualTo(clock.nowUtc());
+    assertThat(packageAfterCheck.getLastNotificationSent().get()).isEqualTo(clock.now());
   }
 }

--- a/core/src/test/java/google/registry/batch/DeleteExpiredDomainsActionTest.java
+++ b/core/src/test/java/google/registry/batch/DeleteExpiredDomainsActionTest.java
@@ -25,9 +25,10 @@ import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.END_INSTANT;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
+import static google.registry.util.DateTimeUtils.minusDays;
+import static google.registry.util.DateTimeUtils.minusMonths;
 import static google.registry.util.DateTimeUtils.plusDays;
 import static google.registry.util.DateTimeUtils.plusYears;
-import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.google.common.collect.ImmutableSet;
 import google.registry.flows.DaggerEppTestComponent;
@@ -89,7 +90,7 @@ class DeleteExpiredDomainsActionTest {
         persistResource(
             DatabaseHelper.newDomain("bar.tld")
                 .asBuilder()
-                .setAutorenewEndTime(Optional.of(clock.nowUtc().minusDays(10)))
+                .setAutorenewEndTime(Optional.of(minusDays(clock.now(), 10)))
                 .setDeletionTime(plusDays(clock.now(), 17))
                 .build());
 
@@ -98,7 +99,7 @@ class DeleteExpiredDomainsActionTest {
         persistResource(
             DatabaseHelper.newDomain("baz.tld")
                 .asBuilder()
-                .setAutorenewEndTime(Optional.of(clock.nowUtc().plusDays(15)))
+                .setAutorenewEndTime(Optional.of(plusDays(clock.now(), 15)))
                 .build());
 
     // A non-autorenewing domain that is past its expiration time and should be deleted.
@@ -171,7 +172,7 @@ class DeleteExpiredDomainsActionTest {
             new DomainHistory.Builder()
                 .setType(DOMAIN_CREATE)
                 .setDomain(pendingExpirationDomain)
-                .setModificationTime(toInstant(clock.nowUtc().minusMonths(9)))
+                .setModificationTime(minusMonths(clock.now(), 9))
                 .setRegistrarId(pendingExpirationDomain.getCreationRegistrarId())
                 .build());
     BillingRecurrence autorenewBillingEvent =
@@ -182,7 +183,7 @@ class DeleteExpiredDomainsActionTest {
         persistResource(
             pendingExpirationDomain
                 .asBuilder()
-                .setAutorenewEndTime(Optional.of(clock.nowUtc().minusDays(10)))
+                .setAutorenewEndTime(Optional.of(minusDays(clock.now(), 10)))
                 .setAutorenewBillingEvent(autorenewBillingEvent.createVKey())
                 .setAutorenewPollMessage(autorenewPollMessage.createVKey())
                 .build());

--- a/core/src/test/java/google/registry/batch/SendExpiringCertificateNotificationEmailActionTest.java
+++ b/core/src/test/java/google/registry/batch/SendExpiringCertificateNotificationEmailActionTest.java
@@ -118,7 +118,7 @@ class SendExpiringCertificateNotificationEmailActionTest {
         persistResource(
             makeRegistrar1()
                 .asBuilder()
-                .setFailoverClientCertificate(cert.get(), clock.nowUtc())
+                .setFailoverClientCertificate(cert.get(), clock.now())
                 .build());
     persistSampleContacts(registrar, Type.TECH);
     assertThat(
@@ -140,7 +140,7 @@ class SendExpiringCertificateNotificationEmailActionTest {
         persistResource(
             makeRegistrar1()
                 .asBuilder()
-                .setFailoverClientCertificate(cert.get(), clock.nowUtc())
+                .setFailoverClientCertificate(cert.get(), clock.now())
                 .build());
     persistSampleContacts(registrar, Type.ADMIN);
     assertThat(
@@ -211,7 +211,7 @@ class SendExpiringCertificateNotificationEmailActionTest {
         persistResource(
             makeRegistrar1()
                 .asBuilder()
-                .setFailoverClientCertificate(cert.get(), clock.nowUtc())
+                .setFailoverClientCertificate(cert.get(), clock.now())
                 .build());
     ImmutableList<RegistrarPoc> contacts =
         ImmutableList.of(
@@ -340,7 +340,7 @@ class SendExpiringCertificateNotificationEmailActionTest {
     persistResource(registrar);
     action.updateLastNotificationSentDate(registrar, clock.nowUtc(), CertificateType.PRIMARY);
     assertThat(loadByEntity(registrar).getLastExpiringCertNotificationSentDate())
-        .isEqualTo(clock.nowUtc());
+        .isEqualTo(clock.now());
   }
 
   @Test
@@ -356,7 +356,7 @@ class SendExpiringCertificateNotificationEmailActionTest {
     persistResource(registrar);
     action.updateLastNotificationSentDate(registrar, clock.nowUtc(), CertificateType.FAILOVER);
     assertThat(loadByEntity(registrar).getLastExpiringFailoverCertNotificationSentDate())
-        .isEqualTo(clock.nowUtc());
+        .isEqualTo(clock.now());
   }
 
   @Test
@@ -690,11 +690,11 @@ class SendExpiringCertificateNotificationEmailActionTest {
 
     if (failOverCertificate != null) {
       builder.setFailoverClientCertificate(
-          certificateChecker.serializeCertificate(failOverCertificate), clock.nowUtc());
+          certificateChecker.serializeCertificate(failOverCertificate), clock.now());
     }
     if (certificate != null) {
       builder.setClientCertificate(
-          certificateChecker.serializeCertificate(certificate), clock.nowUtc());
+          certificateChecker.serializeCertificate(certificate), clock.now());
     }
     return builder;
   }

--- a/core/src/test/java/google/registry/beam/common/RegistryJpaReadTest.java
+++ b/core/src/test/java/google/registry/beam/common/RegistryJpaReadTest.java
@@ -20,7 +20,8 @@ import static google.registry.testing.DatabaseHelper.newTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DatabaseHelper.persistResources;
 import static google.registry.util.DateTimeUtils.END_INSTANT;
-import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
+import static google.registry.util.DateTimeUtils.plusYears;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -176,7 +177,7 @@ public class RegistryJpaReadTest {
             .setCreationRegistrarId(registrar.getRegistrarId())
             .setLastEppUpdateTime(fakeClock.now())
             .setLastEppUpdateRegistrarId(registrar.getRegistrarId())
-            .setLastTransferTime(fakeClock.nowUtc())
+            .setLastTransferTime(fakeClock.now())
             .setStatusValues(
                 ImmutableSet.of(
                     StatusValue.CLIENT_DELETE_PROHIBITED,
@@ -187,11 +188,11 @@ public class RegistryJpaReadTest {
                     StatusValue.SERVER_HOLD))
             .setSubordinateHosts(ImmutableSet.of("ns1.example.com"))
             .setPersistedCurrentSponsorRegistrarId(registrar.getRegistrarId())
-            .setRegistrationExpirationTime(fakeClock.nowUtc().plusYears(1))
+            .setRegistrationExpirationTime(plusYears(fakeClock.now(), 1))
             .setAuthInfo(DomainAuthInfo.create(PasswordAuth.create("password")))
             .setDsData(ImmutableSet.of(DomainDsData.create(1, 2, 3, new byte[] {0, 1, 2})))
             .setLaunchNotice(
-                LaunchNotice.create("tcnid", "validatorId", START_OF_TIME, START_OF_TIME))
+                LaunchNotice.create("tcnid", "validatorId", START_INSTANT, START_INSTANT))
             .setSmdId("smdid")
             .addGracePeriod(
                 GracePeriod.create(

--- a/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
+++ b/core/src/test/java/google/registry/beam/spec11/Spec11PipelineTest.java
@@ -22,6 +22,7 @@ import static google.registry.persistence.transaction.TransactionManagerFactory.
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
+import static google.registry.util.DateTimeUtils.plusYears;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -289,9 +290,9 @@ class Spec11PipelineTest {
         .setCreationRegistrarId(registrar.getRegistrarId())
         .setLastEppUpdateTime(fakeClock.now())
         .setLastEppUpdateRegistrarId(registrar.getRegistrarId())
-        .setLastTransferTime(fakeClock.nowUtc())
+        .setLastTransferTime(fakeClock.now())
         .setPersistedCurrentSponsorRegistrarId(registrar.getRegistrarId())
-        .setRegistrationExpirationTime(fakeClock.nowUtc().plusYears(1))
+        .setRegistrationExpirationTime(plusYears(fakeClock.now(), 1))
         .setAuthInfo(DomainAuthInfo.create(PasswordAuth.create("password")))
         .build();
   }

--- a/core/src/test/java/google/registry/bsa/persistence/DomainsRefresherTest.java
+++ b/core/src/test/java/google/registry/bsa/persistence/DomainsRefresherTest.java
@@ -24,7 +24,6 @@ import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.newDomain;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_INSTANT;
-import static google.registry.util.DateTimeUtils.toDateTime;
 
 import com.google.common.collect.ImmutableList;
 import google.registry.bsa.api.UnblockableDomain;
@@ -58,7 +57,7 @@ public class DomainsRefresherTest {
     persistResource(
         Tld.get("tld")
             .asBuilder()
-            .setBsaEnrollStartTime(Optional.of(toDateTime(fakeClock.now().minusMillis(1))))
+            .setBsaEnrollStartTime(Optional.of(fakeClock.nowUtc().minusMillis(1)))
             .build());
     refresher = new DomainsRefresher(START_INSTANT, fakeClock.now(), Duration.ZERO, 100);
   }

--- a/core/src/test/java/google/registry/bsa/persistence/QueriesTest.java
+++ b/core/src/test/java/google/registry/bsa/persistence/QueriesTest.java
@@ -34,7 +34,6 @@ import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistDomainAsDeleted;
 import static google.registry.testing.DatabaseHelper.persistNewRegistrar;
 import static google.registry.util.DateTimeUtils.END_INSTANT;
-import static google.registry.util.DateTimeUtils.toDateTime;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -284,7 +283,7 @@ class QueriesTest {
     // Deleted in the future
     persistDomainAsDeleted(
         newDomain("label3.tld2").asBuilder().setCreationTimeForTest(fakeClock.now()).build(),
-        toDateTime(fakeClock.now().plus(Duration.ofHours(1))));
+        fakeClock.nowUtc().plusHours(1));
     fakeClock.advanceOneMilli();
     assertThat(
             (ImmutableList<DomainLifeSpan>)

--- a/core/src/test/java/google/registry/flows/EppLifecycleDomainTest.java
+++ b/core/src/test/java/google/registry/flows/EppLifecycleDomainTest.java
@@ -488,8 +488,9 @@ class EppLifecycleDomainTest extends EppTestCase {
     assertThatLogoutSucceeds();
 
     // Make sure that in the future, the domain expiration is unchanged after deletion
-    Domain clonedDomain = domain.cloneProjectedAtTime(deleteTime.plusYears(5));
-    assertThat(clonedDomain.getRegistrationExpirationDateTime()).isEqualTo(createTime.plusYears(2));
+    Domain clonedDomain = domain.cloneProjectedAtTime(toInstant(deleteTime.plusYears(5)));
+    assertThat(clonedDomain.getRegistrationExpirationTime())
+        .isEqualTo(toInstant(createTime.plusYears(2)));
   }
 
   @Test

--- a/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
+++ b/core/src/test/java/google/registry/flows/EppLoginTlsTest.java
@@ -18,6 +18,7 @@ import static google.registry.testing.CertificateSamples.SAMPLE_CERT3_HASH;
 import static google.registry.testing.DatabaseHelper.loadRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.toInstant;
 import static google.registry.util.X509Utils.getCertificateHash;
 
 import com.google.common.collect.ImmutableMap;
@@ -77,13 +78,13 @@ class EppLoginTlsTest extends EppTestCase {
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()
-            .setClientCertificate(CertificateSamples.SAMPLE_CERT3, clock.nowUtc())
+            .setClientCertificate(CertificateSamples.SAMPLE_CERT3, clock.now())
             .build());
     // Set a cert for the second registrar, or else any cert will be allowed for login.
     persistResource(
         loadRegistrar("TheRegistrar")
             .asBuilder()
-            .setClientCertificate(CertificateSamples.SAMPLE_CERT2, clock.nowUtc())
+            .setClientCertificate(CertificateSamples.SAMPLE_CERT2, clock.now())
             .build());
   }
 
@@ -156,8 +157,8 @@ class EppLoginTlsTest extends EppTestCase {
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()
-            .setClientCertificate(CertificateSamples.SAMPLE_CERT3, now)
-            .setFailoverClientCertificate(CertificateSamples.SAMPLE_CERT2, now)
+            .setClientCertificate(CertificateSamples.SAMPLE_CERT3, toInstant(now))
+            .setFailoverClientCertificate(CertificateSamples.SAMPLE_CERT2, toInstant(now))
             .build());
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
   }
@@ -169,8 +170,8 @@ class EppLoginTlsTest extends EppTestCase {
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()
-            .setClientCertificate(CertificateSamples.SAMPLE_CERT, now)
-            .setFailoverClientCertificate(CertificateSamples.SAMPLE_CERT3, now)
+            .setClientCertificate(CertificateSamples.SAMPLE_CERT, toInstant(now))
+            .setFailoverClientCertificate(CertificateSamples.SAMPLE_CERT3, toInstant(now))
             .build());
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
   }
@@ -182,8 +183,8 @@ class EppLoginTlsTest extends EppTestCase {
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()
-            .setClientCertificate(null, now)
-            .setFailoverClientCertificate(CertificateSamples.SAMPLE_CERT3, now)
+            .setClientCertificate(null, toInstant(now))
+            .setFailoverClientCertificate(CertificateSamples.SAMPLE_CERT3, toInstant(now))
             .build());
     assertThatLoginSucceeds("NewRegistrar", "foo-BAR2");
   }
@@ -195,8 +196,8 @@ class EppLoginTlsTest extends EppTestCase {
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()
-            .setClientCertificate(null, now)
-            .setFailoverClientCertificate(null, now)
+            .setClientCertificate(null, toInstant(now))
+            .setFailoverClientCertificate(null, toInstant(now))
             .build());
     assertThatLogin("NewRegistrar", "foo-BAR2")
         .hasResponse(
@@ -211,8 +212,8 @@ class EppLoginTlsTest extends EppTestCase {
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()
-            .setClientCertificate(CertificateSamples.SAMPLE_CERT, clock.nowUtc())
-            .setFailoverClientCertificate(CertificateSamples.SAMPLE_CERT2, clock.nowUtc())
+            .setClientCertificate(CertificateSamples.SAMPLE_CERT, clock.now())
+            .setFailoverClientCertificate(CertificateSamples.SAMPLE_CERT2, clock.now())
             .build());
     assertThatLogin("NewRegistrar", "foo-BAR2")
         .hasResponse(
@@ -244,8 +245,8 @@ class EppLoginTlsTest extends EppTestCase {
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()
-            .setClientCertificate(sw.toString(), clock.nowUtc())
-            .setFailoverClientCertificate(CertificateSamples.SAMPLE_CERT2, clock.nowUtc())
+            .setClientCertificate(sw.toString(), clock.now())
+            .setFailoverClientCertificate(CertificateSamples.SAMPLE_CERT2, clock.now())
             .build());
     assertThatLogin("NewRegistrar", "foo-BAR2")
         .hasResponse(
@@ -255,9 +256,10 @@ class EppLoginTlsTest extends EppTestCase {
                 "2200",
                 "MSG",
                 """
-                    Registrar certificate contains the following security violations:
-                    Certificate is expired.
-                    Certificate validity period is too long; it must be less than or equal to 398\
-                     days."""));
+                Registrar certificate contains the following security violations:
+                Certificate is expired.
+                Certificate validity period is too long; it must be less than or equal to 398\
+                 days.\
+                """));
   }
 }

--- a/core/src/test/java/google/registry/flows/ResourceFlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/ResourceFlowTestCase.java
@@ -17,6 +17,7 @@ package google.registry.flows;
 import static google.registry.model.ImmutableObjectSubject.assertAboutImmutableObjects;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.LogsSubject.assertAboutLogs;
+import static google.registry.util.DateTimeUtils.toInstant;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -81,7 +82,7 @@ public abstract class ResourceFlowTestCase<F extends Flow, R extends EppResource
   protected <T extends EppResource> T reloadResourceAndCloneAtTime(T resource, DateTime now) {
     @SuppressWarnings("unchecked")
     T refreshedResource =
-        (T) tm().transact(() -> tm().loadByEntity(resource)).cloneProjectedAtTime(now);
+        (T) tm().transact(() -> tm().loadByEntity(resource)).cloneProjectedAtTime(toInstant(now));
     return refreshedResource;
   }
 

--- a/core/src/test/java/google/registry/flows/TlsCredentialsTest.java
+++ b/core/src/test/java/google/registry/flows/TlsCredentialsTest.java
@@ -79,7 +79,7 @@ final class TlsCredentialsTest {
     persistResource(
         loadRegistrar("TheRegistrar")
             .asBuilder()
-            .setClientCertificate(SAMPLE_CERT, clock.nowUtc())
+            .setClientCertificate(SAMPLE_CERT, clock.now())
             .build());
     assertThrows(
         MissingRegistrarCertificateException.class,
@@ -97,7 +97,7 @@ final class TlsCredentialsTest {
     persistResource(
         loadRegistrar("TheRegistrar")
             .asBuilder()
-            .setClientCertificate(SAMPLE_CERT, clock.nowUtc())
+            .setClientCertificate(SAMPLE_CERT, clock.now())
             .setIpAddressAllowList(ImmutableSet.of(CidrAddressBlock.create("3.5.8.13")))
             .build());
 
@@ -118,7 +118,7 @@ final class TlsCredentialsTest {
     persistResource(
         loadRegistrar("TheRegistrar")
             .asBuilder()
-            .setClientCertificate(SAMPLE_CERT, clock.nowUtc())
+            .setClientCertificate(SAMPLE_CERT, clock.now())
             .setIpAddressAllowList(ImmutableSet.of(CidrAddressBlock.create("3.5.8.13")))
             .build());
 
@@ -155,8 +155,8 @@ final class TlsCredentialsTest {
     persistResource(
         loadRegistrar("TheRegistrar")
             .asBuilder()
-            .setClientCertificate(null, clock.nowUtc())
-            .setFailoverClientCertificate(null, clock.nowUtc())
+            .setClientCertificate(null, clock.now())
+            .setFailoverClientCertificate(null, clock.now())
             .build());
     // This would throw a RegistrarCertificateNotConfiguredException if cert hashes wren't bypassed.
     tls.validateCertificateHash(Registrar.loadByRegistrarId("TheRegistrar").get());
@@ -173,8 +173,8 @@ final class TlsCredentialsTest {
     persistResource(
         loadRegistrar("TheRegistrar")
             .asBuilder()
-            .setClientCertificate(null, clock.nowUtc())
-            .setFailoverClientCertificate(SAMPLE_CERT, clock.nowUtc())
+            .setClientCertificate(null, clock.now())
+            .setFailoverClientCertificate(SAMPLE_CERT, clock.now())
             .build());
     tls.validateCertificateHash(Registrar.loadByRegistrarId("TheRegistrar").get());
   }

--- a/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCheckFlowTest.java
@@ -346,7 +346,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setToken("abc123")
             .setTokenType(SINGLE_USE)
             .setDomainName("specificuse.tld")
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)
@@ -370,7 +370,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE))
             .setDiscountFraction(0.5)
             .setDiscountYears(2)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)
@@ -393,7 +393,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountFraction(0.5)
             .setDiscountYears(2)
             .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE))
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)
@@ -415,7 +415,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountFraction(0.9)
             .setDiscountYears(3)
             .setDiscountPremiums(true)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)
@@ -473,7 +473,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setToken("abc123")
             .setTokenType(SINGLE_USE)
             .setDomainName("specificuse.tld")
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 2), TokenStatus.VALID)
@@ -535,7 +535,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDomainName("single.tld")
             .setDiscountFraction(0.444)
             .setDiscountYears(2)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)
@@ -568,7 +568,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setToken("abc123")
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(plusDays(clock.now(), 1), TokenStatus.VALID)
@@ -592,7 +592,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setAllowedTlds(ImmutableSet.of("example"))
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)
@@ -616,7 +616,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setAllowedRegistrarIds(ImmutableSet.of("someOtherClient"))
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)
@@ -1218,7 +1218,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
     persistResource(
         setUpDefaultToken("NewRegistrar")
             .asBuilder()
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.of(
                     START_INSTANT,
                     TokenStatus.NOT_STARTED,
@@ -2117,7 +2117,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
     persistResource(
         setUpDefaultToken("NewRegistrar")
             .asBuilder()
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.of(
                     START_INSTANT,
                     TokenStatus.NOT_STARTED,
@@ -2156,7 +2156,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountFraction(0.5)
             .setDiscountYears(2)
             .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE))
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)
@@ -2190,7 +2190,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDomainName("single.tld")
             .setDiscountFraction(0.444)
             .setDiscountYears(2)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)
@@ -2225,7 +2225,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setDiscountFraction(0.9)
             .setDiscountYears(3)
             .setDiscountPremiums(true)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)
@@ -2274,7 +2274,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setToken("abc123")
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(plusDays(clock.now(), 1), TokenStatus.VALID)
@@ -2303,7 +2303,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE))
             .setDiscountFraction(0.5)
             .setDiscountYears(2)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)
@@ -2323,7 +2323,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setAllowedTlds(ImmutableSet.of("example"))
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)
@@ -2351,7 +2351,7 @@ class DomainCheckFlowTest extends ResourceCheckFlowTestCase<DomainCheckFlow, Dom
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
             .setAllowedRegistrarIds(ImmutableSet.of("someOtherClient"))
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -583,7 +583,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             new AllocationToken.Builder()
                 .setTokenType(UNLIMITED_USE)
                 .setToken("abc123")
-                .setTokenStatusTransitionsInstant(
+                .setTokenStatusTransitions(
                     ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                         .put(START_INSTANT, TokenStatus.NOT_STARTED)
                         .put(minusDays(clock.now(), 1), TokenStatus.VALID)
@@ -1327,7 +1327,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setToken("abc123")
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(clock.now().plusMillis(1), TokenStatus.VALID)
@@ -1371,7 +1371,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDiscountFraction(discountFraction)
             .setDiscountYears(discountYears)
             .setDiscountPremiums(discountPremiums)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(clock.now().plusMillis(1), TokenStatus.VALID)
@@ -1408,7 +1408,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDiscountFraction(0.98)
             .setDiscountYears(2)
             .setDiscountPremiums(true)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(clock.now().plusMillis(1), TokenStatus.VALID)
@@ -1447,7 +1447,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDomainName("rich.example")
             .setDiscountFraction(0.95555)
             .setDiscountPremiums(true)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(clock.now().plusMillis(1), TokenStatus.VALID)
@@ -1504,7 +1504,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setToken("abc123")
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(plusDays(clock.now(), 1), TokenStatus.VALID)
@@ -1528,7 +1528,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setTokenType(UNLIMITED_USE)
             .setAllowedRegistrarIds(ImmutableSet.of("someClientId"))
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)
@@ -1615,7 +1615,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         setupDefaultTokenWithDiscount()
             .asBuilder()
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 2), TokenStatus.VALID)
@@ -3287,7 +3287,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         setupDefaultTokenWithDiscount("NewRegistrar")
             .asBuilder()
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.of(
                     START_INSTANT,
                     TokenStatus.NOT_STARTED,
@@ -3879,7 +3879,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDiscountFraction(0.98)
             .setDiscountYears(2)
             .setDiscountPremiums(true)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(clock.now().plusMillis(1), TokenStatus.VALID)
@@ -3988,7 +3988,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
             .setDomainName("rich.example")
             .setDiscountFraction(0.95555)
             .setDiscountPremiums(true)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(clock.now().plusMillis(1), TokenStatus.VALID)
@@ -4019,7 +4019,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistResource(
         setupDefaultTokenWithDiscount("NewRegistrar")
             .asBuilder()
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.of(
                     START_INSTANT,
                     TokenStatus.NOT_STARTED,

--- a/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainDeleteFlowTest.java
@@ -385,7 +385,7 @@ class DomainDeleteFlowTest extends ResourceFlowTestCase<DomainDeleteFlow, Domain
 
     Domain domain = reloadResourceByForeignKey();
     Instant redemptionEndTime = plusDays(domain.getLastEppUpdateTime(), 3);
-    Domain domainAtRedemptionTime = domain.cloneProjectedAtInstant(redemptionEndTime);
+    Domain domainAtRedemptionTime = domain.cloneProjectedAtTime(redemptionEndTime);
     assertAboutDomains()
         .that(domainAtRedemptionTime)
         .hasLastEppUpdateRegistrarId("TheRegistrar")

--- a/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRenewFlowTest.java
@@ -39,6 +39,7 @@ import static google.registry.testing.DomainSubject.assertAboutDomains;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
 import static google.registry.testing.HistoryEntrySubject.assertAboutHistoryEntries;
 import static google.registry.testing.TestDataHelper.updateSubstitutions;
+import static google.registry.util.DateTimeUtils.END_INSTANT;
 import static google.registry.util.DateTimeUtils.END_OF_TIME;
 import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
@@ -47,7 +48,6 @@ import static google.registry.util.DateTimeUtils.minusYears;
 import static google.registry.util.DateTimeUtils.plusDays;
 import static google.registry.util.DateTimeUtils.plusMinutes;
 import static google.registry.util.DateTimeUtils.plusYears;
-import static google.registry.util.DateTimeUtils.toInstant;
 import static org.joda.money.CurrencyUnit.EUR;
 import static org.joda.money.CurrencyUnit.JPY;
 import static org.joda.money.CurrencyUnit.USD;
@@ -174,7 +174,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
               .setTargetId(getUniqueIdFromCommand())
               .setRegistrarId("TheRegistrar")
               .setEventTime(expirationTime)
-              .setRecurrenceEndTime(toInstant(END_OF_TIME))
+              .setRecurrenceEndTime(END_INSTANT)
               .setDomainHistory(historyEntryDomainCreate)
               .setRenewalPriceBehavior(renewalPriceBehavior)
               .setRenewalPrice(renewalPrice)
@@ -311,8 +311,8 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
             .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
             .setTargetId(getUniqueIdFromCommand())
             .setRegistrarId("TheRegistrar")
-            .setEventTime(toInstant(domain.getRegistrationExpirationDateTime()))
-            .setRecurrenceEndTime(toInstant(END_OF_TIME))
+            .setEventTime(domain.getRegistrationExpirationTime())
+            .setRecurrenceEndTime(END_INSTANT)
             .setDomainHistory(historyEntryDomainRenew)
             .build());
     // There should only be the new autorenew poll message, as the old one will have been deleted
@@ -321,7 +321,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
         new PollMessage.Autorenew.Builder()
             .setTargetId(getUniqueIdFromCommand())
             .setRegistrarId("TheRegistrar")
-            .setEventTime(toInstant(domain.getRegistrationExpirationDateTime()))
+            .setEventTime(domain.getRegistrationExpirationTime())
             .setAutorenewEndTime(END_OF_TIME)
             .setMsg("Domain was auto-renewed.")
             .setHistoryEntry(historyEntryDomainRenew)
@@ -667,7 +667,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
             .setToken("abc123")
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(plusDays(clock.now(), 1), TokenStatus.VALID)
@@ -691,7 +691,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
             .setTokenType(UNLIMITED_USE)
             .setAllowedRegistrarIds(ImmutableSet.of("someClientId"))
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)
@@ -716,7 +716,7 @@ class DomainRenewFlowTest extends ResourceFlowTestCase<DomainRenewFlow, Domain> 
             .setTokenType(UNLIMITED_USE)
             .setAllowedTlds(ImmutableSet.of("example"))
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)

--- a/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainRestoreRequestFlowTest.java
@@ -208,7 +208,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
         new PollMessage.Autorenew.Builder()
             .setTargetId("example.tld")
             .setRegistrarId("TheRegistrar")
-            .setEventTime(domain.getRegistrationExpirationDateTime())
+            .setEventTime(domain.getRegistrationExpirationTime())
             .setAutorenewEndTime(END_OF_TIME)
             .setMsg("Domain was auto-renewed.")
             .setHistoryEntry(historyEntryDomainRestore)
@@ -276,7 +276,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
         new PollMessage.Autorenew.Builder()
             .setTargetId("example.tld")
             .setRegistrarId("TheRegistrar")
-            .setEventTime(domain.getRegistrationExpirationDateTime())
+            .setEventTime(domain.getRegistrationExpirationTime())
             .setAutorenewEndTime(END_OF_TIME)
             .setMsg("Domain was auto-renewed.")
             .setHistoryEntry(historyEntryDomainRestore)
@@ -322,7 +322,7 @@ class DomainRestoreRequestFlowTest extends ResourceFlowTestCase<DomainRestoreReq
     persistResource(
         reloadResourceByForeignKey()
             .asBuilder()
-            .setAutorenewEndTimeInstant(Optional.of(plusYears(clock.now(), 2)))
+            .setAutorenewEndTime(Optional.of(plusYears(clock.now(), 2)))
             .build());
     assertThat(reloadResourceByForeignKey().getAutorenewEndTime()).isPresent();
     runFlowAssertResponse(

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferApproveFlowTest.java
@@ -259,7 +259,7 @@ class DomainTransferApproveFlowTest
     // After the expected grace time, the grace period should be gone.
     assertThat(
             domain
-                .cloneProjectedAtInstant(
+                .cloneProjectedAtTime(
                     clock.now().plusMillis(registry.getTransferGracePeriodLength().getMillis()))
                 .getGracePeriods())
         .isEmpty();
@@ -917,7 +917,7 @@ class DomainTransferApproveFlowTest
             .setToken("abc123")
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(plusDays(clock.now(), 1), TokenStatus.VALID)
@@ -937,7 +937,7 @@ class DomainTransferApproveFlowTest
             .setTokenType(UNLIMITED_USE)
             .setAllowedRegistrarIds(ImmutableSet.of("someClientId"))
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)
@@ -958,7 +958,7 @@ class DomainTransferApproveFlowTest
             .setTokenType(UNLIMITED_USE)
             .setAllowedTlds(ImmutableSet.of("example"))
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferQueryFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferQueryFlowTest.java
@@ -146,8 +146,7 @@ class DomainTransferQueryFlowTest
         persistResource(
             domain
                 .asBuilder()
-                .setRegistrationExpirationTime(
-                    domain.getRegistrationExpirationDateTime().plusYears(9))
+                .setRegistrationExpirationTime(plusYears(domain.getRegistrationExpirationTime(), 9))
                 .build());
     doSuccessfulTest("domain_transfer_query.xml", "domain_transfer_query_response_10_years.xml", 1);
   }
@@ -235,7 +234,7 @@ class DomainTransferQueryFlowTest
     // Set the clock to just past the extended registration time.  We'd expect the domain to have
     // auto-renewed once, but the transfer query response should be the same.
     clock.setTo(EXTENDED_REGISTRATION_EXPIRATION_TIME.plusMillis(1));
-    assertThat(domain.cloneProjectedAtInstant(clock.now()).getRegistrationExpirationTime())
+    assertThat(domain.cloneProjectedAtTime(clock.now()).getRegistrationExpirationTime())
         .isEqualTo(plusYears(EXTENDED_REGISTRATION_EXPIRATION_TIME, 1));
     doSuccessfulTest(
         "domain_transfer_query.xml", "domain_transfer_query_response_server_approved.xml", 2);

--- a/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainTransferRequestFlowTest.java
@@ -52,7 +52,6 @@ import static google.registry.util.DateTimeUtils.minusDays;
 import static google.registry.util.DateTimeUtils.minusYears;
 import static google.registry.util.DateTimeUtils.plusDays;
 import static google.registry.util.DateTimeUtils.plusYears;
-import static google.registry.util.DateTimeUtils.toDateTime;
 import static org.joda.money.CurrencyUnit.JPY;
 import static org.joda.money.CurrencyUnit.USD;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -345,7 +344,7 @@ class DomainTransferRequestFlowTest
     assertThat(domain.getGracePeriods()).containsExactlyElementsIn(originalGracePeriods);
     // If we fast forward AUTOMATIC_TRANSFER_DAYS, the transfer should have cleared out all other
     // grace periods, but expect a transfer grace period (if there was a transfer billing event).
-    Domain domainAfterAutomaticTransfer = domain.cloneProjectedAtInstant(implicitTransferTime);
+    Domain domainAfterAutomaticTransfer = domain.cloneProjectedAtTime(implicitTransferTime);
     if (expectTransferBillingEvent) {
       assertGracePeriods(
           domainAfterAutomaticTransfer.getGracePeriods(),
@@ -440,7 +439,7 @@ class DomainTransferRequestFlowTest
       Instant expectedExpirationTime, Instant implicitTransferTime, Period expectedPeriod)
       throws Exception {
     Tld registry = Tld.get(domain.getTld());
-    Domain domainAfterAutomaticTransfer = domain.cloneProjectedAtInstant(implicitTransferTime);
+    Domain domainAfterAutomaticTransfer = domain.cloneProjectedAtTime(implicitTransferTime);
     assertTransferApproved(domainAfterAutomaticTransfer, implicitTransferTime, expectedPeriod);
     assertAboutDomains()
         .that(domainAfterAutomaticTransfer)
@@ -453,7 +452,7 @@ class DomainTransferRequestFlowTest
         .isEqualTo(expectedExpirationTime);
     // And after the expected grace time, the grace period should be gone.
     Domain afterGracePeriod =
-        domain.cloneProjectedAtInstant(
+        domain.cloneProjectedAtTime(
             clock
                 .now()
                 .plusMillis(registry.getAutomaticTransferLength().getMillis())
@@ -526,9 +525,7 @@ class DomainTransferRequestFlowTest
             .header("content-type", "application/x-www-form-urlencoded")
             .param(PARAM_RESOURCE_KEY, domain.createVKey().stringify())
             .param(PARAM_REQUESTED_TIME, clock.now().toString())
-            .scheduleTime(
-                toDateTime(
-                    clock.now().plusMillis(registry.getAutomaticTransferLength().getMillis()))));
+            .scheduleTime(clock.nowUtc().plus(registry.getAutomaticTransferLength())));
   }
 
   private void doSuccessfulTest(
@@ -1795,7 +1792,7 @@ class DomainTransferRequestFlowTest
             .setToken("abc123")
             .setTokenType(UNLIMITED_USE)
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(plusDays(clock.now(), 1), TokenStatus.VALID)
@@ -1816,7 +1813,7 @@ class DomainTransferRequestFlowTest
             .setTokenType(UNLIMITED_USE)
             .setAllowedRegistrarIds(ImmutableSet.of("someClientId"))
             .setDiscountFraction(0.5)
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, TokenStatus.NOT_STARTED)
                     .put(minusDays(clock.now(), 1), TokenStatus.VALID)

--- a/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
@@ -53,7 +53,6 @@ import static google.registry.testing.HistoryEntrySubject.assertAboutHistoryEntr
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static google.registry.util.DateTimeUtils.plusDays;
 import static google.registry.util.DateTimeUtils.plusYears;
-import static google.registry.util.DateTimeUtils.toDateTime;
 import static org.joda.money.CurrencyUnit.USD;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -1503,7 +1502,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     persistResource(
         persistDomain()
             .asBuilder()
-            .setAutorenewEndTime(Optional.of(toDateTime(expirationTime)))
+            .setAutorenewEndTime(Optional.of(expirationTime))
             .setRegistrationExpirationTime(expirationTime)
             .build());
     clock.advanceOneMilli();

--- a/core/src/test/java/google/registry/flows/domain/token/AllocationTokenFlowUtilsTest.java
+++ b/core/src/test/java/google/registry/flows/domain/token/AllocationTokenFlowUtilsTest.java
@@ -293,7 +293,7 @@ class AllocationTokenFlowUtilsTest {
     // the promo would be valid, but it was cancelled 12 hours ago
     persistResource(
         createOneMonthPromoTokenBuilder(minusDays(clock.now(), 1))
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, NOT_STARTED)
                     .put(minusMonths(clock.now(), 1), VALID)
@@ -485,7 +485,7 @@ class AllocationTokenFlowUtilsTest {
     return new AllocationToken.Builder()
         .setToken("tokeN")
         .setTokenType(UNLIMITED_USE)
-        .setTokenStatusTransitionsInstant(
+        .setTokenStatusTransitions(
             ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                 .put(START_INSTANT, NOT_STARTED)
                 .put(promoStart, VALID)

--- a/core/src/test/java/google/registry/flows/host/HostUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/host/HostUpdateFlowTest.java
@@ -39,7 +39,6 @@ import static google.registry.testing.HostSubject.assertAboutHosts;
 import static google.registry.util.DateTimeUtils.END_INSTANT;
 import static google.registry.util.DateTimeUtils.minusDays;
 import static google.registry.util.DateTimeUtils.plusDays;
-import static google.registry.util.DateTimeUtils.toInstant;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.cloud.tasks.v2.HttpMethod;
@@ -296,7 +295,7 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
         .hasPersistedCurrentSponsorRegistrarId("TheRegistrar")
         .and()
         .hasLastTransferTime(oneDayAgo);
-    Domain reloadedDomain = loadByEntity(domain).cloneProjectedAtInstant(now);
+    Domain reloadedDomain = loadByEntity(domain).cloneProjectedAtTime(now);
     assertThat(reloadedDomain.getSubordinateHosts()).containsExactly("ns2.example.tld");
     assertHostDnsRequests("ns1.example.tld", "ns2.example.tld");
   }
@@ -330,8 +329,8 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
         .hasPersistedCurrentSponsorRegistrarId("TheRegistrar")
         .and()
         .hasLastTransferTime(null);
-    assertThat(loadByEntity(foo).cloneProjectedAtInstant(now).getSubordinateHosts()).isEmpty();
-    assertThat(loadByEntity(example).cloneProjectedAtInstant(now).getSubordinateHosts())
+    assertThat(loadByEntity(foo).cloneProjectedAtTime(now).getSubordinateHosts()).isEmpty();
+    assertThat(loadByEntity(example).cloneProjectedAtTime(now).getSubordinateHosts())
         .containsExactly("ns2.example.tld");
     assertHostDnsRequests("ns2.foo.tld", "ns2.example.tld");
   }
@@ -366,9 +365,9 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
         .hasPersistedCurrentSponsorRegistrarId("TheRegistrar")
         .and()
         .hasLastTransferTime(null);
-    Domain reloadedFooDomain = loadByEntity(fooDomain).cloneProjectedAtInstant(now);
+    Domain reloadedFooDomain = loadByEntity(fooDomain).cloneProjectedAtTime(now);
     assertThat(reloadedFooDomain.getSubordinateHosts()).isEmpty();
-    Domain reloadedTldDomain = loadByEntity(tldDomain).cloneProjectedAtInstant(now);
+    Domain reloadedTldDomain = loadByEntity(tldDomain).cloneProjectedAtTime(now);
     assertThat(reloadedTldDomain.getSubordinateHosts()).containsExactly("ns2.example.tld");
     assertHostDnsRequests("ns1.example.foo", "ns2.example.tld");
   }
@@ -411,7 +410,7 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
         .and()
         .hasLastSuperordinateChange(clock.now());
     assertThat(renamedHost.getLastTransferTime()).isEqualTo(oneDayAgo);
-    Domain reloadedDomain = loadByEntity(domain).cloneProjectedAtInstant(clock.now());
+    Domain reloadedDomain = loadByEntity(domain).cloneProjectedAtTime(clock.now());
     assertThat(reloadedDomain.getSubordinateHosts()).isEmpty();
     assertHostDnsRequests("ns1.example.foo");
   }
@@ -447,7 +446,7 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
         .hasPersistedCurrentSponsorRegistrarId("TheRegistrar")
         .and()
         .hasLastTransferTime(null);
-    assertThat(loadByEntity(domain).cloneProjectedAtInstant(now).getSubordinateHosts())
+    assertThat(loadByEntity(domain).cloneProjectedAtTime(now).getSubordinateHosts())
         .containsExactly("ns2.example.tld");
     assertHostDnsRequests("ns2.example.tld");
   }
@@ -520,7 +519,7 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
     persistResource(
         DatabaseHelper.newDomain("example.tld")
             .asBuilder()
-            .setLastTransferTime(clock.nowUtc().minusDays(10))
+            .setLastTransferTime(minusDays(clock.now(), 10))
             .build());
 
     persistResource(
@@ -553,14 +552,14 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
         persistResource(
             DatabaseHelper.newDomain("foo.tld")
                 .asBuilder()
-                .setLastTransferTime(clock.nowUtc().minusDays(5))
+                .setLastTransferTime(minusDays(clock.now(), 5))
                 .build());
     // Set the new domain to have a last transfer time that is different from the last transfer
     // time on the host in question.
     persistResource(
         DatabaseHelper.newDomain("example.tld")
             .asBuilder()
-            .setLastTransferTime(clock.nowUtc().minusDays(10))
+            .setLastTransferTime(minusDays(clock.now(), 10))
             .build());
     Host host =
         persistResource(
@@ -595,7 +594,7 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
         persistResource(
             DatabaseHelper.newDomain("foo.tld")
                 .asBuilder()
-                .setLastTransferTime(clock.nowUtc().minusDays(5))
+                .setLastTransferTime(minusDays(clock.now(), 5))
                 .build());
     // Set the new domain to have a null last transfer time.
     persistResource(
@@ -678,7 +677,7 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
         persistResource(
             DatabaseHelper.newDomain("foo.tld")
                 .asBuilder()
-                .setLastTransferTime(clock.nowUtc().minusDays(5))
+                .setLastTransferTime(minusDays(clock.now(), 5))
                 .build());
     // Set the new domain to have a null last transfer time.
     persistResource(
@@ -731,7 +730,7 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
     clock.advanceOneMilli();
     Host renamedHost = doSuccessfulTest();
     clock.advanceOneMilli();
-    persistResource(domain.asBuilder().setLastTransferTime(clock.nowUtc().minusDays(1)).build());
+    persistResource(domain.asBuilder().setLastTransferTime(minusDays(clock.now(), 1)).build());
     // The last transfer time should be what was on the superordinate domain at the time of the host
     // update, not what it is later changed to.
     assertAboutHosts()
@@ -767,7 +766,7 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
     persistResource(
         domain
             .asBuilder()
-            .setLastTransferTime(clock.nowUtc().minusDays(14))
+            .setLastTransferTime(minusDays(clock.now(), 14))
             .setSubordinateHosts(ImmutableSet.of(oldHostName()))
             .build());
     clock.advanceOneMilli();
@@ -805,7 +804,7 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
         persistResource(
             domain
                 .asBuilder()
-                .setLastTransferTime(clock.nowUtc().minusDays(2))
+                .setLastTransferTime(minusDays(clock.now(), 2))
                 .setSubordinateHosts(ImmutableSet.of(oldHostName()))
                 .build());
     Host renamedHost = doSuccessfulTest();
@@ -815,7 +814,7 @@ class HostUpdateFlowTest extends ResourceFlowTestCase<HostUpdateFlow, Host> {
         .that(renamedHost)
         .hasPersistedCurrentSponsorRegistrarId("TheRegistrar")
         .and()
-        .hasLastTransferTime(toInstant(domain.getLastTransferTime()));
+        .hasLastTransferTime(domain.getLastTransferTime());
   }
 
   private void doExternalToInternalLastTransferTimeTest(

--- a/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
+++ b/core/src/test/java/google/registry/flows/session/LoginFlowViaTlsTest.java
@@ -16,7 +16,6 @@ package google.registry.flows.session;
 
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
-import static org.joda.time.DateTimeZone.UTC;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -31,6 +30,8 @@ import google.registry.model.registrar.Registrar;
 import google.registry.testing.CertificateSamples;
 import google.registry.util.CidrAddressBlock;
 import java.net.InetAddress;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
@@ -63,7 +64,7 @@ public class LoginFlowViaTlsTest extends LoginFlowTestCase {
   @Override
   protected Registrar.Builder getRegistrarBuilder() {
     return super.getRegistrarBuilder()
-        .setClientCertificate(GOOD_CERT.get(), DateTime.now(UTC))
+        .setClientCertificate(GOOD_CERT.get(), Instant.now().truncatedTo(ChronoUnit.MILLIS))
         .setIpAddressAllowList(ImmutableList.of(CidrAddressBlock.create(GOOD_IP.get(), 32)));
   }
 

--- a/core/src/test/java/google/registry/model/billing/BillingBaseTest.java
+++ b/core/src/test/java/google/registry/model/billing/BillingBaseTest.java
@@ -22,11 +22,11 @@ import static google.registry.testing.DatabaseHelper.loadByKey;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.END_INSTANT;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static google.registry.util.DateTimeUtils.plusDays;
 import static google.registry.util.DateTimeUtils.plusYears;
 import static google.registry.util.SerializeUtils.serializeDeserialize;
 import static org.joda.money.CurrencyUnit.USD;
-import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableSet;
@@ -43,11 +43,11 @@ import google.registry.model.domain.token.AllocationToken;
 import google.registry.model.domain.token.AllocationToken.TokenStatus;
 import google.registry.model.reporting.HistoryEntry;
 import google.registry.persistence.VKey;
-import google.registry.util.DateTimeUtils;
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -100,10 +100,12 @@ public class BillingBaseTest extends EntityTestCase {
                 .setTokenType(UNLIMITED_USE)
                 .setDiscountFraction(0.5)
                 .setTokenStatusTransitions(
-                    ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                        .put(DateTimeUtils.START_OF_TIME, TokenStatus.NOT_STARTED)
-                        .put(DateTime.now(UTC), TokenStatus.VALID)
-                        .put(DateTime.now(UTC).plusWeeks(8), TokenStatus.ENDED)
+                    ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                        .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                        .put(Instant.now().truncatedTo(ChronoUnit.MILLIS), TokenStatus.VALID)
+                        .put(
+                            Instant.now().truncatedTo(ChronoUnit.MILLIS).plus(Duration.ofDays(56)),
+                            TokenStatus.ENDED)
                         .build())
                 .build());
 

--- a/core/src/test/java/google/registry/model/domain/DomainCommandTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainCommandTest.java
@@ -81,7 +81,7 @@ class DomainCommandTest extends ResourceCommandTestCase {
     persistActiveHost("ns2.example.net");
     DomainCommand.Create create =
         (DomainCommand.Create) loadEppResourceCommand("domain_create.xml");
-    create.cloneAndLinkReferences(fakeClock.nowUtc());
+    create.cloneAndLinkReferences(fakeClock.now());
   }
 
   @Test
@@ -91,8 +91,7 @@ class DomainCommandTest extends ResourceCommandTestCase {
     DomainCommand.Create create =
         (DomainCommand.Create) loadEppResourceCommand("domain_create_with_contacts.xml");
     assertThrows(
-        RegistrantProhibitedException.class,
-        () -> create.cloneAndLinkReferences(fakeClock.nowUtc()));
+        RegistrantProhibitedException.class, () -> create.cloneAndLinkReferences(fakeClock.now()));
   }
 
   @Test
@@ -101,15 +100,14 @@ class DomainCommandTest extends ResourceCommandTestCase {
         (DomainCommand.Create)
             loadEppResourceCommand("domain_create_missing_non_registrant_contacts.xml");
     assertThrows(
-        RegistrantProhibitedException.class,
-        () -> create.cloneAndLinkReferences(fakeClock.nowUtc()));
+        RegistrantProhibitedException.class, () -> create.cloneAndLinkReferences(fakeClock.now()));
   }
 
   @Test
   void testCreate_emptyCommand_cloneAndLinkReferences() throws Exception {
     DomainCommand.Create create =
         (DomainCommand.Create) loadEppResourceCommand("domain_create_empty.xml");
-    create.cloneAndLinkReferences(fakeClock.nowUtc());
+    create.cloneAndLinkReferences(fakeClock.now());
   }
 
   @Test
@@ -134,7 +132,7 @@ class DomainCommandTest extends ResourceCommandTestCase {
     persistActiveHost("ns2.example.com");
     DomainCommand.Update update =
         (DomainCommand.Update) loadEppResourceCommand("domain_update.xml");
-    update.cloneAndLinkReferences(fakeClock.nowUtc());
+    update.cloneAndLinkReferences(fakeClock.now());
   }
 
   @Test
@@ -144,7 +142,7 @@ class DomainCommandTest extends ResourceCommandTestCase {
     DomainCommand.Update update =
         (DomainCommand.Update) loadEppResourceCommand("domain_update_with_contacts.xml");
     assertThrows(
-        ContactsProhibitedException.class, () -> update.cloneAndLinkReferences(fakeClock.nowUtc()));
+        ContactsProhibitedException.class, () -> update.cloneAndLinkReferences(fakeClock.now()));
   }
 
   @Test
@@ -152,7 +150,7 @@ class DomainCommandTest extends ResourceCommandTestCase {
     // This EPP command wouldn't be allowed for policy reasons, but should clone-and-link fine.
     DomainCommand.Update update =
         (DomainCommand.Update) loadEppResourceCommand("domain_update_empty.xml");
-    update.cloneAndLinkReferences(fakeClock.nowUtc());
+    update.cloneAndLinkReferences(fakeClock.now());
   }
 
   @Test

--- a/core/src/test/java/google/registry/model/domain/DomainSqlTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainSqlTest.java
@@ -128,7 +128,7 @@ public class DomainSqlTest {
             .setRenewalPriceBehavior(RenewalPriceBehavior.SPECIFIED)
             .setRenewalPrice(Money.of(CurrencyUnit.USD, 0))
             .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE))
-            .setTokenStatusTransitionsInstant(
+            .setTokenStatusTransitions(
                 ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                     .put(START_INSTANT, NOT_STARTED)
                     .put(fakeClock.now(), TokenStatus.VALID)

--- a/core/src/test/java/google/registry/model/domain/DomainTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainTest.java
@@ -30,6 +30,7 @@ import static google.registry.testing.DatabaseHelper.persistResources;
 import static google.registry.testing.DomainSubject.assertAboutDomains;
 import static google.registry.testing.SqlHelper.saveRegistrar;
 import static google.registry.util.DateTimeUtils.END_INSTANT;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static google.registry.util.DateTimeUtils.minusDays;
 import static google.registry.util.DateTimeUtils.plusDays;
@@ -178,7 +179,7 @@ public class DomainTest {
                     .setLastEppUpdateTime(fakeClock.now())
                     .setLastEppUpdateRegistrarId("NewRegistrar")
                     .setPersistedCurrentSponsorRegistrarId("NewRegistrar")
-                    .setLastTransferTime(fakeClock.nowUtc())
+                    .setLastTransferTime(fakeClock.now())
                     .setStatusValues(
                         ImmutableSet.of(
                             StatusValue.CLIENT_DELETE_PROHIBITED,
@@ -190,11 +191,11 @@ public class DomainTest {
                     .setNameservers(ImmutableSet.of(hostKey))
                     .setSubordinateHosts(ImmutableSet.of("ns1.example.com"))
                     .setPersistedCurrentSponsorRegistrarId("NewRegistrar")
-                    .setRegistrationExpirationTime(fakeClock.nowUtc().plusYears(1))
+                    .setRegistrationExpirationTime(plusYears(fakeClock.now(), 1))
                     .setAuthInfo(DomainAuthInfo.create(PasswordAuth.create("password")))
                     .setDsData(ImmutableSet.of(DomainDsData.create(1, 2, 3, new byte[] {0, 1, 2})))
                     .setLaunchNotice(
-                        LaunchNotice.create("tcnid", "validatorId", START_OF_TIME, START_OF_TIME))
+                        LaunchNotice.create("tcnid", "validatorId", START_INSTANT, START_INSTANT))
                     .setTransferData(
                         new DomainTransferData.Builder()
                             .setGainingRegistrarId("TheRegistrar")
@@ -223,7 +224,7 @@ public class DomainTest {
                             plusDays(fakeClock.now(), 1),
                             "TheRegistrar",
                             oneTimeBillKey))
-                    .setAutorenewEndTime(Optional.of(fakeClock.nowUtc().plusYears(2)))
+                    .setAutorenewEndTime(Optional.of(plusYears(fakeClock.now(), 2)))
                     .build()));
   }
 
@@ -393,8 +394,8 @@ public class DomainTest {
     assertThat(domain.getTransferData().getTransferStatus())
         .isEqualTo(TransferStatus.SERVER_APPROVED);
     assertThat(domain.getCurrentSponsorRegistrarId()).isEqualTo("TheRegistrar");
-    assertThat(domain.getLastTransferTime()).isEqualTo(fakeClock.nowUtc().plusDays(1));
-    assertThat(domain.getRegistrationExpirationDateTime()).isEqualTo(newExpirationTime);
+    assertThat(domain.getLastTransferTime()).isEqualTo(plusDays(fakeClock.now(), 1));
+    assertThat(domain.getRegistrationExpirationTime()).isEqualTo(toInstant(newExpirationTime));
     assertThat(domain.getAutorenewBillingEvent()).isEqualTo(newAutorenewEvent);
   }
 
@@ -427,7 +428,7 @@ public class DomainTest {
     domain =
         domain
             .asBuilder()
-            .setRegistrationExpirationTime(oldExpirationTime)
+            .setRegistrationExpirationTime(toInstant(oldExpirationTime))
             .setTransferData(
                 domain
                     .getTransferData()
@@ -452,7 +453,7 @@ public class DomainTest {
                     "TheRegistrar",
                     oneTimeBillKey))
             .build();
-    Domain afterTransfer = domain.cloneProjectedAtTime(fakeClock.nowUtc().plusDays(1));
+    Domain afterTransfer = domain.cloneProjectedAtTime(plusDays(fakeClock.now(), 1));
     DateTime newExpirationTime = oldExpirationTime.plusYears(1);
     VKey<BillingRecurrence> serverApproveAutorenewEvent =
         domain.getTransferData().getServerApproveAutorenewEvent();
@@ -473,7 +474,11 @@ public class DomainTest {
     // If we project after the grace period expires all should be the same except the grace period.
     Domain afterGracePeriod =
         domain.cloneProjectedAtTime(
-            fakeClock.nowUtc().plusDays(2).plus(Tld.get("com").getTransferGracePeriodLength()));
+            toInstant(
+                fakeClock
+                    .nowUtc()
+                    .plusDays(2)
+                    .plus(Tld.get("com").getTransferGracePeriodLength())));
     assertTransferred(afterGracePeriod, newExpirationTime, serverApproveAutorenewEvent);
     assertThat(afterGracePeriod.getGracePeriods()).isEmpty();
   }
@@ -496,7 +501,7 @@ public class DomainTest {
     domain =
         domain
             .asBuilder()
-            .setRegistrationExpirationTime(toDateTime(oldExpirationTime))
+            .setRegistrationExpirationTime(oldExpirationTime)
             .setTransferData(
                 domain
                     .getTransferData()
@@ -518,13 +523,13 @@ public class DomainTest {
     Instant transferSuccessDateTime = plusDays(now, 5);
     setupPendingTransferDomain(autorenewDateTime, transferRequestDateTime, transferSuccessDateTime);
 
-    Domain beforeAutoRenew = domain.cloneProjectedAtInstant(minusDays(autorenewDateTime, 1));
+    Domain beforeAutoRenew = domain.cloneProjectedAtTime(minusDays(autorenewDateTime, 1));
     assertThat(beforeAutoRenew.getLastEppUpdateTime()).isEqualTo(transferRequestDateTime);
     assertThat(beforeAutoRenew.getLastEppUpdateRegistrarId()).isEqualTo("TheRegistrar");
 
     // If autorenew happens before transfer succeeds(before transfer grace period starts as well),
     // lastEppUpdateRegistrarId should still be the current sponsor client id
-    Domain afterAutoRenew = domain.cloneProjectedAtInstant(plusDays(autorenewDateTime, 1));
+    Domain afterAutoRenew = domain.cloneProjectedAtTime(plusDays(autorenewDateTime, 1));
     assertThat(afterAutoRenew.getLastEppUpdateTime()).isEqualTo(autorenewDateTime);
     assertThat(afterAutoRenew.getLastEppUpdateRegistrarId()).isEqualTo("NewRegistrar");
   }
@@ -537,12 +542,11 @@ public class DomainTest {
     Instant transferSuccessDateTime = plusDays(now, 5);
     setupPendingTransferDomain(autorenewDateTime, transferRequestDateTime, transferSuccessDateTime);
 
-    Domain beforeAutoRenew = domain.cloneProjectedAtInstant(minusDays(autorenewDateTime, 1));
+    Domain beforeAutoRenew = domain.cloneProjectedAtTime(minusDays(autorenewDateTime, 1));
     assertThat(beforeAutoRenew.getLastEppUpdateTime()).isEqualTo(transferRequestDateTime);
     assertThat(beforeAutoRenew.getLastEppUpdateRegistrarId()).isEqualTo("TheRegistrar");
 
-    Domain afterTransferSuccess =
-        domain.cloneProjectedAtInstant(plusDays(transferSuccessDateTime, 1));
+    Domain afterTransferSuccess = domain.cloneProjectedAtTime(plusDays(transferSuccessDateTime, 1));
     assertThat(afterTransferSuccess.getLastEppUpdateTime()).isEqualTo(transferSuccessDateTime);
     assertThat(afterTransferSuccess.getLastEppUpdateRegistrarId()).isEqualTo("TheRegistrar");
   }
@@ -551,7 +555,7 @@ public class DomainTest {
     domain =
         domain
             .asBuilder()
-            .setRegistrationExpirationTime(oldExpirationTime)
+            .setRegistrationExpirationTime(toInstant(oldExpirationTime))
             .setTransferData(DomainTransferData.EMPTY)
             .setGracePeriods(ImmutableSet.of())
             .setLastEppUpdateTime((Instant) null)
@@ -565,11 +569,11 @@ public class DomainTest {
     DateTime autorenewDateTime = now.plusDays(3);
     setupUnmodifiedDomain(autorenewDateTime);
 
-    Domain beforeAutoRenew = domain.cloneProjectedAtTime(autorenewDateTime.minusDays(1));
+    Domain beforeAutoRenew = domain.cloneProjectedAtTime(toInstant(autorenewDateTime.minusDays(1)));
     assertThat(beforeAutoRenew.getLastEppUpdateTime()).isEqualTo(null);
     assertThat(beforeAutoRenew.getLastEppUpdateRegistrarId()).isEqualTo(null);
 
-    Domain afterAutoRenew = domain.cloneProjectedAtTime(autorenewDateTime.plusDays(1));
+    Domain afterAutoRenew = domain.cloneProjectedAtTime(toInstant(autorenewDateTime.plusDays(1)));
     assertThat(afterAutoRenew.getLastEppUpdateTime()).isEqualTo(toInstant(autorenewDateTime));
     assertThat(afterAutoRenew.getLastEppUpdateRegistrarId()).isEqualTo("NewRegistrar");
   }
@@ -598,7 +602,7 @@ public class DomainTest {
                 null));
     domain = domain.asBuilder().setGracePeriods(ImmutableSet.copyOf(gracePeriods)).build();
     for (int i = 1; i < 3; ++i) {
-      assertThat(domain.cloneProjectedAtTime(fakeClock.nowUtc().plusDays(i)).getGracePeriods())
+      assertThat(domain.cloneProjectedAtTime(plusDays(fakeClock.now(), i)).getGracePeriods())
           .containsExactlyElementsIn(Iterables.limit(gracePeriods, 3 - i));
     }
   }
@@ -647,7 +651,7 @@ public class DomainTest {
 
   @Test
   void testRenewalsHappenAtExpiration() {
-    Domain renewed = domain.cloneProjectedAtInstant(domain.getRegistrationExpirationTime());
+    Domain renewed = domain.cloneProjectedAtTime(domain.getRegistrationExpirationTime());
     assertThat(renewed.getRegistrationExpirationTime())
         .isEqualTo(plusYears(domain.getRegistrationExpirationTime(), 1));
     assertThat(renewed.getLastEppUpdateTime()).isEqualTo(domain.getRegistrationExpirationTime());
@@ -667,10 +671,10 @@ public class DomainTest {
     domain =
         domain
             .asBuilder()
-            .setRegistrationExpirationTime(DateTime.parse("2004-02-29T22:00:00.0Z"))
+            .setRegistrationExpirationTime(Instant.parse("2004-02-29T22:00:00.0Z"))
             .build();
     Domain renewed =
-        domain.cloneProjectedAtInstant(plusYears(domain.getRegistrationExpirationTime(), 4));
+        domain.cloneProjectedAtTime(plusYears(domain.getRegistrationExpirationTime(), 4));
     assertThat(renewed.getRegistrationExpirationTime().atZone(ZoneOffset.UTC).getDayOfMonth())
         .isEqualTo(28);
   }
@@ -679,35 +683,36 @@ public class DomainTest {
   void testMultipleAutoRenews() {
     // Change the registry so that renewal costs change every year to make sure we are using the
     // autorenew time as the lookup time for the cost.
-    DateTime oldExpirationTime = domain.getRegistrationExpirationDateTime();
+    Instant oldExpirationTime = domain.getRegistrationExpirationTime();
     persistResource(
         Tld.get("com")
             .asBuilder()
             .setRenewBillingCostTransitions(
                 new ImmutableSortedMap.Builder<DateTime, Money>(Ordering.natural())
                     .put(START_OF_TIME, Money.of(USD, 1))
-                    .put(oldExpirationTime.plusMillis(1), Money.of(USD, 2))
-                    .put(oldExpirationTime.plusYears(1).plusMillis(1), Money.of(USD, 3))
+                    .put(toDateTime(oldExpirationTime.plusMillis(1)), Money.of(USD, 2))
+                    .put(
+                        toDateTime(plusYears(oldExpirationTime, 1).plusMillis(1)), Money.of(USD, 3))
                     // Surround the third autorenew with price changes right before and after just
                     // to be 100% sure that we lookup the cost at the expiration time.
-                    .put(oldExpirationTime.plusYears(2).minusMillis(1), Money.of(USD, 4))
-                    .put(oldExpirationTime.plusYears(2).plusMillis(1), Money.of(USD, 5))
+                    .put(
+                        toDateTime(plusYears(oldExpirationTime, 2).minusMillis(1)),
+                        Money.of(USD, 4))
+                    .put(
+                        toDateTime(plusYears(oldExpirationTime, 2).plusMillis(1)), Money.of(USD, 5))
                     .build())
             .build());
-    Domain renewedThreeTimes = domain.cloneProjectedAtTime(oldExpirationTime.plusYears(2));
-    assertThat(renewedThreeTimes.getRegistrationExpirationDateTime())
-        .isEqualTo(oldExpirationTime.plusYears(3));
-    assertThat(renewedThreeTimes.getLastEppUpdateTime())
-        .isEqualTo(toInstant(oldExpirationTime.plusYears(2)));
+    Domain renewedThreeTimes = domain.cloneProjectedAtTime(plusYears(oldExpirationTime, 2));
+    assertThat(renewedThreeTimes.getRegistrationExpirationTime())
+        .isEqualTo(plusYears(oldExpirationTime, 3));
+    assertThat(renewedThreeTimes.getLastEppUpdateTime()).isEqualTo(plusYears(oldExpirationTime, 2));
     assertThat(renewedThreeTimes.getGracePeriods())
         .containsExactly(
             GracePeriod.createForRecurrence(
                 GracePeriodStatus.AUTO_RENEW,
                 domain.getRepoId(),
-                toInstant(
-                    oldExpirationTime
-                        .plusYears(2)
-                        .plus(Tld.get("com").getAutoRenewGracePeriodLength())),
+                plusYears(oldExpirationTime, 2)
+                    .plusMillis(Tld.get("com").getAutoRenewGracePeriodLength().getMillis()),
                 renewedThreeTimes.getCurrentSponsorRegistrarId(),
                 renewedThreeTimes.autorenewBillingEvent,
                 renewedThreeTimes.getGracePeriods().iterator().next().getGracePeriodId()));
@@ -745,12 +750,12 @@ public class DomainTest {
         persistResource(
             domain
                 .asBuilder()
-                .setRegistrationExpirationTime(now.minusDays(1))
+                .setRegistrationExpirationTime(toInstant(now.minusDays(1)))
                 .setDeletionTime(toInstant(now.minusDays(10)))
                 .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE, StatusValue.INACTIVE))
                 .build());
-    assertThat(domain.cloneProjectedAtTime(now).getRegistrationExpirationDateTime())
-        .isEqualTo(now.minusDays(1));
+    assertThat(domain.cloneProjectedAtTime(toInstant(now)).getRegistrationExpirationTime())
+        .isEqualTo(toInstant(now.minusDays(1)));
   }
 
   @Test
@@ -761,12 +766,12 @@ public class DomainTest {
         persistResource(
             domain
                 .asBuilder()
-                .setRegistrationExpirationTime(now.plusDays(1))
+                .setRegistrationExpirationTime(toInstant(now.plusDays(1)))
                 .setDeletionTime(toInstant(now.plusDays(20)))
                 .setStatusValues(ImmutableSet.of(StatusValue.PENDING_DELETE, StatusValue.INACTIVE))
                 .build());
-    assertThat(domain.cloneProjectedAtTime(now).getRegistrationExpirationDateTime())
-        .isEqualTo(now.plusDays(1));
+    assertThat(domain.cloneProjectedAtTime(toInstant(now)).getRegistrationExpirationTime())
+        .isEqualTo(toInstant(now.plusDays(1)));
   }
 
   @Test
@@ -788,12 +793,12 @@ public class DomainTest {
         persistResource(
             domain
                 .asBuilder()
-                .setRegistrationExpirationTime(previousExpiration)
+                .setRegistrationExpirationTime(toInstant(previousExpiration))
                 .setTransferData(transferData)
                 .build());
 
-    assertThat(domain.cloneProjectedAtTime(now).getRegistrationExpirationDateTime())
-        .isEqualTo(newExpiration);
+    assertThat(domain.cloneProjectedAtTime(toInstant(now)).getRegistrationExpirationTime())
+        .isEqualTo(toInstant(newExpiration));
   }
 
   @Test
@@ -816,12 +821,12 @@ public class DomainTest {
         persistResource(
             domain
                 .asBuilder()
-                .setRegistrationExpirationTime(previousExpiration)
+                .setRegistrationExpirationTime(toInstant(previousExpiration))
                 .setTransferData(transferData)
                 .build());
 
-    assertThat(domain.cloneProjectedAtTime(now).getRegistrationExpirationDateTime())
-        .isEqualTo(newExpiration);
+    assertThat(domain.cloneProjectedAtTime(toInstant(now)).getRegistrationExpirationTime())
+        .isEqualTo(toInstant(newExpiration));
   }
 
   @Test
@@ -855,14 +860,14 @@ public class DomainTest {
         persistResource(
             domain
                 .asBuilder()
-                .setRegistrationExpirationTime(previousExpiration)
+                .setRegistrationExpirationTime(toInstant(previousExpiration))
                 .setTransferData(transferData)
                 .setCurrentBulkToken(allocationToken.createVKey())
                 .build());
 
     assertThat(domain.getCurrentBulkToken()).isPresent();
-    Domain clonedDomain = domain.cloneProjectedAtTime(now);
-    assertThat(clonedDomain.getRegistrationExpirationDateTime()).isEqualTo(newExpiration);
+    Domain clonedDomain = domain.cloneProjectedAtTime(toInstant(now));
+    assertThat(clonedDomain.getRegistrationExpirationTime()).isEqualTo(toInstant(newExpiration));
     assertThat(clonedDomain.getCurrentBulkToken()).isEmpty();
   }
 
@@ -883,12 +888,12 @@ public class DomainTest {
         persistResource(
             domain
                 .asBuilder()
-                .setRegistrationExpirationTime(previousExpiration)
+                .setRegistrationExpirationTime(toInstant(previousExpiration))
                 .setTransferData(transferData)
                 .build());
 
-    assertThat(domain.cloneProjectedAtTime(now).getRegistrationExpirationDateTime())
-        .isEqualTo(previousExpiration);
+    assertThat(domain.cloneProjectedAtTime(toInstant(now)).getRegistrationExpirationTime())
+        .isEqualTo(toInstant(previousExpiration));
   }
 
   @Test
@@ -919,13 +924,14 @@ public class DomainTest {
         persistResource(
             domain
                 .asBuilder()
-                .setRegistrationExpirationTime(previousExpiration)
+                .setRegistrationExpirationTime(toInstant(previousExpiration))
                 .setTransferData(transferData)
                 .setCurrentBulkToken(allocationToken.createVKey())
                 .build());
 
-    Domain clonedDomain = domain.cloneProjectedAtTime(now);
-    assertThat(clonedDomain.getRegistrationExpirationDateTime()).isEqualTo(previousExpiration);
+    Domain clonedDomain = domain.cloneProjectedAtTime(toInstant(now));
+    assertThat(clonedDomain.getRegistrationExpirationTime())
+        .isEqualTo(toInstant(previousExpiration));
     assertThat(clonedDomain.getCurrentBulkToken().get()).isEqualTo(allocationToken.createVKey());
   }
 
@@ -949,7 +955,7 @@ public class DomainTest {
         persistResource(
             domain
                 .asBuilder()
-                .setRegistrationExpirationTime(previousExpiration)
+                .setRegistrationExpirationTime(toInstant(previousExpiration))
                 .setGracePeriods(
                     ImmutableSet.of(
                         GracePeriod.createForRecurrence(
@@ -961,9 +967,9 @@ public class DomainTest {
                 .setTransferData(transferData)
                 .setAutorenewBillingEvent(recurrenceBillKey)
                 .build());
-    Domain clone = domain.cloneProjectedAtTime(now);
-    assertThat(clone.getRegistrationExpirationDateTime())
-        .isEqualTo(domain.getRegistrationExpirationDateTime().plusYears(1));
+    Domain clone = domain.cloneProjectedAtTime(toInstant(now));
+    assertThat(clone.getRegistrationExpirationTime())
+        .isEqualTo(plusYears(domain.getRegistrationExpirationTime(), 1));
     // Transferring removes the AUTORENEW grace period and adds a TRANSFER grace period
     assertThat(getOnlyElement(clone.getGracePeriods()).getType())
         .isEqualTo(GracePeriodStatus.TRANSFER);
@@ -977,7 +983,7 @@ public class DomainTest {
         persistResource(
             domain
                 .asBuilder()
-                .setRegistrationExpirationTime(now.plusYears(1))
+                .setRegistrationExpirationTime(toInstant(now.plusYears(1)))
                 .setGracePeriods(
                     ImmutableSet.of(
                         GracePeriod.createForRecurrence(

--- a/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
+++ b/core/src/test/java/google/registry/model/domain/token/AllocationTokenTest.java
@@ -74,7 +74,7 @@ public class AllocationTokenTest extends EntityTestCase {
                 .setDiscountFraction(0.5)
                 .setDiscountPremiums(true)
                 .setDiscountYears(3)
-                .setTokenStatusTransitionsInstant(
+                .setTokenStatusTransitions(
                     ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                         .put(START_INSTANT, NOT_STARTED)
                         .put(fakeClock.now(), TokenStatus.VALID)
@@ -111,7 +111,7 @@ public class AllocationTokenTest extends EntityTestCase {
                 .setDiscountFraction(0.5)
                 .setDiscountPremiums(true)
                 .setDiscountYears(3)
-                .setTokenStatusTransitionsInstant(
+                .setTokenStatusTransitions(
                     ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                         .put(START_INSTANT, NOT_STARTED)
                         .put(fakeClock.now(), TokenStatus.VALID)
@@ -420,7 +420,7 @@ public class AllocationTokenTest extends EntityTestCase {
             IllegalArgumentException.class,
             () ->
                 new AllocationToken.Builder()
-                    .setTokenStatusTransitionsInstant(
+                    .setTokenStatusTransitions(
                         ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                             .put(fakeClock.now(), NOT_STARTED)
                             .put(plusDays(fakeClock.now(), 1), TokenStatus.VALID)
@@ -438,7 +438,7 @@ public class AllocationTokenTest extends EntityTestCase {
             IllegalArgumentException.class,
             () ->
                 new AllocationToken.Builder()
-                    .setTokenStatusTransitionsInstant(
+                    .setTokenStatusTransitions(
                         ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                             .put(START_INSTANT, TokenStatus.VALID)
                             .put(fakeClock.now(), TokenStatus.ENDED)
@@ -720,7 +720,7 @@ public class AllocationTokenTest extends EntityTestCase {
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,
-            () -> new AllocationToken.Builder().setTokenStatusTransitionsInstant(map));
+            () -> new AllocationToken.Builder().setTokenStatusTransitions(map));
     assertThat(thrown)
         .hasMessageThat()
         .isEqualTo(
@@ -734,7 +734,7 @@ public class AllocationTokenTest extends EntityTestCase {
             IllegalArgumentException.class,
             () ->
                 new AllocationToken.Builder()
-                    .setTokenStatusTransitionsInstant(
+                    .setTokenStatusTransitions(
                         ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
                             .put(START_INSTANT, NOT_STARTED)
                             .put(fakeClock.now(), VALID)

--- a/core/src/test/java/google/registry/model/domain/token/BulkPricingPackageTest.java
+++ b/core/src/test/java/google/registry/model/domain/token/BulkPricingPackageTest.java
@@ -29,7 +29,6 @@ import google.registry.model.domain.token.AllocationToken.TokenType;
 import java.time.Instant;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -67,7 +66,7 @@ public class BulkPricingPackageTest extends EntityTestCase {
             .setBulkPrice(Money.of(CurrencyUnit.USD, 10000))
             .setMaxCreates(40)
             .setMaxDomains(10)
-            .setNextBillingDate(DateTime.parse("2011-11-12T05:00:00Z"))
+            .setNextBillingDate(Instant.parse("2011-11-12T05:00:00Z"))
             .build();
 
     tm().transact(() -> tm().put(bulkPricingPackage));
@@ -99,7 +98,7 @@ public class BulkPricingPackageTest extends EntityTestCase {
                         .setBulkPrice(Money.of(CurrencyUnit.USD, 10000))
                         .setMaxCreates(40)
                         .setMaxDomains(10)
-                        .setNextBillingDate(DateTime.parse("2011-11-12T05:00:00Z"))
+                        .setNextBillingDate(Instant.parse("2011-11-12T05:00:00Z"))
                         .build()));
 
     assertThat(thrown).hasMessageThat().isEqualTo("Allocation token must be a BULK_PRICING type");

--- a/core/src/test/java/google/registry/model/registrar/RegistrarTest.java
+++ b/core/src/test/java/google/registry/model/registrar/RegistrarTest.java
@@ -27,6 +27,7 @@ import static google.registry.testing.DatabaseHelper.createTlds;
 import static google.registry.testing.DatabaseHelper.newTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DatabaseHelper.persistResources;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.joda.money.CurrencyUnit.JPY;
 import static org.joda.money.CurrencyUnit.USD;
@@ -88,7 +89,7 @@ class RegistrarTest extends EntityTestCase {
                 .setAllowedTlds(ImmutableSet.of("xn--q9jyb4c"))
                 .setWhoisServer("whois.example.com")
                 .setBlockPremiumNames(true)
-                .setClientCertificate(SAMPLE_CERT, fakeClock.nowUtc())
+                .setClientCertificate(SAMPLE_CERT, fakeClock.now())
                 .setIpAddressAllowList(
                     ImmutableList.of(
                         CidrAddressBlock.create("192.168.1.1/31"),
@@ -222,10 +223,10 @@ class RegistrarTest extends EntityTestCase {
 
   @Test
   void testSetCertificateHash_alsoSetsHash() {
-    registrar = registrar.asBuilder().setClientCertificate(null, fakeClock.nowUtc()).build();
+    registrar = registrar.asBuilder().setClientCertificate(null, fakeClock.now()).build();
     fakeClock.advanceOneMilli();
-    registrar = registrar.asBuilder().setClientCertificate(SAMPLE_CERT, fakeClock.nowUtc()).build();
-    assertThat(registrar.getLastCertificateUpdateTime()).isEqualTo(fakeClock.nowUtc());
+    registrar = registrar.asBuilder().setClientCertificate(SAMPLE_CERT, fakeClock.now()).build();
+    assertThat(registrar.getLastCertificateUpdateTime()).isEqualTo(fakeClock.now());
     assertThat(registrar.getClientCertificate()).hasValue(SAMPLE_CERT);
     assertThat(registrar.getClientCertificateHash()).hasValue(SAMPLE_CERT_HASH);
   }
@@ -234,8 +235,8 @@ class RegistrarTest extends EntityTestCase {
   void testDeleteCertificateHash_alsoDeletesHash() {
     assertThat(registrar.getClientCertificateHash()).isPresent();
     fakeClock.advanceOneMilli();
-    registrar = registrar.asBuilder().setClientCertificate(null, fakeClock.nowUtc()).build();
-    assertThat(registrar.getLastCertificateUpdateTime()).isEqualTo(fakeClock.nowUtc());
+    registrar = registrar.asBuilder().setClientCertificate(null, fakeClock.now()).build();
+    assertThat(registrar.getLastCertificateUpdateTime()).isEqualTo(fakeClock.now());
     assertThat(registrar.getClientCertificate()).isEmpty();
     assertThat(registrar.getClientCertificateHash()).isEmpty();
   }
@@ -244,11 +245,8 @@ class RegistrarTest extends EntityTestCase {
   void testSetFailoverCertificateHash_alsoSetsHash() {
     fakeClock.advanceOneMilli();
     registrar =
-        registrar
-            .asBuilder()
-            .setFailoverClientCertificate(SAMPLE_CERT2, fakeClock.nowUtc())
-            .build();
-    assertThat(registrar.getLastCertificateUpdateTime()).isEqualTo(fakeClock.nowUtc());
+        registrar.asBuilder().setFailoverClientCertificate(SAMPLE_CERT2, fakeClock.now()).build();
+    assertThat(registrar.getLastCertificateUpdateTime()).isEqualTo(fakeClock.now());
     assertThat(registrar.getFailoverClientCertificate()).hasValue(SAMPLE_CERT2);
     assertThat(registrar.getFailoverClientCertificateHash()).hasValue(SAMPLE_CERT2_HASH);
   }
@@ -256,12 +254,11 @@ class RegistrarTest extends EntityTestCase {
   @Test
   void testDeleteFailoverCertificateHash_alsoDeletesHash() {
     registrar =
-        registrar.asBuilder().setFailoverClientCertificate(SAMPLE_CERT, fakeClock.nowUtc()).build();
+        registrar.asBuilder().setFailoverClientCertificate(SAMPLE_CERT, fakeClock.now()).build();
     assertThat(registrar.getFailoverClientCertificateHash()).isPresent();
     fakeClock.advanceOneMilli();
-    registrar =
-        registrar.asBuilder().setFailoverClientCertificate(null, fakeClock.nowUtc()).build();
-    assertThat(registrar.getLastCertificateUpdateTime()).isEqualTo(fakeClock.nowUtc());
+    registrar = registrar.asBuilder().setFailoverClientCertificate(null, fakeClock.now()).build();
+    assertThat(registrar.getLastCertificateUpdateTime()).isEqualTo(fakeClock.now());
     assertThat(registrar.getFailoverClientCertificate()).isEmpty();
     assertThat(registrar.getFailoverClientCertificateHash()).isEmpty();
   }
@@ -456,13 +453,13 @@ class RegistrarTest extends EntityTestCase {
 
   @Test
   void testSuccess_getLastExpiringCertNotificationSentDate_returnsInitialValue() {
-    assertThat(registrar.getLastExpiringCertNotificationSentDate()).isEqualTo(START_OF_TIME);
+    assertThat(registrar.getLastExpiringCertNotificationSentDate()).isEqualTo(START_INSTANT);
   }
 
   @Test
   void testSuccess_getLastExpiringFailoverCertNotificationSentDate_returnsInitialValue() {
     assertThat(registrar.getLastExpiringFailoverCertNotificationSentDate())
-        .isEqualTo(START_OF_TIME);
+        .isEqualTo(START_INSTANT);
   }
 
   @Test
@@ -470,10 +467,10 @@ class RegistrarTest extends EntityTestCase {
     assertThat(
             registrar
                 .asBuilder()
-                .setLastExpiringCertNotificationSentDate(fakeClock.nowUtc())
+                .setLastExpiringCertNotificationSentDate(fakeClock.now())
                 .build()
                 .getLastExpiringCertNotificationSentDate())
-        .isEqualTo(fakeClock.nowUtc());
+        .isEqualTo(fakeClock.now());
   }
 
   @Test
@@ -495,10 +492,10 @@ class RegistrarTest extends EntityTestCase {
     assertThat(
             registrar
                 .asBuilder()
-                .setLastExpiringFailoverCertNotificationSentDate(fakeClock.nowUtc())
+                .setLastExpiringFailoverCertNotificationSentDate(fakeClock.now())
                 .build()
                 .getLastExpiringFailoverCertNotificationSentDate())
-        .isEqualTo(fakeClock.nowUtc());
+        .isEqualTo(fakeClock.now());
   }
 
   @Test
@@ -506,10 +503,10 @@ class RegistrarTest extends EntityTestCase {
     assertThat(
             registrar
                 .asBuilder()
-                .setLastPocVerificationDate(fakeClock.nowUtc())
+                .setLastPocVerificationDate(fakeClock.now())
                 .build()
                 .getLastPocVerificationDate())
-        .isEqualTo(fakeClock.nowUtc());
+        .isEqualTo(fakeClock.now());
   }
 
   @Test

--- a/core/src/test/java/google/registry/rdap/RdapDomainSearchActionTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapDomainSearchActionTest.java
@@ -29,7 +29,6 @@ import static google.registry.testing.GsonSubject.assertAboutJson;
 import static google.registry.util.DateTimeUtils.minusDays;
 import static google.registry.util.DateTimeUtils.minusMonths;
 import static google.registry.util.DateTimeUtils.minusYears;
-import static google.registry.util.DateTimeUtils.toDateTime;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.common.collect.ImmutableList;
@@ -304,7 +303,7 @@ class RdapDomainSearchActionTest extends RdapSearchActionTestCase<RdapDomainSear
             HistoryEntry.Type.DOMAIN_DELETE,
             Period.create(1, Period.Unit.YEARS),
             "deleted",
-            toDateTime(minusMonths(clock.now(), 6))));
+            clock.nowUtc().minusMonths(6)));
   }
 
   private void createManyDomainsAndHosts(

--- a/core/src/test/java/google/registry/rdap/RdapJsonFormatterTest.java
+++ b/core/src/test/java/google/registry/rdap/RdapJsonFormatterTest.java
@@ -28,7 +28,6 @@ import static google.registry.testing.TestDataHelper.loadFile;
 import static google.registry.util.DateTimeUtils.minusDays;
 import static google.registry.util.DateTimeUtils.minusMonths;
 import static google.registry.util.DateTimeUtils.plusYears;
-import static google.registry.util.DateTimeUtils.toInstant;
 import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 
 import com.google.common.collect.ImmutableList;
@@ -148,7 +147,7 @@ class RdapJsonFormatterTest {
             makeDomain("cat.みんな", hostIpv4, hostIpv6, registrar)
                 .asBuilder()
                 .setCreationTimeForTest(minusMonths(clock.now(), 4))
-                .setLastEppUpdateTime(toInstant(clock.nowUtc().minusMonths(1)))
+                .setLastEppUpdateTime(minusMonths(clock.now(), 1))
                 .build());
     domainNoNameserversNoTransfers =
         persistResource(

--- a/core/src/test/java/google/registry/rde/DomainToXjcConverterTest.java
+++ b/core/src/test/java/google/registry/rde/DomainToXjcConverterTest.java
@@ -265,7 +265,7 @@ public class DomainToXjcConverterTest {
                     makeHost(clock, "3-Q9JYB4C", "bird.or.devil.みんな", "1.2.3.4").createVKey(),
                     makeHost(clock, "4-Q9JYB4C", "ns2.cat.みんな", "bad:f00d:cafe::15:beef")
                         .createVKey()))
-            .setRegistrationExpirationTime(DateTime.parse("1930-01-01T00:00:00Z"))
+            .setRegistrationExpirationTime(Instant.parse("1930-01-01T00:00:00Z"))
             .setGracePeriods(
                 ImmutableSet.of(
                     GracePeriod.forBillingEvent(

--- a/core/src/test/java/google/registry/rde/HostToXjcConverterTest.java
+++ b/core/src/test/java/google/registry/rde/HostToXjcConverterTest.java
@@ -62,7 +62,7 @@ public class HostToXjcConverterTest {
         DatabaseHelper.newDomain("love.foobar")
             .asBuilder()
             .setPersistedCurrentSponsorRegistrarId("LeisureDog")
-            .setLastTransferTime(DateTime.parse("2010-01-01T00:00:00Z"))
+            .setLastTransferTime(Instant.parse("2010-01-01T00:00:00Z"))
             .addStatusValue(StatusValue.PENDING_TRANSFER)
             .build();
     XjcRdeHost bean =

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -180,7 +180,7 @@ public final class DatabaseHelper {
         .setPersistedCurrentSponsorRegistrarId("TheRegistrar")
         .setCreationTimeForTest(START_INSTANT)
         .setAuthInfo(DomainAuthInfo.create(PasswordAuth.create("2fooBAR")))
-        .setRegistrationExpirationTime(END_OF_TIME)
+        .setRegistrationExpirationTime(END_INSTANT)
         .build();
   }
 
@@ -259,7 +259,7 @@ public final class DatabaseHelper {
         newDomain(domainName)
             .asBuilder()
             .setCreationTimeForTest(toInstant(creationTime))
-            .setRegistrationExpirationTime(expirationTime)
+            .setRegistrationExpirationTime(toInstant(expirationTime))
             .build());
   }
 
@@ -535,7 +535,7 @@ public final class DatabaseHelper {
             .setPersistedCurrentSponsorRegistrarId("TheRegistrar")
             .setCreationRegistrarId("TheRegistrar")
             .setCreationTimeForTest(toInstant(creationTime))
-            .setRegistrationExpirationTime(expirationTime)
+            .setRegistrationExpirationTime(toInstant(expirationTime))
             .setAuthInfo(DomainAuthInfo.create(PasswordAuth.create("fooBAR")));
     Duration addGracePeriodLength = Tld.get(tld).getAddGracePeriodLength();
     if (creationTime.plus(addGracePeriodLength).isAfter(now)) {

--- a/core/src/test/java/google/registry/testing/DomainSubject.java
+++ b/core/src/test/java/google/registry/testing/DomainSubject.java
@@ -92,8 +92,7 @@ public final class DomainSubject extends AbstractEppResourceSubject<Domain, Doma
   }
 
   public And<DomainSubject> hasLastTransferTime(Instant lastTransferTime) {
-    return hasValue(
-        lastTransferTime, toInstant(actual.getLastTransferTime()), "getLastTransferTime()");
+    return hasValue(lastTransferTime, actual.getLastTransferTime(), "getLastTransferTime()");
   }
 
   public And<DomainSubject> hasLastTransferTimeNotEqualTo(DateTime lastTransferTime) {
@@ -102,7 +101,7 @@ public final class DomainSubject extends AbstractEppResourceSubject<Domain, Doma
 
   public And<DomainSubject> hasLastTransferTimeNotEqualTo(Instant lastTransferTime) {
     return doesNotHaveValue(
-        lastTransferTime, toInstant(actual.getLastTransferTime()), "getLastTransferTime()");
+        lastTransferTime, actual.getLastTransferTime(), "getLastTransferTime()");
   }
 
   public And<DomainSubject> hasDeletePollMessage() {
@@ -130,13 +129,11 @@ public final class DomainSubject extends AbstractEppResourceSubject<Domain, Doma
   public And<DomainSubject> hasAutorenewEndTime(Instant autorenewEndTime) {
     checkArgumentNotNull(autorenewEndTime, "Use hasNoAutorenewEndTime() instead");
     return hasValue(
-        autorenewEndTime,
-        toInstant(actual.getAutorenewEndTime().orElse(null)),
-        "getAutorenewEndTime()");
+        autorenewEndTime, actual.getAutorenewEndTime().orElse(null), "getAutorenewEndTime()");
   }
 
   public And<DomainSubject> hasNoAutorenewEndTime() {
-    return hasNoValue(actual.getAutorenewEndTimeInstant(), "getAutorenewEndTime()");
+    return hasNoValue(actual.getAutorenewEndTime(), "getAutorenewEndTime()");
   }
 
   public static SimpleSubjectBuilder<DomainSubject, Domain> assertAboutDomains() {

--- a/core/src/test/java/google/registry/testing/FullFieldsTestEntityHelper.java
+++ b/core/src/test/java/google/registry/testing/FullFieldsTestEntityHelper.java
@@ -189,7 +189,7 @@ public final class FullFieldsTestEntityHelper {
             .setRepoId(generateNewDomainRoid(getTldFromDomainName(Idn.toASCII(domain))))
             .setLastEppUpdateTime(Instant.parse("2009-05-29T20:13:00Z"))
             .setCreationTimeForTest(Instant.parse("2000-10-08T00:45:00Z"))
-            .setRegistrationExpirationTime(DateTime.parse("2110-10-08T00:44:59Z"))
+            .setRegistrationExpirationTime(Instant.parse("2110-10-08T00:44:59Z"))
             .setPersistedCurrentSponsorRegistrarId(registrar.getRegistrarId())
             .setCreationRegistrarId(registrar.getRegistrarId())
             .setStatusValues(

--- a/core/src/test/java/google/registry/tmch/NordnUploadActionTest.java
+++ b/core/src/test/java/google/registry/tmch/NordnUploadActionTest.java
@@ -23,6 +23,7 @@ import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.loadRegistrar;
 import static google.registry.testing.DatabaseHelper.newDomain;
 import static google.registry.testing.DatabaseHelper.persistResource;
+import static google.registry.util.DateTimeUtils.minusHours;
 import static jakarta.servlet.http.HttpServletResponse.SC_ACCEPTED;
 import static jakarta.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -199,7 +200,7 @@ class NordnUploadActionTest {
             .setCreationTimeForTest(clock.now())
             .setCreationRegistrarId("NewRegistrar")
             .setLaunchNotice(
-                LaunchNotice.create("landrush2tcn", null, null, clock.nowUtc().minusHours(2)))
+                LaunchNotice.create("landrush2tcn", null, null, minusHours(clock.now(), 2)))
             .setLordnPhase(LordnPhase.CLAIMS)
             .build());
     clock.advanceBy(Duration.standardDays(1));
@@ -208,7 +209,7 @@ class NordnUploadActionTest {
             .asBuilder()
             .setCreationTimeForTest(clock.now())
             .setLaunchNotice(
-                LaunchNotice.create("landrush1tcn", null, null, clock.nowUtc().minusHours(1)))
+                LaunchNotice.create("landrush1tcn", null, null, minusHours(clock.now(), 1)))
             .setLordnPhase(LordnPhase.CLAIMS)
             .build());
   }

--- a/core/src/test/java/google/registry/tools/CreateBulkPricingPackageCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateBulkPricingPackageCommandTest.java
@@ -17,7 +17,7 @@ package google.registry.tools;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.util.DateTimeUtils.END_OF_TIME;
+import static google.registry.util.DateTimeUtils.END_INSTANT;
 import static org.joda.money.CurrencyUnit.USD;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -31,7 +31,6 @@ import java.time.Instant;
 import java.util.Optional;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for {@link CreateBulkPricingPackageCommand}. */
@@ -67,7 +66,7 @@ public class CreateBulkPricingPackageCommandTest
     assertThat(bulkPricingPackage.getMaxCreates()).isEqualTo(500);
     assertThat(bulkPricingPackage.getBulkPrice()).isEqualTo(Money.of(CurrencyUnit.USD, 1000));
     assertThat(bulkPricingPackage.getNextBillingDate())
-        .isEqualTo(DateTime.parse("2012-03-17T00:00:00Z"));
+        .isEqualTo(Instant.parse("2012-03-17T00:00:00Z"));
     assertThat(bulkPricingPackage.getLastNotificationSent()).isEmpty();
   }
 
@@ -176,7 +175,7 @@ public class CreateBulkPricingPackageCommandTest
     assertThat(bulkPricingPackage.getMaxCreates()).isEqualTo(0);
     assertThat(bulkPricingPackage.getBulkPrice()).isEqualTo(Money.of(CurrencyUnit.USD, 1000));
     assertThat(bulkPricingPackage.getNextBillingDate())
-        .isEqualTo(DateTime.parse("2012-03-17T00:00:00Z"));
+        .isEqualTo(Instant.parse("2012-03-17T00:00:00Z"));
     assertThat(bulkPricingPackage.getLastNotificationSent()).isEmpty();
   }
 
@@ -203,7 +202,7 @@ public class CreateBulkPricingPackageCommandTest
     assertThat(bulkPricingPackage.getMaxDomains()).isEqualTo(100);
     assertThat(bulkPricingPackage.getMaxCreates()).isEqualTo(500);
     assertThat(bulkPricingPackage.getBulkPrice()).isEqualTo(Money.of(CurrencyUnit.USD, 1000));
-    assertThat(bulkPricingPackage.getNextBillingDate()).isEqualTo(END_OF_TIME);
+    assertThat(bulkPricingPackage.getNextBillingDate()).isEqualTo(END_INSTANT);
     assertThat(bulkPricingPackage.getLastNotificationSent()).isEmpty();
   }
 

--- a/core/src/test/java/google/registry/tools/CreateRegistrarCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateRegistrarCommandTest.java
@@ -103,7 +103,7 @@ class CreateRegistrarCommandTest extends CommandTestCase<CreateRegistrarCommand>
     assertThat(registrar.getClientCertificateHash()).isEmpty();
     assertThat(registrar.getPhonePasscode()).isEqualTo("01234");
     assertThat(registrar.getCreationTime()).isIn(Range.closed(before, after));
-    assertThat(registrar.getLastUpdateTimeInstant()).isEqualTo(registrar.getCreationTime());
+    assertThat(registrar.getLastUpdateTime()).isEqualTo(registrar.getCreationTime());
     assertThat(registrar.getBlockPremiumNames()).isFalse();
     assertThat(registrar.isRegistryLockAllowed()).isFalse();
     assertThat(registrar.getPoNumber()).isEmpty();

--- a/core/src/test/java/google/registry/tools/DomainLockUtilsTest.java
+++ b/core/src/test/java/google/registry/tools/DomainLockUtilsTest.java
@@ -265,7 +265,8 @@ public final class DomainLockUtilsTest {
                 RelockDomainAction.OLD_UNLOCK_REVISION_ID_PARAM,
                 String.valueOf(lock.getRevisionId()))
             .param(RelockDomainAction.PREVIOUS_ATTEMPTS_PARAM, "0")
-            .scheduleTime(clock.nowUtc().plus(lock.getRelockDuration().get())));
+            .scheduleTime(
+                clock.nowUtc().plusMillis((int) lock.getRelockDuration().get().getMillis())));
   }
 
   @Test
@@ -491,7 +492,8 @@ public final class DomainLockUtilsTest {
                 RelockDomainAction.OLD_UNLOCK_REVISION_ID_PARAM,
                 String.valueOf(lock.getRevisionId()))
             .param(RelockDomainAction.PREVIOUS_ATTEMPTS_PARAM, "0")
-            .scheduleTime(clock.nowUtc().plus(lock.getRelockDuration().get())));
+            .scheduleTime(
+                clock.nowUtc().plusMillis((int) lock.getRelockDuration().get().getMillis())));
   }
 
   @MockitoSettings(strictness = Strictness.LENIENT)

--- a/core/src/test/java/google/registry/tools/GenerateAllocationTokensCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateAllocationTokensCommandTest.java
@@ -24,7 +24,9 @@ import static google.registry.testing.DatabaseHelper.assertAllocationTokens;
 import static google.registry.testing.DatabaseHelper.createTlds;
 import static google.registry.testing.DatabaseHelper.loadAllOf;
 import static google.registry.testing.DatabaseHelper.persistResource;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.toInstant;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -44,6 +46,7 @@ import google.registry.testing.DeterministicStringGenerator;
 import google.registry.testing.DeterministicStringGenerator.Rule;
 import google.registry.util.StringGenerator.Alphabets;
 import java.io.File;
+import java.time.Instant;
 import java.util.Collection;
 import javax.annotation.Nullable;
 import org.joda.money.CurrencyUnit;
@@ -158,10 +161,10 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
             .setDiscountPremiums(true)
             .setDiscountYears(6)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(promoStart, TokenStatus.VALID)
-                    .put(promoEnd, TokenStatus.ENDED)
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(toInstant(promoStart), TokenStatus.VALID)
+                    .put(toInstant(promoEnd), TokenStatus.ENDED)
                     .build())
             .build());
   }
@@ -200,10 +203,10 @@ class GenerateAllocationTokensCommandTest extends CommandTestCase<GenerateAlloca
             .setDiscountPremiums(false)
             .setDiscountYears(6)
             .setTokenStatusTransitions(
-                ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                    .put(START_OF_TIME, TokenStatus.NOT_STARTED)
-                    .put(promoStart, TokenStatus.VALID)
-                    .put(promoEnd, TokenStatus.ENDED)
+                ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                    .put(START_INSTANT, TokenStatus.NOT_STARTED)
+                    .put(toInstant(promoStart), TokenStatus.VALID)
+                    .put(toInstant(promoEnd), TokenStatus.ENDED)
                     .build())
             .build());
   }

--- a/core/src/test/java/google/registry/tools/GenerateLordnCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GenerateLordnCommandTest.java
@@ -17,7 +17,7 @@ package google.registry.tools;
 import static com.google.common.truth.Truth.assertThat;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import google.registry.model.domain.launch.LaunchNotice;
@@ -47,7 +47,7 @@ class GenerateLordnCommandTest extends CommandTestCase<GenerateLordnCommand> {
     persistResource(
         DatabaseHelper.newDomain("fleecey.tld")
             .asBuilder()
-            .setLaunchNotice(LaunchNotice.create("smd3", "validator", START_OF_TIME, START_OF_TIME))
+            .setLaunchNotice(LaunchNotice.create("smd3", "validator", START_INSTANT, START_INSTANT))
             .setSmdId("smd3")
             .build());
     Path claimsCsv = outputDir.resolve("claims.csv");

--- a/core/src/test/java/google/registry/tools/GetAllocationTokenCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetAllocationTokenCommandTest.java
@@ -54,9 +54,9 @@ class GetAllocationTokenCommandTest extends CommandTestCase<GetAllocationTokenCo
                 .setDiscountYears(2)
                 .setTokenStatusTransitions(
                     ImmutableSortedMap.of(
-                        DateTimeUtils.START_OF_TIME,
+                        DateTimeUtils.START_INSTANT,
                         AllocationToken.TokenStatus.NOT_STARTED,
-                        fakeClock.nowUtc(),
+                        fakeClock.now(),
                         AllocationToken.TokenStatus.VALID))
                 .setDomainName("foo.bar")
                 .build());

--- a/core/src/test/java/google/registry/tools/GetBulkPricingPackageCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetBulkPricingPackageCommandTest.java
@@ -30,7 +30,6 @@ import google.registry.model.domain.token.BulkPricingPackage;
 import java.time.Instant;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -64,8 +63,8 @@ public class GetBulkPricingPackageCommandTest
             .setMaxDomains(100)
             .setMaxCreates(500)
             .setBulkPrice(Money.of(CurrencyUnit.USD, 1000))
-            .setNextBillingDate(DateTime.parse("2012-11-12T05:00:00Z"))
-            .setLastNotificationSent(DateTime.parse("2010-11-12T05:00:00Z"))
+            .setNextBillingDate(Instant.parse("2012-11-12T05:00:00Z"))
+            .setLastNotificationSent(Instant.parse("2010-11-12T05:00:00Z"))
             .build();
     tm().transact(() -> tm().put(bulkPricingPackage));
     runCommand("abc123");
@@ -94,8 +93,8 @@ public class GetBulkPricingPackageCommandTest
                             .setMaxDomains(100)
                             .setMaxCreates(500)
                             .setBulkPrice(Money.of(CurrencyUnit.USD, 1000))
-                            .setNextBillingDate(DateTime.parse("2012-11-12T05:00:00Z"))
-                            .setLastNotificationSent(DateTime.parse("2010-11-12T05:00:00Z"))
+                            .setNextBillingDate(Instant.parse("2012-11-12T05:00:00Z"))
+                            .setLastNotificationSent(Instant.parse("2010-11-12T05:00:00Z"))
                             .build()));
     AllocationToken token2 =
         persistResource(
@@ -118,8 +117,8 @@ public class GetBulkPricingPackageCommandTest
                             .setMaxDomains(1000)
                             .setMaxCreates(700)
                             .setBulkPrice(Money.of(CurrencyUnit.USD, 3000))
-                            .setNextBillingDate(DateTime.parse("2014-11-12T05:00:00Z"))
-                            .setLastNotificationSent(DateTime.parse("2013-11-12T05:00:00Z"))
+                            .setNextBillingDate(Instant.parse("2014-11-12T05:00:00Z"))
+                            .setLastNotificationSent(Instant.parse("2013-11-12T05:00:00Z"))
                             .build()));
 
     runCommand("abc123", "123abc");

--- a/core/src/test/java/google/registry/tools/RenewDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/RenewDomainCommandTest.java
@@ -80,7 +80,7 @@ public class RenewDomainCommandTest extends EppToolCommandTestCase<RenewDomainCo
             DatabaseHelper.newDomain("domain3.tld")
                 .asBuilder()
                 .setCreationTimeForTest(Instant.parse("2015-01-05T05:05:05Z"))
-                .setRegistrationExpirationTime(DateTime.parse("2016-01-05T05:05:05Z"))
+                .setRegistrationExpirationTime(Instant.parse("2016-01-05T05:05:05Z"))
                 .setPersistedCurrentSponsorRegistrarId("NewRegistrar")
                 .build()));
     return domains.build();

--- a/core/src/test/java/google/registry/tools/UniformRapidSuspensionCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UniformRapidSuspensionCommandTest.java
@@ -32,7 +32,6 @@ import google.registry.persistence.VKey;
 import google.registry.testing.DatabaseHelper;
 import jakarta.xml.bind.annotation.adapters.HexBinaryAdapter;
 import java.time.Instant;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -299,7 +298,7 @@ class UniformRapidSuspensionCommandTest
         DatabaseHelper.newDomain("evil.tld")
             .asBuilder()
             .setCreationTimeForTest(Instant.parse("2021-10-01T05:01:11Z"))
-            .setRegistrationExpirationTime(DateTime.parse("2022-10-01T05:01:11Z"))
+            .setRegistrationExpirationTime(Instant.parse("2022-10-01T05:01:11Z"))
             .setPersistedCurrentSponsorRegistrarId("CharlestonRoad")
             .build(),
         defaultDsData,
@@ -336,7 +335,7 @@ class UniformRapidSuspensionCommandTest
         DatabaseHelper.newDomain("evil.tld")
             .asBuilder()
             .setCreationTimeForTest(Instant.parse("2021-10-01T05:01:11Z"))
-            .setRegistrationExpirationTime(DateTime.parse("2022-10-01T05:01:11Z"))
+            .setRegistrationExpirationTime(Instant.parse("2022-10-01T05:01:11Z"))
             .setPersistedCurrentSponsorRegistrarId("CharlestonRoad")
             .build(),
         defaultDsData,
@@ -374,7 +373,7 @@ class UniformRapidSuspensionCommandTest
         DatabaseHelper.newDomain("evil.tld")
             .asBuilder()
             .setCreationTimeForTest(Instant.parse("2021-10-01T05:01:11Z"))
-            .setRegistrationExpirationTime(DateTime.parse("2022-10-01T05:01:11Z"))
+            .setRegistrationExpirationTime(Instant.parse("2022-10-01T05:01:11Z"))
             .setPersistedCurrentSponsorRegistrarId("CharlestonRoad")
             .build(),
         defaultDsData,

--- a/core/src/test/java/google/registry/tools/UnrenewDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UnrenewDomainCommandTest.java
@@ -42,6 +42,8 @@ import google.registry.model.domain.DomainHistory;
 import google.registry.model.eppcommon.StatusValue;
 import google.registry.model.poll.PollMessage;
 import google.registry.testing.DatabaseHelper;
+import google.registry.util.DateTimeUtils;
+import java.time.Instant;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,7 +54,7 @@ public class UnrenewDomainCommandTest extends CommandTestCase<UnrenewDomainComma
   @BeforeEach
   void beforeEach() {
     createTld("tld");
-    fakeClock.setTo(DateTime.parse("2016-12-06T13:55:01Z"));
+    fakeClock.setTo(Instant.parse("2016-12-06T13:55:01Z"));
     command.clock = fakeClock;
     command.printStream = System.out;
   }
@@ -79,13 +81,13 @@ public class UnrenewDomainCommandTest extends CommandTestCase<UnrenewDomainComma
     assertThat(
             ForeignKeyUtils.loadResource(Domain.class, "foo.tld", fakeClock.nowUtc())
                 .get()
-                .getRegistrationExpirationDateTime())
-        .isEqualTo(DateTime.parse("2019-12-06T13:55:01.001Z"));
+                .getRegistrationExpirationTime())
+        .isEqualTo(Instant.parse("2019-12-06T13:55:01.001Z"));
     assertThat(
             ForeignKeyUtils.loadResource(Domain.class, "bar.tld", fakeClock.nowUtc())
                 .get()
-                .getRegistrationExpirationDateTime())
-        .isEqualTo(DateTime.parse("2018-12-06T13:55:01.002Z"));
+                .getRegistrationExpirationTime())
+        .isEqualTo(Instant.parse("2018-12-06T13:55:01.002Z"));
     assertInStdout("Successfully unrenewed all domains.");
   }
 
@@ -98,16 +100,16 @@ public class UnrenewDomainCommandTest extends CommandTestCase<UnrenewDomainComma
         fakeClock.nowUtc(),
         fakeClock.nowUtc(),
         fakeClock.nowUtc().plusYears(5));
-    DateTime newExpirationTime = fakeClock.nowUtc().plusYears(3);
+    Instant newExpirationTime = DateTimeUtils.plusYears(fakeClock.now(), 3);
     fakeClock.advanceOneMilli();
     runCommandForced("-p", "2", "foo.tld");
-    DateTime unrenewTime = fakeClock.nowUtc();
+    Instant unrenewTime = fakeClock.now();
     fakeClock.advanceOneMilli();
     Domain domain = ForeignKeyUtils.loadResource(Domain.class, "foo.tld", fakeClock.nowUtc()).get();
 
     assertAboutHistoryEntries()
         .that(getOnlyHistoryEntryOfType(domain, SYNTHETIC))
-        .hasModificationTime(toInstant(unrenewTime))
+        .hasModificationTime(unrenewTime)
         .and()
         .hasMetadataReason("Domain unrenewal")
         .and()
@@ -128,7 +130,7 @@ public class UnrenewDomainCommandTest extends CommandTestCase<UnrenewDomainComma
             .setFlags(ImmutableSet.of(Flag.AUTO_RENEW))
             .setTargetId(domain.getDomainName())
             .setRegistrarId("TheRegistrar")
-            .setEventTime(toInstant(newExpirationTime))
+            .setEventTime(newExpirationTime)
             .build());
     assertPollMessagesEqual(
         getPollMessages(domain),
@@ -139,19 +141,19 @@ public class UnrenewDomainCommandTest extends CommandTestCase<UnrenewDomainComma
                 .setMsg(
                     "Domain foo.tld was unrenewed by 2 years; "
                         + "now expires at 2019-12-06T13:55:01.001Z.")
-                .setEventTime(toInstant(unrenewTime))
+                .setEventTime(unrenewTime)
                 .build(),
             new PollMessage.Autorenew.Builder()
                 .setHistoryEntry(synthetic)
                 .setTargetId("foo.tld")
                 .setRegistrarId("TheRegistrar")
-                .setEventTime(toInstant(newExpirationTime))
+                .setEventTime(newExpirationTime)
                 .setMsg("Domain was auto-renewed.")
                 .build()));
 
     // Check that fields on domain were updated correctly.
-    assertThat(domain.getRegistrationExpirationDateTime()).isEqualTo(newExpirationTime);
-    assertThat(domain.getLastEppUpdateTime()).isEqualTo(toInstant(unrenewTime));
+    assertThat(domain.getRegistrationExpirationTime()).isEqualTo(newExpirationTime);
+    assertThat(domain.getLastEppUpdateTime()).isEqualTo(unrenewTime);
     assertThat(domain.getLastEppUpdateRegistrarId()).isEqualTo("TheRegistrar");
   }
 

--- a/core/src/test/java/google/registry/tools/UpdateAllocationTokensCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateAllocationTokensCommandTest.java
@@ -29,7 +29,9 @@ import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.loadByEntity;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistResource;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
+import static google.registry.util.DateTimeUtils.toInstant;
 import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -41,6 +43,7 @@ import google.registry.model.domain.token.AllocationToken;
 import google.registry.model.domain.token.AllocationToken.RegistrationBehavior;
 import google.registry.model.domain.token.AllocationToken.TokenStatus;
 import google.registry.testing.DatabaseHelper;
+import java.time.Instant;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
@@ -423,9 +426,9 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
                 .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE))
                 .setAllowedRegistrarIds(ImmutableSet.of("TheRegistrar"))
                 .setTokenStatusTransitions(
-                    ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                        .put(START_OF_TIME, NOT_STARTED)
-                        .put(now.minusDays(1), VALID)
+                    ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                        .put(START_INSTANT, NOT_STARTED)
+                        .put(toInstant(now.minusDays(1)), VALID)
                         .build())
                 .build());
     runCommandForced(
@@ -452,9 +455,9 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
                 .setAllowedEppActions(ImmutableSet.of(CommandName.CREATE))
                 .setAllowedRegistrarIds(ImmutableSet.of("TheRegistrar"))
                 .setTokenStatusTransitions(
-                    ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                        .put(START_OF_TIME, NOT_STARTED)
-                        .put(now.minusDays(1), VALID)
+                    ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                        .put(START_INSTANT, NOT_STARTED)
+                        .put(toInstant(now.minusDays(1)), VALID)
                         .build())
                 .build());
     createTld("tld");
@@ -568,10 +571,10 @@ class UpdateAllocationTokensCommandTest extends CommandTestCase<UpdateAllocation
         .setToken("token")
         .setTokenType(UNLIMITED_USE)
         .setTokenStatusTransitions(
-            ImmutableSortedMap.<DateTime, TokenStatus>naturalOrder()
-                .put(START_OF_TIME, NOT_STARTED)
-                .put(now.minusDays(1), VALID)
-                .put(now.plusDays(1), ENDED)
+            ImmutableSortedMap.<Instant, TokenStatus>naturalOrder()
+                .put(START_INSTANT, NOT_STARTED)
+                .put(toInstant(now.minusDays(1)), VALID)
+                .put(toInstant(now.plusDays(1)), ENDED)
                 .build());
   }
 }

--- a/core/src/test/java/google/registry/tools/UpdateBulkPricingPackageCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateBulkPricingPackageCommandTest.java
@@ -30,7 +30,6 @@ import java.time.Instant;
 import java.util.Optional;
 import org.joda.money.CurrencyUnit;
 import org.joda.money.Money;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -59,8 +58,8 @@ public class UpdateBulkPricingPackageCommandTest
             .setMaxDomains(100)
             .setMaxCreates(500)
             .setBulkPrice(Money.of(CurrencyUnit.USD, 1000))
-            .setNextBillingDate(DateTime.parse("2012-11-12T05:00:00Z"))
-            .setLastNotificationSent(DateTime.parse("2010-11-12T05:00:00Z"))
+            .setNextBillingDate(Instant.parse("2012-11-12T05:00:00Z"))
+            .setLastNotificationSent(Instant.parse("2010-11-12T05:00:00Z"))
             .build();
     tm().transact(() -> tm().put(bulkPricingPackage));
   }
@@ -83,7 +82,7 @@ public class UpdateBulkPricingPackageCommandTest
     assertThat(bulkPricingPackage.getMaxCreates()).isEqualTo(1000);
     assertThat(bulkPricingPackage.getBulkPrice()).isEqualTo(Money.of(CurrencyUnit.USD, 2000));
     assertThat(bulkPricingPackage.getNextBillingDate())
-        .isEqualTo(DateTime.parse("2013-03-17T00:00:00Z"));
+        .isEqualTo(Instant.parse("2013-03-17T00:00:00Z"));
     assertThat(bulkPricingPackage.getLastNotificationSent()).isEmpty();
   }
 
@@ -132,7 +131,7 @@ public class UpdateBulkPricingPackageCommandTest
     assertThat(bulkPricingPackage.getMaxCreates()).isEqualTo(1000);
     assertThat(bulkPricingPackage.getBulkPrice()).isEqualTo(Money.of(CurrencyUnit.USD, 2000));
     assertThat(bulkPricingPackage.getNextBillingDate())
-        .isEqualTo(DateTime.parse("2013-03-17T00:00:00Z"));
+        .isEqualTo(Instant.parse("2013-03-17T00:00:00Z"));
     assertThat(bulkPricingPackage.getLastNotificationSent()).isEmpty();
   }
 
@@ -153,7 +152,7 @@ public class UpdateBulkPricingPackageCommandTest
     assertThat(bulkPricingPackage.getMaxCreates()).isEqualTo(1000);
     assertThat(bulkPricingPackage.getBulkPrice()).isEqualTo(Money.of(CurrencyUnit.USD, 2000));
     assertThat(bulkPricingPackage.getNextBillingDate())
-        .isEqualTo(DateTime.parse("2012-11-12T05:00:00Z"));
+        .isEqualTo(Instant.parse("2012-11-12T05:00:00Z"));
     assertThat(bulkPricingPackage.getLastNotificationSent()).isEmpty();
   }
 
@@ -174,7 +173,7 @@ public class UpdateBulkPricingPackageCommandTest
     assertThat(bulkPricingPackage.getMaxCreates()).isEqualTo(1000);
     assertThat(bulkPricingPackage.getBulkPrice()).isEqualTo(Money.of(CurrencyUnit.USD, 1000));
     assertThat(bulkPricingPackage.getNextBillingDate())
-        .isEqualTo(DateTime.parse("2013-03-17T00:00:00Z"));
+        .isEqualTo(Instant.parse("2013-03-17T00:00:00Z"));
     assertThat(bulkPricingPackage.getLastNotificationSent()).isEmpty();
   }
 
@@ -190,8 +189,8 @@ public class UpdateBulkPricingPackageCommandTest
     assertThat(bulkPricingPackage.getMaxCreates()).isEqualTo(1000);
     assertThat(bulkPricingPackage.getBulkPrice()).isEqualTo(Money.of(CurrencyUnit.USD, 2000));
     assertThat(bulkPricingPackage.getNextBillingDate())
-        .isEqualTo(DateTime.parse("2012-11-12T05:00:00Z"));
+        .isEqualTo(Instant.parse("2012-11-12T05:00:00Z"));
     assertThat(bulkPricingPackage.getLastNotificationSent().get())
-        .isEqualTo(DateTime.parse("2010-11-12T05:00:00.000Z"));
+        .isEqualTo(Instant.parse("2010-11-12T05:00:00.000Z"));
   }
 }

--- a/core/src/test/java/google/registry/tools/UpdateDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateDomainCommandTest.java
@@ -295,7 +295,7 @@ class UpdateDomainCommandTest extends EppToolCommandTestCase<UpdateDomainCommand
     persistResource(
         domain
             .asBuilder()
-            .setRegistrationExpirationTime(fakeClock.nowUtc().plusDays(360))
+            .setRegistrationExpirationTime(plusDays(fakeClock.now(), 360))
             .setAutorenewBillingEvent(autorenewBillingEvent.createVKey())
             .setGracePeriods(
                 ImmutableSet.of(

--- a/core/src/test/java/google/registry/tools/UpdateRegistrarCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateRegistrarCommandTest.java
@@ -25,7 +25,6 @@ import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
 import static org.joda.money.CurrencyUnit.JPY;
 import static org.joda.money.CurrencyUnit.USD;
-import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.beust.jcommander.ParameterException;
@@ -42,6 +41,8 @@ import google.registry.model.registrar.Registrar.Type;
 import google.registry.persistence.transaction.JpaTransactionManagerExtension;
 import google.registry.util.CidrAddressBlock;
 import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import org.joda.money.Money;
 import org.joda.time.DateTime;
@@ -275,8 +276,8 @@ class UpdateRegistrarCommandTest extends CommandTestCase<UpdateRegistrarCommand>
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()
-            .setClientCertificate(SAMPLE_CERT3, fakeClock.nowUtc())
-            .setFailoverClientCertificate(null, fakeClock.nowUtc())
+            .setClientCertificate(SAMPLE_CERT3, fakeClock.now())
+            .setFailoverClientCertificate(null, fakeClock.now())
             .build());
 
     Registrar registrar = loadRegistrar("NewRegistrar");
@@ -408,7 +409,7 @@ class UpdateRegistrarCommandTest extends CommandTestCase<UpdateRegistrarCommand>
     persistResource(
         loadRegistrar("NewRegistrar")
             .asBuilder()
-            .setClientCertificate(SAMPLE_CERT, DateTime.now(UTC))
+            .setClientCertificate(SAMPLE_CERT, Instant.now().truncatedTo(ChronoUnit.MILLIS))
             .build());
     assertThat(loadRegistrar("NewRegistrar").getClientCertificate()).isPresent();
     runCommand("--cert_file=/dev/null", "--force", "NewRegistrar");

--- a/core/src/test/java/google/registry/tools/ValidateLoginCredentialsCommandTest.java
+++ b/core/src/test/java/google/registry/tools/ValidateLoginCredentialsCommandTest.java
@@ -21,7 +21,6 @@ import static google.registry.testing.DatabaseHelper.loadRegistrar;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
 import static google.registry.util.DateTimeUtils.START_OF_TIME;
-import static org.joda.time.DateTimeZone.UTC;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.beust.jcommander.ParameterException;
@@ -37,6 +36,8 @@ import google.registry.testing.CertificateSamples;
 import google.registry.util.CidrAddressBlock;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +57,8 @@ class ValidateLoginCredentialsCommandTest extends CommandTestCase<ValidateLoginC
         loadRegistrar("NewRegistrar")
             .asBuilder()
             .setPassword(PASSWORD)
-            .setClientCertificate(CertificateSamples.SAMPLE_CERT3, DateTime.now(UTC))
+            .setClientCertificate(
+                CertificateSamples.SAMPLE_CERT3, Instant.now().truncatedTo(ChronoUnit.MILLIS))
             .setIpAddressAllowList(ImmutableList.of(new CidrAddressBlock(CLIENT_IP)))
             .setState(ACTIVE)
             .setAllowedTlds(ImmutableSet.of("tld"))

--- a/core/src/test/java/google/registry/ui/server/console/ConsoleUpdateRegistrarActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/ConsoleUpdateRegistrarActionTest.java
@@ -46,8 +46,8 @@ import jakarta.mail.internet.InternetAddress;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.time.Instant;
 import java.util.Optional;
-import org.joda.time.DateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -115,7 +115,7 @@ class ConsoleUpdateRegistrarActionTest extends ConsoleActionBaseTestCase {
     action.run();
     Registrar newRegistrar = Registrar.loadByRegistrarId("TheRegistrar").get();
     assertThat(newRegistrar.getLastPocVerificationDate())
-        .isEqualTo(DateTime.parse("1970-01-01T00:00:00.000Z"));
+        .isEqualTo(Instant.parse("1970-01-01T00:00:00.000Z"));
   }
 
   @Test

--- a/core/src/test/java/google/registry/webdriver/ConsoleScreenshotTest.java
+++ b/core/src/test/java/google/registry/webdriver/ConsoleScreenshotTest.java
@@ -23,9 +23,9 @@ import google.registry.model.console.GlobalRole;
 import google.registry.model.console.RegistrarRole;
 import google.registry.model.registrar.Registrar;
 import google.registry.server.RegistryTestServer;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -80,7 +80,10 @@ public class ConsoleScreenshotTest {
     server.setRegistrarRoles(ImmutableMap.of("TheRegistrar", RegistrarRole.ACCOUNT_MANAGER));
     Registrar registrar = Registrar.loadByRegistrarId("TheRegistrar").get();
     registrar =
-        registrar.asBuilder().setLastPocVerificationDate(DateTime.now(DateTimeZone.UTC)).build();
+        registrar
+            .asBuilder()
+            .setLastPocVerificationDate(Instant.now().truncatedTo(ChronoUnit.MILLIS))
+            .build();
     persistResource(registrar);
     loadHomePage();
   }


### PR DESCRIPTION
Migrated core EppResource and Token models from Joda-Time DateTime to java.time.Instant.

Specific migrations include:
- `DomainBase` and `Domain`: Migrated `registrationExpirationTime` and various other timestamps to use `Instant` directly.
- `Registrar`: Migrated `lastPocVerificationDate` and certificate dates to `Instant`.
- `BulkPricingPackage`: Migrated `nextBillingDate` and `lastNotificationSent`.
- `AllocationToken`: Migrated `tokenStatusTransitions` map keys to `Instant`.
- `LaunchNotice`: Migrated `acceptedTime` and `expirationTime`.

Updated all associated EPP flows (e.g., DomainCreateFlow, DomainRenewFlow), batch actions (e.g., CheckBulkComplianceAction, DeleteExpiredDomainsAction), command-line tools (e.g., UnrenewDomainCommand, UpdateBulkPricingPackageCommand), and tests to handle `Instant` directly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3022)
<!-- Reviewable:end -->
