### PR TITLE
Don't use the cache in checking host liveness

### DIFF
--- a/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
+++ b/core/src/main/java/google/registry/flows/domain/DomainFlowUtils.java
@@ -70,7 +70,6 @@ import google.registry.flows.EppException.RequiredParameterMissingException;
 import google.registry.flows.EppException.StatusProhibitsOperationException;
 import google.registry.flows.EppException.UnimplementedOptionException;
 import google.registry.flows.exceptions.ResourceHasClientUpdateProhibitedException;
-import google.registry.model.EppResource;
 import google.registry.model.billing.BillingBase.Flag;
 import google.registry.model.billing.BillingBase.Reason;
 import google.registry.model.billing.BillingRecurrence;
@@ -410,11 +409,9 @@ public class DomainFlowUtils {
   /** Verify that no linked nameservers have disallowed statuses. */
   static void verifyNotInPendingDelete(ImmutableSet<VKey<Host>> nameservers)
       throws StatusProhibitsOperationException {
-    for (EppResource resource :
-        EppResource.loadByCacheIfEnabled(ImmutableSet.copyOf(nameservers)).values()) {
-      if (resource.getStatusValues().contains(StatusValue.PENDING_DELETE)) {
-        throw new LinkedResourceInPendingDeleteProhibitsOperationException(
-            resource.getForeignKey());
+    for (Host host : tm().loadByKeys(nameservers).values()) {
+      if (host.getStatusValues().contains(StatusValue.PENDING_DELETE)) {
+        throw new LinkedResourceInPendingDeleteProhibitsOperationException(host.getForeignKey());
       }
     }
   }


### PR DESCRIPTION
i think we don't generally use the EPP resource cache anyway, but just in case

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3122)
<!-- Reviewable:end -->
