### PR TITLE
Fix GCS gradle hash verification in Cloud Build

### DIFF
--- a/release/cloudbuild-release.yaml
+++ b/release/cloudbuild-release.yaml
@@ -269,7 +269,7 @@ steps:
     if gcloud storage objects describe gs://${gcs_loc}/${gradle_bin}
     then
       local_md5=$(md5sum ${gradle_bin} | awk '{print $1}')
-      remote_md5=$(gcloud storage hash -h gs://${gcs_loc}/${gradle_bin} | grep md5 | awk '{print $3}')
+      remote_md5=$(gcloud storage hash --hex gs://${gcs_loc}/${gradle_bin} | grep md5 | awk '{print $2}')
       if [[ ${local_md5} != ${remote_md5} ]]
       then
         echo "ERROR: MD5 hash mismatch for ${gradle_bin}! Local (official): ${local_md5}, Remote (GCS cache): ${remote_md5}. Aborting build." >&2


### PR DESCRIPTION
gcloud storage changed the "hex" argument to be --hex instead of -h oops

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3174)
<!-- Reviewable:end -->
