### PR TITLE
Add a reminder to run update_dependency to PR authors

### DIFF
--- a/.github/workflows/update-dependency-reminder.yml
+++ b/.github/workflows/update-dependency-reminder.yml
@@ -1,0 +1,48 @@
+name: Request Lockfile Review
+
+on:
+  pull_request_target:
+    branches: ["master"]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review-lockfiles:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      # We intentionally do NOT use actions/checkout here. 
+      # This keeps the environment completely secure and satisfies CodeQL.
+
+      - name: Check files via GitHub API
+        id: check_files
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+ 
+            // Get the list of files in the PR directly from the API
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100
+            });
+ 
+            // Look for any file **ending** in gradle.lockfile
+            const hasLockfile = files.some(file => file.filename.endsWith('gradle.lockfile'));
+            core.setOutput('has_lockfile', hasLockfile ? 'true' : 'false');
+
+      - name: Post unresolved review comment
+        if: steps.check_files.outputs.has_lockfile == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              event: 'REQUEST_CHANGES',
+              body: `### ⚠️ Attention Required: Lockfile Detected\nThis pull request contains modifications to one or more \`*.lockfile\` files. Please confirm that you have run update_dependency.sh to push new dependencies to the private repo.\n\n_Someone with Admin role must manually dismiss this review before merging._`
+            });


### PR DESCRIPTION
After the public-access removal from GCS buckets, the Kokoro tests can no longer use our private repo for resolve dependencies. And breakage is discovered only during build.

This PR lets Github to create review comment, which triggers on PRs that contain *.lockfile changes and asks the PR author to confirm that the update_dependency script has been executed.

Verified the scannin logic wrt lockfile changes. Review posting cannot be tested until it is merged.

Will test after the merge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3050)
<!-- Reviewable:end -->
