### PR TITLE
Disallow adding ADMIN contacts via server-side ContactAction

### DIFF
--- a/core/src/main/java/google/registry/ui/server/console/settings/ContactAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/settings/ContactAction.java
@@ -255,9 +255,11 @@ public class ContactAction extends ConsoleApiAction {
         newContactsByType.get(Type.ADMIN).stream()
             .map(RegistrarPoc::getEmailAddress)
             .collect(toImmutableSet());
-    if (!newAdminEmails.containsAll(oldAdminEmails)) {
-      throw new ContactRequirementException(
-          "Cannot remove or change the email address of primary contacts");
+    // ADMIN (primary) PoC emails are used for EPP password resets and potentially other
+    // security-sensitive tasks. A user with only EDIT_REGISTRAR_DETAILS should not be able to
+    // change this.
+    if (!newAdminEmails.equals(oldAdminEmails)) {
+      throw new ContactRequirementException("Cannot alter the set of primary contacts");
     }
   }
 

--- a/core/src/test/java/google/registry/ui/server/console/settings/ContactActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/settings/ContactActionTest.java
@@ -343,10 +343,23 @@ visibleInRdapAsTech=true, visibleInDomainRdapAsAbuse=false}
             testRegistrar.getRegistrarId(),
             adminPoc.asBuilder().setEmailAddress("testemail@example.com").build());
     action.run();
-    FakeResponse fakeResponse = response;
-    assertThat(fakeResponse.getStatus()).isEqualTo(400);
-    assertThat(fakeResponse.getPayload())
-        .isEqualTo("Cannot remove or change the email address of primary contacts");
+    assertThat(response.getStatus()).isEqualTo(SC_BAD_REQUEST);
+    assertThat(response.getPayload()).isEqualTo("Cannot alter the set of primary contacts");
+  }
+
+  @Test
+  void testFailure_addsAdminEmail() throws Exception {
+    RegistrarPoc newAdminPoc =
+        adminPoc
+            .asBuilder()
+            .setName("New Admin Contact")
+            .setEmailAddress("new.admin@example.com")
+            .build();
+    ContactAction action =
+        createAction(Action.Method.POST, fteUser, testRegistrar.getRegistrarId(), newAdminPoc);
+    action.run();
+    assertThat(response.getStatus()).isEqualTo(SC_BAD_REQUEST);
+    assertThat(response.getPayload()).isEqualTo("Cannot alter the set of primary contacts");
   }
 
   private ContactAction createAction(


### PR DESCRIPTION
We already did not allow it through the registrar console web UI, but this prevents it on the server-side action as well, to prevent potential client-side bypasses.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3160)
<!-- Reviewable:end -->
