### PR TITLE
Generate partial phases kubernetes manifests in CB release job

### DIFF
--- a/release/cloudbuild-release.yaml
+++ b/release/cloudbuild-release.yaml
@@ -236,14 +236,12 @@ steps:
         # partial phase manifests
         for stage in 1 5
         do
-          cp ./jetty/kubernetes/nomulus-${env}-${service}.yaml ./jetty/kubernetes/nomulus-${env}-${service}-partial-phase-${stage}.yaml
-          echo "---" >> ./jetty/kubernetes/nomulus-${env}-${service}-partial-phase-${stage}.yaml
           awk 'NR==1,/^---$/ {if ($0 != "---") print}' ./jetty/kubernetes/nomulus-${env}-${service}.yaml | \
             sed s/name:\ ${service}/name:\ ${service}-partial-phase/g | \
             sed s/service:\ ${service}/deployment:\ ${service}-partial-phase/g | \
             sed s/value:\ ${service}/value:\ ${service}-partial-phase/g | \
             sed "/^spec:$/a\  replicas: ${stage}" \
-            >> ./jetty/kubernetes/nomulus-${env}-${service}-partial-phase-${stage}.yaml
+            > ./jetty/kubernetes/nomulus-${env}-${service}-partial-phase-${stage}.yaml
         done
         # gateway
         sed s/BASE_DOMAIN/${base_domain}/g \

--- a/release/cloudbuild-release.yaml
+++ b/release/cloudbuild-release.yaml
@@ -239,8 +239,8 @@ steps:
           cp ./jetty/kubernetes/nomulus-${env}-${service}.yaml ./jetty/kubernetes/nomulus-${env}-${service}-partial-phase-${stage}.yaml
           echo "---" >> ./jetty/kubernetes/nomulus-${env}-${service}-partial-phase-${stage}.yaml
           awk 'NR==1,/^---$/ {if ($0 != "---") print}' ./jetty/kubernetes/nomulus-${env}-${service}.yaml | \
-            sed s/name:\ ${service}/name:\ ${service}-canary-phase-${stage}/g | \
-            sed s/service:\ ${service}/deployment:\ ${service}-canary-phase-${stage}/g | \
+            sed s/name:\ ${service}/name:\ ${service}-partial-phase/g | \
+            sed s/service:\ ${service}/deployment:\ ${service}-partial-phase/g | \
             sed "/^spec:$/a\  replicas: ${stage}" \
             >> ./jetty/kubernetes/nomulus-${env}-${service}-partial-phase-${stage}.yaml
         done

--- a/release/cloudbuild-release.yaml
+++ b/release/cloudbuild-release.yaml
@@ -241,6 +241,7 @@ steps:
           awk 'NR==1,/^---$/ {if ($0 != "---") print}' ./jetty/kubernetes/nomulus-${env}-${service}.yaml | \
             sed s/name:\ ${service}/name:\ ${service}-partial-phase/g | \
             sed s/service:\ ${service}/deployment:\ ${service}-partial-phase/g | \
+            sed s/value:\ ${service}/value:\ ${service}-partial-phase/g | \
             sed "/^spec:$/a\  replicas: ${stage}" \
             >> ./jetty/kubernetes/nomulus-${env}-${service}-partial-phase-${stage}.yaml
         done

--- a/release/cloudbuild-release.yaml
+++ b/release/cloudbuild-release.yaml
@@ -233,6 +233,17 @@ steps:
           sed -i s/${PROJECT_ID}.iam.gserviceaccount.com/${project}.iam.gserviceaccount.com/g \
             ./jetty/kubernetes/nomulus-${env}-${service}-canary.yaml
         fi
+        # partial phase manifests
+        for stage in 1 5
+        do
+          cp ./jetty/kubernetes/nomulus-${env}-${service}.yaml ./jetty/kubernetes/nomulus-${env}-${service}-partial-phase-${stage}.yaml
+          echo "---" >> ./jetty/kubernetes/nomulus-${env}-${service}-partial-phase-${stage}.yaml
+          awk 'NR==1,/^---$/ {if ($0 != "---") print}' ./jetty/kubernetes/nomulus-${env}-${service}.yaml | \
+            sed s/name:\ ${service}/name:\ ${service}-canary-phase-${stage}/g | \
+            sed s/service:\ ${service}/deployment:\ ${service}-canary-phase-${stage}/g | \
+            sed "/^spec:$/a\  replicas: ${stage}" \
+            >> ./jetty/kubernetes/nomulus-${env}-${service}-partial-phase-${stage}.yaml
+        done
         # gateway
         sed s/BASE_DOMAIN/${base_domain}/g \
           ./jetty/kubernetes/gateway/nomulus-route-${service}.yaml \


### PR DESCRIPTION
These manifests will be used in Cloud Deploy canary phases. They contain a new Deployment that is a copy of the "stable" deployment, but have a custom name, a fixed number of replicas (1 or 5 depending on the stage). They will canary the new nomulus image that's going to be deployed. 

These files are not tracked artifacts in Spinnaker so even if they are generated when preparing a release, they shouldn't be deployed until we onboard Cloud Deploy to the release process.

b/507126629

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3048)
<!-- Reviewable:end -->
