### PR TITLE
Fix typo in .gitignore

### DIFF
--- a/prober/.gitignore
+++ b/prober/.gitignore
@@ -1,2 +1,2 @@
 out/
-src/main/resources/google/registry/monitoring/blackbox/modules/secrets/
+src/main/resources/google/registry/monitoring/blackbox/module/secrets/


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3130)
<!-- Reviewable:end -->
