### PR TITLE
Change syncRemoteTask scheduled task to be a POST

### DIFF
--- a/core/src/main/java/google/registry/config/files/tasks/cloud-scheduler-tasks-production.xml
+++ b/core/src/main/java/google/registry/config/files/tasks/cloud-scheduler-tasks-production.xml
@@ -326,6 +326,7 @@
   <task>
     <url><![CDATA[/_dr/task/syncRemoteCache]]></url>
     <name>syncRemoteCache</name>
+    <method>POST</method>
     <description>
       Syncs remote (Valkey/Redis) EPP resource caches with changes made recently.
     </description>

--- a/release/builder/deployCloudSchedulerAndQueue.go
+++ b/release/builder/deployCloudSchedulerAndQueue.go
@@ -71,6 +71,7 @@ type Task struct {
 	Timeout     string `xml:"timeout"`
 	Schedule    string `xml:"schedule"`
 	Name        string `xml:"name"`
+	Method      string `xml:"method"`
 }
 
 type QueuesSyncManager struct {
@@ -191,6 +192,11 @@ func (manager TasksSyncManager) getArgs(task Task, operationType string) []strin
 	var uri string
 	uri = fmt.Sprintf("https://%s.%s%s", service, baseDomain, strings.TrimSpace(task.URL))
 
+	method := "get"
+	if task.Method != "" {
+		method = strings.ToLower(task.Method)
+	}
+
 	args := []string{
 		"--project", projectName,
 		"scheduler", "jobs", operationType,
@@ -199,7 +205,7 @@ func (manager TasksSyncManager) getArgs(task Task, operationType string) []strin
 		"--schedule", task.Schedule,
 		"--uri", uri,
 		"--description", description,
-		"--http-method", "get",
+		"--http-method", method,
 		"--oidc-service-account-email", getCloudSchedulerServiceAccountEmail(),
 		"--oidc-token-audience", clientId,
 	}


### PR DESCRIPTION
Turns out before we were using GET for everything. The action is, and should remain, a POST on the back end so let's call that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3185)
<!-- Reviewable:end -->
