### PR TITLE
Add pre and post deploy steps to Cloud Deploy delivery pipeline

### DIFF
--- a/release/cloudbuild-clouddeploy.yaml
+++ b/release/cloudbuild-clouddeploy.yaml
@@ -84,6 +84,7 @@ steps:
           
           sed -i "s|artifactStorage: artifactStorage|artifactStorage: $artifact_storage|" "$target_file"
           sed -i "s|serviceAccount: serviceAccount|serviceAccount: $service_account|" "$target_file"
+          sed -i "s|serviceAccount: serviceAccount|serviceAccount: $service_account|" release/clouddeploy/delivery-pipeline.yaml
           sed -i "s|cluster: cluster|cluster: $cluster_val|" "$target_file"
           sed -i "s|workerPool: workerPool|workerPool: $worker_pool|" "$target_file"
         fi

--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -204,6 +204,7 @@ steps:
       --source=. \
       --skaffold-file=release/clouddeploy/skaffold.yaml \
       --deploy-parameters="deployed_image=gcr.io/${PROJECT_ID}/nomulus@${nomulus_digest},base_image=us-docker.pkg.dev/${PROJECT_ID}/gcr.io/nomulus"
+
 # The tarballs and jars to upload to GCS.
 artifacts:
   objects:

--- a/release/cloudbuild-nomulus.yaml
+++ b/release/cloudbuild-nomulus.yaml
@@ -203,8 +203,7 @@ steps:
       --images="gcr.io/${PROJECT_ID}/nomulus=gcr.io/${PROJECT_ID}/nomulus@${nomulus_digest}" \
       --source=. \
       --skaffold-file=release/clouddeploy/skaffold.yaml \
-      --deploy-parameters="deployed_image=gcr.io/${PROJECT_ID}/nomulus@${nomulus_digest},base_image=us-docker.pkg.dev/${PROJECT_ID}/gcr.io/nomulus"
-
+      --deploy-parameters="deployed_image=gcr.io/${PROJECT_ID}/nomulus@${nomulus_digest},base_image=us-docker.pkg.dev/${PROJECT_ID}/gcr.io/nomulus,tag_name=${TAG_NAME},project_id=${PROJECT_ID}"
 # The tarballs and jars to upload to GCS.
 artifacts:
   objects:

--- a/release/cloudbuild-release.yaml
+++ b/release/cloudbuild-release.yaml
@@ -236,11 +236,17 @@ steps:
         # partial phase manifests
         for stage in 1 5
         do
+          if [ ${service} == backend ] || [ ${service} == console ]
+          then
+            replicas=1
+          else
+            replicas=${stage}
+          fi
           awk 'NR==1,/^---$/ {if ($0 != "---") print}' ./jetty/kubernetes/nomulus-${env}-${service}.yaml | \
             sed s/name:\ ${service}/name:\ ${service}-partial-phase/g | \
             sed s/service:\ ${service}/deployment:\ ${service}-partial-phase/g | \
             sed s/value:\ ${service}/value:\ ${service}-partial-phase/g | \
-            sed "/^spec:$/a\  replicas: ${stage}" \
+            sed "/^spec:$/a\  replicas: ${replicas}" \
             > ./jetty/kubernetes/nomulus-${env}-${service}-partial-phase-${stage}.yaml
         done
         # gateway

--- a/release/cloudbuild-release.yaml
+++ b/release/cloudbuild-release.yaml
@@ -292,27 +292,6 @@ steps:
     if [[ "${TAG_NAME}" =~ ^nomulus-20[0-9]{2}[0-1][0-9][0-3][0-9]-RC[0-9]{2}$ ]]; then
       echo "Tag format matches a nomulus release. Triggering nomulus build..."
       gcloud builds submit . --config=release/cloudbuild-nomulus.yaml --substitutions=TAG_NAME=$TAG_NAME
-      echo "============================================="
-      echo "Triggering Google Cloud Deploy Release"
-      echo "============================================="
-      echo "Tag Name: ${TAG_NAME}"
-      echo "Project ID: ${PROJECT_ID}"
-      pipeline="deploy-nomulus"
-      region="us-central1"
-      # Release names must consist of lowercase letters, numbers, and hyphens.
-      release_name=$(echo "${TAG_NAME}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
-      echo "Release Name: $release_name"
-      echo "============================================="
-      nomulus_digest=$(gcloud container images list-tags gcr.io/${PROJECT_ID}/nomulus \
-        --format="get(digest)" --filter="tags = ${TAG_NAME}")
-      gcloud deploy releases create "$release_name" \
-        --delivery-pipeline="$pipeline" \
-        --region="$region" \
-        --project=${PROJECT_ID} \
-        --images="gcr.io/${PROJECT_ID}/nomulus=gcr.io/${PROJECT_ID}/nomulus@${nomulus_digest}" \
-        --source=. \
-        --skaffold-file=release/clouddeploy/skaffold.yaml \
-        --deploy-parameters="deployed_image=gcr.io/${PROJECT_ID}/nomulus@${nomulus_digest},base_image=us-docker.pkg.dev/${PROJECT_ID}/gcr.io/nomulus"
     # Check for a proxy release tag (e.g., "proxy-v1.2.3")
     elif [[ "${TAG_NAME}" =~ ^proxy-20[0-9]{2}[0-1][0-9][0-3][0-9]-RC[0-9]{2}$ ]]; then
       echo "Tag format matches a proxy release. Triggering proxy build..."

--- a/release/cloudbuild-release.yaml
+++ b/release/cloudbuild-release.yaml
@@ -292,6 +292,27 @@ steps:
     if [[ "${TAG_NAME}" =~ ^nomulus-20[0-9]{2}[0-1][0-9][0-3][0-9]-RC[0-9]{2}$ ]]; then
       echo "Tag format matches a nomulus release. Triggering nomulus build..."
       gcloud builds submit . --config=release/cloudbuild-nomulus.yaml --substitutions=TAG_NAME=$TAG_NAME
+      echo "============================================="
+      echo "Triggering Google Cloud Deploy Release"
+      echo "============================================="
+      echo "Tag Name: ${TAG_NAME}"
+      echo "Project ID: ${PROJECT_ID}"
+      pipeline="deploy-nomulus"
+      region="us-central1"
+      # Release names must consist of lowercase letters, numbers, and hyphens.
+      release_name=$(echo "${TAG_NAME}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+      echo "Release Name: $release_name"
+      echo "============================================="
+      nomulus_digest=$(gcloud container images list-tags gcr.io/${PROJECT_ID}/nomulus \
+        --format="get(digest)" --filter="tags = ${TAG_NAME}")
+      gcloud deploy releases create "$release_name" \
+        --delivery-pipeline="$pipeline" \
+        --region="$region" \
+        --project=${PROJECT_ID} \
+        --images="gcr.io/${PROJECT_ID}/nomulus=gcr.io/${PROJECT_ID}/nomulus@${nomulus_digest}" \
+        --source=. \
+        --skaffold-file=release/clouddeploy/skaffold.yaml \
+        --deploy-parameters="deployed_image=gcr.io/${PROJECT_ID}/nomulus@${nomulus_digest},base_image=us-docker.pkg.dev/${PROJECT_ID}/gcr.io/nomulus"
     # Check for a proxy release tag (e.g., "proxy-v1.2.3")
     elif [[ "${TAG_NAME}" =~ ^proxy-20[0-9]{2}[0-1][0-9][0-3][0-9]-RC[0-9]{2}$ ]]; then
       echo "Tag format matches a proxy release. Triggering proxy build..."

--- a/release/clouddeploy/README.md
+++ b/release/clouddeploy/README.md
@@ -5,7 +5,7 @@ This directory contains the Google Cloud Deploy configuration files for the Nomu
 ## Files
 
 ### `delivery-pipeline.yaml`
-Defines the `DeliveryPipeline` resource named `deploy-nomulus`. It sets up the serial pipeline for rolling out changes to different targets.
+Defines the `DeliveryPipeline` resource named `deploy-nomulus` and its associated `Automation` resource (`deploy-nomulus/auto-advance-canary`). It sets up the serial pipeline for rolling out changes to different targets and automatically advancing canary rollouts.
 
 ### Target Configurations (e.g., `crash-target.yaml`)
 Files matching this format define the `Target` resources for Cloud Deploy. They specify the GKE cluster and other environment-specific settings for deployment.

--- a/release/clouddeploy/delivery-pipeline.yaml
+++ b/release/clouddeploy/delivery-pipeline.yaml
@@ -27,7 +27,7 @@ serialPipeline:
                 - "-c"
                 - |
                   gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/cloudbuild-schema-verify-${TARGET_ID}.yaml .
-                  gcloud builds submit --config=cloudbuild-schema-verify-${TARGET_ID}.yaml
+                  gcloud builds submit --no-source --config=cloudbuild-schema-verify-${TARGET_ID}.yaml
             analysis:
               # 10 minutes.
               duration: 600s
@@ -71,7 +71,7 @@ serialPipeline:
                 - "-c"
                 - |
                   gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/cloudbuild-schema-deploy-${TARGET_ID}.yaml .
-                  gcloud builds submit --config=cloudbuild-schema-deploy-${TARGET_ID}.yaml
+                  gcloud builds submit --no-source --config=cloudbuild-schema-deploy-${TARGET_ID}.yaml
             analysis:
               # 10 minutes.
               duration: 600s
@@ -99,7 +99,7 @@ serialPipeline:
                 - "-c"
                 - |
                   gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/cloudbuild-schema-verify-${TARGET_ID}.yaml .
-                  gcloud builds submit --config=cloudbuild-schema-verify-${TARGET_ID}.yaml
+                  gcloud builds submit --no-source --config=cloudbuild-schema-verify-${TARGET_ID}.yaml
             analysis:
               # 10 minutes.
               duration: 600s
@@ -143,7 +143,7 @@ serialPipeline:
                 - "-c"
                 - |
                   gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/cloudbuild-schema-deploy-${TARGET_ID}.yaml .
-                  gcloud builds submit --config=cloudbuild-schema-deploy-${TARGET_ID}.yaml
+                  gcloud builds submit --no-source --config=cloudbuild-schema-deploy-${TARGET_ID}.yaml
             analysis:
               # 10 minutes.
               duration: 600s

--- a/release/clouddeploy/delivery-pipeline.yaml
+++ b/release/clouddeploy/delivery-pipeline.yaml
@@ -20,11 +20,14 @@ serialPipeline:
                 image: gcr.io/google.com/cloudsdktool/google-cloud-cli:stable
                 env:
                   TARGET_ID: ${{ target.id }}
+                  TAG_NAME: ${{ deploy_params['tag_name'] }}
+                  PROJECT_ID: ${{ deploy_params['project_id'] }}
                 command: ["/bin/bash"]
                 args:
                 - "-c"
                 - |
-                  gcloud builds submit --config=release/cloudbuild-schema-verify-${TARGET_ID}.yaml
+                  gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/release/cloudbuild-schema-verify-${TARGET_ID}.yaml .
+                  gcloud builds submit --config=cloudbuild-schema-verify-${TARGET_ID}.yaml
             analysis:
               # 10 minutes.
               duration: 600s
@@ -61,11 +64,14 @@ serialPipeline:
                 image: gcr.io/google.com/cloudsdktool/google-cloud-cli:stable
                 env:
                   TARGET_ID: ${{ target.id }}
+                  TAG_NAME: ${{ deploy_params['tag_name'] }}
+                  PROJECT_ID: ${{ deploy_params['project_id'] }}
                 command: ["/bin/bash"]
                 args:
                 - "-c"
                 - |
-                  gcloud builds submit --config=release/cloudbuild-schema-deploy-${TARGET_ID}.yaml
+                  gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/release/cloudbuild-schema-deploy-${TARGET_ID}.yaml .
+                  gcloud builds submit --config=cloudbuild-schema-deploy-${TARGET_ID}.yaml
             analysis:
               # 10 minutes.
               duration: 600s
@@ -86,11 +92,14 @@ serialPipeline:
                 image: gcr.io/google.com/cloudsdktool/google-cloud-cli:stable
                 env:
                   TARGET_ID: ${{ target.id }}
+                  TAG_NAME: ${{ deploy_params['tag_name'] }}
+                  PROJECT_ID: ${{ deploy_params['project_id'] }}
                 command: ["/bin/bash"]
                 args:
                 - "-c"
                 - |
-                  gcloud builds submit --config=release/cloudbuild-schema-verify-${TARGET_ID}.yaml
+                  gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/release/cloudbuild-schema-verify-${TARGET_ID}.yaml .
+                  gcloud builds submit --config=cloudbuild-schema-verify-${TARGET_ID}.yaml
             analysis:
               # 10 minutes.
               duration: 600s
@@ -127,11 +136,14 @@ serialPipeline:
                 image: gcr.io/google.com/cloudsdktool/google-cloud-cli:stable
                 env:
                   TARGET_ID: ${{ target.id }}
+                  TAG_NAME: ${{ deploy_params['tag_name'] }}
+                  PROJECT_ID: ${{ deploy_params['project_id'] }}
                 command: ["/bin/bash"]
                 args:
                 - "-c"
                 - |
-                  gcloud builds submit --config=release/cloudbuild-schema-deploy-${TARGET_ID}.yaml
+                  gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/release/cloudbuild-schema-deploy-${TARGET_ID}.yaml .
+                  gcloud builds submit --config=cloudbuild-schema-deploy-${TARGET_ID}.yaml
             analysis:
               # 10 minutes.
               duration: 600s

--- a/release/clouddeploy/delivery-pipeline.yaml
+++ b/release/clouddeploy/delivery-pipeline.yaml
@@ -26,7 +26,7 @@ serialPipeline:
                 args:
                 - "-c"
                 - |
-                  gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/release/cloudbuild-schema-verify-${TARGET_ID}.yaml .
+                  gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/cloudbuild-schema-verify-${TARGET_ID}.yaml .
                   gcloud builds submit --config=cloudbuild-schema-verify-${TARGET_ID}.yaml
             analysis:
               # 10 minutes.
@@ -70,7 +70,7 @@ serialPipeline:
                 args:
                 - "-c"
                 - |
-                  gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/release/cloudbuild-schema-deploy-${TARGET_ID}.yaml .
+                  gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/cloudbuild-schema-deploy-${TARGET_ID}.yaml .
                   gcloud builds submit --config=cloudbuild-schema-deploy-${TARGET_ID}.yaml
             analysis:
               # 10 minutes.
@@ -98,7 +98,7 @@ serialPipeline:
                 args:
                 - "-c"
                 - |
-                  gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/release/cloudbuild-schema-verify-${TARGET_ID}.yaml .
+                  gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/cloudbuild-schema-verify-${TARGET_ID}.yaml .
                   gcloud builds submit --config=cloudbuild-schema-verify-${TARGET_ID}.yaml
             analysis:
               # 10 minutes.
@@ -142,7 +142,7 @@ serialPipeline:
                 args:
                 - "-c"
                 - |
-                  gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/release/cloudbuild-schema-deploy-${TARGET_ID}.yaml .
+                  gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/cloudbuild-schema-deploy-${TARGET_ID}.yaml .
                   gcloud builds submit --config=cloudbuild-schema-deploy-${TARGET_ID}.yaml
             analysis:
               # 10 minutes.

--- a/release/clouddeploy/delivery-pipeline.yaml
+++ b/release/clouddeploy/delivery-pipeline.yaml
@@ -14,20 +14,6 @@ serialPipeline:
           - phaseId: "canary-1"
             profiles: ["crash-partial-phase-1"]
             percentage: 10
-            predeploy:
-              tasks:
-              - type: container
-                image: gcr.io/google.com/cloudsdktool/google-cloud-cli:stable
-                env:
-                  TARGET_ID: ${{ target.id }}
-                  TAG_NAME: ${{ deploy_params['tag_name'] }}
-                  PROJECT_ID: ${{ deploy_params['project_id'] }}
-                command: ["/bin/bash"]
-                args:
-                - "-c"
-                - |
-                  gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/cloudbuild-schema-verify-${TARGET_ID}.yaml .
-                  gcloud builds submit --no-source --config=cloudbuild-schema-verify-${TARGET_ID}.yaml
             analysis:
               # 10 minutes.
               duration: 600s
@@ -58,8 +44,8 @@ serialPipeline:
                 args:
                 - "-c"
                 - |
-                  gcloud artifacts docker tags add $DEPLOYED_IMAGE \
-                    ${BASE_IMAGE}:live-cd-${TARGET_ID}
+                  gcloud container images add-tag $DEPLOYED_IMAGE \
+                    ${BASE_IMAGE}:live-cd-${TARGET_ID} --quiet
               - type: container
                 image: gcr.io/google.com/cloudsdktool/google-cloud-cli:stable
                 env:
@@ -130,8 +116,8 @@ serialPipeline:
                 args:
                 - "-c"
                 - |
-                  gcloud artifacts docker tags add $DEPLOYED_IMAGE \
-                    ${BASE_IMAGE}:live-cd-${TARGET_ID}
+                  gcloud container images add-tag $DEPLOYED_IMAGE \
+                    ${BASE_IMAGE}:live-cd-${TARGET_ID} --quiet
               - type: container
                 image: gcr.io/google.com/cloudsdktool/google-cloud-cli:stable
                 env:
@@ -150,3 +136,19 @@ serialPipeline:
               googleCloud:
                 alertPolicyChecks:
                     sandboxStableDeploymentAlertPolicyChecks
+---
+apiVersion: deploy.cloud.google.com/v1
+kind: Automation
+metadata:
+  name: auto-advance-canary
+description: Automatically advances rollouts through canary-1 phase after successful deployment and analysis.
+selector:
+  targets:
+  - id: crash
+  - id: sandbox
+rules:
+- advanceRolloutRule:
+    id: advance-canary-phases
+    sourcePhases:
+    - "canary-1"
+    wait: 0s

--- a/release/clouddeploy/delivery-pipeline.yaml
+++ b/release/clouddeploy/delivery-pipeline.yaml
@@ -140,8 +140,10 @@ serialPipeline:
 apiVersion: deploy.cloud.google.com/v1
 kind: Automation
 metadata:
-  name: auto-advance-canary
+  name: deploy-nomulus/auto-advance-canary
 description: Automatically advances rollouts through canary-1 phase after successful deployment and analysis.
+# Placeholder: Replace with project service account.
+serviceAccount: serviceAccount
 selector:
   targets:
   - id: crash
@@ -151,4 +153,5 @@ rules:
     id: advance-canary-phases
     sourcePhases:
     - "canary-1"
-    wait: 0s
+    wait: 0m
+


### PR DESCRIPTION
This also introduces some QoL changes to the pipeline: 

- It fixes the image tagging step and adds an automation rule so the canary steps don't need manual approval. 
- The verify schema step in crash is skipped, since the db in this env can be manually modified to test local changes.
- It sets the number of replicas in partial deployments of backend and console = 1, otherwise they would be bigger than the stable deployments.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3187)
<!-- Reviewable:end -->
