### PR TITLE
Add canary strategy to crash stage in Cloud Deploy pipeline

### DIFF
--- a/release/cloudbuild-clouddeploy.yaml
+++ b/release/cloudbuild-clouddeploy.yaml
@@ -56,21 +56,21 @@ steps:
         sed -i '/stableDeploymentAlertPolicyChecks/d' release/clouddeploy/delivery-pipeline.yaml
         rm -f checks.tmp
 
-        # Extract only the indented block under canaryDeploymentAlertPolicyChecks.
-        if grep -q "^canaryDeploymentAlertPolicyChecks:" "$config_file"; then
-          echo "Extracting canary checks from $config_file..."
+        # Extract only the indented block under partialDeploymentAlertPolicyChecks.
+        if grep -q "^partialDeploymentAlertPolicyChecks:" "$config_file"; then
+          echo "Extracting partial checks from $config_file..."
           awk '
-          /^canaryDeploymentAlertPolicyChecks:/ { capture = 1; next }
+          /^partialDeploymentAlertPolicyChecks:/ { capture = 1; next }
           capture {
             if ($0 ~ /^[^[:space:]]/ && $0 != "") { capture = 0; exit }
             print "            " $0
           }
-          ' "$config_file" > canary_checks.tmp
+          ' "$config_file" > partial_checks.tmp
           
           # Insert the checks where the placeholder is located and remove the placeholder
-          sed -i '/canaryDeploymentAlertPolicyChecks/r canary_checks.tmp' release/clouddeploy/delivery-pipeline.yaml
-          sed -i '/canaryDeploymentAlertPolicyChecks/d' release/clouddeploy/delivery-pipeline.yaml
-          rm -f canary_checks.tmp
+          sed -i '/partialDeploymentAlertPolicyChecks/r partial_checks.tmp' release/clouddeploy/delivery-pipeline.yaml
+          sed -i '/partialDeploymentAlertPolicyChecks/d' release/clouddeploy/delivery-pipeline.yaml
+          rm -f partial_checks.tmp
         fi
         
         # Populate variables in target file

--- a/release/cloudbuild-clouddeploy.yaml
+++ b/release/cloudbuild-clouddeploy.yaml
@@ -47,7 +47,7 @@ steps:
         /^stableDeploymentAlertPolicyChecks:/ { capture = 1; next }
         capture {
           if ($0 ~ /^[^[:space:]]/ && $0 != "") { capture = 0; exit }
-          print "            " $0
+          print "                " $0
         }
         ' "$config_file" > checks.tmp
         
@@ -63,7 +63,7 @@ steps:
           /^partialDeploymentAlertPolicyChecks:/ { capture = 1; next }
           capture {
             if ($0 ~ /^[^[:space:]]/ && $0 != "") { capture = 0; exit }
-            print "            " $0
+            print "                " $0
           }
           ' "$config_file" > partial_checks.tmp
           

--- a/release/cloudbuild-clouddeploy.yaml
+++ b/release/cloudbuild-clouddeploy.yaml
@@ -55,6 +55,23 @@ steps:
         sed -i '/stableDeploymentAlertPolicyChecks/r checks.tmp' release/clouddeploy/delivery-pipeline.yaml
         sed -i '/stableDeploymentAlertPolicyChecks/d' release/clouddeploy/delivery-pipeline.yaml
         rm -f checks.tmp
+
+        # Extract only the indented block under canaryDeploymentAlertPolicyChecks.
+        if grep -q "^canaryDeploymentAlertPolicyChecks:" "$config_file"; then
+          echo "Extracting canary checks from $config_file..."
+          awk '
+          /^canaryDeploymentAlertPolicyChecks:/ { capture = 1; next }
+          capture {
+            if ($0 ~ /^[^[:space:]]/ && $0 != "") { capture = 0; exit }
+            print "            " $0
+          }
+          ' "$config_file" > canary_checks.tmp
+          
+          # Insert the checks where the placeholder is located and remove the placeholder
+          sed -i '/canaryDeploymentAlertPolicyChecks/r canary_checks.tmp' release/clouddeploy/delivery-pipeline.yaml
+          sed -i '/canaryDeploymentAlertPolicyChecks/d' release/clouddeploy/delivery-pipeline.yaml
+          rm -f canary_checks.tmp
+        fi
         
         # Populate variables in target file
         target_file="release/clouddeploy/${env}-target.yaml"

--- a/release/clouddeploy/delivery-pipeline.yaml
+++ b/release/clouddeploy/delivery-pipeline.yaml
@@ -7,13 +7,34 @@ description: deploy-nomulus is a Cloud native replacement for Spinnaker that ena
 serialPipeline:
   stages:
   - targetId: crash
-    profiles:
-    - crash
     strategy:
-      standard:
-        analysis:
-          # 10 minutes.
-          duration: 600s
-          googleCloud:
-            alertPolicyChecks:
-                stableDeploymentAlertPolicyChecks
+      canary:
+        customCanaryDeployment:
+          phaseConfigs:
+          - phaseId: "canary-1"
+            profiles: ["crash-partial-phase-1"]
+            percentage: 10
+            analysis:
+              # 10 minutes.
+              duration: 600s
+              googleCloud:
+                alertPolicyChecks:
+                    canaryDeploymentAlertPolicyChecks
+          - phaseId: "canary-5"
+            profiles: ["crash-partial-phase-5"]
+            percentage: 50
+            analysis:
+              # 10 minutes.
+              duration: 600s
+              googleCloud:
+                alertPolicyChecks:
+                    canaryDeploymentAlertPolicyChecks
+          - phaseId: "stable"
+            profiles: ["crash"]
+            percentage: 100
+            analysis:
+              # 10 minutes.
+              duration: 600s
+              googleCloud:
+                alertPolicyChecks:
+                    stableDeploymentAlertPolicyChecks

--- a/release/clouddeploy/delivery-pipeline.yaml
+++ b/release/clouddeploy/delivery-pipeline.yaml
@@ -19,7 +19,7 @@ serialPipeline:
               duration: 600s
               googleCloud:
                 alertPolicyChecks:
-                    canaryDeploymentAlertPolicyChecks
+                    partialDeploymentAlertPolicyChecks
           - phaseId: "canary-5"
             profiles: ["crash-partial-phase-5"]
             percentage: 50
@@ -28,7 +28,7 @@ serialPipeline:
               duration: 600s
               googleCloud:
                 alertPolicyChecks:
-                    canaryDeploymentAlertPolicyChecks
+                    partialDeploymentAlertPolicyChecks
           - phaseId: "stable"
             profiles: ["crash"]
             percentage: 100

--- a/release/clouddeploy/skaffold.yaml
+++ b/release/clouddeploy/skaffold.yaml
@@ -13,3 +13,21 @@ profiles:
     - ../jetty/kubernetes/nomulus-crash-pubapi.yaml
   deploy:
     kubectl: { }
+- name: crash-partial-phase-1
+  manifests:
+    rawYaml:
+    - ../jetty/kubernetes/nomulus-crash-backend-partial-phase-1.yaml
+    - ../jetty/kubernetes/nomulus-crash-console-partial-phase-1.yaml
+    - ../jetty/kubernetes/nomulus-crash-frontend-partial-phase-1.yaml
+    - ../jetty/kubernetes/nomulus-crash-pubapi-partial-phase-1.yaml
+  deploy:
+    kubectl: { }
+- name: crash-partial-phase-5
+  manifests:
+    rawYaml:
+    - ../jetty/kubernetes/nomulus-crash-backend-partial-phase-5.yaml
+    - ../jetty/kubernetes/nomulus-crash-console-partial-phase-5.yaml
+    - ../jetty/kubernetes/nomulus-crash-frontend-partial-phase-5.yaml
+    - ../jetty/kubernetes/nomulus-crash-pubapi-partial-phase-5.yaml
+  deploy:
+    kubectl: { }


### PR DESCRIPTION
This maps the manifests that are being generated after https://github.com/google/nomulus/pull/3048 to canary phases in the "deploy to crash" stage in the CD pipeline via crash-partial-phase-* skaffold profiles. 

It also links the analysis phase to alerts in the  "partialDeploymentAlertPolicyChecks" in the internal repo. The replacement is done in the release/cloudbuild-clouddeploy.yaml job (and fixes and issue with indentation in the script).

I ran the job manually to update the pipeline and results are as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3057)
<!-- Reviewable:end -->
