### PR TITLE
docs: fix five typos across docs/

### DIFF
--- a/docs/console-endpoints/README.md
+++ b/docs/console-endpoints/README.md
@@ -1,11 +1,11 @@
 # Registry Console Swagger API 
 
-This is the Swagger-based Registry Console API documentation. The project endpoints documentation in json format can be found in `console-api-swagger.json`, rest of the files in the folder compose Swagger standalone distributive stripped to bare miminum necessary to start the Swagger UI. 
+This is the Swagger-based Registry Console API documentation. The project endpoints documentation in json format can be found in `console-api-swagger.json`, rest of the files in the folder compose Swagger standalone distributive stripped to bare minimum necessary to start the Swagger UI. 
 
 ## How to run Swagger to view the endpoints documentation
 
 Since Swagger standalone distributive is nothing but a simple static website it's extremely easy to get it started and view the documentation in a matter of seconds. 
-Note - just a simple opening of `index.html` wouldn't be enough, as with any static website, it'd not be able to handle relative resources requests therefore succesfully render Swagger UI. For this reason it's configured to spin off a simple node.js based http server to serve Swagger UI resources. The following steps required to succesfully start the Swagger UI:
+Note - just a simple opening of `index.html` wouldn't be enough, as with any static website, it'd not be able to handle relative resources requests therefore successfully render Swagger UI. For this reason it's configured to spin off a simple node.js based http server to serve Swagger UI resources. The following steps required to succesfully start the Swagger UI:
 
 * Install npm dependencies - `npm install`
 * Run - `npm run swagger`

--- a/docs/gradle.md
+++ b/docs/gradle.md
@@ -45,5 +45,5 @@ reason why all test tasks in the :core project contain the exclude pattern
 Some Nomulus tests are not hermetic: they modify global state, but do not clean
 up on completion. This becomes a problem with Gradle. In the beginning we forced
 Gradle to run every test class in a new process, and incurred heavy overheads.
-Since then, we have fixed some tests, and manged to divide all tests into two
+Since then, we have fixed some tests, and managed to divide all tests into two
 suites that do not have intra-suite conflicts (`fragileTest` and `standardTest`)

--- a/docs/proxy-setup.md
+++ b/docs/proxy-setup.md
@@ -565,10 +565,10 @@ fill its role. Similarly a node may be shut down due to under-utilization
 (thanks to GKE autoscaling). In order to reliably route incoming traffic to the
 proxy, a
 [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport)
-service is used to expose the proxy on specificed port(s) on every running node
+service is used to expose the proxy on specified port(s) on every running node
 in the cluster, even if the proxy does not run on a VM (in which case the
 traffic is routed to a VM that has the proxy running). With a [NodePort]
-service, the load balancer can alway route traffic to any healthy node, and
+service, the load balancer can always route traffic to any healthy node, and
 kubernetes takes care of delivering that traffic to a servicing proxy pod.
 
 To deploy the NodePort service:


### PR DESCRIPTION
Five small docs typos caught by codespell:

| File | Fix |
|---|---|
| `docs/gradle.md` | `manged` → `managed` |
| `docs/proxy-setup.md` | `specificed` → `specified`, `alway` → `always` |
| `docs/console-endpoints/README.md` | `miminum` → `minimum`, `succesfully` → `successfully` |

Codespell also flagged `OT` 9+ times in `docs/registrar-faq.md` / `docs/architecture.md`. That looks like a registry-domain abbreviation (Operational Test or similar), not a misspelling — left alone.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3043)
<!-- Reviewable:end -->
