### PR TITLE
Remediate XML Signature Wrapping in SMD validation

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainFlowTmchUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowTmchUtils.java
@@ -101,8 +101,9 @@ public final class DomainFlowTmchUtils {
       throw new SignedMarkRevokedErrorException();
     }
 
+    String signedElementId;
     try {
-      tmchXmlSignature.verify(signedMarkData);
+      signedElementId = tmchXmlSignature.verify(signedMarkData);
     } catch (CertificateExpiredException e) {
       throw new SignedMarkCertificateExpiredException(e);
     } catch (CertificateNotYetValidException e) {
@@ -120,6 +121,10 @@ public final class DomainFlowTmchUtils {
         | SAXException
         | ParserConfigurationException e) {
       throw new SignedMarkParsingErrorException(e);
+    }
+
+    if (!signedElementId.equals(signedMark.getXsdId())) {
+      throw new SignedMarkSignatureException(new Exception("Signature reference ID mismatch."));
     }
 
     if (now.isBefore(signedMark.getCreationTime())) {

--- a/core/src/main/java/google/registry/model/smd/SignedMark.java
+++ b/core/src/main/java/google/registry/model/smd/SignedMark.java
@@ -78,6 +78,10 @@ public class SignedMark extends ImmutableObject implements AbstractSignedMark {
     return mark;
   }
 
+  public String getXsdId() {
+    return xsdId;
+  }
+
   public boolean hasSignature() {
     return xmlSignature != null;
   }

--- a/core/src/main/java/google/registry/tmch/TmchXmlSignature.java
+++ b/core/src/main/java/google/registry/tmch/TmchXmlSignature.java
@@ -51,6 +51,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.validation.Schema;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
@@ -78,11 +79,32 @@ public class TmchXmlSignature {
    * @throws GeneralSecurityException for unsupported protocols, certs not signed by the TMCH,
    *     incorrect keys, and for invalid, old, not-yet-valid or revoked certificates.
    */
-  public void verify(byte[] smdXml)
-      throws GeneralSecurityException, IOException, MarshalException, ParserConfigurationException,
-          SAXException, XMLSignatureException {
+  public String verify(byte[] smdXml)
+      throws GeneralSecurityException,
+          IOException,
+          MarshalException,
+          ParserConfigurationException,
+          SAXException,
+          XMLSignatureException {
     checkArgument(smdXml.length > 0);
     Document doc = parseSmdDocument(new ByteArrayInputStream(smdXml));
+
+    Element rootElement = doc.getDocumentElement();
+    if (!"signedMark".equals(rootElement.getLocalName())
+        || !"urn:ietf:params:xml:ns:signedMark-1.0".equals(rootElement.getNamespaceURI())) {
+      throw new XMLSignatureException("Invalid root element name or namespace.");
+    }
+    String rootId = rootElement.getAttribute("id");
+    if (rootId.isEmpty()) {
+      throw new XMLSignatureException("Root element missing id attribute.");
+    }
+
+    // Verify that exactly one <smd:signedMark> element exists in the DOM
+    NodeList smdNodes =
+        doc.getElementsByTagNameNS("urn:ietf:params:xml:ns:signedMark-1.0", "signedMark");
+    if (smdNodes.getLength() != 1) {
+      throw new XMLSignatureException("Expected exactly one <smd:signedMark> element.");
+    }
 
     NodeList signatureNodes = doc.getElementsByTagNameNS(XMLSignature.XMLNS, "Signature");
     if (signatureNodes.getLength() != 1) {
@@ -103,6 +125,23 @@ public class TmchXmlSignature {
     if (!isValid) {
       throw new XMLSignatureException(explainValidationProblem(context, signature));
     }
+
+    @SuppressWarnings("unchecked")
+    List<Reference> references = signature.getSignedInfo().getReferences();
+    if (references.isEmpty()) {
+      throw new XMLSignatureException("No references found in signature.");
+    }
+    Reference reference = references.get(0);
+    String uri = reference.getURI();
+    if (uri == null || !uri.startsWith("#")) {
+      throw new XMLSignatureException("Invalid signature reference URI: " + uri);
+    }
+    String signedElementId = uri.substring(1);
+    if (!signedElementId.equals(rootId)) {
+      throw new XMLSignatureException(
+          String.format("Signature reference ID mismatch: expected #%s, got %s", rootId, uri));
+    }
+    return signedElementId;
   }
 
   private static Document parseSmdDocument(InputStream input)

--- a/core/src/test/java/google/registry/tmch/TmchXmlSignatureTest.java
+++ b/core/src/test/java/google/registry/tmch/TmchXmlSignatureTest.java
@@ -23,17 +23,26 @@ import google.registry.persistence.transaction.JpaTestExtensions;
 import google.registry.persistence.transaction.JpaTestExtensions.JpaIntegrationTestExtension;
 import google.registry.testing.FakeClock;
 import google.registry.tmch.TmchXmlSignature.CertificateSignatureException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.security.cert.CertificateExpiredException;
 import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.CertificateRevokedException;
 import java.time.Instant;
 import javax.xml.crypto.dsig.XMLSignatureException;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
 import org.junitpioneer.jupiter.cartesian.CartesianTest.Values;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 /**
  * Unit tests for {@link TmchXmlSignature}.
@@ -138,5 +147,38 @@ class TmchXmlSignatureTest {
     CertificateRevokedException e =
         assertThrows(CertificateRevokedException.class, () -> tmchXmlSignature.verify(smdData));
     assertThat(e).hasMessageThat().contains("Certificate has been revoked");
+  }
+
+  @Test
+  void testVerify_signatureReferenceIdMismatch() throws Exception {
+    smdData = loadSmd("smd/active.smd");
+    DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+    dbf.setNamespaceAware(true);
+    Document originalDoc = dbf.newDocumentBuilder().parse(new ByteArrayInputStream(smdData));
+    Element originalRoot = originalDoc.getDocumentElement();
+
+    // Create a new document to construct the XML Signature Wrapping (XSW) payload
+    Document forgedDoc = dbf.newDocumentBuilder().newDocument();
+    Element forgedRoot =
+        forgedDoc.createElementNS("urn:ietf:params:xml:ns:signedMark-1.0", "smd:signedMark");
+    forgedRoot.setAttribute("id", "forged-id");
+    forgedRoot.setIdAttribute("id", true);
+    forgedDoc.appendChild(forgedRoot);
+
+    // Import the original valid signedMark element as a child of the forged root
+    Element importedChild = (Element) forgedDoc.importNode(originalRoot, true);
+    forgedRoot.appendChild(importedChild);
+    // Ensure the DOM resolver treats the original ID attribute correctly
+    importedChild.setIdAttribute("id", true);
+
+    // Serialize the XSW DOM back to bytes
+    Transformer transformer = TransformerFactory.newInstance().newTransformer();
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    transformer.transform(new DOMSource(forgedDoc), new StreamResult(bos));
+    byte[] manipulatedData = bos.toByteArray();
+
+    XMLSignatureException e =
+        assertThrows(XMLSignatureException.class, () -> tmchXmlSignature.verify(manipulatedData));
+    assertThat(e).hasMessageThat().contains("Expected exactly one <smd:signedMark> element");
   }
 }


### PR DESCRIPTION
Implement multi-layered defense-in-depth to completely block XML Signature Wrapping (XSW) vulnerabilities during Sunrise phase SMD verification:
- Expose the unmarshalled XML id attribute (xsdId) from the SignedMark JAXB model.
- Refactor TmchXmlSignature.verify() to assert that the root element name is 'signedMark' in the correct namespace, that exactly one such element exists in the DOM, and that the signature's Reference URI matches the root element ID. Return the validated ID.
- In DomainFlowTmchUtils.verifyEncodedSignedMark(), assert that the cryptographically verified ID matches the unmarshalled xsdId.
- Add a robust integration test case to TmchXmlSignatureTest.java verifying that XSW payloads are correctly caught and rejected by our DOM uniqueness check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3116)
<!-- Reviewable:end -->

BUG= http://b/529387728