### PR TITLE
Add TLD verification to GenerateZoneFilesAction

### DIFF
--- a/core/src/main/java/google/registry/tools/server/GenerateZoneFilesAction.java
+++ b/core/src/main/java/google/registry/tools/server/GenerateZoneFilesAction.java
@@ -33,6 +33,7 @@ import google.registry.model.domain.Domain;
 import google.registry.model.domain.secdns.DomainDsData;
 import google.registry.model.host.Host;
 import google.registry.model.tld.Tld;
+import google.registry.model.tld.Tlds;
 import google.registry.request.Action;
 import google.registry.request.HttpException.BadRequestException;
 import google.registry.request.JsonActionRunner;
@@ -119,6 +120,7 @@ public class GenerateZoneFilesAction implements Runnable, JsonActionRunner.JsonA
   public Map<String, Object> handleJsonRequest(Map<String, ?> json) {
     @SuppressWarnings("unchecked")
     ImmutableSet<String> tlds = ImmutableSet.copyOf((List<String>) json.get("tlds"));
+    Tlds.assertTldsExist(tlds);
     Instant exportTime = Instant.parse(json.get("exportTime").toString());
     // We disallow exporting within the past 2 minutes because there might be outstanding writes.
     // We can only reliably call loadAtPointInTime at times that are UTC midnight and >

--- a/core/src/test/java/google/registry/tools/server/GenerateZoneFilesActionTest.java
+++ b/core/src/test/java/google/registry/tools/server/GenerateZoneFilesActionTest.java
@@ -23,6 +23,7 @@ import static google.registry.testing.DatabaseHelper.persistResource;
 import static google.registry.testing.TestDataHelper.loadFile;
 import static google.registry.util.DateTimeUtils.plusMinutes;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
@@ -55,6 +56,20 @@ class GenerateZoneFilesActionTest {
       new JpaTestExtensions.Builder().buildIntegrationTestExtension();
 
   private final GcsUtils gcsUtils = new GcsUtils(LocalStorageHelper.getOptions());
+
+  @Test
+  void testGenerate_nonexistentTld_throwsException() {
+    GenerateZoneFilesAction action = new GenerateZoneFilesAction();
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                action.handleJsonRequest(
+                    ImmutableMap.<String, Object>of(
+                        "tlds", ImmutableList.of("nonexistent-tld"),
+                        "exportTime", Instant.parse("2024-03-27T00:00:00Z"))));
+    assertThat(thrown).hasMessageThat().contains("TLDs do not exist: nonexistent-tld");
+  }
 
   @Test
   void testGenerate_defaultTtls() throws Exception {


### PR DESCRIPTION
1. this is a good idea in general
2. it can prevent GCS path traversal if someone somehow bypasses auth to add a weird path

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3132)
<!-- Reviewable:end -->
