### PR TITLE
Test database should use real locale configs

### DIFF
--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerExtension.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerExtension.java
@@ -139,6 +139,11 @@ public abstract class JpaTransactionManagerExtension
   private static JdbcDatabaseContainer<?> create() {
     PostgreSQLContainer<?> container =
         new PostgreSQLContainer<>(NomulusPostgreSql.getDockerImageName())
+            // Locale configs in use on Cloud SQL in all environments
+            .withEnv(
+                "POSTGRES_INITDB_ARGS",
+                "--encoding=UTF8 --lc-collate=en_US.UTF8 --lc-ctype=en_US.UTF8"
+                    + " --locale-provider=libc --no-locale")
             .withDatabaseName(POSTGRES_DB_NAME);
     container.start();
     return container;

--- a/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerExtensionTest.java
+++ b/core/src/test/java/google/registry/persistence/transaction/JpaTransactionManagerExtensionTest.java
@@ -25,7 +25,10 @@ import google.registry.persistence.transaction.JpaTestExtensions.JpaUnitTestExte
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.PersistenceException;
+import jakarta.persistence.Tuple;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -57,6 +60,40 @@ public class JpaTransactionManagerExtensionTest {
                       .getResultList();
               assertThat(results).isEmpty();
             });
+  }
+
+  @Test
+  void verifyDatabaseEncodingConfig() {
+    String sql =
+        """
+        SELECT
+            pg_encoding_to_char(encoding) AS encoding,
+            datcollate AS collation,
+            datctype AS ctype,
+            datlocprovider AS locale_provider,
+            datlocale AS locale
+        FROM
+            pg_database
+        WHERE
+            datname = 'postgres'
+        """;
+    List<Tuple> rows =
+        tm().transact(
+                () -> tm().getEntityManager().createNativeQuery(sql, Tuple.class).getResultList());
+    assertThat(rows).hasSize(1);
+    var row =
+        rows.get(0).getElements().stream()
+            .collect(
+                HashMap::new, // Use HashMap since there may be null value
+                (m, element) -> m.put(element.getAlias(), rows.get(0).get(element)),
+                Map::putAll);
+    assertThat(row)
+        .containsExactly(
+            "encoding", "UTF8",
+            "collation", "en_US.UTF8",
+            "ctype", "en_US.UTF8",
+            "locale_provider", 'c', // c --> libc
+            "locale", null);
   }
 
   @Test


### PR DESCRIPTION
Use the real locale configs from Cloud SQL when creating postgres database using docker.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3204)
<!-- Reviewable:end -->
