### PR TITLE
Forbid deprecated algorithms in DNSSEC data

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -389,6 +389,10 @@ public class DomainFlowUtils {
     if (alg > 255 || alg < 0) {
       return true;
     }
+    if (DomainDsData.FORBIDDEN_ALGORITHMS.contains(alg)
+        && FeatureFlag.isActiveNow(FORBID_INSECURE_ALGORITHMS_RFC_9904)) {
+      return true;
+    }
     // Algorithms that are reserved or unassigned will just return a string representation of their
     // integer wire value.
     String algorithm = Algorithm.string(alg);

--- a/core/src/main/java/google/registry/model/domain/secdns/DomainDsDataBase.java
+++ b/core/src/main/java/google/registry/model/domain/secdns/DomainDsDataBase.java
@@ -14,6 +14,7 @@
 
 package google.registry.model.domain.secdns;
 
+import com.google.common.collect.ImmutableSet;
 import google.registry.model.ImmutableObject;
 import google.registry.model.UnsafeSerializable;
 import jakarta.persistence.Access;
@@ -26,12 +27,23 @@ import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.adapters.HexBinaryAdapter;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import org.xbill.DNS.DNSSEC.Algorithm;
 
 /** Base class for {@link DomainDsData} and {@link DomainDsDataHistory}. */
 @MappedSuperclass
 @Access(AccessType.FIELD)
 @XmlType(propOrder = {"keyTag", "algorithm", "digestType", "digest"})
 public abstract class DomainDsDataBase extends ImmutableObject implements UnsafeSerializable {
+
+  // A set of algorithms that we do not allow. See RFC 9904 for more details.
+  public static final ImmutableSet<Integer> FORBIDDEN_ALGORITHMS =
+      ImmutableSet.of(
+          Algorithm.RSAMD5,
+          Algorithm.RSASHA1,
+          Algorithm.RSA_NSEC3_SHA1,
+          Algorithm.DSA,
+          Algorithm.DSA_NSEC3_SHA1,
+          Algorithm.ECC_GOST);
 
   @XmlTransient @Transient @Insignificant String domainRepoId;
 

--- a/core/src/main/java/google/registry/tools/DsRecord.java
+++ b/core/src/main/java/google/registry/tools/DsRecord.java
@@ -15,6 +15,7 @@
 package google.registry.tools;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.util.PreconditionsUtils.checkArgumentPresent;
 
 import com.beust.jcommander.IStringConverter;
@@ -46,7 +47,7 @@ record DsRecord(int keyTag, int alg, int digestType, String digest) {
           String.format("DS record has an invalid digest length: %s", digest));
     }
 
-    if (DomainFlowUtils.algorithmIsInvalid(alg)) {
+    if (tm().reTransact(() -> DomainFlowUtils.algorithmIsInvalid(alg))) {
       throw new IllegalArgumentException(
           String.format("DS record uses an unrecognized algorithm: %d", alg));
     }

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -798,7 +798,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         .hasExactlyDsData(
             DomainDsData.create(
                     12345,
-                    3,
+                    8,
                     2,
                     base16()
                         .decode("D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A"))
@@ -992,7 +992,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
         .that(domain)
         .hasExactlyDsData(
             DomainDsData.create(
-                    12345, 3, 1, base16().decode("49FD46E6C4B45C55D4AC49FD46E6C4B45C55D4AC"))
+                    12345, 8, 1, base16().decode("49FD46E6C4B45C55D4AC49FD46E6C4B45C55D4AC"))
                 .cloneWithDomainRepoId(domain.getRepoId()));
   }
 
@@ -1002,6 +1002,42 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
     persistHosts();
     EppException thrown = assertThrows(InvalidDsRecordException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
+  }
+
+  @Test
+  void testFailure_secDnsForbiddenAlgorithm() throws Exception {
+    setEppInput("domain_create_dsdata_forbidden_algorithm.xml");
+    persistHosts();
+    DatabaseHelper.persistResource(
+        new FeatureFlag.Builder()
+            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
+            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.ACTIVE))
+            .build());
+    EppException thrown = assertThrows(InvalidDsRecordException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
+  }
+
+  @Test
+  void testSuccess_secDnsForbiddenAlgorithm_flagInactive() throws Exception {
+    setEppInput("domain_create_dsdata_forbidden_algorithm.xml");
+    persistHosts();
+    DatabaseHelper.persistResource(
+        new FeatureFlag.Builder()
+            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
+            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.INACTIVE))
+            .build());
+    doSuccessfulTest("tld");
+    Domain domain = reloadResourceByForeignKey();
+    assertAboutDomains()
+        .that(domain)
+        .hasExactlyDsData(
+            DomainDsData.create(
+                    12345,
+                    1,
+                    2,
+                    base16()
+                        .decode("D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A"))
+                .cloneWithDomainRepoId(domain.getRepoId()));
   }
 
   @Test

--- a/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainInfoFlowTest.java
@@ -98,6 +98,8 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
           "UNIT", "y");
 
   private static final Pattern OK_PATTERN = Pattern.compile("\"ok\"");
+  private static final String SHA_256_DIGEST =
+      "D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A";
 
   private Host host1;
   private Host host2;
@@ -314,8 +316,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
         domain
             .asBuilder()
             .setDsData(
-                ImmutableSet.of(
-                    DomainDsData.create(12345, 3, 1, base16().decode("49FD46E6C4B45C55D4AC"))))
+                ImmutableSet.of(DomainDsData.create(12345, 8, 2, base16().decode(SHA_256_DIGEST))))
             .setNameservers(ImmutableSet.of(host1.createVKey(), host3.createVKey()))
             .build());
     doSuccessfulTest("domain_info_response_dsdata.xml", false);
@@ -519,8 +520,7 @@ class DomainInfoFlowTest extends ResourceFlowTestCase<DomainInfoFlow, Domain> {
                     "TheRegistrar",
                     null))
             .setDsData(
-                ImmutableSet.of(
-                    DomainDsData.create(12345, 3, 1, base16().decode("49FD46E6C4B45C55D4AC"))))
+                ImmutableSet.of(DomainDsData.create(12345, 8, 2, base16().decode(SHA_256_DIGEST))))
             .build());
     doSuccessfulTest("domain_info_response_dsdata_addperiod.xml", false);
   }

--- a/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
@@ -130,7 +130,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
   private static final ImmutableMap<String, String> OTHER_DSDATA_TEMPLATE_MAP =
       ImmutableMap.of(
           "KEY_TAG", "12346",
-          "ALG", "3",
+          "ALG", "8",
           "DIGEST_TYPE", "2",
           "DIGEST", SHA_256_DIGEST);
 
@@ -459,9 +459,9 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     doSecDnsSuccessfulTest(
         "domain_update_dsdata_add.xml",
         null,
-        ImmutableSet.of(DomainDsData.create(12346, 3, 2, base16().decode(SHA_256_DIGEST))),
+        ImmutableSet.of(DomainDsData.create(12346, 8, 2, base16().decode(SHA_256_DIGEST))),
         ImmutableMap.of(
-            "KEY_TAG", "12346", "ALG", "3", "DIGEST_TYPE", "2", "DIGEST", SHA_256_DIGEST),
+            "KEY_TAG", "12346", "ALG", "8", "DIGEST_TYPE", "2", "DIGEST", SHA_256_DIGEST),
         true);
   }
 
@@ -471,9 +471,9 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
         "domain_update_dsdata_add.xml",
         ImmutableSet.of(SOME_DSDATA),
         ImmutableSet.of(
-            SOME_DSDATA, DomainDsData.create(12346, 3, 2, base16().decode(SHA_256_DIGEST))),
+            SOME_DSDATA, DomainDsData.create(12346, 8, 2, base16().decode(SHA_256_DIGEST))),
         ImmutableMap.of(
-            "KEY_TAG", "12346", "ALG", "3", "DIGEST_TYPE", "2", "DIGEST", SHA_256_DIGEST),
+            "KEY_TAG", "12346", "ALG", "8", "DIGEST_TYPE", "2", "DIGEST", SHA_256_DIGEST),
         true);
   }
 
@@ -648,7 +648,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             union(
                 commonDsData,
                 ImmutableSet.of(
-                    DomainDsData.create(12346, 3, 2, base16().decode(SHA_256_DIGEST))))),
+                    DomainDsData.create(12346, 8, 2, base16().decode(SHA_256_DIGEST))))),
         true);
   }
 
@@ -657,7 +657,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     doSecDnsSuccessfulTest(
         "domain_update_dsdata_rem.xml",
         ImmutableSet.of(
-            SOME_DSDATA, DomainDsData.create(12346, 3, 2, base16().decode(SHA_256_DIGEST))),
+            SOME_DSDATA, DomainDsData.create(12346, 8, 2, base16().decode(SHA_256_DIGEST))),
         ImmutableSet.of(SOME_DSDATA),
         true);
   }
@@ -668,7 +668,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     doSecDnsSuccessfulTest(
         "domain_update_dsdata_rem_all.xml",
         ImmutableSet.of(
-            SOME_DSDATA, DomainDsData.create(12346, 3, 2, base16().decode(SHA_256_DIGEST))),
+            SOME_DSDATA, DomainDsData.create(12346, 8, 2, base16().decode(SHA_256_DIGEST))),
         ImmutableSet.of(),
         true);
   }
@@ -678,9 +678,9 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     doSecDnsSuccessfulTest(
         "domain_update_dsdata_add_rem.xml",
         ImmutableSet.of(
-            SOME_DSDATA, DomainDsData.create(12345, 3, 2, base16().decode(SHA_256_DIGEST))),
+            SOME_DSDATA, DomainDsData.create(12345, 8, 2, base16().decode(SHA_256_DIGEST))),
         ImmutableSet.of(
-            SOME_DSDATA, DomainDsData.create(12346, 3, 2, base16().decode(SHA_256_DIGEST))),
+            SOME_DSDATA, DomainDsData.create(12346, 8, 2, base16().decode(SHA_256_DIGEST))),
         true);
   }
 
@@ -703,12 +703,12 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             union(
                 commonDsData,
                 ImmutableSet.of(
-                    DomainDsData.create(12345, 3, 2, base16().decode(SHA_256_DIGEST))))),
+                    DomainDsData.create(12345, 8, 2, base16().decode(SHA_256_DIGEST))))),
         ImmutableSet.copyOf(
             union(
                 commonDsData,
                 ImmutableSet.of(
-                    DomainDsData.create(12346, 3, 2, base16().decode(SHA_256_DIGEST))))),
+                    DomainDsData.create(12346, 8, 2, base16().decode(SHA_256_DIGEST))))),
         true);
   }
 
@@ -988,6 +988,82 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .build());
     EppException thrown = assertThrows(InvalidDsRecordException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
+  }
+
+  @Test
+  void testFailure_secDnsForbiddenAlgorithm() throws Exception {
+    setEppInput("domain_update_dsdata_add.xml", OTHER_DSDATA_TEMPLATE_MAP);
+    persistResource(
+        DatabaseHelper.newDomain(getUniqueIdFromCommand())
+            .asBuilder()
+            .setDsData(
+                ImmutableSet.of(DomainDsData.create(1, 1, 2, base16().decode(SHA_256_DIGEST))))
+            .build());
+    DatabaseHelper.persistResource(
+        new FeatureFlag.Builder()
+            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
+            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.ACTIVE))
+            .build());
+    EppException thrown = assertThrows(InvalidDsRecordException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
+  }
+
+  @Test
+  void testSuccess_secDnsForbiddenAlgorithm_flagInactive() throws Exception {
+    setEppInput("domain_update_dsdata_add.xml", OTHER_DSDATA_TEMPLATE_MAP);
+    persistResource(
+        DatabaseHelper.newDomain(getUniqueIdFromCommand())
+            .asBuilder()
+            .setDsData(
+                ImmutableSet.of(DomainDsData.create(1, 1, 2, base16().decode(SHA_256_DIGEST))))
+            .build());
+    DatabaseHelper.persistResource(
+        new FeatureFlag.Builder()
+            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
+            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.INACTIVE))
+            .build());
+    runFlow();
+    Domain domain = reloadResourceByForeignKey();
+    assertAboutDomains()
+        .that(domain)
+        .hasExactlyDsData(
+            DomainDsData.create(1, 1, 2, base16().decode(SHA_256_DIGEST)),
+            DomainDsData.create(12346, 8, 2, base16().decode(SHA_256_DIGEST)));
+  }
+
+  @Test
+  void testFailure_unrelatedUpdate_existingForbiddenAlgorithm() throws Exception {
+    persistReferencedEntities();
+    persistResource(
+        persistDomain()
+            .asBuilder()
+            .setDsData(
+                ImmutableSet.of(DomainDsData.create(1, 1, 2, base16().decode(SHA_256_DIGEST))))
+            .build());
+    DatabaseHelper.persistResource(
+        new FeatureFlag.Builder()
+            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
+            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.ACTIVE))
+            .build());
+    assertAboutEppExceptions()
+        .that(assertThrows(InvalidDsRecordException.class, this::runFlow))
+        .marshalsToXml();
+  }
+
+  @Test
+  void testSuccess_unrelatedUpdate_existingForbiddenAlgorithm_flagInactive() throws Exception {
+    persistReferencedEntities();
+    persistResource(
+        persistDomain()
+            .asBuilder()
+            .setDsData(
+                ImmutableSet.of(DomainDsData.create(1, 1, 2, base16().decode(SHA_256_DIGEST))))
+            .build());
+    runFlow();
+    Domain updatedDomain = reloadResourceByForeignKey();
+    assertAboutDomains()
+        .that(updatedDomain)
+        .hasExactlyDsData(DomainDsData.create(1, 1, 2, base16().decode(SHA_256_DIGEST)));
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/CreateDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateDomainCommandTest.java
@@ -15,16 +15,21 @@
 package google.registry.tools;
 
 import static com.google.common.truth.Truth.assertThat;
+import static google.registry.model.common.FeatureFlag.FeatureName.FORBID_INSECURE_ALGORITHMS_RFC_9904;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistPremiumList;
 import static google.registry.testing.DatabaseHelper.persistResource;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static org.joda.money.CurrencyUnit.JPY;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.beust.jcommander.ParameterException;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 import google.registry.dns.writer.VoidDnsWriter;
+import google.registry.model.common.FeatureFlag;
+import google.registry.model.common.FeatureFlag.FeatureStatus;
 import google.registry.model.pricing.StaticPremiumListPricingEngine;
 import google.registry.model.tld.Tld;
 import google.registry.model.tld.label.PremiumListDao;
@@ -49,9 +54,9 @@ class CreateDomainCommandTest extends EppToolCommandTestCase<CreateDomainCommand
         "--period=1",
         "--nameservers=ns1.zdns.google,ns2.zdns.google,ns3.zdns.google,ns4.zdns.google",
         "--password=2fooBAR",
-        "--ds_records=1 2 2 9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08,4 5 2"
+        "--ds_records=1 2 2 9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08,4 8 2"
             + " D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A",
-        "--ds_records=60485 5  2  D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A",
+        "--ds_records=60485 8  2  D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A",
         "example.tld");
     eppVerifier.verifySent("domain_create_complete.xml");
   }
@@ -63,9 +68,9 @@ class CreateDomainCommandTest extends EppToolCommandTestCase<CreateDomainCommand
         "--period=1",
         "--nameservers=NS1.zdns.google,ns2.ZDNS.google,ns3.zdns.gOOglE,ns4.zdns.google",
         "--password=2fooBAR",
-        "--ds_records=1 2 2 9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08,4 5 2"
+        "--ds_records=1 2 2 9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08,4 8 2"
             + " D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A",
-        "--ds_records=60485 5  2  D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A",
+        "--ds_records=60485 8  2  D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A",
         "example.tld");
     eppVerifier.verifySent("domain_create_complete.xml");
   }
@@ -77,9 +82,9 @@ class CreateDomainCommandTest extends EppToolCommandTestCase<CreateDomainCommand
         "--period=1",
         "--nameservers=ns[1-4].zdns.google",
         "--password=2fooBAR",
-        "--ds_records=1 2 2 9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08,4 5 2"
+        "--ds_records=1 2 2 9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08,4 8 2"
             + " D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A",
-        "--ds_records=60485 5  2  D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A",
+        "--ds_records=60485 8  2  D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A",
         "example.tld");
     eppVerifier.verifySent("domain_create_complete.xml");
   }
@@ -91,9 +96,9 @@ class CreateDomainCommandTest extends EppToolCommandTestCase<CreateDomainCommand
         "--period=1",
         "--nameservers=NS[1-4].zdns.google",
         "--password=2fooBAR",
-        "--ds_records=1 2 2 9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08,4 5 2"
+        "--ds_records=1 2 2 9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08,4 8 2"
             + " D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A",
-        "--ds_records=60485 5  2  D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A",
+        "--ds_records=60485 8  2  D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A",
         "example.tld");
     eppVerifier.verifySent("domain_create_complete.xml");
   }
@@ -277,6 +282,25 @@ class CreateDomainCommandTest extends EppToolCommandTestCase<CreateDomainCommand
                     "--ds_records=1 2 3 abcd",
                     "example.tld"));
     assertThat(thrown).hasMessageThat().isEqualTo("DS record uses an unrecognized digest type: 3");
+  }
+
+  @Test
+  void testFailure_forbiddenAlgorithm() {
+    persistResource(
+        new FeatureFlag.Builder()
+            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
+            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.ACTIVE))
+            .build());
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                runCommandForced(
+                    "--client=NewRegistrar",
+                    "--ds_records=1 1 2"
+                        + " D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A",
+                    "example.tld"));
+    assertThat(thrown).hasMessageThat().isEqualTo("DS record uses an unrecognized algorithm: 1");
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/UpdateDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateDomainCommandTest.java
@@ -15,6 +15,7 @@
 package google.registry.tools;
 
 import static com.google.common.truth.Truth.assertThat;
+import static google.registry.model.common.FeatureFlag.FeatureName.FORBID_INSECURE_ALGORITHMS_RFC_9904;
 import static google.registry.model.domain.rgp.GracePeriodStatus.AUTO_RENEW;
 import static google.registry.model.eppcommon.StatusValue.PENDING_DELETE;
 import static google.registry.model.eppcommon.StatusValue.SERVER_UPDATE_PROHIBITED;
@@ -26,6 +27,7 @@ import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.TestLogHandlerUtils.assertLogMessage;
 import static google.registry.testing.TestLogHandlerUtils.assertNoLogMessage;
 import static google.registry.util.DateTimeUtils.END_INSTANT;
+import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static google.registry.util.DateTimeUtils.minusDays;
 import static google.registry.util.DateTimeUtils.plusDays;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -33,9 +35,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.beust.jcommander.ParameterException;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedMap;
 import google.registry.model.billing.BillingBase.Flag;
 import google.registry.model.billing.BillingBase.Reason;
 import google.registry.model.billing.BillingRecurrence;
+import google.registry.model.common.FeatureFlag;
+import google.registry.model.common.FeatureFlag.FeatureStatus;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainHistory;
 import google.registry.model.domain.GracePeriod;
@@ -533,6 +538,25 @@ class UpdateDomainCommandTest extends EppToolCommandTestCase<UpdateDomainCommand
                         + " D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A",
                     "example.tld"));
     assertThat(thrown).hasMessageThat().isEqualTo("DS record uses an unrecognized digest type: 3");
+  }
+
+  @Test
+  void testFailure_forbiddenDsRecordAlgorithm() {
+    persistResource(
+        new FeatureFlag.Builder()
+            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
+            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.ACTIVE))
+            .build());
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                runCommandForced(
+                    "--client=NewRegistrar",
+                    "--add_ds_records=1 1 2"
+                        + " D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A",
+                    "example.tld"));
+    assertThat(thrown).hasMessageThat().isEqualTo("DS record uses an unrecognized algorithm: 1");
   }
 
   @Test

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_dsdata.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_dsdata.xml
@@ -22,7 +22,7 @@
         <secDNS:maxSigLife>604800</secDNS:maxSigLife>
         <secDNS:dsData>
           <secDNS:keyTag>12345</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_dsdata_8_records.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_dsdata_8_records.xml
@@ -21,49 +21,49 @@
        xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1">
         <secDNS:dsData>
           <secDNS:keyTag>12345</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>2</secDNS:digestType>
           <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12346</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>2</secDNS:digestType>
           <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12347</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>2</secDNS:digestType>
           <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12348</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>2</secDNS:digestType>
           <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12349</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>2</secDNS:digestType>
           <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12350</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>2</secDNS:digestType>
           <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12351</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>2</secDNS:digestType>
           <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12352</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>2</secDNS:digestType>
           <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
         </secDNS:dsData>

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_dsdata_9_records.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_dsdata_9_records.xml
@@ -21,55 +21,55 @@
        xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1">
         <secDNS:dsData>
           <secDNS:keyTag>12345</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12346</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12347</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12348</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12349</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12350</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12351</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12352</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12353</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_dsdata_bad_algorithms.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_dsdata_bad_algorithms.xml
@@ -27,19 +27,19 @@
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12346</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12347</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12348</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
@@ -51,19 +51,19 @@
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12350</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12351</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12352</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_dsdata_bad_digest_types.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_dsdata_bad_digest_types.xml
@@ -21,49 +21,49 @@
           xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1">
         <secDNS:dsData>
           <secDNS:keyTag>12345</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>100</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12346</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>3</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12347</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12348</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12349</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12350</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12351</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>12352</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_dsdata_forbidden_algorithm.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_dsdata_forbidden_algorithm.xml
@@ -1,17 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <epp xmlns="urn:ietf:params:xml:ns:epp-1.0"
-     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <command>
     <create>
       <domain:create
-       xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
+          xmlns:domain="urn:ietf:params:xml:ns:domain-1.0">
         <domain:name>example.tld</domain:name>
         <domain:period unit="y">2</domain:period>
         <domain:ns>
           <domain:hostObj>ns1.example.net</domain:hostObj>
           <domain:hostObj>ns2.example.net</domain:hostObj>
         </domain:ns>
-        <domain:registrant>jd1234</domain:registrant>
         <domain:authInfo>
           <domain:pw>2fooBAR</domain:pw>
         </domain:authInfo>
@@ -19,13 +18,12 @@
     </create>
     <extension>
       <secDNS:create
-       xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1">
-        <secDNS:maxSigLife>604800</secDNS:maxSigLife>
+          xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1">
         <secDNS:dsData>
           <secDNS:keyTag>12345</secDNS:keyTag>
-          <secDNS:alg>8</secDNS:alg>
-          <secDNS:digestType>1</secDNS:digestType>
-          <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
+          <secDNS:alg>1</secDNS:alg>
+          <secDNS:digestType>2</secDNS:digestType>
+          <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
         </secDNS:dsData>
       </secDNS:create>
     </extension>

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_dsdata_no_maxsiglife.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_dsdata_no_maxsiglife.xml
@@ -21,7 +21,7 @@
        xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1">
         <secDNS:dsData>
           <secDNS:keyTag>12345</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>2</secDNS:digestType>
           <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
         </secDNS:dsData>

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_dsdata_sha1.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_dsdata_sha1.xml
@@ -21,7 +21,7 @@
           xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1">
         <secDNS:dsData>
           <secDNS:keyTag>12345</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>

--- a/core/src/test/resources/google/registry/flows/domain/domain_create_wrong_extension.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_create_wrong_extension.xml
@@ -20,7 +20,7 @@
         <secDNS:add>
           <secDNS:dsData>
             <secDNS:keyTag>12345</secDNS:keyTag>
-            <secDNS:alg>3</secDNS:alg>
+            <secDNS:alg>8</secDNS:alg>
             <secDNS:digestType>1</secDNS:digestType>
             <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
           </secDNS:dsData>

--- a/core/src/test/resources/google/registry/flows/domain/domain_info_response_dsdata.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_info_response_dsdata.xml
@@ -34,9 +34,9 @@
        xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1">
         <secDNS:dsData>
           <secDNS:keyTag>12345</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
-          <secDNS:digestType>1</secDNS:digestType>
-          <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
+          <secDNS:alg>8</secDNS:alg>
+          <secDNS:digestType>2</secDNS:digestType>
+          <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
         </secDNS:dsData>
       </secDNS:infData>
     </extension>

--- a/core/src/test/resources/google/registry/flows/domain/domain_info_response_dsdata_addperiod.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_info_response_dsdata_addperiod.xml
@@ -33,9 +33,9 @@
        xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1">
         <secDNS:dsData>
           <secDNS:keyTag>12345</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
-          <secDNS:digestType>1</secDNS:digestType>
-          <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
+          <secDNS:alg>8</secDNS:alg>
+          <secDNS:digestType>2</secDNS:digestType>
+          <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
         </secDNS:dsData>
       </secDNS:infData>
       <rgp:infData xmlns:rgp="urn:ietf:params:xml:ns:rgp-1.0">

--- a/core/src/test/resources/google/registry/flows/domain/domain_update_dsdata_add_rem.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_update_dsdata_add_rem.xml
@@ -14,7 +14,7 @@
         <secDNS:rem>
           <secDNS:dsData>
             <secDNS:keyTag>12345</secDNS:keyTag>
-            <secDNS:alg>3</secDNS:alg>
+            <secDNS:alg>8</secDNS:alg>
             <secDNS:digestType>2</secDNS:digestType>
             <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
           </secDNS:dsData>
@@ -22,7 +22,7 @@
         <secDNS:add>
           <secDNS:dsData>
             <secDNS:keyTag>12346</secDNS:keyTag>
-            <secDNS:alg>3</secDNS:alg>
+            <secDNS:alg>8</secDNS:alg>
             <secDNS:digestType>2</secDNS:digestType>
             <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
           </secDNS:dsData>

--- a/core/src/test/resources/google/registry/flows/domain/domain_update_dsdata_add_rem_same.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_update_dsdata_add_rem_same.xml
@@ -14,7 +14,7 @@
         <secDNS:rem>
           <secDNS:dsData>
             <secDNS:keyTag>12345</secDNS:keyTag>
-            <secDNS:alg>3</secDNS:alg>
+            <secDNS:alg>8</secDNS:alg>
             <secDNS:digestType>1</secDNS:digestType>
             <secDNS:digest>A94A8FE5CCB19BA61C4C0873D391E987982FBBD3</secDNS:digest>
           </secDNS:dsData>
@@ -22,7 +22,7 @@
         <secDNS:add>
           <secDNS:dsData>
             <secDNS:keyTag>12345</secDNS:keyTag>
-            <secDNS:alg>3</secDNS:alg>
+            <secDNS:alg>8</secDNS:alg>
             <secDNS:digestType>1</secDNS:digestType>
             <secDNS:digest>A94A8FE5CCB19BA61C4C0873D391E987982FBBD3</secDNS:digest>
           </secDNS:dsData>

--- a/core/src/test/resources/google/registry/flows/domain/domain_update_dsdata_rem.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_update_dsdata_rem.xml
@@ -14,7 +14,7 @@
         <secDNS:rem>
           <secDNS:dsData>
             <secDNS:keyTag>12346</secDNS:keyTag>
-            <secDNS:alg>3</secDNS:alg>
+            <secDNS:alg>8</secDNS:alg>
             <secDNS:digestType>2</secDNS:digestType>
             <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
           </secDNS:dsData>

--- a/core/src/test/resources/google/registry/flows/domain/domain_update_dsdata_urgent.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_update_dsdata_urgent.xml
@@ -17,7 +17,7 @@
         <secDNS:add>
           <secDNS:dsData>
             <secDNS:keyTag>12346</secDNS:keyTag>
-            <secDNS:alg>3</secDNS:alg>
+            <secDNS:alg>8</secDNS:alg>
             <secDNS:digestType>1</secDNS:digestType>
             <secDNS:digest>38EC35D5B3A34B44C39B</secDNS:digest>
           </secDNS:dsData>

--- a/core/src/test/resources/google/registry/flows/domain/domain_update_restore_request_with_secdns.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_update_restore_request_with_secdns.xml
@@ -16,7 +16,7 @@
         <secDNS:add>
           <secDNS:dsData>
             <secDNS:keyTag>12346</secDNS:keyTag>
-            <secDNS:alg>3</secDNS:alg>
+            <secDNS:alg>8</secDNS:alg>
             <secDNS:digestType>1</secDNS:digestType>
             <secDNS:digest>38EC35D5B3A34B44C39B</secDNS:digest>
           </secDNS:dsData>

--- a/core/src/test/resources/google/registry/flows/domain/domain_update_wrong_extension.xml
+++ b/core/src/test/resources/google/registry/flows/domain/domain_update_wrong_extension.xml
@@ -13,7 +13,7 @@
        xmlns:secDNS="urn:ietf:params:xml:ns:secDNS-1.1">
         <secDNS:dsData>
           <secDNS:keyTag>12345</secDNS:keyTag>
-          <secDNS:alg>3</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>1</secDNS:digestType>
           <secDNS:digest>49FD46E6C4B45C55D4AC</secDNS:digest>
         </secDNS:dsData>

--- a/core/src/test/resources/google/registry/flows/domain_update_dsdata_add.xml
+++ b/core/src/test/resources/google/registry/flows/domain_update_dsdata_add.xml
@@ -14,7 +14,7 @@
         <secDNS:add>
           <secDNS:dsData>
             <secDNS:keyTag>12346</secDNS:keyTag>
-            <secDNS:alg>3</secDNS:alg>
+            <secDNS:alg>8</secDNS:alg>
             <secDNS:digestType>2</secDNS:digestType>
             <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
           </secDNS:dsData>

--- a/core/src/test/resources/google/registry/flows/domain_update_dsdata_rem.xml
+++ b/core/src/test/resources/google/registry/flows/domain_update_dsdata_rem.xml
@@ -14,7 +14,7 @@
         <secDNS:rem>
           <secDNS:dsData>
             <secDNS:keyTag>12346</secDNS:keyTag>
-            <secDNS:alg>3</secDNS:alg>
+            <secDNS:alg>8</secDNS:alg>
             <secDNS:digestType>2</secDNS:digestType>
             <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
           </secDNS:dsData>

--- a/core/src/test/resources/google/registry/model/domain_update_with_secdns.xml
+++ b/core/src/test/resources/google/registry/model/domain_update_with_secdns.xml
@@ -16,7 +16,7 @@
         <secDNS:add>
           <secDNS:dsData>
             <secDNS:keyTag>12346</secDNS:keyTag>
-            <secDNS:alg>3</secDNS:alg>
+            <secDNS:alg>8</secDNS:alg>
             <secDNS:digestType>1</secDNS:digestType>
             <secDNS:digest>38EC35D5B3A34B44C39B</secDNS:digest>
           </secDNS:dsData>

--- a/core/src/test/resources/google/registry/tools/server/domain_create_complete.xml
+++ b/core/src/test/resources/google/registry/tools/server/domain_create_complete.xml
@@ -27,13 +27,13 @@
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>4</secDNS:keyTag>
-          <secDNS:alg>5</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>2</secDNS:digestType>
           <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
         </secDNS:dsData>
         <secDNS:dsData>
           <secDNS:keyTag>60485</secDNS:keyTag>
-          <secDNS:alg>5</secDNS:alg>
+          <secDNS:alg>8</secDNS:alg>
           <secDNS:digestType>2</secDNS:digestType>
           <secDNS:digest>D4B7D520E7BB5F0F67674A0CCEB1E3E0614B93C4F9E99B8383F6A1E4469DA50A</secDNS:digest>
         </secDNS:dsData>


### PR DESCRIPTION
This is similar to PR #3069 but for the algorithms themselves rather than the digest data. This forbids algorithms, that, according to RFC 9904, should not be used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3078)
<!-- Reviewable:end -->
