### PR TITLE
  Fix Kythe extraction failure caused by Error Prone access to JDK internals

### DIFF
--- a/release/cloudbuild-kythe.yaml
+++ b/release/cloudbuild-kythe.yaml
@@ -36,6 +36,7 @@ steps:
     jvmopts="$${jvmopts} --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED"
     jvmopts="$${jvmopts} --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
     jvmopts="$${jvmopts} --add-exports=jdk.internal.opt/jdk.internal.opt=ALL-UNNAMED"
+    jvmopts="$${jvmopts} --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"
     export KYTHE_JAVA_RUNTIME_OPTIONS=$${jvmopts}
     export KYTHE_VNAMES="$${PWD}/vnames.json"
     export KYTHE_ROOT_DIRECTORY="$${PWD}"


### PR DESCRIPTION
  This PR fixes a build failure in the Kythe extraction pipeline (`cloudbuild-kythe.yaml`).
  
  ### Problem
  The build was failing during the `:util:compileJava` task because the Error Prone static analysis plugin was trying to access internal compiler APIs (`com.sun.tools.javac.comp.Resolve.findIdent`) that are strictly encapsulated in newer Java versions. This resulted in a `java.lang.reflect.InaccessibleObjectException`.
  
  ### Fix
  Added `--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED` to `jvmopts` in `cloudbuild-kythe.yaml` to grant Error Prone the necessary access to the `jdk.compiler` module internals.
  
  This should allow the Kythe extraction to complete successfully and resume generating new kzips for CodeSearch indexing.
  
  Fixes: b/496522435

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3026)
<!-- Reviewable:end -->
