### PR TITLE
Add buildAll task and fix fragile builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -609,3 +609,15 @@ gradle.taskGraph.whenReady { graph ->
     }
   }
 }
+
+task buildAll {
+  group = 'build'
+  description = 'Runs the standard build plus all heavy staging/Docker dependencies and fragile tests that were stripped out of the default build for performance.'
+  dependsOn build
+  dependsOn ':core:fragileTest'
+  dependsOn ':core:sqlIntegrationTest'
+  dependsOn ':core:buildToolImage'
+  dependsOn ':stage'
+  dependsOn ':jetty:buildNomulusImage'
+  dependsOn ':console-webapp:buildConsoleForAll'
+}

--- a/console-webapp/build.gradle
+++ b/console-webapp/build.gradle
@@ -74,6 +74,14 @@ def createConsoleTask = { env ->
   createConsoleTask(env)
 }
 
+// Force an order so we don't run these tasks in parallel.
+tasks.buildConsoleForCrash.mustRunAfter(tasks.buildConsoleForAlpha)
+tasks.buildConsoleForQa.mustRunAfter(tasks.buildConsoleForCrash)
+tasks.buildConsoleForSandbox.mustRunAfter(tasks.buildConsoleForQa)
+tasks.buildConsoleForProduction.mustRunAfter(tasks.buildConsoleForSandbox)
+// This task must run last, otherwise the previous tasks will have deleted the "dist" folder.
+tasks.buildConsoleWebapp.mustRunAfter(tasks.buildConsoleForProduction)
+
 task applyFormatting(type: Exec) {
   workingDir "${consoleDir}/"
   executable 'npm'

--- a/core/src/test/java/google/registry/server/RegistryTestServer.java
+++ b/core/src/test/java/google/registry/server/RegistryTestServer.java
@@ -33,7 +33,7 @@ public final class RegistryTestServer {
 
   public static final ImmutableMap<String, Path> RUNFILES =
       new ImmutableMap.Builder<String, Path>()
-          .put("/console/*", PROJECT_ROOT.resolve("console-webapp/staged/dist"))
+          .put("/console/*", PROJECT_ROOT.resolve("console-webapp/staged/dist/browser"))
           .build();
 
   public static final ImmutableList<Route> ROUTES =

--- a/core/src/test/java/google/registry/webdriver/ConsoleScreenshotTest.java
+++ b/core/src/test/java/google/registry/webdriver/ConsoleScreenshotTest.java
@@ -174,7 +174,9 @@ public class ConsoleScreenshotTest {
     // Script that set cursor to transparent to prevent blanking cursor flakiness when comparing
     // screenshots
     String script =
-        "document.styleSheets[0].insertRule(\"html * {caret-color: transparent !important;}\")";
+        "var style = document.createElement('style');"
+            + "style.innerHTML = 'html * {caret-color: transparent !important;}';"
+            + "document.head.appendChild(style);";
     driver.executeScript(script);
   }
 


### PR DESCRIPTION
This commit adds the buildAll task to restore the existence of a target that builds everything, which was unintentionally removed when the default build was stripped down in PR #3068. It also introduces necessary sequential constraints to the console-webapp build tasks to prevent parallel execution from corrupting the Angular CLI cache. Finally, it addresses paths for the newer Angular esbuild output and hardens the style injection in ConsoleScreenshotTest to prevent fragile test failures.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3077)
<!-- Reviewable:end -->
