### PR TITLE
Lower maximum message length bytes in EPP server

### DIFF
--- a/proxy/src/main/java/google/registry/proxy/config/default-config.yaml
+++ b/proxy/src/main/java/google/registry/proxy/config/default-config.yaml
@@ -61,13 +61,11 @@ epp:
   #
   # The first 4 bytes in a message is the total length of message, in bytes.
   #
-  # We accept a message up to 1 GB, which should be plentiful, if not over the
-  # top. In fact, we should probably limit this to a more reasonable number, as
-  # a 1 GB message will likely cause the proxy to go out of memory.
+  # We accept a message up to 10 MB, which should be plentiful.
   #
   # See also: RFC 5734 4 Data Unit Format
   # (https://tools.ietf.org/html/rfc5734#section-4).
-  maxMessageLengthBytes: 1073741824
+  maxMessageLengthBytes: 10485760
 
   # Length of the header field in bytes.
   #


### PR DESCRIPTION
We don't need to accept anything anywhere close to this big, and we shouldn't risk large messages causing OOMs

D.1 number 2

b/535251458

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3207)
<!-- Reviewable:end -->
