### PR TITLE
Add arity to registrar_request boolean flags

### DIFF
--- a/core/src/main/java/google/registry/tools/BulkDomainTransferCommand.java
+++ b/core/src/main/java/google/registry/tools/BulkDomainTransferCommand.java
@@ -88,7 +88,8 @@ public class BulkDomainTransferCommand extends ConfirmingCommand implements Comm
 
   @Parameter(
       names = {"--registrar_request"},
-      description = "Whether the change was requested by a registrar.")
+      description = "Whether the change was requested by a registrar.",
+      arity = 1)
   private boolean requestedByRegistrar = false;
 
   @Parameter(

--- a/core/src/main/java/google/registry/tools/DeleteDomainCommand.java
+++ b/core/src/main/java/google/registry/tools/DeleteDomainCommand.java
@@ -52,7 +52,8 @@ final class DeleteDomainCommand extends MutatingEppToolCommand {
 
   @Parameter(
       names = {"--registrar_request"},
-      description = "Whether the change was requested by a registrar.")
+      description = "Whether the change was requested by a registrar.",
+      arity = 1)
   private boolean requestedByRegistrar = false;
 
   @Override

--- a/core/src/test/java/google/registry/tools/BulkDomainTransferCommandTest.java
+++ b/core/src/test/java/google/registry/tools/BulkDomainTransferCommandTest.java
@@ -165,4 +165,32 @@ public class BulkDomainTransferCommandTest extends CommandTestCase<BulkDomainTra
         .isEqualTo(
             "Must specify exactly one input method, either --domains or --domain_names_file");
   }
+
+  @Test
+  void testSuccess_registrarRequestExplicit() throws Exception {
+    runCommandForced(
+        "--gaining_registrar_id",
+        "NewRegistrar",
+        "--losing_registrar_id",
+        "TheRegistrar",
+        "--reason",
+        "someReason",
+        "--domains",
+        "foo.tld,bar.tld",
+        "--registrar_request=false");
+    verify(connection)
+        .sendPostRequest(
+            "/_dr/task/bulkDomainTransfer",
+            ImmutableMap.of(
+                "gainingRegistrarId",
+                "NewRegistrar",
+                "losingRegistrarId",
+                "TheRegistrar",
+                "requestedByRegistrar",
+                false,
+                "reason",
+                "someReason"),
+            MediaType.PLAIN_TEXT_UTF_8,
+            "[\"foo.tld\",\"bar.tld\"]".getBytes(UTF_8));
+  }
 }

--- a/core/src/test/java/google/registry/tools/DeleteDomainCommandTest.java
+++ b/core/src/test/java/google/registry/tools/DeleteDomainCommandTest.java
@@ -53,8 +53,18 @@ class DeleteDomainCommandTest extends EppToolCommandTestCase<DeleteDomainCommand
         "--client=NewRegistrar",
         "--domain_name=example.tld",
         "--reason=Test",
-        "--registrar_request");
+        "--registrar_request=true");
     eppVerifier.verifySent("domain_delete_by_registrar.xml");
+  }
+
+  @Test
+  void testSuccess_requestedByRegistrarExplicitFalse() throws Exception {
+    runCommandForced(
+        "--client=NewRegistrar",
+        "--domain_name=example.tld",
+        "--reason=Test",
+        "--registrar_request=false");
+    eppVerifier.verifySent("domain_delete.xml");
   }
 
   @Test


### PR DESCRIPTION
Define arity 1 on requestedByRegistrar options in BulkDomainTransferCommand and DeleteDomainCommand to accept explicit false arguments without parsing failures. Up-to-date tests verify space-separated and equals argument syntax.

BUG= http://b/537308816

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3168)
<!-- Reviewable:end -->
