### PR TITLE
Add -J to --add-opens for Kythe extraction

### DIFF
--- a/release/cloudbuild-kythe.yaml
+++ b/release/cloudbuild-kythe.yaml
@@ -36,7 +36,7 @@ steps:
     jvmopts="$${jvmopts} --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED"
     jvmopts="$${jvmopts} --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
     jvmopts="$${jvmopts} --add-exports=jdk.internal.opt/jdk.internal.opt=ALL-UNNAMED"
-    jvmopts="$${jvmopts} --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"
+    jvmopts="$${jvmopts} -J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"
     export KYTHE_JAVA_RUNTIME_OPTIONS=$${jvmopts}
     export KYTHE_VNAMES="$${PWD}/vnames.json"
     export KYTHE_ROOT_DIRECTORY="$${PWD}"


### PR DESCRIPTION
  This is a follow-up to PR #3026.
  
  ### Problem
  The previous fix added `--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED` to `jvmopts`. However, the build still failed with the same error, and the compiler issued a warning: `warning: [options] --add-opens has no effect at compile time`. This means `javac` ignored the option because it is a runtime option.
  
  ### Fix
  Prefixed the option with **`-J`** to correctly pass it to the JVM running `javac`: `-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED`.
  
  This should properly grant Error Prone the necessary access to the `jdk.compiler` module internals.
  
  Fixes: b/496522435

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3028)
<!-- Reviewable:end -->
