### PR TITLE
Add postdeploy task in CD pipeline to tag deployed image

### DIFF
--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -202,7 +202,8 @@ steps:
       --project=${PROJECT_ID} \
       --images="nomulus=gcr.io/${PROJECT_ID}/nomulus@${nomulus_digest}" \
       --source=. \
-      --skaffold-file=release/clouddeploy/skaffold.yaml
+      --skaffold-file=release/clouddeploy/skaffold.yaml \
+      --deploy-parameters="deployed_image=gcr.io/${PROJECT_ID}/nomulus@${nomulus_digest},base_image=us-docker.pkg.dev/${PROJECT_ID}/gcr.io/nomulus"
 # The tarballs and jars to upload to GCS.
 artifacts:
   objects:

--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -192,6 +192,7 @@ steps:
     region="us-central1"
     # Release names must consist of lowercase letters, numbers, and hyphens.
     release_name=$(echo "${TAG_NAME}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+    
     echo "Release Name: $release_name"
     echo "============================================="
     # Read the pre-fetched image digest from the workspace file

--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -192,7 +192,6 @@ steps:
     region="us-central1"
     # Release names must consist of lowercase letters, numbers, and hyphens.
     release_name=$(echo "${TAG_NAME}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
-    
     echo "Release Name: $release_name"
     echo "============================================="
     # Read the pre-fetched image digest from the workspace file

--- a/release/clouddeploy/delivery-pipeline.yaml
+++ b/release/clouddeploy/delivery-pipeline.yaml
@@ -32,6 +32,20 @@ serialPipeline:
           - phaseId: "stable"
             profiles: ["crash"]
             percentage: 100
+            postdeploy:
+              tasks:
+              - type: container
+                image: gcr.io/google.com/cloudsdktool/google-cloud-cli:stable
+                env:
+                  DEPLOYED_IMAGE: ${{ deploy_params['deployed_image'] }}
+                  BASE_IMAGE: ${{ deploy_params['base_image'] }}
+                  TARGET_ID: ${{ target.id }}
+                command: ["/bin/bash"]
+                args:
+                - "-c"
+                - |
+                  gcloud artifacts docker tags add $DEPLOYED_IMAGE \
+                    ${BASE_IMAGE}:live-cd-${TARGET_ID}
             analysis:
               # 10 minutes.
               duration: 600s


### PR DESCRIPTION
This will add a a tag to an image after it deploys to a stable in a target/environment:

For example,  nomulus@sha256:xxx gets deployed to stable in crash. This will add "live-cd-crash" tag to it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3063)
<!-- Reviewable:end -->
