### PR TITLE
Fix image replacement in Cloud Deploy pipeline

### DIFF
--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -200,7 +200,7 @@ steps:
       --delivery-pipeline="$pipeline" \
       --region="$region" \
       --project=${PROJECT_ID} \
-      --images="nomulus=gcr.io/${PROJECT_ID}/nomulus@${nomulus_digest}" \
+      --images="gcr.io/${PROJECT_ID}/nomulus=gcr.io/${PROJECT_ID}/nomulus@${nomulus_digest}" \
       --source=. \
       --skaffold-file=release/clouddeploy/skaffold.yaml \
       --deploy-parameters="deployed_image=gcr.io/${PROJECT_ID}/nomulus@${nomulus_digest},base_image=us-docker.pkg.dev/${PROJECT_ID}/gcr.io/nomulus"

--- a/release/clouddeploy/crash-target.yaml
+++ b/release/clouddeploy/crash-target.yaml
@@ -6,6 +6,7 @@ metadata:
 requireApproval: true
 executionConfigs:
 - usages:
+  - PREDEPLOY
   - RENDER
   - ANALYSIS
   - POSTDEPLOY

--- a/release/clouddeploy/sandbox-target.yaml
+++ b/release/clouddeploy/sandbox-target.yaml
@@ -5,6 +5,7 @@ metadata:
 requireApproval: true
 executionConfigs:
 - usages:
+  - PREDEPLOY
   - RENDER
   - ANALYSIS
   - POSTDEPLOY


### PR DESCRIPTION
This correctly maps how the nomulus images are rendered in the manifests so they can be replaced with the appropiate image + hash values.

Also, adds a PREDEPLOY step so we can execute the SQL verification task.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3186)
<!-- Reviewable:end -->
