### PR TITLE
Restore RFC schemas, prober XML, and OT&E route

### DIFF
--- a/console-webapp/src/app/registrar/registrarDetails.component.ts
+++ b/console-webapp/src/app/registrar/registrarDetails.component.ts
@@ -75,7 +75,7 @@ export class RegistrarDetailsComponent implements OnInit {
   }
 
   checkOteStatus() {
-    this.router.navigate(['ote-status/', this.registrarInEdit.registrarId], {
+    this.router.navigate(['ote-status', this.registrarInEdit.registrarId], {
       queryParamsHandling: 'merge',
     });
   }

--- a/core/src/main/java/google/registry/model/domain/DomainCommand.java
+++ b/core/src/main/java/google/registry/model/domain/DomainCommand.java
@@ -158,11 +158,11 @@ public class DomainCommand {
         throws InvalidReferencesException, ParameterValuePolicyErrorException {
       Create clone = clone(this);
       clone.nameservers = linkHosts(nullSafeImmutableCopy(clone.nameserverHostNames), now);
-      if (registrantContactId != null) {
-        throw new RegistrantProhibitedException();
-      }
       if (!isNullOrEmpty(foreignKeyedDesignatedContacts)) {
         throw new ContactsProhibitedException();
+      }
+      if (registrantContactId != null) {
+        throw new RegistrantProhibitedException();
       }
       return clone;
     }

--- a/core/src/main/java/google/registry/xml/xsd/domain.xsd
+++ b/core/src/main/java/google/registry/xml/xsd/domain.xsd
@@ -47,6 +47,8 @@ Child elements of the <create> command.
     minOccurs="0"/>
    <element name="registrant" type="eppcom:clIDType"
     minOccurs="0"/>
+   <element name="contact" type="domain:contactType"
+    minOccurs="0" maxOccurs="unbounded"/>
    <element name="authInfo" type="domain:authInfoType"/>
  </sequence>
 </complexType>
@@ -97,6 +99,22 @@ Name servers are either host objects or attributes.
 If attributes, addresses are optional and follow the
 structure defined in the host mapping.
 -->
+
+<complexType name="contactType">
+ <simpleContent>
+   <extension base="eppcom:clIDType">
+     <attribute name="type" type="domain:contactAttrType"/>
+   </extension>
+ </simpleContent>
+</complexType>
+
+<simpleType name="contactAttrType">
+ <restriction base="token">
+   <enumeration value="admin"/>
+   <enumeration value="billing"/>
+   <enumeration value="tech"/>
+ </restriction>
+</simpleType>
 
 <complexType name="authInfoType">
  <choice>
@@ -198,6 +216,8 @@ Data elements that can be added or removed.
  <sequence>
    <element name="ns" type="domain:nsType"
     minOccurs="0"/>
+   <element name="contact" type="domain:contactType"
+    minOccurs="0" maxOccurs="unbounded"/>
    <element name="status" type="domain:statusType"
     minOccurs="0" maxOccurs="11"/>
  </sequence>
@@ -299,6 +319,8 @@ Child response elements.
     minOccurs="0" maxOccurs="11"/>
    <element name="registrant" type="eppcom:clIDType"
     minOccurs="0"/>
+   <element name="contact" type="domain:contactType"
+    minOccurs="0" maxOccurs="unbounded"/>
    <element name="ns" type="domain:nsType"
     minOccurs="0"/>
    <element name="host" type="eppcom:labelType"

--- a/core/src/main/java/google/registry/xml/xsd/rde-domain.xsd
+++ b/core/src/main/java/google/registry/xml/xsd/rde-domain.xsd
@@ -60,6 +60,9 @@
             maxOccurs="unbounded"/>
           <element name="registrant"
             type="eppcom:clIDType" minOccurs="0"/>
+          <element name="contact"
+            type="domain:contactType"
+            minOccurs="0" maxOccurs="unbounded"/>
           <element name="ns"
             type="domain:nsType" minOccurs="0"/>
           <element name="clID"

--- a/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainCreateFlowTest.java
@@ -81,7 +81,6 @@ import google.registry.flows.EppException;
 import google.registry.flows.EppException.UnimplementedExtensionException;
 import google.registry.flows.EppRequestSource;
 import google.registry.flows.ExtensionManager.UndeclaredServiceExtensionException;
-import google.registry.flows.FlowUtils;
 import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.FlowUtils.UnknownCurrencyEppException;
 import google.registry.flows.ResourceFlowTestCase;
@@ -144,6 +143,7 @@ import google.registry.flows.domain.token.AllocationTokenFlowUtils.AllocationTok
 import google.registry.flows.domain.token.AllocationTokenFlowUtils.AllocationTokenNotValidForRegistrarException;
 import google.registry.flows.domain.token.AllocationTokenFlowUtils.AlreadyRedeemedAllocationTokenException;
 import google.registry.flows.domain.token.AllocationTokenFlowUtils.NonexistentAllocationTokenException;
+import google.registry.flows.exceptions.ContactsProhibitedException;
 import google.registry.flows.exceptions.OnlyToolCanPassMetadataException;
 import google.registry.flows.exceptions.ResourceCreateContentionException;
 import google.registry.model.billing.BillingBase;
@@ -1937,8 +1937,7 @@ class DomainCreateFlowTest extends ResourceFlowTestCase<DomainCreateFlow, Domain
   void testFailure_minimumDataset_noRegistrantButSomeOtherContactTypes() throws Exception {
     setEppInput("domain_create_other_contact_types.xml");
     persistHosts();
-    EppException thrown =
-        assertThrows(FlowUtils.GenericXmlSyntaxErrorException.class, this::runFlow);
+    EppException thrown = assertThrows(ContactsProhibitedException.class, this::runFlow);
     assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 

--- a/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
+++ b/core/src/test/java/google/registry/flows/domain/DomainUpdateFlowTest.java
@@ -67,7 +67,6 @@ import google.registry.config.RegistryConfig;
 import google.registry.flows.EppException;
 import google.registry.flows.EppException.UnimplementedExtensionException;
 import google.registry.flows.EppRequestSource;
-import google.registry.flows.FlowUtils;
 import google.registry.flows.FlowUtils.NotLoggedInException;
 import google.registry.flows.ResourceFlowTestCase;
 import google.registry.flows.ResourceFlowUtils.AddExistingValueException;
@@ -90,6 +89,7 @@ import google.registry.flows.domain.DomainFlowUtils.SecDnsAllUsageException;
 import google.registry.flows.domain.DomainFlowUtils.TooManyDsRecordsException;
 import google.registry.flows.domain.DomainFlowUtils.TooManyNameserversException;
 import google.registry.flows.domain.DomainFlowUtils.UrgentAttributeNotSupportedException;
+import google.registry.flows.exceptions.ContactsProhibitedException;
 import google.registry.flows.exceptions.OnlyToolCanPassMetadataException;
 import google.registry.flows.exceptions.ResourceHasClientUpdateProhibitedException;
 import google.registry.flows.exceptions.ResourceStatusProhibitsOperationException;
@@ -283,8 +283,10 @@ class DomainUpdateFlowTest extends ResourceFlowTestCase<DomainUpdateFlow, Domain
     // This EPP adds a new technical contact mak21 that wasn't already present.
     setEppInput("domain_update_empty_registrant.xml");
     persistReferencedEntities();
+    persistDomain();
     // Fails because the update adds some new contacts, although the registrant has been removed.
-    assertThrows(FlowUtils.GenericXmlSyntaxErrorException.class, this::persistDomain);
+    EppException thrown = assertThrows(ContactsProhibitedException.class, this::runFlow);
+    assertAboutEppExceptions().that(thrown).marshalsToXml();
   }
 
   private void modifyDomainToHave13Nameservers() throws Exception {

--- a/core/src/test/java/google/registry/model/domain/DomainCommandTest.java
+++ b/core/src/test/java/google/registry/model/domain/DomainCommandTest.java
@@ -17,8 +17,8 @@ package google.registry.model.domain;
 import static google.registry.testing.DatabaseHelper.persistActiveHost;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import google.registry.flows.FlowUtils;
 import google.registry.flows.domain.DomainFlowUtils.RegistrantProhibitedException;
+import google.registry.flows.exceptions.ContactsProhibitedException;
 import google.registry.model.ResourceCommandTestCase;
 import google.registry.model.eppinput.EppInput;
 import google.registry.model.eppinput.EppInput.ResourceCommandWrapper;
@@ -88,9 +88,10 @@ class DomainCommandTest extends ResourceCommandTestCase {
   void testCreate_cloneAndLinkReferences_failsWithContacts() throws Exception {
     persistActiveHost("ns1.example.net");
     persistActiveHost("ns2.example.net");
+    DomainCommand.Create create =
+        (DomainCommand.Create) loadEppResourceCommand("domain_create_with_contacts.xml");
     assertThrows(
-        FlowUtils.GenericXmlSyntaxErrorException.class,
-        () -> loadEppResourceCommand("domain_create_with_contacts.xml"));
+        ContactsProhibitedException.class, () -> create.cloneAndLinkReferences(fakeClock.now()));
   }
 
   @Test
@@ -138,9 +139,10 @@ class DomainCommandTest extends ResourceCommandTestCase {
   void testUpdate_cloneAndLinkReferences_failsWithContacts() throws Exception {
     persistActiveHost("ns1.example.com");
     persistActiveHost("ns2.example.com");
+    DomainCommand.Update update =
+        (DomainCommand.Update) loadEppResourceCommand("domain_update_with_contacts.xml");
     assertThrows(
-        FlowUtils.GenericXmlSyntaxErrorException.class,
-        () -> loadEppResourceCommand("domain_update_with_contacts.xml"));
+        ContactsProhibitedException.class, () -> update.cloneAndLinkReferences(fakeClock.now()));
   }
 
   @Test

--- a/prober/src/main/resources/google/registry/monitoring/blackbox/message/create.xml
+++ b/prober/src/main/resources/google/registry/monitoring/blackbox/message/create.xml
@@ -9,8 +9,6 @@
           <domain:hostObj>ns.fake-domain.tld</domain:hostObj>
         </domain:ns>
         <domain:registrant>google-mon</domain:registrant>
-        <domain:contact type="admin">google-mon</domain:contact>
-        <domain:contact type="tech">google-mon</domain:contact>
         <domain:authInfo>
           <domain:pw>insecure</domain:pw>
         </domain:authInfo>


### PR DESCRIPTION
Restore <element name="contact" minOccurs="0" maxOccurs="unbounded"/> to core/src/main/java/google/registry/xml/xsd/domain.xsd (RFC 5731) and rde-domain.xsd (RFC 5831) so all XSD schemas conform strictly to published EPP RFCs. This allows OteStats to cleanly unmarshal archived HistoryEntry records during OT&E status checks without throwing cvc-complex-type.2.4.a schema validation errors on historical contact elements.

Remove deprecated <domain:contact> elements from prober creation payload (prober/.../create.xml) to match current flow rules where contact associations are forbidden.

Remove trailing slash from ote-status route parameter in RegistrarDetailsComponent to prevent double-slash (/ote-status//<id>) URL generation when checking OT&E status.

BUG= http://b/529391412

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3120)
<!-- Reviewable:end -->
