### PR TITLE
Fix npx build overriding Angular output paths

### DIFF
--- a/console-webapp/build.gradle
+++ b/console-webapp/build.gradle
@@ -53,9 +53,16 @@ def createConsoleTask = { env ->
   project.tasks.register("buildConsoleFor${env.capitalize()}", Exec) {
     workingDir "${consoleDir}/"
     executable 'npx'
-    args 'ng', 'build', '--base-href=/console/', "--configuration=${env}", "--output-path=staged/console-${env}"
+    args 'ng', 'build', '--base-href=/console/', "--configuration=${env}"
     doFirst {
       println "Building console for environment: ${env}"
+    }
+    doLast {
+      copy {
+        from "${consoleDir}/staged/dist/"
+        into "${consoleDir}/staged/console-${env}"
+      }
+      delete "${consoleDir}/staged/dist"
     }
     dependsOn(tasks.npmInstallDeps)
   }


### PR DESCRIPTION
This commit reverts changes from PR #3068 that swapped 'npm run build' for 'npx ng build' while attempting to dynamically set the '--output-path' via the CLI.

Passing '--output-path' on the command line overrides the entire 'outputPath' configuration object in angular.json. Because the new Angular 18 Application Builder (esbuild) nests outputs inside a 'browser/' directory by default, overriding the configuration bypassed the 'browser: ""' flattening property, causing all client assets to be nested deeper than expected.

This resulted in empty deployments because downstream tasks (like Jetty's copyConsole and the deployment tar scripts) expected the assets to be completely flat. By removing the '--output-path' override from the 'npx ng build' calls, the Angular CLI once again respects angular.json, flattens the output into 'staged/dist/', and the restored 'doLast' block successfully copies the artifacts where they belong.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3082)
<!-- Reviewable:end -->
