### PR TITLE
ci: declare empty permissions for do-not-merge label check

### DIFF
--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -12,6 +12,8 @@ on:
     branches: ["master"]
     types: [checks_requested]
 
+permissions: {}
+
 jobs:
   fail-by-label:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `Check labels` workflow only reads `github.event.pull_request.labels.*.name` and exits 1 if `do not merge` is present. It does not check out the repo, install anything, or call any GitHub API. `permissions: {}` (deny all scopes) is the right default for this case.

YAML parses cleanly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3042)
<!-- Reviewable:end -->
