### PR TITLE
Tighten control on Marksdb URL hostname

### DIFF
--- a/core/src/main/java/google/registry/tmch/NordnVerifyAction.java
+++ b/core/src/main/java/google/registry/tmch/NordnVerifyAction.java
@@ -64,7 +64,7 @@ public final class NordnVerifyAction implements Runnable {
   static final String NORDN_URL_PARAM = "nordnUrl";
   static final String NORDN_LOG_ID_PARAM = "nordnLogId";
 
-  private static final String MARKSDB_URL_BEGINNING = "ry.marksdb.org";
+  private static final String MARKSDB_HOST_NAME = "ry.marksdb.org";
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
@@ -109,11 +109,7 @@ public final class NordnVerifyAction implements Runnable {
   @VisibleForTesting
   LordnLog verify() throws IOException, GeneralSecurityException {
     String host = Ascii.toLowerCase(url.getHost());
-    checkArgument(
-        host.startsWith(MARKSDB_URL_BEGINNING),
-        "URL %s must start with %s",
-        url,
-        MARKSDB_URL_BEGINNING);
+    checkArgument(host.equals(MARKSDB_HOST_NAME), "Host %s must equal %s", host, MARKSDB_HOST_NAME);
     logger.atInfo().log("LORDN verify task %s: Sending request to URL %s", actionLogId, url);
     HttpURLConnection connection = urlConnectionService.createConnection(url);
     lordnRequestInitializer.initialize(connection, tld);

--- a/core/src/test/java/google/registry/tmch/NordnVerifyActionTest.java
+++ b/core/src/test/java/google/registry/tmch/NordnVerifyActionTest.java
@@ -170,9 +170,7 @@ class NordnVerifyActionTest {
   void testFailure_badUrl() throws Exception {
     action.url = URI.create("http://example.com/blobio").toURL();
     IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, action::run);
-    assertThat(thrown)
-        .hasMessageThat()
-        .isEqualTo("URL http://example.com/blobio must start with ry.marksdb.org");
+    assertThat(thrown).hasMessageThat().isEqualTo("Host example.com must equal ry.marksdb.org");
   }
 
   @Test


### PR DESCRIPTION
this doesn't really matter but eh, a URL shouldn't be able to be like, ry.marksdb.org.attacker.com

b/535251045

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3198)
<!-- Reviewable:end -->
