### PR TITLE
Fix CSP directive in production

### DIFF
--- a/console-webapp/angular.json
+++ b/console-webapp/angular.json
@@ -61,6 +61,14 @@
                   "with": "src/environments/environment.prod.ts"
                 }
               ],
+              "optimization": {
+                "scripts": true,
+                "styles": {
+                  "minify": true,
+                  "inlineCritical": false
+                },
+                "fonts": true
+              },
               "outputHashing": "all"
             },
             "sandbox": {

--- a/jetty/src/main/jetty-base/webapps/console/WEB-INF/web.xml
+++ b/jetty/src/main/jetty-base/webapps/console/WEB-INF/web.xml
@@ -9,8 +9,8 @@
             <init-param>
                 <param-name>headerConfig</param-name>
                 <param-value>
-                    set Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'self';
-                    set X-Content-Type-Options: nosniff
+                    set Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; object-src 'none'; base-uri 'self';,
+                    set X-Content-Type-Options: nosniff,
                     set X-Frame-Options: DENY
                 </param-value>
             </init-param>


### PR DESCRIPTION
In prod, when loading the console, we were failing to get some
scripts/styles with the error "Executing
  inline event handler violates the following Content Security Policy directive 'script-src
  'self''. Either the 'unsafe-inline' keyword, a hash ('sha256-...'), or a nonce ('nonce-
  ...') is required to enable inline execution. Note that hashes do not apply to event
  handlers, style attributes and javascript: navigations unless the 'unsafe-hashes' keyword
  is present. The action has been blocked."

We fix this by disabling inline-critical optimization for prod in the
angular file.

In addition, the web.xml header values are comma-separated -- we forgot
one comma before.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3176)
<!-- Reviewable:end -->
