### PR TITLE
Forbid negative premium prices

### DIFF
--- a/core/src/main/java/google/registry/model/tld/label/PremiumList.java
+++ b/core/src/main/java/google/registry/model/tld/label/PremiumList.java
@@ -169,6 +169,14 @@ public final class PremiumList extends BaseDomainLabelList<BigDecimal, PremiumEn
         getInstance().revisionId = revisionId;
         return this;
       }
+
+      @Override
+      public PremiumEntry build() {
+        checkArgument(getInstance().price != null, "Price must not be null");
+        checkArgument(
+            getInstance().price.compareTo(BigDecimal.ZERO) >= 0, "Price must not be negative");
+        return super.build();
+      }
     }
   }
 

--- a/core/src/test/java/google/registry/model/tld/label/PremiumListTest.java
+++ b/core/src/test/java/google/registry/model/tld/label/PremiumListTest.java
@@ -110,28 +110,44 @@ public class PremiumListTest {
 
   @Test
   void testValidation_labelMustBeLowercase() {
-    Exception e =
-        assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                new PremiumEntry.Builder()
-                    .setPrice(BigDecimal.valueOf(399))
-                    .setLabel("UPPER.tld")
-                    .build());
-    assertThat(e).hasMessageThat().contains("must be in puny-coded, lower-case form");
+    assertThat(
+            assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                    new PremiumEntry.Builder()
+                        .setPrice(BigDecimal.valueOf(399))
+                        .setLabel("UPPER.tld")
+                        .build()))
+        .hasMessageThat()
+        .contains("must be in puny-coded, lower-case form");
+  }
+
+  @Test
+  void testValidation_priceMustNotBeNegative() {
+    assertThat(
+            assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                    new PremiumEntry.Builder()
+                        .setPrice(BigDecimal.valueOf(-100))
+                        .setLabel("anchor")
+                        .build()))
+        .hasMessageThat()
+        .isEqualTo("Price must not be negative");
   }
 
   @Test
   void testValidation_labelMustBePunyCoded() {
-    Exception e =
-        assertThrows(
-            IllegalArgumentException.class,
-            () ->
-                new PremiumEntry.Builder()
-                    .setPrice(BigDecimal.valueOf(399))
-                    .setLabel("lower.みんな")
-                    .build());
-    assertThat(e).hasMessageThat().contains("must be in puny-coded, lower-case form");
+    assertThat(
+            assertThrows(
+                IllegalArgumentException.class,
+                () ->
+                    new PremiumEntry.Builder()
+                        .setPrice(BigDecimal.valueOf(399))
+                        .setLabel("lower.みんな")
+                        .build()))
+        .hasMessageThat()
+        .contains("must be in puny-coded, lower-case form");
   }
 
   @Test


### PR DESCRIPTION
This hasn't been an issue, but it seems like a good idea. Note that I'm allowing prices of 0 here just in case there's some shenanigans at some point in time where we want a domain to technically be premium without having a cost.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3108)
<!-- Reviewable:end -->
