### PR TITLE
Don't claim that only one abuse contact is allowed

### DIFF
--- a/core/src/main/java/google/registry/model/registrar/Registrar.java
+++ b/core/src/main/java/google/registry/model/registrar/Registrar.java
@@ -631,7 +631,7 @@ public class Registrar extends UpdateAutoTimestampEntity implements Buildable, J
   }
 
   /**
-   * Returns the {@link RegistrarPoc} that is the RDAP abuse contact for this registrar, or empty if
+   * Returns a {@link RegistrarPoc} that is the RDAP abuse contact for this registrar, or empty if
    * one does not exist.
    */
   public Optional<RegistrarPoc> getRdapAbuseContact() {

--- a/core/src/main/java/google/registry/ui/server/console/settings/ContactAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/settings/ContactAction.java
@@ -228,17 +228,23 @@ public class ContactAction extends ConsoleApiAction {
 
     enforcePrimaryContactRestrictions(oldContactsByType, newContactsByType);
     ensurePhoneNumberNotRemovedForContactTypes(oldContactsByType, newContactsByType, Type.TECH);
-    Optional<RegistrarPoc> domainRdapAbuseContact =
-        getDomainRdapVisibleAbuseContact(updatedContacts);
-    // If the new set has a domain RDAP abuse contact, it must have a phone number.
-    if (domainRdapAbuseContact.isPresent()
-        && domainRdapAbuseContact.get().getPhoneNumber() == null) {
-      throw new ContactRequirementException(
-          "The abuse contact visible in domain RDAP query must have a phone number");
-    }
+
+    ImmutableSet<RegistrarPoc> abusePocs =
+        updatedContacts.stream()
+            .filter(RegistrarPoc::getVisibleInDomainRdapAsAbuse)
+            .collect(toImmutableSet());
+
+    // All abuse POCs must have a phone number attached
+    abusePocs.forEach(
+        poc -> {
+          if (poc.getPhoneNumber() == null) {
+            throw new ContactRequirementException(
+                "The abuse contact visible in domain RDAP query must have a phone number");
+          }
+        });
     // If there was a domain RDAP abuse contact in the old set, the new set must have one.
-    if (getDomainRdapVisibleAbuseContact(existingContacts).isPresent()
-        && domainRdapAbuseContact.isEmpty()) {
+    if (existingContacts.stream().anyMatch(RegistrarPoc::getVisibleInDomainRdapAsAbuse)
+        && abusePocs.isEmpty()) {
       throw new ContactRequirementException(
           "An abuse contact visible in domain RDAP query must be designated");
     }
@@ -259,20 +265,6 @@ public class ContactAction extends ConsoleApiAction {
       throw new ContactRequirementException(
           "Cannot remove or change the email address of primary contacts");
     }
-  }
-
-  /**
-   * Retrieves the registrar contact whose phone number and email address is visible in domain RDAP
-   * query as abuse contact (if any).
-   *
-   * <p>Frontend processing ensures that only one contact can be set as abuse contact in domain RDAP
-   * record.
-   *
-   * <p>Therefore, it is possible to return inside the loop once one such contact is found.
-   */
-  private static Optional<RegistrarPoc> getDomainRdapVisibleAbuseContact(
-      Set<RegistrarPoc> contacts) {
-    return contacts.stream().filter(RegistrarPoc::getVisibleInDomainRdapAsAbuse).findFirst();
   }
 
   /**


### PR DESCRIPTION
nowhere in the RFCs does it say that only one contact is allowed, and indeed there are many situations where it's actually an array of contacts. We have a bunch of registrars that already have multiple abuse contacts. I'm not sure why the comment originally claimed this, but it's from years and years ago.

more details after ben's investigation: 

https://www.icann.org/en/contracted-parties/consensus-policies/registry-registration-data-directory-services-consistent-labeling-and-display-policy/registry-registration-data-directory-services-consistent-labeling-and-display-policy-01-02-2017-en is the ICANN WHOIS data display policy. This basically says that there's precisely one abuse contact per registrar. With the advent of RDAP, this WHOIS restriction is no longer relevant. https://datatracker.ietf.org/doc/rfc9083/ removes these limits and we can include more than one if we wish. 

b/534931561

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3173)
<!-- Reviewable:end -->
