### PR TITLE
Add a step to cloudbuild-nomulus CB job to create a release in Cloud Deploy

### DIFF
--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -175,6 +175,29 @@ steps:
     cp db/build/libs/schema.jar output/
     cp core/build/libs/nomulus-public.jar output/
     cp core/build/libs/nomulus-tests-alldeps.jar output/
+# Create a release in Cloud Deploy to trigger the deployment pipeline
+- name: 'gcr.io/${PROJECT_ID}/builder:latest'
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    echo "============================================="
+    echo "Triggering Google Cloud Deploy Release"
+    echo "============================================="
+    echo "Tag Name: ${TAG_NAME}"
+    echo "Project ID: ${PROJECT_ID}"
+    
+    # Release names must consist of lowercase letters, numbers, and hyphens.
+    release_name=$(echo "${TAG_NAME}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+    echo "Release Name: $release_name"
+    echo "============================================="
+    
+    gcloud deploy releases create "$release_name" \
+      --delivery-pipeline=deploy-nomulus \
+      --region=us-central1 \
+      --project=${PROJECT_ID} \
+      --images=nomulus=gcr.io/${PROJECT_ID}/nomulus:${TAG_NAME}
 # The tarballs and jars to upload to GCS.
 artifacts:
   objects:

--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -188,14 +188,17 @@ steps:
     echo "Tag Name: ${TAG_NAME}"
     echo "Project ID: ${PROJECT_ID}"
     
+    pipeline="deploy-nomulus"
+    region="us-central1"
     # Release names must consist of lowercase letters, numbers, and hyphens.
     release_name=$(echo "${TAG_NAME}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+    
     echo "Release Name: $release_name"
     echo "============================================="
     
     gcloud deploy releases create "$release_name" \
-      --delivery-pipeline=deploy-nomulus \
-      --region=us-central1 \
+      --delivery-pipeline="$pipeline" \
+      --region="$region" \
       --project=${PROJECT_ID} \
       --images=nomulus=gcr.io/${PROJECT_ID}/nomulus:${TAG_NAME}
 # The tarballs and jars to upload to GCS.

--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -188,18 +188,14 @@ steps:
     echo "============================================="
     echo "Tag Name: ${TAG_NAME}"
     echo "Project ID: ${PROJECT_ID}"
-    
     pipeline="deploy-nomulus"
     region="us-central1"
     # Release names must consist of lowercase letters, numbers, and hyphens.
     release_name=$(echo "${TAG_NAME}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
-    
     echo "Release Name: $release_name"
     echo "============================================="
-    
     # Read the pre-fetched image digest from the workspace file
     nomulus_digest=$(cat /workspace/nomulus_digest)
-    
     gcloud deploy releases create "$release_name" \
       --delivery-pipeline="$pipeline" \
       --region="$region" \

--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -73,6 +73,7 @@ steps:
   - |
     nomulus_digest=$(gcloud container images list-tags gcr.io/${PROJECT_ID}/nomulus \
     --format="get(digest)" --filter="tags = ${TAG_NAME}")
+    echo "$nomulus_digest" > /workspace/nomulus_digest
     proxy_digest=$(gcloud container images list-tags gcr.io/${PROJECT_ID}/proxy \
     --format="get(digest)" --filter="tags = ${TAG_NAME}")
     gcloud --project=${PROJECT_ID} beta container binauthz attestations \
@@ -196,11 +197,14 @@ steps:
     echo "Release Name: $release_name"
     echo "============================================="
     
+    # Read the pre-fetched image digest from the workspace file
+    nomulus_digest=$(cat /workspace/nomulus_digest)
+    
     gcloud deploy releases create "$release_name" \
       --delivery-pipeline="$pipeline" \
       --region="$region" \
       --project=${PROJECT_ID} \
-      --images=nomulus=gcr.io/${PROJECT_ID}/nomulus:${TAG_NAME}
+      --images="nomulus=gcr.io/${PROJECT_ID}/nomulus@${nomulus_digest}"
 # The tarballs and jars to upload to GCS.
 artifacts:
   objects:

--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -204,7 +204,9 @@ steps:
       --delivery-pipeline="$pipeline" \
       --region="$region" \
       --project=${PROJECT_ID} \
-      --images="nomulus=gcr.io/${PROJECT_ID}/nomulus@${nomulus_digest}"
+      --images="nomulus=gcr.io/${PROJECT_ID}/nomulus@${nomulus_digest}" \
+      --source=. \
+      --skaffold-file=release/clouddeploy/skaffold.yaml
 # The tarballs and jars to upload to GCS.
 artifacts:
   objects:


### PR DESCRIPTION
This is added as the last step of the current release jobs in Cloud Build. It stores the previously computed digest for nomulus to use when creating the release.

This is safe because:
* I've verified the command manually and gave the service account cd permissions.
* The pipeline only has crash target configured + it requires manual approval to start the deployment.
* If CB fails for whatever reason, I have until monday to fix before it becomes a problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3059)
<!-- Reviewable:end -->
