### PR TITLE
Enforce OT&E accounts existing in the console gSuite domain

### DIFF
--- a/core/src/main/java/google/registry/ui/server/console/ConsoleOteAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleOteAction.java
@@ -59,28 +59,31 @@ public class ConsoleOteAction extends ConsoleApiAction {
   private static final String STAT_TYPE_DESCRIPTION_PARAM = "description";
   private static final String STAT_TYPE_REQUIREMENT_PARAM = "requirement";
   private static final String STAT_TYPE_TIMES_PERFORMED_PARAM = "timesPerformed";
+  private final IamClient iamClient;
   private final StringGenerator passwordGenerator;
   private final Optional<OteCreateData> oteCreateData;
   private final Optional<String> maybeGroupEmailAddress;
   private final Optional<String> consoleIapServiceId;
-  private final IamClient iamClient;
+  private final String gSuiteDomainName;
   private final String registrarId;
 
   @Inject
   public ConsoleOteAction(
       ConsoleApiParams consoleApiParams,
       IamClient iamClient,
-      @Parameter("registrarId") String registrarId, // Get request param
+      @Named("base58StringGenerator") StringGenerator passwordGenerator,
+      @Parameter("oteCreateData") Optional<OteCreateData> oteCreateData,
       @Config("gSuiteConsoleUserGroupEmailAddress") Optional<String> maybeGroupEmailAddress,
       @Config("consoleIapServiceId") Optional<String> consoleIapServiceId,
-      @Named("base58StringGenerator") StringGenerator passwordGenerator,
-      @Parameter("oteCreateData") Optional<OteCreateData> oteCreateData) {
+      @Config("gSuiteDomainName") String gSuiteDomainName,
+      @Parameter("registrarId") String registrarId) {
     super(consoleApiParams);
+    this.iamClient = iamClient;
     this.passwordGenerator = passwordGenerator;
     this.oteCreateData = oteCreateData;
     this.maybeGroupEmailAddress = maybeGroupEmailAddress;
     this.consoleIapServiceId = consoleIapServiceId;
-    this.iamClient = iamClient;
+    this.gSuiteDomainName = gSuiteDomainName;
     this.registrarId = registrarId;
   }
 
@@ -97,8 +100,11 @@ public class ConsoleOteAction extends ConsoleApiAction {
         this.oteCreateData.isPresent()
             && !this.oteCreateData.get().registrarId.isEmpty()
             && !this.oteCreateData.get().registrarEmail.isEmpty();
-
     checkArgument(isBodyValid, "OT&E create body is invalid");
+    checkArgument(
+        this.oteCreateData.get().registrarEmail.endsWith("@" + gSuiteDomainName),
+        "Email address must exist in the %s domain",
+        gSuiteDomainName);
 
     String password = passwordGenerator.createString(PASSWORD_LENGTH);
 

--- a/core/src/test/java/google/registry/ui/server/console/ConsoleOteActionTest.java
+++ b/core/src/test/java/google/registry/ui/server/console/ConsoleOteActionTest.java
@@ -203,6 +203,24 @@ class ConsoleOteActionTest extends ConsoleActionBaseTestCase {
             ImmutableList.of("domain creates idn", "domain restores", "host deletes"));
   }
 
+  @Test
+  void testFailure_invalidEmailDomain() {
+    AuthResult authResult = AuthResult.createUser(fteUser);
+    consoleApiParams = ConsoleApiParamsUtils.createFake(authResult);
+    ConsoleOteAction action =
+        createAction(
+            Action.Method.POST,
+            authResult,
+            "theregistrar",
+            Optional.of("someRandomString@email.test"),
+            Optional.of(new OteCreateData("theregistrar", "contact@invalid.com")));
+    action.cloudTasksUtils = cloudTasksHelper.getTestCloudTasksUtils();
+    action.run();
+    assertThat(response.getStatus()).isEqualTo(SC_BAD_REQUEST);
+    assertThat(response.getPayload())
+        .isEqualTo("Email address must exist in the registry.example domain");
+  }
+
   private ConsoleOteAction createAction(
       Action.Method method,
       AuthResult authResult,
@@ -215,10 +233,11 @@ class ConsoleOteActionTest extends ConsoleActionBaseTestCase {
     return new ConsoleOteAction(
         consoleApiParams,
         iamClient,
-        registrarId,
+        passwordGenerator,
+        oteCreateData,
         maybeGroupEmailAddress,
         Optional.of("consoleIapServiceId"),
-        passwordGenerator,
-        oteCreateData);
+        "registry.example",
+        registrarId);
   }
 }


### PR DESCRIPTION
This is non-production so it's not a huge deal but in general, we should restrict the OT&E users so that they only exist within the workspace that we control. Other users that are created using the console already follow this format.

b/534932209 for more info

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3178)
<!-- Reviewable:end -->
