### PR TITLE
Pass KYTHE_JAVA_RUNTIME_OPTIONS via Gradle forkOptions

### DIFF
--- a/java_common.gradle
+++ b/java_common.gradle
@@ -103,7 +103,7 @@ tasks.withType(Test).configureEach {
 
 tasks.withType(JavaCompile).configureEach {
   options.fork = true
-  options.forkOptions.jvmArgs += ['--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED']
+  options.compilerArgs += ['-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED']
   // The -Werror flag causes Intellij to fail on deprecated api use.
   // Allow IDE user to turn off this flag by specifying a Gradle VM
   // option from inside the IDE.

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -102,8 +102,6 @@ tasks.withType(Test).configureEach {
 }
 
 tasks.withType(JavaCompile).configureEach {
-  options.fork = true
-  options.compilerArgs += ['-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED']
   // The -Werror flag causes Intellij to fail on deprecated api use.
   // Allow IDE user to turn off this flag by specifying a Gradle VM
   // option from inside the IDE.

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -103,9 +103,7 @@ tasks.withType(Test).configureEach {
 
 tasks.withType(JavaCompile).configureEach {
   options.fork = true
-  options.forkOptions.environment += [
-      "KYTHE_JAVA_RUNTIME_OPTIONS": "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"
-  ]
+  options.forkOptions.jvmArgs += ['--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED']
   // The -Werror flag causes Intellij to fail on deprecated api use.
   // Allow IDE user to turn off this flag by specifying a Gradle VM
   // option from inside the IDE.

--- a/java_common.gradle
+++ b/java_common.gradle
@@ -102,6 +102,10 @@ tasks.withType(Test).configureEach {
 }
 
 tasks.withType(JavaCompile).configureEach {
+  options.fork = true
+  options.forkOptions.environment += [
+      "KYTHE_JAVA_RUNTIME_OPTIONS": "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"
+  ]
   // The -Werror flag causes Intellij to fail on deprecated api use.
   // Allow IDE user to turn off this flag by specifying a Gradle VM
   // option from inside the IDE.

--- a/release/cloudbuild-kythe.yaml
+++ b/release/cloudbuild-kythe.yaml
@@ -28,8 +28,6 @@ steps:
     export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which javac))))
     mv $${JAVA_HOME}/bin/javac $${JAVA_HOME}/bin/javac.real
     cp ./kythe/extractors/javac-wrapper.sh $${JAVA_HOME}/bin/javac
-    chmod +x $${JAVA_HOME}/bin/javac
-    sed -i 's/"$REAL_JAVAC" "$@"/ "$REAL_JAVAC" $REAL_JAVAC_JVM_OPTIONS "$@"/g' $${JAVA_HOME}/bin/javac
     export JAVAC_EXTRACTOR_JAR="$${PWD}/kythe/extractors/javac_extractor.jar"
     jvmopts="--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED"
     jvmopts="$${jvmopts} --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
@@ -39,7 +37,6 @@ steps:
     jvmopts="$${jvmopts} --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
     jvmopts="$${jvmopts} --add-exports=jdk.internal.opt/jdk.internal.opt=ALL-UNNAMED"
     export KYTHE_JAVA_RUNTIME_OPTIONS=$${jvmopts}
-    export REAL_JAVAC_JVM_OPTIONS="--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"
     export KYTHE_VNAMES="$${PWD}/vnames.json"
     export KYTHE_ROOT_DIRECTORY="$${PWD}"
     export KYTHE_OUTPUT_DIRECTORY="$${PWD}/kythe_output"

--- a/release/cloudbuild-kythe.yaml
+++ b/release/cloudbuild-kythe.yaml
@@ -28,6 +28,7 @@ steps:
     export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which javac))))
     mv $${JAVA_HOME}/bin/javac $${JAVA_HOME}/bin/javac.real
     cp ./kythe/extractors/javac-wrapper.sh $${JAVA_HOME}/bin/javac
+    sed -i 's/"$$REAL_JAVAC" "$$@"/ "$$REAL_JAVAC" $$REAL_JAVAC_JVM_OPTIONS "$$@"/g' $${JAVA_HOME}/bin/javac
     export JAVAC_EXTRACTOR_JAR="$${PWD}/kythe/extractors/javac_extractor.jar"
     jvmopts="--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED"
     jvmopts="$${jvmopts} --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
@@ -37,6 +38,7 @@ steps:
     jvmopts="$${jvmopts} --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
     jvmopts="$${jvmopts} --add-exports=jdk.internal.opt/jdk.internal.opt=ALL-UNNAMED"
     export KYTHE_JAVA_RUNTIME_OPTIONS=$${jvmopts}
+    export REAL_JAVAC_JVM_OPTIONS="--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"
     export KYTHE_VNAMES="$${PWD}/vnames.json"
     export KYTHE_ROOT_DIRECTORY="$${PWD}"
     export KYTHE_OUTPUT_DIRECTORY="$${PWD}/kythe_output"

--- a/release/cloudbuild-kythe.yaml
+++ b/release/cloudbuild-kythe.yaml
@@ -36,7 +36,6 @@ steps:
     jvmopts="$${jvmopts} --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED"
     jvmopts="$${jvmopts} --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
     jvmopts="$${jvmopts} --add-exports=jdk.internal.opt/jdk.internal.opt=ALL-UNNAMED"
-    jvmopts="$${jvmopts} -J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"
     export KYTHE_JAVA_RUNTIME_OPTIONS=$${jvmopts}
     export KYTHE_VNAMES="$${PWD}/vnames.json"
     export KYTHE_ROOT_DIRECTORY="$${PWD}"

--- a/release/cloudbuild-kythe.yaml
+++ b/release/cloudbuild-kythe.yaml
@@ -42,7 +42,7 @@ steps:
     export KYTHE_OUTPUT_DIRECTORY="$${PWD}/kythe_output"
     mkdir -p $${KYTHE_OUTPUT_DIRECTORY}
     mkdir -p $${KYTHE_OUTPUT_DIRECTORY}/merged
-    export JDK_JAVA_OPTIONS="--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED"
+    export JAVA_TOOL_OPTIONS="--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED"
     ./release/install_gradle.sh
     ./gradlew clean testClasses \
       -Dno_werror=true -PenableCrossReferencing=true

--- a/release/cloudbuild-kythe.yaml
+++ b/release/cloudbuild-kythe.yaml
@@ -28,7 +28,6 @@ steps:
     export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which javac))))
     mv $${JAVA_HOME}/bin/javac $${JAVA_HOME}/bin/javac.real
     cp ./kythe/extractors/javac-wrapper.sh $${JAVA_HOME}/bin/javac
-    sed -i 's/"$$REAL_JAVAC" "$$@"/ "$$REAL_JAVAC" $$REAL_JAVAC_JVM_OPTIONS "$$@"/g' $${JAVA_HOME}/bin/javac
     export JAVAC_EXTRACTOR_JAR="$${PWD}/kythe/extractors/javac_extractor.jar"
     jvmopts="--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED"
     jvmopts="$${jvmopts} --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
@@ -38,12 +37,12 @@ steps:
     jvmopts="$${jvmopts} --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
     jvmopts="$${jvmopts} --add-exports=jdk.internal.opt/jdk.internal.opt=ALL-UNNAMED"
     export KYTHE_JAVA_RUNTIME_OPTIONS=$${jvmopts}
-    export REAL_JAVAC_JVM_OPTIONS="--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"
     export KYTHE_VNAMES="$${PWD}/vnames.json"
     export KYTHE_ROOT_DIRECTORY="$${PWD}"
     export KYTHE_OUTPUT_DIRECTORY="$${PWD}/kythe_output"
     mkdir -p $${KYTHE_OUTPUT_DIRECTORY}
     mkdir -p $${KYTHE_OUTPUT_DIRECTORY}/merged
+    export JDK_JAVA_OPTIONS="--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED"
     ./release/install_gradle.sh
     ./gradlew clean testClasses \
       -Dno_werror=true -PenableCrossReferencing=true

--- a/release/cloudbuild-kythe.yaml
+++ b/release/cloudbuild-kythe.yaml
@@ -28,6 +28,8 @@ steps:
     export JAVA_HOME=$(dirname $(dirname $(readlink -f $(which javac))))
     mv $${JAVA_HOME}/bin/javac $${JAVA_HOME}/bin/javac.real
     cp ./kythe/extractors/javac-wrapper.sh $${JAVA_HOME}/bin/javac
+    chmod +x $${JAVA_HOME}/bin/javac
+    sed -i 's/"$REAL_JAVAC" "$@"/ "$REAL_JAVAC" $REAL_JAVAC_JVM_OPTIONS "$@"/g' $${JAVA_HOME}/bin/javac
     export JAVAC_EXTRACTOR_JAR="$${PWD}/kythe/extractors/javac_extractor.jar"
     jvmopts="--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED"
     jvmopts="$${jvmopts} --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
@@ -37,6 +39,7 @@ steps:
     jvmopts="$${jvmopts} --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED"
     jvmopts="$${jvmopts} --add-exports=jdk.internal.opt/jdk.internal.opt=ALL-UNNAMED"
     export KYTHE_JAVA_RUNTIME_OPTIONS=$${jvmopts}
+    export REAL_JAVAC_JVM_OPTIONS="--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED"
     export KYTHE_VNAMES="$${PWD}/vnames.json"
     export KYTHE_ROOT_DIRECTORY="$${PWD}"
     export KYTHE_OUTPUT_DIRECTORY="$${PWD}/kythe_output"


### PR DESCRIPTION
  This PR fixes the Kythe extraction failure caused by Error Prone access to JDK internals.
  
  ### Problem
  The build was failing during the `:util:compileJava` task because the Error Prone static analysis plugin was trying to access internal compiler APIs (`com.sun.tools.javac.comp.Resolve.findIdent`) that are strictly encapsulated in newer Java versions. Previous attempts to pass `--add-opens` via compiler arguments or specific environment variables failed or were ignored by the wrapper scripts.
  
  ### Fix
  Used the standard `JAVA_TOOL_OPTIONS` environment variable in `cloudbuild-kythe.yaml` to pass the required `--add-opens` flags to all JVMs started during the build (including the Gradle daemon and forked compiler workers). This ensures that Error Prone has the necessary access to `jdk.compiler` modules.
  
  This has been tested manually in Cloud Build and successfully generated and uploaded the kzip file.
  
  BUG=496522435

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3030)
<!-- Reviewable:end -->
