### PR TITLE
Add FeatureFlag helper methods to DatabaseHelper

### DIFF
--- a/core/src/test/java/google/registry/export/ExportDomainListsActionTest.java
+++ b/core/src/test/java/google/registry/export/ExportDomainListsActionTest.java
@@ -21,8 +21,8 @@ import static google.registry.model.common.FeatureFlag.FeatureStatus.INACTIVE;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistDeletedDomain;
+import static google.registry.testing.DatabaseHelper.persistFeatureFlag;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static google.registry.util.DateTimeUtils.plusDays;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -35,10 +35,8 @@ import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.net.MediaType;
 import google.registry.gcs.GcsUtils;
-import google.registry.model.common.FeatureFlag;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.GracePeriod;
 import google.registry.model.domain.rgp.GracePeriodStatus;
@@ -80,7 +78,7 @@ class ExportDomainListsActionTest {
     action.gcsUtils = gcsUtils;
     action.clock = clock;
     action.driveConnection = driveConnection;
-    persistFeatureFlag(INACTIVE);
+    persistFeatureFlag(INCLUDE_PENDING_DELETE_DATE_FOR_DOMAINS, INACTIVE);
   }
 
   private void verifyExportedToDrive(String folderId, String filename, String domains)
@@ -110,7 +108,7 @@ class ExportDomainListsActionTest {
 
   @Test
   void test_outputsOnlyActiveDomains_csv() throws Exception {
-    persistFeatureFlag(ACTIVE);
+    persistFeatureFlag(INCLUDE_PENDING_DELETE_DATE_FOR_DOMAINS, ACTIVE);
     persistActiveDomain("onetwo.tld");
     persistActiveDomain("rudnitzky.tld");
     persistDeletedDomain("mortuary.tld", Instant.parse("2001-03-14T10:11:12Z"));
@@ -144,7 +142,7 @@ class ExportDomainListsActionTest {
 
   @Test
   void test_outputsOnlyDomainsOnRealTlds_csv() throws Exception {
-    persistFeatureFlag(ACTIVE);
+    persistFeatureFlag(INCLUDE_PENDING_DELETE_DATE_FOR_DOMAINS, ACTIVE);
     persistActiveDomain("onetwo.tld");
     persistActiveDomain("rudnitzky.tld");
     persistActiveDomain("wontgo.testtld");
@@ -164,7 +162,7 @@ class ExportDomainListsActionTest {
 
   @Test
   void test_outputIncludesDeletionTimes_forPendingDeletes_notRdemption() throws Exception {
-    persistFeatureFlag(ACTIVE);
+    persistFeatureFlag(INCLUDE_PENDING_DELETE_DATE_FOR_DOMAINS, ACTIVE);
     // Domains pending delete (meaning the 5 day period, not counting the 30 day redemption period)
     // should include their pending deletion date
     persistActiveDomain("active.tld");
@@ -227,7 +225,7 @@ class ExportDomainListsActionTest {
 
   @Test
   void test_outputsDomainsFromDifferentTldsToMultipleFiles_csv() throws Exception {
-    persistFeatureFlag(ACTIVE);
+    persistFeatureFlag(INCLUDE_PENDING_DELETE_DATE_FOR_DOMAINS, ACTIVE);
     createTld("tldtwo");
     persistResource(Tld.get("tldtwo").asBuilder().setDriveFolderId("hooray").build());
 
@@ -254,14 +252,5 @@ class ExportDomainListsActionTest {
         "hooray", "registered_domains_tldtwo.txt", "buddy.tldtwo,\nrudolph.tldtwo,\nsanta.tldtwo,");
     // tldthree does not have a drive id, so no export to drive is performed.
     verifyNoMoreInteractions(driveConnection);
-  }
-
-  private void persistFeatureFlag(FeatureFlag.FeatureStatus status) {
-    persistResource(
-        new FeatureFlag()
-            .asBuilder()
-            .setFeatureName(INCLUDE_PENDING_DELETE_DATE_FOR_DOMAINS)
-            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, status))
-            .build());
   }
 }

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -53,6 +53,7 @@ import static google.registry.testing.DatabaseHelper.loadRegistrar;
 import static google.registry.testing.DatabaseHelper.newHost;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistActiveHost;
+import static google.registry.testing.DatabaseHelper.persistFeatureFlag;
 import static google.registry.testing.DatabaseHelper.persistReservedList;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DomainSubject.assertAboutDomains;
@@ -151,7 +152,6 @@ import google.registry.model.billing.BillingBase.Reason;
 import google.registry.model.billing.BillingBase.RenewalPriceBehavior;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingRecurrence;
-import google.registry.model.common.FeatureFlag;
 import google.registry.model.common.FeatureFlag.FeatureStatus;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainHistory;
@@ -968,11 +968,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   void testFailure_secDnsSha1DigestType() throws Exception {
     setEppInput("domain_create_dsdata_sha1.xml");
     persistHosts();
-    DatabaseHelper.persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
-            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.ACTIVE))
-            .build());
+    persistFeatureFlag(FORBID_INSECURE_ALGORITHMS_RFC_9904, FeatureStatus.ACTIVE);
     EppException thrown = assertThrows(InvalidDsRecordException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
@@ -981,11 +977,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   void testSuccess_secDnsSha1_flagInactive() throws Exception {
     setEppInput("domain_create_dsdata_sha1.xml");
     persistHosts();
-    DatabaseHelper.persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
-            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.INACTIVE))
-            .build());
+    persistFeatureFlag(FORBID_INSECURE_ALGORITHMS_RFC_9904, FeatureStatus.INACTIVE);
     doSuccessfulTest("tld");
     Domain domain = reloadResourceByForeignKey();
     assertAboutDomains()
@@ -1008,11 +1000,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   void testFailure_secDnsForbiddenAlgorithm() throws Exception {
     setEppInput("domain_create_dsdata_forbidden_algorithm.xml");
     persistHosts();
-    DatabaseHelper.persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
-            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.ACTIVE))
-            .build());
+    persistFeatureFlag(FORBID_INSECURE_ALGORITHMS_RFC_9904, FeatureStatus.ACTIVE);
     EppException thrown = assertThrows(InvalidDsRecordException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
@@ -1021,11 +1009,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   void testSuccess_secDnsForbiddenAlgorithm_flagInactive() throws Exception {
     setEppInput("domain_create_dsdata_forbidden_algorithm.xml");
     persistHosts();
-    DatabaseHelper.persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
-            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.INACTIVE))
-            .build());
+    persistFeatureFlag(FORBID_INSECURE_ALGORITHMS_RFC_9904, FeatureStatus.INACTIVE);
     doSuccessfulTest("tld");
     Domain domain = reloadResourceByForeignKey();
     assertAboutDomains()

--- a/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
@@ -47,6 +47,7 @@ import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistActiveHost;
 import static google.registry.testing.DatabaseHelper.persistActiveSubordinateHost;
 import static google.registry.testing.DatabaseHelper.persistDeletedDomain;
+import static google.registry.testing.DatabaseHelper.persistFeatureFlag;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.DomainSubject.assertAboutDomains;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
@@ -95,7 +96,6 @@ import google.registry.flows.exceptions.ResourceStatusProhibitsOperationExceptio
 import google.registry.model.ImmutableObject;
 import google.registry.model.billing.BillingBase.Reason;
 import google.registry.model.billing.BillingEvent;
-import google.registry.model.common.FeatureFlag;
 import google.registry.model.common.FeatureFlag.FeatureStatus;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainAuthInfo;
@@ -893,11 +893,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             "DIGEST_TYPE", "1",
             "DIGEST", "A94A8FE5CCB19BA61C4C0873D391E987982FBBD3"));
     persistResource(DatabaseHelper.newDomain(getUniqueIdFromCommand()));
-    DatabaseHelper.persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
-            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.ACTIVE))
-            .build());
+    persistFeatureFlag(FORBID_INSECURE_ALGORITHMS_RFC_9904, FeatureStatus.ACTIVE);
     EppException thrown = assertThrows(InvalidDsRecordException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
@@ -912,11 +908,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             "DIGEST_TYPE", "1",
             "DIGEST", "A94A8FE5CCB19BA61C4C0873D391E987982FBBD3"));
     persistResource(DatabaseHelper.newDomain(getUniqueIdFromCommand()));
-    DatabaseHelper.persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
-            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.INACTIVE))
-            .build());
+    persistFeatureFlag(FORBID_INSECURE_ALGORITHMS_RFC_9904, FeatureStatus.INACTIVE);
     runFlow();
     Domain domain = reloadResourceByForeignKey();
     assertAboutDomains()
@@ -999,11 +991,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .setDsData(
                 ImmutableSet.of(DomainDsData.create(1, 1, 2, base16().decode(SHA_256_DIGEST))))
             .build());
-    DatabaseHelper.persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
-            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.ACTIVE))
-            .build());
+    persistFeatureFlag(FORBID_INSECURE_ALGORITHMS_RFC_9904, FeatureStatus.ACTIVE);
     EppException thrown = assertThrows(InvalidDsRecordException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
@@ -1017,11 +1005,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .setDsData(
                 ImmutableSet.of(DomainDsData.create(1, 1, 2, base16().decode(SHA_256_DIGEST))))
             .build());
-    DatabaseHelper.persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
-            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.INACTIVE))
-            .build());
+    persistFeatureFlag(FORBID_INSECURE_ALGORITHMS_RFC_9904, FeatureStatus.INACTIVE);
     runFlow();
     Domain domain = reloadResourceByForeignKey();
     assertAboutDomains()
@@ -1040,11 +1024,7 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
             .setDsData(
                 ImmutableSet.of(DomainDsData.create(1, 1, 2, base16().decode(SHA_256_DIGEST))))
             .build());
-    DatabaseHelper.persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
-            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.ACTIVE))
-            .build());
+    persistFeatureFlag(FORBID_INSECURE_ALGORITHMS_RFC_9904, FeatureStatus.ACTIVE);
     assertAboutEppExceptions()
         .that(assertThrows(InvalidDsRecordException.class, this::runFlow))
         .marshalsToXml();

--- a/core/src/test/java/google/registry/flows/session/LoginFlowTestCase.java
+++ b/core/src/test/java/google/registry/flows/session/LoginFlowTestCase.java
@@ -20,13 +20,12 @@ import static google.registry.model.common.FeatureFlag.FeatureName.PROHIBIT_CONT
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.deleteResource;
 import static google.registry.testing.DatabaseHelper.loadRegistrar;
+import static google.registry.testing.DatabaseHelper.persistFeatureFlag;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.EppExceptionSubject.assertAboutEppExceptions;
-import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSortedMap;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.UnimplementedExtensionException;
 import google.registry.flows.EppException.UnimplementedObjectServiceException;
@@ -39,7 +38,6 @@ import google.registry.flows.session.LoginFlow.BadRegistrarIdException;
 import google.registry.flows.session.LoginFlow.RegistrarAccountNotActiveException;
 import google.registry.flows.session.LoginFlow.TooManyFailedLoginsException;
 import google.registry.flows.session.LoginFlow.UnsupportedLanguageException;
-import google.registry.model.common.FeatureFlag;
 import google.registry.model.common.FeatureFlag.FeatureStatus;
 import google.registry.model.eppoutput.EppOutput;
 import google.registry.model.registrar.Registrar;
@@ -61,11 +59,7 @@ public abstract class LoginFlowTestCase extends FlowTestCase<LoginFlow> {
     sessionMetadata.setRegistrarId(null); // Don't implicitly log in (all other flows need to).
     registrar = loadRegistrar("NewRegistrar");
     registrarBuilder = registrar.asBuilder();
-    persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(PROHIBIT_CONTACT_OBJECTS_ON_LOGIN)
-            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.ACTIVE))
-            .build());
+    persistFeatureFlag(PROHIBIT_CONTACT_OBJECTS_ON_LOGIN, FeatureStatus.ACTIVE);
   }
 
   // Can't inline this since it may be overridden in subclasses.

--- a/core/src/test/java/google/registry/testing/DatabaseHelper.java
+++ b/core/src/test/java/google/registry/testing/DatabaseHelper.java
@@ -69,6 +69,9 @@ import google.registry.model.billing.BillingCancellation;
 import google.registry.model.billing.BillingEvent;
 import google.registry.model.billing.BillingRecurrence;
 import google.registry.model.common.DnsRefreshRequest;
+import google.registry.model.common.FeatureFlag;
+import google.registry.model.common.FeatureFlag.FeatureName;
+import google.registry.model.common.FeatureFlag.FeatureStatus;
 import google.registry.model.console.GlobalRole;
 import google.registry.model.console.User;
 import google.registry.model.console.UserRoles;
@@ -680,6 +683,32 @@ public final class DatabaseHelper {
       newRegistrars.add(persistNewRegistrar(registrarId));
     }
     return newRegistrars.build();
+  }
+
+  /** Persists and returns a {@link FeatureFlag} with a single status starting from the epoch. */
+  public static FeatureFlag persistFeatureFlag(FeatureName featureName, FeatureStatus status) {
+    return persistFeatureFlag(featureName, ImmutableSortedMap.of(START_INSTANT, status));
+  }
+
+  /** Persists and returns a {@link FeatureFlag} with an initial status and one transition. */
+  public static FeatureFlag persistFeatureFlag(
+      FeatureName featureName,
+      FeatureStatus initialStatus,
+      Instant transitionTime,
+      FeatureStatus status) {
+    return persistFeatureFlag(
+        featureName,
+        ImmutableSortedMap.<Instant, FeatureStatus>naturalOrder()
+            .put(START_INSTANT, initialStatus)
+            .put(transitionTime, status)
+            .build());
+  }
+
+  /** Persists and returns a {@link FeatureFlag} with a custom status map. */
+  public static FeatureFlag persistFeatureFlag(
+      FeatureName featureName, ImmutableSortedMap<Instant, FeatureStatus> statusMap) {
+    return persistResource(
+        new FeatureFlag.Builder().setFeatureName(featureName).setStatusMap(statusMap).build());
   }
 
   public static Iterable<BillingBase> getBillingEvents() {

--- a/core/src/test/java/google/registry/tools/ConfigureFeatureFlagCommandTest.java
+++ b/core/src/test/java/google/registry/tools/ConfigureFeatureFlagCommandTest.java
@@ -19,7 +19,7 @@ import static google.registry.model.common.FeatureFlag.FeatureName.MINIMUM_DATAS
 import static google.registry.model.common.FeatureFlag.FeatureName.TEST_FEATURE;
 import static google.registry.model.common.FeatureFlag.FeatureStatus.ACTIVE;
 import static google.registry.model.common.FeatureFlag.FeatureStatus.INACTIVE;
-import static google.registry.testing.DatabaseHelper.persistResource;
+import static google.registry.testing.DatabaseHelper.persistFeatureFlag;
 import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static google.registry.util.DateTimeUtils.plusWeeks;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.beust.jcommander.ParameterException;
 import com.google.common.collect.ImmutableSortedMap;
 import google.registry.model.common.FeatureFlag;
-import google.registry.model.common.FeatureFlag.FeatureStatus;
 import google.registry.model.common.TimedTransitionProperty;
 import google.registry.testing.FakeClock;
 import java.time.Instant;
@@ -81,14 +80,7 @@ public class ConfigureFeatureFlagCommandTest extends CommandTestCase<ConfigureFe
 
   @Test
   void testUpdate() throws Exception {
-    persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(TEST_FEATURE)
-            .setStatusMap(
-                ImmutableSortedMap.<Instant, FeatureStatus>naturalOrder()
-                    .put(START_INSTANT, INACTIVE)
-                    .build())
-            .build());
+    persistFeatureFlag(TEST_FEATURE, INACTIVE);
 
     Instant featureStart = plusWeeks(clock.now(), 6);
     assertThat(FeatureFlag.get(TEST_FEATURE).getStatusMap())
@@ -110,14 +102,7 @@ public class ConfigureFeatureFlagCommandTest extends CommandTestCase<ConfigureFe
 
   @Test
   void testConfigure_multipleFlags() throws Exception {
-    persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(TEST_FEATURE)
-            .setStatusMap(
-                ImmutableSortedMap.<Instant, FeatureStatus>naturalOrder()
-                    .put(START_INSTANT, INACTIVE)
-                    .build())
-            .build());
+    persistFeatureFlag(TEST_FEATURE, INACTIVE);
 
     Instant featureStart = plusWeeks(clock.now(), 6);
     assertThat(FeatureFlag.get(TEST_FEATURE).getStatusMap())
@@ -179,14 +164,7 @@ public class ConfigureFeatureFlagCommandTest extends CommandTestCase<ConfigureFe
 
   @Test
   void testUpdate_invalidStatusMap() throws Exception {
-    persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(TEST_FEATURE)
-            .setStatusMap(
-                ImmutableSortedMap.<Instant, FeatureStatus>naturalOrder()
-                    .put(START_INSTANT, INACTIVE)
-                    .build())
-            .build());
+    persistFeatureFlag(TEST_FEATURE, INACTIVE);
 
     Instant featureStart = plusWeeks(clock.now(), 6);
     assertThat(FeatureFlag.get(TEST_FEATURE).getStatusMap())

--- a/core/src/test/java/google/registry/tools/CreateDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateDomainCommandTest.java
@@ -18,17 +18,15 @@ import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.common.FeatureFlag.FeatureName.FORBID_INSECURE_ALGORITHMS_RFC_9904;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 import static google.registry.testing.DatabaseHelper.createTld;
+import static google.registry.testing.DatabaseHelper.persistFeatureFlag;
 import static google.registry.testing.DatabaseHelper.persistPremiumList;
 import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static org.joda.money.CurrencyUnit.JPY;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.beust.jcommander.ParameterException;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedMap;
 import google.registry.dns.writer.VoidDnsWriter;
-import google.registry.model.common.FeatureFlag;
 import google.registry.model.common.FeatureFlag.FeatureStatus;
 import google.registry.model.pricing.StaticPremiumListPricingEngine;
 import google.registry.model.tld.Tld;
@@ -286,11 +284,7 @@ class CreateDomainCommandTest extends EppToolCommandTestCase<CreateDomainCommand
 
   @Test
   void testFailure_forbiddenAlgorithm() {
-    persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
-            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.ACTIVE))
-            .build());
+    persistFeatureFlag(FORBID_INSECURE_ALGORITHMS_RFC_9904, FeatureStatus.ACTIVE);
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,

--- a/core/src/test/java/google/registry/tools/DeleteFeatureFlagCommandTest.java
+++ b/core/src/test/java/google/registry/tools/DeleteFeatureFlagCommandTest.java
@@ -18,10 +18,8 @@ import static com.google.common.truth.Truth.assertThat;
 import static google.registry.model.common.FeatureFlag.FeatureName.TEST_FEATURE;
 import static google.registry.model.common.FeatureFlag.FeatureStatus.ACTIVE;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
-import static google.registry.testing.DatabaseHelper.persistResource;
-import static google.registry.util.DateTimeUtils.START_INSTANT;
+import static google.registry.testing.DatabaseHelper.persistFeatureFlag;
 
-import com.google.common.collect.ImmutableSortedMap;
 import google.registry.model.common.FeatureFlag;
 import org.junit.jupiter.api.Test;
 
@@ -30,12 +28,7 @@ public class DeleteFeatureFlagCommandTest extends CommandTestCase<DeleteFeatureF
 
   @Test
   void testSimpleSuccess() throws Exception {
-    persistResource(
-        new FeatureFlag()
-            .asBuilder()
-            .setFeatureName(TEST_FEATURE)
-            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, ACTIVE))
-            .build());
+    persistFeatureFlag(TEST_FEATURE, ACTIVE);
     assertThat(tm().transact(() -> FeatureFlag.isActiveNow(TEST_FEATURE))).isTrue();
     runCommandForced("TEST_FEATURE");
     assertThat(FeatureFlag.getUncached(TEST_FEATURE)).isEmpty();

--- a/core/src/test/java/google/registry/tools/GetFeatureFlagCommandTest.java
+++ b/core/src/test/java/google/registry/tools/GetFeatureFlagCommandTest.java
@@ -19,7 +19,7 @@ import static google.registry.model.common.FeatureFlag.FeatureName.MINIMUM_DATAS
 import static google.registry.model.common.FeatureFlag.FeatureName.TEST_FEATURE;
 import static google.registry.model.common.FeatureFlag.FeatureStatus.ACTIVE;
 import static google.registry.model.common.FeatureFlag.FeatureStatus.INACTIVE;
-import static google.registry.testing.DatabaseHelper.persistResource;
+import static google.registry.testing.DatabaseHelper.persistFeatureFlag;
 import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static google.registry.util.DateTimeUtils.plusWeeks;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.beust.jcommander.ParameterException;
 import com.google.common.collect.ImmutableSortedMap;
 import google.registry.model.EntityYamlUtils;
-import google.registry.model.common.FeatureFlag;
 import google.registry.model.common.FeatureFlag.FeatureFlagNotFoundException;
 import google.registry.model.common.FeatureFlag.FeatureStatus;
 import google.registry.testing.FakeClock;
@@ -47,15 +46,7 @@ public class GetFeatureFlagCommandTest extends CommandTestCase<GetFeatureFlagCom
 
   @Test
   void testSuccess() throws Exception {
-    persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(TEST_FEATURE)
-            .setStatusMap(
-                ImmutableSortedMap.<Instant, FeatureStatus>naturalOrder()
-                    .put(START_INSTANT, INACTIVE)
-                    .put(plusWeeks(clock.now(), 8), ACTIVE)
-                    .build())
-            .build());
+    persistFeatureFlag(TEST_FEATURE, INACTIVE, plusWeeks(clock.now(), 8), ACTIVE);
     runCommand("TEST_FEATURE");
     assertInStdout(
         """
@@ -68,24 +59,13 @@ public class GetFeatureFlagCommandTest extends CommandTestCase<GetFeatureFlagCom
 
   @Test
   void testSuccess_multipleArguments() throws Exception {
-    persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(TEST_FEATURE)
-            .setStatusMap(
-                ImmutableSortedMap.<Instant, FeatureStatus>naturalOrder()
-                    .put(START_INSTANT, INACTIVE)
-                    .put(plusWeeks(clock.now(), 8), ACTIVE)
-                    .build())
-            .build());
-    persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(MINIMUM_DATASET_CONTACTS_OPTIONAL)
-            .setStatusMap(
-                ImmutableSortedMap.<Instant, FeatureStatus>naturalOrder()
-                    .put(START_INSTANT, INACTIVE)
-                    .put(plusWeeks(clock.now(), 3), ACTIVE)
-                    .put(plusWeeks(clock.now(), 6), INACTIVE)
-                    .build())
+    persistFeatureFlag(TEST_FEATURE, INACTIVE, plusWeeks(clock.now(), 8), ACTIVE);
+    persistFeatureFlag(
+        MINIMUM_DATASET_CONTACTS_OPTIONAL,
+        ImmutableSortedMap.<Instant, FeatureStatus>naturalOrder()
+            .put(START_INSTANT, INACTIVE)
+            .put(plusWeeks(clock.now(), 3), ACTIVE)
+            .put(plusWeeks(clock.now(), 6), INACTIVE)
             .build());
     runCommand("TEST_FEATURE", "MINIMUM_DATASET_CONTACTS_OPTIONAL");
     assertInStdout(
@@ -114,15 +94,7 @@ public class GetFeatureFlagCommandTest extends CommandTestCase<GetFeatureFlagCom
 
   @Test
   void testFailure_oneFlagDoesNotExist() {
-    persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(TEST_FEATURE)
-            .setStatusMap(
-                ImmutableSortedMap.<Instant, FeatureStatus>naturalOrder()
-                    .put(START_INSTANT, INACTIVE)
-                    .put(plusWeeks(clock.now(), 8), ACTIVE)
-                    .build())
-            .build());
+    persistFeatureFlag(TEST_FEATURE, INACTIVE, plusWeeks(clock.now(), 8), ACTIVE);
     assertThrows(
         FeatureFlagNotFoundException.class,
         () -> runCommand("TEST_FEATURE", "MINIMUM_DATASET_CONTACTS_OPTIONAL"));

--- a/core/src/test/java/google/registry/tools/ListFeatureFlagsCommandTest.java
+++ b/core/src/test/java/google/registry/tools/ListFeatureFlagsCommandTest.java
@@ -18,14 +18,13 @@ import static google.registry.model.common.FeatureFlag.FeatureName.MINIMUM_DATAS
 import static google.registry.model.common.FeatureFlag.FeatureName.TEST_FEATURE;
 import static google.registry.model.common.FeatureFlag.FeatureStatus.ACTIVE;
 import static google.registry.model.common.FeatureFlag.FeatureStatus.INACTIVE;
-import static google.registry.testing.DatabaseHelper.persistResource;
+import static google.registry.testing.DatabaseHelper.persistFeatureFlag;
 import static google.registry.testing.TestDataHelper.loadFile;
 import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static google.registry.util.DateTimeUtils.plusWeeks;
 
 import com.google.common.collect.ImmutableSortedMap;
 import google.registry.model.EntityYamlUtils;
-import google.registry.model.common.FeatureFlag;
 import google.registry.model.common.FeatureFlag.FeatureStatus;
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,49 +40,23 @@ public class ListFeatureFlagsCommandTest extends CommandTestCase<ListFeatureFlag
 
   @Test
   void testSuccess_oneFlag() throws Exception {
-    persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(TEST_FEATURE)
-            .setStatusMap(
-                ImmutableSortedMap.<Instant, FeatureStatus>naturalOrder()
-                    .put(START_INSTANT, INACTIVE)
-                    .put(plusWeeks(fakeClock.now(), 8), ACTIVE)
-                    .build())
-            .build());
+    persistFeatureFlag(TEST_FEATURE, INACTIVE, plusWeeks(fakeClock.now(), 8), ACTIVE);
     runCommand();
     assertInStdout(loadFile(getClass(), "oneFlag.yaml"));
   }
 
   @Test
   void test_success_manyFlags() throws Exception {
-    persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(TEST_FEATURE)
-            .setStatusMap(
-                ImmutableSortedMap.<Instant, FeatureStatus>naturalOrder()
-                    .put(START_INSTANT, INACTIVE)
-                    .put(plusWeeks(fakeClock.now(), 8), ACTIVE)
-                    .build())
+    persistFeatureFlag(TEST_FEATURE, INACTIVE, plusWeeks(fakeClock.now(), 8), ACTIVE);
+    persistFeatureFlag(
+        MINIMUM_DATASET_CONTACTS_OPTIONAL,
+        ImmutableSortedMap.<Instant, FeatureStatus>naturalOrder()
+            .put(START_INSTANT, INACTIVE)
+            .put(plusWeeks(fakeClock.now(), 1), ACTIVE)
+            .put(plusWeeks(fakeClock.now(), 8), INACTIVE)
+            .put(plusWeeks(fakeClock.now(), 10), ACTIVE)
             .build());
-    persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(MINIMUM_DATASET_CONTACTS_OPTIONAL)
-            .setStatusMap(
-                ImmutableSortedMap.<Instant, FeatureStatus>naturalOrder()
-                    .put(START_INSTANT, INACTIVE)
-                    .put(plusWeeks(fakeClock.now(), 1), ACTIVE)
-                    .put(plusWeeks(fakeClock.now(), 8), INACTIVE)
-                    .put(plusWeeks(fakeClock.now(), 10), ACTIVE)
-                    .build())
-            .build());
-    persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(MINIMUM_DATASET_CONTACTS_PROHIBITED)
-            .setStatusMap(
-                ImmutableSortedMap.<Instant, FeatureStatus>naturalOrder()
-                    .put(START_INSTANT, ACTIVE)
-                    .build())
-            .build());
+    persistFeatureFlag(MINIMUM_DATASET_CONTACTS_PROHIBITED, ACTIVE);
     runCommand();
     assertInStdout(loadFile(getClass(), "threeFlags.yaml"));
   }

--- a/core/src/test/java/google/registry/tools/UpdateDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateDomainCommandTest.java
@@ -23,11 +23,11 @@ import static google.registry.model.reporting.HistoryEntry.Type.DOMAIN_CREATE;
 import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistActiveHost;
+import static google.registry.testing.DatabaseHelper.persistFeatureFlag;
 import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.TestLogHandlerUtils.assertLogMessage;
 import static google.registry.testing.TestLogHandlerUtils.assertNoLogMessage;
 import static google.registry.util.DateTimeUtils.END_INSTANT;
-import static google.registry.util.DateTimeUtils.START_INSTANT;
 import static google.registry.util.DateTimeUtils.minusDays;
 import static google.registry.util.DateTimeUtils.plusDays;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -35,11 +35,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.beust.jcommander.ParameterException;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSortedMap;
 import google.registry.model.billing.BillingBase.Flag;
 import google.registry.model.billing.BillingBase.Reason;
 import google.registry.model.billing.BillingRecurrence;
-import google.registry.model.common.FeatureFlag;
 import google.registry.model.common.FeatureFlag.FeatureStatus;
 import google.registry.model.domain.Domain;
 import google.registry.model.domain.DomainHistory;
@@ -542,11 +540,7 @@ class UpdateDomainCommandTest extends EppToolCommandTestCase<UpdateDomainCommand
 
   @Test
   void testFailure_forbiddenDsRecordAlgorithm() {
-    persistResource(
-        new FeatureFlag.Builder()
-            .setFeatureName(FORBID_INSECURE_ALGORITHMS_RFC_9904)
-            .setStatusMap(ImmutableSortedMap.of(START_INSTANT, FeatureStatus.ACTIVE))
-            .build());
+    persistFeatureFlag(FORBID_INSECURE_ALGORITHMS_RFC_9904, FeatureStatus.ACTIVE);
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,


### PR DESCRIPTION
Introduced overloaded helper methods `persistFeatureFlag` in `DatabaseHelper` to simplify the creation and persistence of `FeatureFlag` entities in test setups.

1. `persistFeatureFlag(FeatureName, FeatureStatus)`: Persists a feature flag with a single status starting from the Unix Epoch (`START_INSTANT`).
2. `persistFeatureFlag(FeatureName, FeatureStatus, Instant, FeatureStatus)`: Persists a feature flag with an initial status at `START_INSTANT` and a subsequent transition at a specified time.

Refactored 11 occurrences of manual 1-transition flag creation and 5 occurrences of 2-transition flag creation across the test suite to use these new helpers, significantly reducing boilerplate and improving test readability.

TAG=agy
CONV=583b8a23-9fe5-476d-ac35-aeba7b218eb0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3087)
<!-- Reviewable:end -->
