### PR TITLE
Limit proxy protocol header to 256 bytes

### DIFF
--- a/core/src/main/java/google/registry/eppserver/handler/EppProxyProtocolHandler.java
+++ b/core/src/main/java/google/registry/eppserver/handler/EppProxyProtocolHandler.java
@@ -22,6 +22,7 @@ import com.google.common.net.InetAddresses;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
+import io.netty.handler.codec.TooLongFrameException;
 import io.netty.util.AttributeKey;
 import jakarta.inject.Inject;
 import java.net.InetSocketAddress;
@@ -62,6 +63,8 @@ public class EppProxyProtocolHandler extends ByteToMessageDecoder {
   // The proxy header must start with this prefix.
   // Sample header: "PROXY TCP4 255.255.255.255 255.255.255.255 65535 65535\r\n".
   private static final byte[] HEADER_PREFIX = "PROXY".getBytes(US_ASCII);
+
+  private static final int MAX_HEADER_LENGTH = 256;
 
   private boolean finished = false;
   private String proxyHeader = null;
@@ -144,38 +147,49 @@ public class EppProxyProtocolHandler extends ByteToMessageDecoder {
   @Override
   protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
     // Wait until there are more bytes available than the header's length before processing.
-    if (in.readableBytes() >= HEADER_PREFIX.length) {
-      if (containsHeader(in)) {
-        // The inbound message contains the header, it must be a proxied connection. Note that
-        // currently proxied connection is only used for EPP protocol, which requires the connection
-        // to be SSL enabled. So the beginning of the inbound message upon connection can only be
-        // either the proxy header (when proxied), or SSL handshake request (when not proxied),
-        // which does not start with "PROXY". Therefore it is safe to assume that if the beginning
-        // of the message contains "PROXY", it must be proxied, and must contain \r\n.
-        int eol = findEndOfLine(in);
-        // If eol is not found, that is because that we do not yet have enough inbound message, do
-        // nothing and wait for more bytes to be readable. eol will  eventually be positive because
-        // of the reasoning above: The connection starts with "PROXY", so it must be a proxied
-        // connection and contain \r\n.
-        if (eol >= 0) {
-          // ByteBuf.readBytes is called so that the header is processed and not passed to handlers
-          // further in the pipeline.
-          byte[] headerBytes = new byte[eol];
-          in.readBytes(headerBytes);
-          proxyHeader = new String(headerBytes, US_ASCII);
-          // Skip \r\n.
-          in.skipBytes(2);
-          // Proxy header processed, mark finished so that this handler is removed.
-          finished = true;
-        }
-      } else {
-        // The inbound message does not contain a proxy header, mark finished so that this handler
-        // is removed. Note that no inbound bytes are actually processed by this handler because we
-        // did not call ByteBuf.readBytes(), but ByteBuf.getByte(), which does not change reader
-        // index of the ByteBuf. So any inbound byte is then passed to the next handler to process.
-        finished = true;
-      }
+    if (in.readableBytes() < HEADER_PREFIX.length) {
+      return;
     }
+    if (!containsHeader(in)) {
+      // The inbound message does not contain a proxy header, mark finished so that this handler
+      // is removed. Note that no inbound bytes are actually processed by this handler because we
+      // did not call ByteBuf.readBytes(), but ByteBuf.getByte(), which does not change reader
+      // index of the ByteBuf. So any inbound byte is then passed to the next handler to process.
+      finished = true;
+      return;
+    }
+    // The inbound message contains the header, it must be a proxied connection. Note that
+    // currently proxied connection is only used for EPP protocol, which requires the connection
+    // to be SSL enabled. So the beginning of the inbound message upon connection can only be
+    // either the proxy header (when proxied), or SSL handshake request (when not proxied),
+    // which does not start with "PROXY". Therefore it is safe to assume that if the beginning
+    // of the message contains "PROXY", it must be proxied, and must contain \r\n.
+    int eol = findEndOfLine(in);
+    // If eol is not found, that is because that we do not yet have enough inbound message, do
+    // nothing and wait for more bytes to be readable. eol will  eventually be positive because
+    // of the reasoning above: The connection starts with "PROXY", so it must be a proxied
+    // connection and contain \r\n.
+    if (eol < 0) {
+      if (in.readableBytes() > MAX_HEADER_LENGTH) {
+        throw new TooLongFrameException(
+            String.format(
+                "PROXY header exceeded max length of %d bytes without CRLF", MAX_HEADER_LENGTH));
+      }
+      return;
+    }
+    if (eol > MAX_HEADER_LENGTH) {
+      throw new TooLongFrameException(
+          String.format("PROXY header length %d exceeds max %d", eol, MAX_HEADER_LENGTH));
+    }
+    // ByteBuf.readBytes is called so that the header is processed and not passed to handlers
+    // further in the pipeline.
+    byte[] headerBytes = new byte[eol];
+    in.readBytes(headerBytes);
+    proxyHeader = new String(headerBytes, US_ASCII);
+    // Skip \r\n.
+    in.skipBytes(2);
+    // Proxy header processed, mark finished so that this handler is removed.
+    finished = true;
   }
 
   /**

--- a/core/src/test/java/google/registry/eppserver/handler/EppProxyProtocolHandlerTest.java
+++ b/core/src/test/java/google/registry/eppserver/handler/EppProxyProtocolHandlerTest.java
@@ -15,10 +15,12 @@
 package google.registry.eppserver.handler;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.TooLongFrameException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -97,5 +99,33 @@ class EppProxyProtocolHandlerTest {
 
     ByteBuf passedOn = channel.readInbound();
     assertThat(passedOn.toString(StandardCharsets.US_ASCII)).isEqualTo("NOT_A_PROXY_HEADER");
+  }
+
+  @Test
+  void testProxyProtocol_headerExceedsMaxLength_throwsException() {
+    EppProxyProtocolHandler handler = new EppProxyProtocolHandler();
+    EmbeddedChannel channel = new EmbeddedChannel(handler);
+
+    // Create an oversized header prefix (>256 bytes) without a \r\n terminator
+    String oversizedHeader = "PROXY TCP4 " + "A".repeat(300);
+    ByteBuf buffer = Unpooled.wrappedBuffer(oversizedHeader.getBytes(StandardCharsets.US_ASCII));
+
+    assertThat(assertThrows(TooLongFrameException.class, () -> channel.writeInbound(buffer)))
+        .hasMessageThat()
+        .isEqualTo("PROXY header exceeded max length of 256 bytes without CRLF");
+  }
+
+  @Test
+  void testProxyProtocol_headerExceedsMaxLength_evenWithNewline_throwsException() {
+    EppProxyProtocolHandler handler = new EppProxyProtocolHandler();
+    EmbeddedChannel channel = new EmbeddedChannel(handler);
+
+    // Create an oversized header prefix with a \r\n terminator
+    String oversizedHeader = "PROXY TCP4 " + "A".repeat(300) + "\r\n";
+    ByteBuf buffer = Unpooled.wrappedBuffer(oversizedHeader.getBytes(StandardCharsets.US_ASCII));
+
+    assertThat(assertThrows(TooLongFrameException.class, () -> channel.writeInbound(buffer)))
+        .hasMessageThat()
+        .isEqualTo("PROXY header length 311 exceeds max 256");
   }
 }


### PR DESCRIPTION
The maximum length for the proxy header according to https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt is actually 108 bytes but we use 256 just to be safe.

We don't want to allow a potential attacker to send a continuous slow stream of characters, possibly causing an OOM.

All of our traffic should come through the load balancer so this shouldn't be an issue; this is just defense-in-depth

D.4 12

b/535251420

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3199)
<!-- Reviewable:end -->
