### PR TITLE
docs: fix broken external links in documentation

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -158,4 +158,4 @@ Deployment of the Beam pipelines to Cloud Dataflow in the testing environments
 ```
 
 Pipeline deployment in other environments are through CloudBuild. Please refer
-to the [release folder](http://github.com/google/nomulus/release) for details.
+to the [release folder](https://github.com/google/nomulus/releases) for details.

--- a/docs/operational-procedures.md
+++ b/docs/operational-procedures.md
@@ -43,14 +43,14 @@ metrics monitored are as follows:
     described by TLD, reserved list name, and the reservation type found.
 
 Follow the guide to
-[set up a Stackdriver account](https://cloud.google.com/monitoring/accounts/guide)
+[set up a Cloud Monitoring workspace](https://cloud.google.com/monitoring/docs)
 and associate it with the GCP project containing the Nomulus app. Once the two
 have been linked, monitoring will start automatically. For now, because the
 visualization of custom metrics in Stackdriver is embryronic, you can retrieve
 and visualize the collected metrics with a script, as described in the guide on
 [Reading Time Series](https://cloud.google.com/monitoring/custom-metrics/reading-metrics)
 and the
-[custom metric code sample](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/monitoring/api/v3/custom_metric.py).
+[custom metric documentation](https://cloud.google.com/monitoring/custom-metrics).
 
 In addition to the included white-box monitoring, black-box monitoring should be
 set up to exercise the functionality of the registry platform as a user would

--- a/docs/operational-procedures/reserved-list-management.md
+++ b/docs/operational-procedures/reserved-list-management.md
@@ -17,7 +17,7 @@ types are:
     allocation token at time of registration. This token is configured on an
     `AllocationToken` entity with a matching `domainName`, and is sent by the
     registrar using the
-    [allocation token EPP extension](https://tools.ietf.org/id/draft-ietf-regext-allocation-token-07.html).
+    [allocation token EPP extension](https://datatracker.ietf.org/doc/html/rfc8495).
 *   **`RESERVED_FOR_ANCHOR_TENANT`** - Like `RESERVED_FOR_SPECIFIC_USE`, except
     for an anchor tenant (i.e. a registrant participating in a
     [Qualified Launch Program](https://newgtlds.icann.org/en/announcements-and-media/announcement-10apr14-en)),


### PR DESCRIPTION
This PR resolves several `404 Not Found` dead links across the documentation:

1. **`docs/install.md`:** Fixed the link to the repository's releases page (added missing 's').
2. **`docs/operational-procedures.md`:** Updated the legacy Stackdriver account setup guide link to the modern Cloud Monitoring Workspace documentation.
3. **`docs/operational-procedures.md`:** Replaced a broken `python-docs-samples` code snippet link with the canonical custom metrics documentation.
4. **`docs/operational-procedures/reserved-list-management.md`:** Updated the expired IETF draft link for the EPP allocation token extension to the finalized RFC 8495.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3113)
<!-- Reviewable:end -->
