### PR TITLE
Change rotatePrimaryCert type to primitive boolean

### DIFF
--- a/core/src/main/java/google/registry/tools/CreateOrUpdateRegistrarCommand.java
+++ b/core/src/main/java/google/registry/tools/CreateOrUpdateRegistrarCommand.java
@@ -138,7 +138,7 @@ abstract class CreateOrUpdateRegistrarCommand extends MutatingCommand {
       description =
           "Used together with --cert_file when updating an registrar. "
               + "If set, current cert is saved as failover.")
-  private Boolean rotatePrimaryCert = Boolean.FALSE;
+  private boolean rotatePrimaryCert = false;
 
   @Nullable
   @Parameter(


### PR DESCRIPTION
Change the rotatePrimaryCert field in CreateOrUpdateRegistrarCommand from object Boolean to primitive boolean. Since the field is initialized to default false and used as a presence-based switch without tri-state semantics, primitive boolean accurately reflects its behavior and avoids unnecessary object wrapper overhead.

BUG= http://b/537308816

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3205)
<!-- Reviewable:end -->
