### PR TITLE
Map GCB trigger subs to environment vars

### DIFF
--- a/release/cloudbuild-clouddeploy.yaml
+++ b/release/cloudbuild-clouddeploy.yaml
@@ -10,6 +10,8 @@ steps:
 # Check the out internal repo.
 - name: 'gcr.io/cloud-builders/git'
   entrypoint: /bin/bash
+  env:
+    - '_INTERNAL_REPO_URL=${_INTERNAL_REPO_URL}'
   args:
   - -c
   - |
@@ -17,7 +19,7 @@ steps:
     git clone https://gerrit.googlesource.com/gcompute-tools
     sed -i s@/usr/bin/python@/usr/bin/python3@g ./gcompute-tools/git-cookie-authdaemon
     ./gcompute-tools/git-cookie-authdaemon
-    git clone ${_INTERNAL_REPO_URL} nomulus-internal
+    git clone "$_INTERNAL_REPO_URL" nomulus-internal
 
 # Merge the repos.
 - name: 'gcr.io/cloud-builders/git'

--- a/release/cloudbuild-kythe.yaml
+++ b/release/cloudbuild-kythe.yaml
@@ -11,14 +11,16 @@ steps:
 # Download Kythe
 - name: 'gcr.io/${PROJECT_ID}/builder:live'
   entrypoint: /bin/bash
+  env:
+    - '_KYTHE_VERSION=${_KYTHE_VERSION}'
   args:
   - -c
   - |
     wget -q \
-      https://github.com/kythe/kythe/releases/download/${_KYTHE_VERSION}/kythe-${_KYTHE_VERSION}.tar.gz
-    tar xvf kythe-${_KYTHE_VERSION}.tar.gz
-    rm kythe-${_KYTHE_VERSION}.tar.gz
-    mv kythe-${_KYTHE_VERSION} kythe
+      "https://github.com/kythe/kythe/releases/download/${_KYTHE_VERSION}/kythe-${_KYTHE_VERSION}.tar.gz"
+    tar xvf "kythe-${_KYTHE_VERSION}.tar.gz"
+    rm "kythe-${_KYTHE_VERSION}.tar.gz"
+    mv "kythe-${_KYTHE_VERSION}" kythe
 # Build Nomulus with the Kythe wrapper
 - name: 'gcr.io/${PROJECT_ID}/builder:live'
   entrypoint: /bin/bash

--- a/release/cloudbuild-monitor-zfa.yaml
+++ b/release/cloudbuild-monitor-zfa.yaml
@@ -13,10 +13,13 @@ steps:
 # but the request itself should go through
 - name: 'ubuntu'
   entrypoint: '/bin/bash'
+  env:
+    - 'ZFA_SERVER_IP=${_ZFA_SERVER_IP}'
+    - 'TLD=${_TLD}'
   args:
     - -c
     - |
       set -e
       apt-get update
       apt-get install dnsutils -y
-      dig @${_ZFA_SERVER_IP} ${_TLD} axfr | grep "Transfer failed"
+      dig @"$ZFA_SERVER_IP" "$TLD" axfr | grep "Transfer failed"

--- a/release/cloudbuild-release.yaml
+++ b/release/cloudbuild-release.yaml
@@ -14,6 +14,8 @@ steps:
 # Check the out internal repo.
 - name: 'gcr.io/cloud-builders/git'
   entrypoint: /bin/bash
+  env:
+    - '_INTERNAL_REPO_URL=${_INTERNAL_REPO_URL}'
   args:
   - -c
   - |
@@ -21,16 +23,18 @@ steps:
     git clone https://gerrit.googlesource.com/gcompute-tools
     sed -i s@/usr/bin/python@/usr/bin/python3@g ./gcompute-tools/git-cookie-authdaemon
     ./gcompute-tools/git-cookie-authdaemon
-    git clone ${_INTERNAL_REPO_URL} nomulus-internal
+    git clone "$_INTERNAL_REPO_URL" nomulus-internal
 # Tag and push the internal repo.
 - name: 'gcr.io/cloud-builders/git'
   entrypoint: /bin/bash
+  env:
+    - 'TAG_NAME=${TAG_NAME}'
   args:
   - -c
   - |
     set -e
-    git tag ${TAG_NAME}
-    git push origin ${TAG_NAME}
+    git tag "$TAG_NAME"
+    git push origin "$TAG_NAME"
   dir: 'nomulus-internal'
 # Merge the repos.
 - name: 'gcr.io/cloud-builders/git'
@@ -60,38 +64,44 @@ steps:
 # Build the builder image and pull the base images, them upload them to GCR.
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: /bin/bash
+  env:
+    - 'PROJECT_ID=${PROJECT_ID}'
+    - 'TAG_NAME=${TAG_NAME}'
   args:
   - -c
   - |
     set -e
-    docker build -t gcr.io/${PROJECT_ID}/builder:${TAG_NAME} .
-    docker tag gcr.io/${PROJECT_ID}/builder:${TAG_NAME} gcr.io/${PROJECT_ID}/builder:latest
-    docker push gcr.io/${PROJECT_ID}/builder:${TAG_NAME}
-    docker push gcr.io/${PROJECT_ID}/builder:latest
+    docker build -t "gcr.io/${PROJECT_ID}/builder:${TAG_NAME}" .
+    docker tag "gcr.io/${PROJECT_ID}/builder:${TAG_NAME}" "gcr.io/${PROJECT_ID}/builder:latest"
+    docker push "gcr.io/${PROJECT_ID}/builder:${TAG_NAME}"
+    docker push "gcr.io/${PROJECT_ID}/builder:latest"
     docker pull jetty:12-jdk25
-    docker tag jetty:12-jdk25 gcr.io/${PROJECT_ID}/jetty:${TAG_NAME}
-    docker tag jetty:12-jdk25 gcr.io/${PROJECT_ID}/jetty:latest
-    docker push gcr.io/${PROJECT_ID}/jetty:${TAG_NAME}
-    docker push gcr.io/${PROJECT_ID}/jetty:latest
+    docker tag jetty:12-jdk25 "gcr.io/${PROJECT_ID}/jetty:${TAG_NAME}"
+    docker tag jetty:12-jdk25 "gcr.io/${PROJECT_ID}/jetty:latest"
+    docker push "gcr.io/${PROJECT_ID}/jetty:${TAG_NAME}"
+    docker push "gcr.io/${PROJECT_ID}/jetty:latest"
     docker pull eclipse-temurin:25
-    docker tag eclipse-temurin:25 gcr.io/${PROJECT_ID}/temurin:${TAG_NAME}
-    docker tag eclipse-temurin:25 gcr.io/${PROJECT_ID}/temurin:latest
-    docker push gcr.io/${PROJECT_ID}/temurin:${TAG_NAME}
-    docker push gcr.io/${PROJECT_ID}/temurin:latest
+    docker tag eclipse-temurin:25 "gcr.io/${PROJECT_ID}/temurin:${TAG_NAME}"
+    docker tag eclipse-temurin:25 "gcr.io/${PROJECT_ID}/temurin:latest"
+    docker push "gcr.io/${PROJECT_ID}/temurin:${TAG_NAME}"
+    docker push "gcr.io/${PROJECT_ID}/temurin:latest"
   dir: 'release/builder/'
 # Do text replacement in the merged repo, hardcoding image digests.
 - name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: /bin/bash
+  env:
+    - 'PROJECT_ID=${PROJECT_ID}'
+    - 'TAG_NAME=${TAG_NAME}'
   args:
   - -c
   - |
     set -e
-    builder_digest=$(gcloud container images list-tags gcr.io/${PROJECT_ID}/builder \
-      --format='get(digest)' --filter='tags = ${TAG_NAME}')
-    jetty_digest=$(gcloud container images list-tags gcr.io/${PROJECT_ID}/jetty \
-      --format='get(digest)' --filter='tags = ${TAG_NAME}')
-    temurin_digest=$(gcloud container images list-tags gcr.io/${PROJECT_ID}/temurin \
-      --format='get(digest)' --filter='tags = ${TAG_NAME}')
+    builder_digest=$(gcloud container images list-tags "gcr.io/${PROJECT_ID}/builder" \
+      --format='get(digest)' --filter="tags = ${TAG_NAME}")
+    jetty_digest=$(gcloud container images list-tags "gcr.io/${PROJECT_ID}/jetty" \
+      --format='get(digest)' --filter="tags = ${TAG_NAME}")
+    temurin_digest=$(gcloud container images list-tags "gcr.io/${PROJECT_ID}/temurin" \
+      --format='get(digest)' --filter="tags = ${TAG_NAME}")
     sed -i s%eclipse-temurin:25%gcr.io/${PROJECT_ID}/temurin@$temurin_digest%g proxy/Dockerfile
     sed -i s%eclipse-temurin:25%gcr.io/${PROJECT_ID}/temurin@$temurin_digest%g core/Dockerfile
     sed -i s%jetty:12-jdk25%gcr.io/${PROJECT_ID}/jetty@$jetty_digest%g jetty/Dockerfile
@@ -143,16 +153,19 @@ steps:
 # Do text replacement in the cloud build YAML files.
 - name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: /bin/bash
+  env:
+    - 'PROJECT_ID=${PROJECT_ID}'
+    - 'TAG_NAME=${TAG_NAME}'
   args:
   - -c
   - |
     set -e
-    builder_digest=$(gcloud container images list-tags gcr.io/${PROJECT_ID}/builder \
-      --format='get(digest)' --filter='tags = ${TAG_NAME}')
-    schema_deployer_digest=$(gcloud container images list-tags gcr.io/${PROJECT_ID}/schema_deployer \
-      --format='get(digest)' --filter='tags = ${TAG_NAME}')
-    schema_verifier_digest=$(gcloud container images list-tags gcr.io/${PROJECT_ID}/schema_verifier \
-      --format='get(digest)' --filter='tags = ${TAG_NAME}')
+    builder_digest=$(gcloud container images list-tags "gcr.io/${PROJECT_ID}/builder" \
+      --format='get(digest)' --filter="tags = ${TAG_NAME}")
+    schema_deployer_digest=$(gcloud container images list-tags "gcr.io/${PROJECT_ID}/schema_deployer" \
+      --format='get(digest)' --filter="tags = ${TAG_NAME}")
+    schema_verifier_digest=$(gcloud container images list-tags "gcr.io/${PROJECT_ID}/schema_verifier" \
+      --format='get(digest)' --filter="tags = ${TAG_NAME}")
     sed -i s/builder:latest/builder@$builder_digest/g \
       release/cloudbuild-schema-deploy.yaml
     sed -i s/builder:latest/builder@$builder_digest/g \
@@ -177,6 +190,9 @@ steps:
 # Do text replacement in the k8s manifests.
 - name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: /bin/bash
+  env:
+    - 'PROJECT_ID=${PROJECT_ID}'
+    - 'TAG_NAME=${TAG_NAME}'
   args:
   - -c
   - |
@@ -305,18 +321,20 @@ steps:
 # Conditionally trigger the appropriate build based on the tag format.
 - name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: 'bash'
+  env:
+    - 'TAG_NAME=${TAG_NAME}'
   args:
   - -c
   - |
     set -e
     # Check for a nomulus release tag (e.g., "v1.2.3")
-    if [[ "${TAG_NAME}" =~ ^nomulus-20[0-9]{2}[0-1][0-9][0-3][0-9]-RC[0-9]{2}$ ]]; then
+    if [[ "$TAG_NAME" =~ ^nomulus-20[0-9]{2}[0-1][0-9][0-3][0-9]-RC[0-9]{2}$ ]]; then
       echo "Tag format matches a nomulus release. Triggering nomulus build..."
-      gcloud builds submit . --config=release/cloudbuild-nomulus.yaml --substitutions=TAG_NAME=$TAG_NAME
+      gcloud builds submit . --config=release/cloudbuild-nomulus.yaml --substitutions="TAG_NAME=$TAG_NAME"
     # Check for a proxy release tag (e.g., "proxy-v1.2.3")
-    elif [[ "${TAG_NAME}" =~ ^proxy-20[0-9]{2}[0-1][0-9][0-3][0-9]-RC[0-9]{2}$ ]]; then
+    elif [[ "$TAG_NAME" =~ ^proxy-20[0-9]{2}[0-1][0-9][0-3][0-9]-RC[0-9]{2}$ ]]; then
       echo "Tag format matches a proxy release. Triggering proxy build..."
-      gcloud builds submit . --config=release/cloudbuild-proxy.yaml --substitutions=TAG_NAME=$TAG_NAME
+      gcloud builds submit . --config=release/cloudbuild-proxy.yaml --substitutions="TAG_NAME=$TAG_NAME"
     else
       echo "Tag format '$TAG_NAME' does not match a known release type. Exiting."
       exit 1
@@ -324,15 +342,19 @@ steps:
 # Run the BEAM smoke test, using the builder and pipeline image just created
 - name: 'gcr.io/$PROJECT_ID/builder:latest'
   entrypoint: /bin/bash
+  env:
+    - 'TAG_NAME=${TAG_NAME}'
+    - 'PROJECT_ID=${PROJECT_ID}'
+    - '_TEST_PROJECT=${_TEST_PROJECT}'
   args:
     - -c
     - |
       set -e
-      if [[ "${TAG_NAME}" =~ ^nomulus-20[0-9]{2}[0-1][0-9][0-3][0-9]-RC[0-9]{2}$ ]]; then
+      if [[ "$TAG_NAME" =~ ^nomulus-20[0-9]{2}[0-1][0-9][0-3][0-9]-RC[0-9]{2}$ ]]; then
         gcloud secrets versions access latest \
           --secret nomulus-tool-cloudbuild-credential > tool-credential.json
         gcloud auth activate-service-account --key-file=tool-credential.json
-        ./release/run_beam_smoketest.sh "${TAG_NAME}" "${PROJECT_ID}" "${_TEST_PROJECT}"
+        ./release/run_beam_smoketest.sh "$TAG_NAME" "$PROJECT_ID" "$_TEST_PROJECT"
       fi
 timeout: 5400s
 options:

--- a/release/cloudbuild-sync-db-objects.yaml
+++ b/release/cloudbuild-sync-db-objects.yaml
@@ -17,6 +17,8 @@ steps:
 # Check out the internal repo.
 - name: 'gcr.io/cloud-builders/git:latest'
   entrypoint: /bin/bash
+  env:
+    - '_INTERNAL_REPO_URL=${_INTERNAL_REPO_URL}'
   args:
   - -c
   - |
@@ -26,7 +28,7 @@ steps:
       ln -s /usr/bin/python3 /usr/bin/python
     fi
     ./gcompute-tools/git-cookie-authdaemon
-    git clone ${_INTERNAL_REPO_URL} nomulus-internal
+    git clone "$_INTERNAL_REPO_URL" nomulus-internal
 # Download and decrypt the nomulus tool credential
 - name: 'gcr.io/$PROJECT_ID/builder:live'
   entrypoint: /bin/bash


### PR DESCRIPTION
Also quote the variables.

Passing the variables through the "env" block means that we avoid any situations where the characters trigger some evaluation.

https://docs.cloud.google.com/build/docs/configuring-builds/substitute-variable-values

This hasn't caused any issues, but is a general good-practice sort of thing.

G.4 number 2

b/535251126

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3208)
<!-- Reviewable:end -->
