### PR TITLE
Support dry-run and build-environment flags in Nomulus creation commands

### DIFF
--- a/core/src/main/java/google/registry/tools/CreateOrUpdatePremiumListCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdatePremiumListCommand.java
@@ -14,6 +14,7 @@
 
 package google.registry.tools;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
 
 import com.beust.jcommander.Parameter;
@@ -38,6 +39,19 @@ abstract class CreateOrUpdatePremiumListCommand extends ConfirmingCommand {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
   protected List<String> inputData;
   protected CurrencyUnit currency;
+
+  @Parameter(
+      names = {"-d", "--dry_run"},
+      description = "Does not execute the entity mutation")
+  boolean dryRun;
+
+  @Parameter(
+      names = {"--build_environment"},
+      description =
+          "DO NOT USE THIS FLAG ON THE COMMAND LINE! This flag indicates the command is being run"
+              + " by the build environment tools. This flag should never be used by a human user"
+              + " from the command line.")
+  boolean buildEnv;
 
   @Nullable
   @Parameter(
@@ -67,5 +81,18 @@ abstract class CreateOrUpdatePremiumListCommand extends ConfirmingCommand {
       logger.atSevere().withCause(e).log(message);
     }
     return message;
+  }
+
+  @Override
+  protected boolean dontRunCommand() {
+    return dryRun;
+  }
+
+  @Override
+  protected boolean checkExecutionState() {
+    checkArgument(
+        !RegistryToolEnvironment.get().equals(RegistryToolEnvironment.PRODUCTION) || buildEnv,
+        "The --build_environment flag must be used when running in production");
+    return super.checkExecutionState();
   }
 }

--- a/core/src/main/java/google/registry/tools/CreateOrUpdateReservedListCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdateReservedListCommand.java
@@ -14,6 +14,8 @@
 
 package google.registry.tools;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.beust.jcommander.Parameter;
 import com.google.common.flogger.FluentLogger;
 import google.registry.model.tld.label.ReservedList;
@@ -34,6 +36,19 @@ public abstract class CreateOrUpdateReservedListCommand extends ConfirmingComman
   @Inject Clock clock;
 
   static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
+  @Parameter(
+      names = {"-d", "--dry_run"},
+      description = "Does not execute the entity mutation")
+  boolean dryRun;
+
+  @Parameter(
+      names = {"--build_environment"},
+      description =
+          "DO NOT USE THIS FLAG ON THE COMMAND LINE! This flag indicates the command is being run"
+              + " by the build environment tools. This flag should never be used by a human user"
+              + " from the command line.")
+  boolean buildEnv;
 
   @Nullable
   @Parameter(
@@ -73,5 +88,18 @@ public abstract class CreateOrUpdateReservedListCommand extends ConfirmingComman
             .map(rle -> String.format("(%s)", rle.toString()))
             .collect(Collectors.joining(", "))
         + "]";
+  }
+
+  @Override
+  protected boolean dontRunCommand() {
+    return dryRun;
+  }
+
+  @Override
+  protected boolean checkExecutionState() {
+    checkArgument(
+        !RegistryToolEnvironment.get().equals(RegistryToolEnvironment.PRODUCTION) || buildEnv,
+        "The --build_environment flag must be used when running in production");
+    return super.checkExecutionState();
   }
 }

--- a/core/src/main/java/google/registry/tools/UpdatePremiumListCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdatePremiumListCommand.java
@@ -18,7 +18,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.util.ListNamingUtils.convertFilePathToName;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.common.base.Strings;
 import google.registry.model.tld.label.PremiumList;
@@ -30,27 +29,11 @@ import java.nio.file.Files;
 @Parameters(separators = " =", commandDescription = "Update a PremiumList in Database.")
 class UpdatePremiumListCommand extends CreateOrUpdatePremiumListCommand {
 
-  @Parameter(
-      names = {"-d", "--dry_run"},
-      description = "Does not execute the entity mutation")
-  boolean dryRun;
-
-  @Parameter(
-      names = {"--build_environment"},
-      description =
-          "DO NOT USE THIS FLAG ON THE COMMAND LINE! This flag indicates the command is being run"
-              + " by the build environment tools. This flag should never be used by a human user"
-              + " from the command line.")
-  boolean buildEnv;
-
   // Indicates if there is a new change made by this command
   private boolean newChange = false;
 
   @Override
   protected String prompt() throws Exception {
-    checkArgument(
-        !RegistryToolEnvironment.get().equals(RegistryToolEnvironment.PRODUCTION) || buildEnv,
-        "The --build_environment flag must be used when running update_premium_list in production");
     name = Strings.isNullOrEmpty(name) ? convertFilePathToName(inputFile) : name;
     PremiumList existingList =
         PremiumListDao.getLatestRevision(name)

--- a/core/src/main/java/google/registry/tools/UpdateReservedListCommand.java
+++ b/core/src/main/java/google/registry/tools/UpdateReservedListCommand.java
@@ -14,12 +14,10 @@
 
 package google.registry.tools;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static google.registry.util.DiffUtils.prettyPrintEntityDeepDiff;
 import static google.registry.util.ListNamingUtils.convertFilePathToName;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.google.common.base.Strings;
 import google.registry.model.tld.label.ReservedList;
@@ -30,28 +28,11 @@ import java.util.List;
 @Parameters(separators = " =", commandDescription = "Update a ReservedList.")
 final class UpdateReservedListCommand extends CreateOrUpdateReservedListCommand {
 
-  @Parameter(
-      names = {"-d", "--dry_run"},
-      description = "Does not execute the entity mutation")
-  boolean dryRun;
-
-  @Parameter(
-      names = {"--build_environment"},
-      description =
-          "DO NOT USE THIS FLAG ON THE COMMAND LINE! This flag indicates the command is being run"
-              + " by the build environment tools. This flag should never be used by a human user"
-              + " from the command line.")
-  boolean buildEnv;
-
   // indicates if there is a new change made by this command
   private boolean newChange = true;
 
   @Override
   protected String prompt() throws Exception {
-    checkArgument(
-        !RegistryToolEnvironment.get().equals(RegistryToolEnvironment.PRODUCTION) || buildEnv,
-        "The --build_environment flag must be used when running update_reserved_list in"
-            + " production");
     name = Strings.isNullOrEmpty(name) ? convertFilePathToName(input) : name;
     ReservedList existingReservedList =
         ReservedList.get(name)

--- a/core/src/test/java/google/registry/tools/CreatePremiumListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreatePremiumListCommandTest.java
@@ -119,4 +119,11 @@ class CreatePremiumListCommandTest<C extends CreatePremiumListCommand>
                     + "yet TLD %s does not exist",
                 fileName));
   }
+
+  @Test
+  void testDryRun_doesNotCreateList() throws Exception {
+    runCommandForced(
+        "--name=" + TLD_TEST, "--input=" + premiumTermsPath, "--currency=USD", "--dry_run");
+    assertThat(PremiumListDao.getLatestRevision(TLD_TEST)).isEmpty();
+  }
 }

--- a/core/src/test/java/google/registry/tools/CreateReservedListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/CreateReservedListCommandTest.java
@@ -180,4 +180,11 @@ class CreateReservedListCommandTest
     command.init();
     assertThat(command.prompt()).contains("reservedListMap=[]");
   }
+
+  @Test
+  void testDryRun_doesNotCreateList() throws Exception {
+    runCommandForced(
+        "--name=xn--q9jyb4c_common-reserved", "--input=" + reservedTermsPath, "--dry_run");
+    assertThat(ReservedList.get("xn--q9jyb4c_common-reserved")).isEmpty();
+  }
 }

--- a/core/src/test/java/google/registry/tools/UpdatePremiumListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdatePremiumListCommandTest.java
@@ -209,9 +209,7 @@ class UpdatePremiumListCommandTest<C extends UpdatePremiumListCommand>
                     "--name=" + TLD_TEST,
                     "--input=" + Paths.get(tmpFile.getPath())));
     assertThat(thrown.getMessage())
-        .isEqualTo(
-            "The --build_environment flag must be used when running update_premium_list in"
-                + " production");
+        .isEqualTo("The --build_environment flag must be used when running in production");
   }
 
   @Test

--- a/core/src/test/java/google/registry/tools/UpdateReservedListCommandTest.java
+++ b/core/src/test/java/google/registry/tools/UpdateReservedListCommandTest.java
@@ -139,9 +139,7 @@ class UpdateReservedListCommandTest
                     "--name=xn--q9jyb4c_common-reserved",
                     "--input=" + reservedTermsPath));
     assertThat(thrown.getMessage())
-        .isEqualTo(
-            "The --build_environment flag must be used when running update_reserved_list in"
-                + " production");
+        .isEqualTo("The --build_environment flag must be used when running in production");
   }
 
   @Test


### PR DESCRIPTION
When checking in a brand new premium list (production/*.txt) or reserved list (reserved/production/*.txt), presubmit testing commands in gradle-runner.sh fall back from update_premium_list / update_reserved_list (which require existing database entities) to create_premium_list / create_reserved_list.

However, because --dry_run (-d) and --build_environment flags were previously only defined in UpdatePremiumListCommand and UpdateReservedListCommand, passing them during non-interactive presubmit creation validation resulted in ParameterException (Was passed main parameter '-d' but no main parameter was defined...) or NullPointerException when ConfirmingCommand attempted to prompt on a null system console.

This change moves --dry_run and --build_environment parameters and dontRunCommand() behavior up into CreateOrUpdatePremiumListCommand and CreateOrUpdateReservedListCommand, enabling safe dry-run presubmit validation for newly created lists in CI environments.

BUG= http://b/534511633, http://b/529397845

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3149)
<!-- Reviewable:end -->
