### PR TITLE
Use a (small) map to cache token verifiers

### DIFF
--- a/core/src/main/java/google/registry/request/auth/AuthModule.java
+++ b/core/src/main/java/google/registry/request/auth/AuthModule.java
@@ -43,6 +43,7 @@ import jakarta.inject.Qualifier;
 import jakarta.inject.Singleton;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
@@ -88,8 +89,8 @@ public class AuthModule {
   TokenVerifier provideIapTokenVerifier(
       @Config("projectIdNumber") long projectIdNumber,
       @Named("backendServiceIdMap") Supplier<ImmutableMap<String, Long>> backendServiceIdMap) {
-    com.google.auth.oauth2.TokenVerifier.Builder tokenVerifierBuilder =
-        com.google.auth.oauth2.TokenVerifier.newBuilder().setIssuer(IAP_ISSUER_URL);
+    ConcurrentHashMap<String, com.google.auth.oauth2.TokenVerifier> tokenVerifiers =
+        new ConcurrentHashMap<>();
     return (String service, String token) -> {
       Long backendServiceId = backendServiceIdMap.get().get(service);
       checkNotNull(
@@ -98,7 +99,15 @@ public class AuthModule {
           service,
           backendServiceIdMap);
       String audience = String.format(IAP_AUDIENCE_FORMAT, projectIdNumber, backendServiceId);
-      return tokenVerifierBuilder.setAudience(audience).build().verify(token);
+      com.google.auth.oauth2.TokenVerifier verifier =
+          tokenVerifiers.computeIfAbsent(
+              audience,
+              aud ->
+                  com.google.auth.oauth2.TokenVerifier.newBuilder()
+                      .setIssuer(IAP_ISSUER_URL)
+                      .setAudience(aud)
+                      .build());
+      return verifier.verify(token);
     };
   }
 


### PR DESCRIPTION
we shouldn't have to rebuild it each time we get a request to a different service or really ever at all -- we might get a tiny bit of cache benefit here

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3088)
<!-- Reviewable:end -->
