### PR TITLE
Add "traffic" label to nomulus pod templates

### DIFF
--- a/jetty/kubernetes/nomulus-backend.yaml
+++ b/jetty/kubernetes/nomulus-backend.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         service: backend
+        traffic: backend-all
     spec:
       serviceAccountName: nomulus
       nodeSelector:

--- a/jetty/kubernetes/nomulus-console.yaml
+++ b/jetty/kubernetes/nomulus-console.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         service: console
+        traffic: console-all
     spec:
       serviceAccountName: nomulus
       containers:

--- a/jetty/kubernetes/nomulus-frontend.yaml
+++ b/jetty/kubernetes/nomulus-frontend.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         service: frontend
+        traffic: frontend-all
     spec:
       serviceAccountName: nomulus
       nodeSelector:

--- a/jetty/kubernetes/nomulus-pubapi.yaml
+++ b/jetty/kubernetes/nomulus-pubapi.yaml
@@ -12,6 +12,7 @@ spec:
     metadata:
       labels:
         service: pubapi
+        traffic: pubapi-all
     spec:
       serviceAccountName: nomulus
       containers:


### PR DESCRIPTION
We want existing Services to load balance traffic across  stable and  canary/partial Deployments. 

Right now, the Service selector routes based on the `service` label. However, we can't add that label to new canary/partial Deployments because it would conflict with the stable Deployment's `spec.selector.matchLabels` and it will cause conflicts over pod management.

The end goal is to add the new label to pods and then to switch the Service's selector to route based on this new label. We're doing this in 2 steps to ensure that this is doesn't disrupt traffic when deployed (services trying to route traffic but pods that don't have the label yet) and adding a release in between to be backwards compatible (if we rollback deployments, they will still have the new tag when the service change is deployed).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3046)
<!-- Reviewable:end -->
