### PR TITLE
Use native query for registrar-users console user query

### DIFF
--- a/core/src/main/java/google/registry/ui/server/console/ConsoleUsersAction.java
+++ b/core/src/main/java/google/registry/ui/server/console/ConsoleUsersAction.java
@@ -15,7 +15,6 @@
 package google.registry.ui.server.console;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.google.common.collect.ImmutableList.toImmutableList;
 import static google.registry.model.console.RegistrarRole.ACCOUNT_MANAGER;
 import static google.registry.model.console.RegistrarRole.TECH_CONTACT;
 import static google.registry.persistence.transaction.TransactionManagerFactory.tm;
@@ -357,12 +356,17 @@ public class ConsoleUsersAction extends ConsoleApiAction {
     return updatedUser;
   }
 
+  @SuppressWarnings("unchecked")
   private ImmutableList<User> getAllRegistrarUsers(String registrarId) {
     return tm().transact(
             () ->
-                tm().loadAllOf(User.class).stream()
-                    .filter(u -> u.getUserRoles().getRegistrarRoles().containsKey(registrarId))
-                    .collect(toImmutableList()));
+                ImmutableList.copyOf(
+                    tm().getEntityManager()
+                        .createNativeQuery(
+                            "SELECT * FROM \"User\" WHERE exist(registrar_roles, :registrarId)",
+                            User.class)
+                        .setParameter("registrarId", registrarId)
+                        .getResultList()));
   }
 
   /** Maps a request role string to a RegistrarRole, using ACCOUNT_MANAGER as the default. */


### PR DESCRIPTION
This means we don't have to load all users and filter them out later. In practice this doesn't matter because the user table is relatively small (a few hundred) but 1. who knows what can happen in the future? 2. this makes the code analysis tools happier

we can get rid of the suppression once we're on jpa 4.0+ and hibernate 8.x+ and the API becomes nicer

we have to use the native query because Hibernate treats hstore as a mystery type and can't "see" inside it

if we had many many more users we could add a GIN index on the hstore column but with a table of this size, that's more trouble than it's worth. 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3182)
<!-- Reviewable:end -->
