### PR TITLE
Centralize Fee validation and add tests

### DIFF
--- a/core/src/main/java/google/registry/model/domain/fee/Fee.java
+++ b/core/src/main/java/google/registry/model/domain/fee/Fee.java
@@ -46,8 +46,14 @@ public class Fee extends BaseFee {
   public static Fee create(
       BigDecimal cost, FeeType type, boolean isPremium, Object... descriptionArgs) {
     checkArgumentNotNull(type, "Must specify the type of the fee");
-    return createWithCustomDescription(
-        cost, type, isPremium, type.renderDescription(descriptionArgs));
+    checkArgumentNotNull(cost, "Cost cannot be null");
+    checkArgument(cost.signum() >= 0, "Cost must be a non-negative number");
+    Fee instance = new Fee();
+    instance.cost = cost;
+    instance.type = type;
+    instance.isPremium = isPremium;
+    instance.description = type.renderDescription(descriptionArgs);
+    return instance;
   }
 
   /** Creates a Fee for the given cost, type, and valid date range with the default description. */
@@ -59,19 +65,6 @@ public class Fee extends BaseFee {
       Object... descriptionArgs) {
     Fee instance = create(cost, type, isPremium, descriptionArgs);
     instance.validDateRange = validDateRange;
-    return instance;
-  }
-
-  /** Creates a Fee for the given cost and type with a custom description. */
-  private static Fee createWithCustomDescription(
-      BigDecimal cost, FeeType type, boolean isPremium, String description) {
-    Fee instance = new Fee();
-    checkArgumentNotNull(cost, "Cost cannot be null");
-    checkArgument(cost.signum() >= 0, "Cost must be a non-negative number");
-    instance.cost = cost;
-    instance.type = type;
-    instance.isPremium = isPremium;
-    instance.description = description;
     return instance;
   }
 

--- a/core/src/test/java/google/registry/model/domain/fee/FeeTest.java
+++ b/core/src/test/java/google/registry/model/domain/fee/FeeTest.java
@@ -1,0 +1,57 @@
+// Copyright 2026 The Nomulus Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package google.registry.model.domain.fee;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import google.registry.model.domain.fee.BaseFee.FeeType;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+class FeeTest {
+
+  @Test
+  void testCreate_success() {
+    Fee fee = Fee.create(BigDecimal.valueOf(10.00), FeeType.CREATE, false);
+    assertThat(fee.getCost()).isEqualTo(BigDecimal.valueOf(10.00));
+    assertThat(fee.getType()).isEqualTo(FeeType.CREATE);
+  }
+
+  @Test
+  void testCreate_nullCost() {
+    IllegalArgumentException thrown =
+        assertThrows(IllegalArgumentException.class, () -> Fee.create(null, FeeType.CREATE, false));
+    assertThat(thrown).hasMessageThat().contains("Cost cannot be null");
+  }
+
+  @Test
+  void testCreate_negativeCost() {
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> Fee.create(BigDecimal.valueOf(-5.00), FeeType.CREATE, false));
+    assertThat(thrown).hasMessageThat().contains("Cost must be a non-negative number");
+  }
+
+  @Test
+  void testCreate_nullType() {
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> Fee.create(BigDecimal.valueOf(10.00), null, false));
+    assertThat(thrown).hasMessageThat().contains("Must specify the type of the fee");
+  }
+}


### PR DESCRIPTION
This commit:
- Centralizes all creation validation checks into Fee.create().
- Inlines the redundant private createWithCustomDescription() method.
- Removes the awkward ternary operator for null type evaluation.
- Adds FeeTest.java to completely cover the Fee instance creation logic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3070)
<!-- Reviewable:end -->
