### PR TITLE
Fix host_create template in load test

### DIFF
--- a/core/src/main/java/google/registry/loadtest/templates/host_create.xml
+++ b/core/src/main/java/google/registry/loadtest/templates/host_create.xml
@@ -4,7 +4,6 @@
       <host:create
        xmlns:host="urn:ietf:params:xml:ns:host-1.0">
         <host:name>%host%.example.com</host:name>
-        <host:addr ip="v4">8.8.8.8</host:addr>
       </host:create>
     </create>
     <clTRID>trid</clTRID>


### PR DESCRIPTION
The hosts created by load test is intentionally non-subordinate. They must not have IP addresses.

BUG=http://b/533414332

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3172)
<!-- Reviewable:end -->
