### PR TITLE
Build Cloud Deploy artifacts via Cloud Build job

### DIFF
--- a/release/cloudbuild-clouddeploy.yaml
+++ b/release/cloudbuild-clouddeploy.yaml
@@ -42,8 +42,7 @@ steps:
       config_file="release/clouddeploy/${env}-config.yaml"
       if [ -f "$config_file" ]; then
         echo "Extracting checks from $config_file..."
-        # Extract only the indented block under stableDeploymentAlertPolicyChecks:
-        # stopping if another top-level key is encountered.
+        # Extract only the indented block under stableDeploymentAlertPolicyChecks.
         awk '
         /^stableDeploymentAlertPolicyChecks:/ { capture = 1; next }
         capture {

--- a/release/cloudbuild-clouddeploy.yaml
+++ b/release/cloudbuild-clouddeploy.yaml
@@ -1,0 +1,94 @@
+# This Cloud Build job prepares and applies Google Cloud Deploy configurations.
+# It merges the internal repository and populates stableDeploymentAlertPolicyChecks
+# in delivery-pipeline.yaml based on environment-specific configuration files.
+#
+# To manually trigger a build on GCB, run:
+# gcloud builds submit --config release/cloudbuild-clouddeploy.yaml --substitutions \
+#   _INTERNAL_REPO_URL=[URL],PROJECT_ID=[PROJECT_ID] ..
+
+steps:
+# Check the out internal repo.
+- name: 'gcr.io/cloud-builders/git'
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    git clone https://gerrit.googlesource.com/gcompute-tools
+    sed -i s@/usr/bin/python@/usr/bin/python3@g ./gcompute-tools/git-cookie-authdaemon
+    ./gcompute-tools/git-cookie-authdaemon
+    git clone ${_INTERNAL_REPO_URL} nomulus-internal
+
+# Merge the repos.
+- name: 'gcr.io/cloud-builders/git'
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    shopt -s dotglob
+    rm -rf .git && rm -rf nomulus-internal/.git
+    cp -rf nomulus-internal/* .
+    rm -rf nomulus-internal
+
+# Populate stableDeploymentAlertPolicyChecks in delivery-pipeline.yaml and variables in targets
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    for env in crash; do
+      config_file="release/clouddeploy/${env}-config.yaml"
+      if [ -f "$config_file" ]; then
+        echo "Extracting checks from $config_file..."
+        # Extract only the indented block under stableDeploymentAlertPolicyChecks:
+        # stopping if another top-level key is encountered.
+        awk '
+        /^stableDeploymentAlertPolicyChecks:/ { capture = 1; next }
+        capture {
+          if ($0 ~ /^[^[:space:]]/ && $0 != "") { capture = 0; exit }
+          print "            " $0
+        }
+        ' "$config_file" > checks.tmp
+        
+        # Insert the checks where the placeholder is located and remove the placeholder
+        sed -i '/stableDeploymentAlertPolicyChecks/r checks.tmp' release/clouddeploy/delivery-pipeline.yaml
+        sed -i '/stableDeploymentAlertPolicyChecks/d' release/clouddeploy/delivery-pipeline.yaml
+        rm -f checks.tmp
+        
+        # Populate variables in target file
+        target_file="release/clouddeploy/${env}-target.yaml"
+        if [ -f "$target_file" ]; then
+          echo "Populating variables in $target_file..."
+          artifact_storage=$(sed -n 's/^artifactStorage: //p' "$config_file")
+          service_account=$(sed -n 's/^serviceAccount: //p' "$config_file")
+          cluster_val=$(sed -n 's/^cluster: //p' "$config_file")
+          
+          sed -i "s|artifactStorage: artifactStorage|artifactStorage: $artifact_storage|" "$target_file"
+          sed -i "s|serviceAccount: serviceAccount|serviceAccount: $service_account|" "$target_file"
+          sed -i "s|cluster: cluster|cluster: $cluster_val|" "$target_file"
+        fi
+      fi
+    done
+
+# Apply Cloud Deploy configuration
+- name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    for env in crash; do
+      target_file="release/clouddeploy/${env}-target.yaml"
+      if [ -f "$target_file" ]; then
+        echo "Applying target $target_file..."
+        gcloud deploy apply --file="$target_file" --region=us-central1 --project=${PROJECT_ID}
+      fi
+    done
+    echo 'Applying delivery-pipeline.yaml...'
+    gcloud deploy apply --file=release/clouddeploy/delivery-pipeline.yaml --region=us-central1 --project=${PROJECT_ID}
+
+timeout: 3600s
+options:
+  machineType: 'E2_HIGHCPU_32'

--- a/release/clouddeploy/README.md
+++ b/release/clouddeploy/README.md
@@ -5,17 +5,35 @@ This directory contains the Google Cloud Deploy configuration files for the Nomu
 ## Files
 
 ### `delivery-pipeline.yaml`
-Defines the `DeliveryPipeline` resource named `deploy-nomulus`. It sets up the serial pipeline for rolling out changes to different targets.
+Defines the `DeliveryPipeline` resource named `deploy-nomulus`. It sets up the serial pipeline for rolling out changes to different targets, including automated post-deployment analysis steps.
 
 ### Target Configurations (e.g., `crash-target.yaml`)
-Files matching this format define the `Target` resources for Cloud Deploy. They specify the GKE cluster and other environment-specific settings for deployment.
+Files matching this format define the `Target` resources for Cloud Deploy. They specify the GKE cluster, service account, artifact storage, and other environment-specific settings for deployment.
+
+### Environment Configurations (e.g., `crash-config.yaml`)
+Configuration files containing environment-specific parameters and SLA-based alert policy checks (such as EPP and RDAP success metrics) used for automated analysis and target population.
 
 ### `skaffold.yaml`
 Defines the Skaffold configuration used by Cloud Deploy to render and deploy the application manifests.
 
-## Usage
+## Automated Configuration and Deployment Process
 
-You can apply or modify these configurations in Google Cloud by using the `gcloud` CLI. For example:
+The preparation and application of Cloud Deploy configurations is automated via Cloud Build using [`release/cloudbuild-clouddeploy.yaml`](file:///usr/local/google/home/jicelhay/nomulus/release/cloudbuild-clouddeploy.yaml).
+
+When executed, the Cloud Build job performs the following workflow:
+1. **Repository Merge**: Clones the internal repository (`nomulus-internal`) and merges internal configurations into the workspace.
+2. **Dynamic Configuration Population**: Reads variables and alert policy checks specified in the configuration file for the environment from the internal repository, populating them into `delivery-pipeline.yaml` and the corresponding target files.
+3. **Apply Configurations**: Runs `gcloud deploy apply` to register the updated targets and delivery pipeline in Google Cloud Deploy.
+
+### Manual Execution on Cloud Build
+To manually trigger this configuration pipeline on Google Cloud Build, run:
+```bash
+gcloud builds submit --config release/cloudbuild-clouddeploy.yaml --substitutions _INTERNAL_REPO_URL=[URL],PROJECT_ID=[PROJECT_ID]
+```
+
+## Manual Local Usage
+
+You can also apply or modify rendered configurations directly using the `gcloud` CLI:
 
 ```bash
 gcloud deploy apply --file=<config-file>.yaml --project=<project-id> --region=<region>

--- a/release/clouddeploy/README.md
+++ b/release/clouddeploy/README.md
@@ -5,10 +5,10 @@ This directory contains the Google Cloud Deploy configuration files for the Nomu
 ## Files
 
 ### `delivery-pipeline.yaml`
-Defines the `DeliveryPipeline` resource named `deploy-nomulus`. It sets up the serial pipeline for rolling out changes to different targets, including automated post-deployment analysis steps.
+Defines the `DeliveryPipeline` resource named `deploy-nomulus`. It sets up the serial pipeline for rolling out changes to different targets.
 
 ### Target Configurations (e.g., `crash-target.yaml`)
-Files matching this format define the `Target` resources for Cloud Deploy. They specify the GKE cluster, service account, artifact storage, and other environment-specific settings for deployment.
+Files matching this format define the `Target` resources for Cloud Deploy. They specify the GKE cluster and other environment-specific settings for deployment.
 
 ### Environment Configurations (e.g., `crash-config.yaml`)
 Configuration files containing environment-specific parameters and SLA-based alert policy checks (such as EPP and RDAP success metrics) used for automated analysis and target population.
@@ -18,7 +18,7 @@ Defines the Skaffold configuration used by Cloud Deploy to render and deploy the
 
 ## Automated Configuration and Deployment Process
 
-The preparation and application of Cloud Deploy configurations is automated via Cloud Build using [`release/cloudbuild-clouddeploy.yaml`](file:///usr/local/google/home/jicelhay/nomulus/release/cloudbuild-clouddeploy.yaml).
+The preparation and application of Cloud Deploy configurations is automated via Cloud Build using `release/cloudbuild-clouddeploy.yaml`.
 
 When executed, the Cloud Build job performs the following workflow:
 1. **Repository Merge**: Clones the internal repository (`nomulus-internal`) and merges internal configurations into the workspace.

--- a/release/clouddeploy/crash-target.yaml
+++ b/release/clouddeploy/crash-target.yaml
@@ -13,9 +13,9 @@ executionConfigs:
   executionTimeout: 3600s
   defaultPool:
     # Placeholder: Replace with artifact bucket name.
-    artifactStorage: gs://_artifact_bucket_
+    artifactStorage: artifactStorage
     # Placeholder: Replace with project number.
-    serviceAccount: _project_number_-compute@developer.gserviceaccount.com
+    serviceAccount: serviceAccount
 gke:
   # Placeholder: Replace with project ID, location, and cluster name.
-  cluster: projects/_project_id_/locations/_location_/clusters/_cluster_name_
+  cluster: cluster

--- a/release/clouddeploy/delivery-pipeline.yaml
+++ b/release/clouddeploy/delivery-pipeline.yaml
@@ -9,3 +9,11 @@ serialPipeline:
   - targetId: crash
     profiles:
     - crash
+    strategy:
+      standard:
+        analysis:
+          # 10 minutes.
+          duration: 600s
+          googleCloud:
+            alertPolicyChecks:
+                stableDeploymentAlertPolicyChecks


### PR DESCRIPTION
This adds a CB job to automatically generate and apply pipeline + target CD files.

This will read the internal repo and populate variables in the public CD templates with values that are internal and env. specific. Currently it's only configured for crash and populates stableDeploymentAlertPolicyChecks in the pipeline plus other variables in the target file.

Here's a result of running the job in dry-run mode:

https://console.cloud.google.com/cloud-build/builds/c594e5fd-be22-4d3a-bc74-6813ce8527e8?project=986522766601 

b/507127490

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3044)
<!-- Reviewable:end -->
