### PR TITLE
Remove class name option in GetRoutingMapCommand

### DIFF
--- a/core/src/main/java/google/registry/module/RequestComponent.java
+++ b/core/src/main/java/google/registry/module/RequestComponent.java
@@ -164,7 +164,7 @@ import google.registry.ui.server.console.settings.SecurityAction;
       ToolsServerModule.class,
       WhiteboxModule.class
     })
-interface RequestComponent {
+public interface RequestComponent {
   FlowComponent.Builder flowComponentBuilder();
 
   BrdaCopyAction brdaCopyAction();

--- a/core/src/main/java/google/registry/request/RouterDisplayHelper.java
+++ b/core/src/main/java/google/registry/request/RouterDisplayHelper.java
@@ -14,11 +14,9 @@
 
 package google.registry.request;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.stream.Collectors.joining;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
 import java.util.Comparator;
@@ -62,18 +60,6 @@ public class RouterDisplayHelper {
   /** Returns a string representation of the routing map in the specified component. */
   public static String extractHumanReadableRoutesFromComponent(Class<?> componentClass) {
     return formatRoutes(Router.extractRoutesFromComponent(componentClass).values());
-  }
-
-  public static ImmutableList<String> extractHumanReadableRoutesWithWrongService(
-      Class<?> componentClass, Action.Service expectedService) {
-    return Router.extractRoutesFromComponent(componentClass).values().stream()
-        .filter(route -> route.action().service() != expectedService)
-        .map(
-            route ->
-                String.format(
-                    "%s (%s%s)",
-                    route.actionClass(), route.action().service(), route.action().path()))
-        .collect(toImmutableList());
   }
 
   private static String getFormatString(Map<String, Integer> columnWidths) {

--- a/core/src/main/java/google/registry/tools/GetRoutingMapCommand.java
+++ b/core/src/main/java/google/registry/tools/GetRoutingMapCommand.java
@@ -14,27 +14,17 @@
 
 package google.registry.tools;
 
-import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import google.registry.module.RequestComponent;
 import google.registry.request.RouterDisplayHelper;
 
 /** Generates the routing map file used for unit testing. */
 @Parameters(commandDescription = "Generate a routing map file")
 final class GetRoutingMapCommand implements Command {
 
-  @Parameter(
-    names = {"-c", "--class"},
-    description =
-        "Request component class (e.g. google.registry.module.backend.BackendRequestComponent)"
-        + " for which routing map should be generated",
-    required = true
-  )
-  private String serviceClassName;
-
   @Override
   public void run() throws Exception {
     System.out.println(
-        RouterDisplayHelper.extractHumanReadableRoutesFromComponent(
-            Class.forName(serviceClassName)));
+        RouterDisplayHelper.extractHumanReadableRoutesFromComponent(RequestComponent.class));
   }
 }

--- a/core/src/test/java/google/registry/testing/GoldenFileTestHelper.java
+++ b/core/src/test/java/google/registry/testing/GoldenFileTestHelper.java
@@ -55,7 +55,7 @@ public class GoldenFileTestHelper {
 
   public static GoldenFileTestHelper assertThatRoutesFromComponent(Class<?> component) {
     return assertThat(RouterDisplayHelper.extractHumanReadableRoutesFromComponent(component))
-        .createdByNomulusCommand("get_routing_map -c " + component.getName());
+        .createdByNomulusCommand("get_routing_map");
   }
 
   public GoldenFileTestHelper createdByNomulusCommand(String nomulusCommand) {


### PR DESCRIPTION
we only have the one component now, and in general it's a good idea to remove class loading based on user input, even if that user is one of us

tested on alpha

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3101)
<!-- Reviewable:end -->
