### PR TITLE
Update Node version in release builder image

### DIFF
--- a/release/builder/build.sh
+++ b/release/builder/build.sh
@@ -53,7 +53,7 @@ npm cache clean -f
 npm install -g n
 # Retrying because fails are possible for node.js intallation. See
 # https://github.com/nodejs/build/issues/1993
-for i in {1..5}; do n 22.12.0 && break || sleep 15; done
+for i in {1..5}; do n 24.19.0 && break || sleep 15; done
 
 # Install gp_dump
 apt-get install postgresql-client-17 procps -y


### PR DESCRIPTION
Update the Node.js installation version in release/builder/build.sh from 22.12.0 to 24.19.0.

In PR #3153, Angular dependencies were upgraded to 22.x, which requires Node.js >= 24.15.0 or >= 22.22.3, and build.gradle was updated to use Node 24.19.0. However, the Cloud Build builder container image script release/builder/build.sh was missed and remained on 22.12.0, causing the :console-webapp:buildConsoleWebapp task to fail during weekly deployment builds on Google Cloud Build.

BUG= http://b/547933107

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3211)
<!-- Reviewable:end -->
