### PR TITLE
Validate non-empty tlds in refresh DNS action

### DIFF
--- a/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
+++ b/core/src/main/java/google/registry/tools/server/RefreshDnsForAllDomainsAction.java
@@ -105,6 +105,7 @@ public class RefreshDnsForAllDomainsAction implements Runnable {
 
   @Override
   public void run() {
+    checkArgument(!tlds.isEmpty(), "Must specify TLDs to refresh");
     assertTldsExist(tlds);
     checkArgument(batchSize > 0, "Must specify a positive number for batch size");
     logger.atInfo().log("Enqueueing DNS refresh tasks for TLDs %s.", tlds);

--- a/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
+++ b/core/src/test/java/google/registry/tools/server/RefreshDnsForAllDomainsActionTest.java
@@ -24,6 +24,7 @@ import static google.registry.testing.DatabaseHelper.createTld;
 import static google.registry.testing.DatabaseHelper.persistActiveDomain;
 import static google.registry.testing.DatabaseHelper.persistDeletedDomain;
 import static google.registry.util.DateTimeUtils.minusYears;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -150,5 +151,19 @@ public class RefreshDnsForAllDomainsActionTest {
     }
     action.run();
     assertDnsRequestsWithRequestTime(clock.now(), 11);
+  }
+
+  @Test
+  void test_runAction_emptyTlds_throwsException() {
+    action =
+        new RefreshDnsForAllDomainsAction(
+            response,
+            ImmutableSet.of(),
+            Optional.of(10),
+            Optional.empty(),
+            Optional.empty(),
+            new Random());
+    IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, action::run);
+    assertThat(thrown).hasMessageThat().isEqualTo("Must specify TLDs to refresh");
   }
 }


### PR DESCRIPTION
Add validation to RefreshDnsForAllDomainsAction to ensure the tlds parameter is not empty when invoked. Previously, invoking the action without specifying tlds would result in a no-op that logged an empty list and exited without error. This change makes missing tlds an explicit error, throwing an IllegalArgumentException so users running the command via nomulus curl receive clear feedback that the parameter is required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3114)
<!-- Reviewable:end -->
