### PR TITLE
Bump node version in builder/build.sh

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,7 @@ dependencyLocking {
     lockAllConfigurations()
 }
 
+// Keep this up to date with the node installation in release/builder/build.sh
 node {
   download = false
   version = "24.19.0"

--- a/release/builder/build.sh
+++ b/release/builder/build.sh
@@ -51,9 +51,10 @@ apt-get install python3 -y
 apt-get install npm -y
 npm cache clean -f
 npm install -g n
-# Retrying because fails are possible for node.js intallation. See
+# Retrying because fails are possible for node.js installation. See
 # https://github.com/nodejs/build/issues/1993
-for i in {1..5}; do n 22.12.0 && break || sleep 15; done
+# Keep this version up to date with the node block in the root build.gradle file
+for i in {1..5}; do n 24.19.0 && break || sleep 15; done
 
 # Install gp_dump
 apt-get install postgresql-client-17 procps -y


### PR DESCRIPTION
In PR https://github.com/google/nomulus/pull/3153, Angular dependencies were upgraded to 22.x, which requires Node.js >= 24.15.0 or >= 22.22.3, and build.gradle was updated to use Node 24.19.0. However, the Cloud Build builder container image script release/builder/build.sh was missed and remained on 22.12.0, causing the :console-webapp:buildConsoleWebapp task to fail during weekly deployment builds on Google Cloud Build.

BUG= http://b/547933107

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3210)
<!-- Reviewable:end -->
