### PR TITLE
Fix substitution names in cloudbuild-monitor-zfa

### DIFF
--- a/release/cloudbuild-monitor-zfa.yaml
+++ b/release/cloudbuild-monitor-zfa.yaml
@@ -14,12 +14,12 @@ steps:
 - name: 'ubuntu'
   entrypoint: '/bin/bash'
   env:
-    - 'ZFA_SERVER_IP=${_ZFA_SERVER_IP}'
-    - 'TLD=${_TLD}'
+    - '_ZFA_SERVER_IP=${_ZFA_SERVER_IP}'
+    - '_TLD=${_TLD}'
   args:
     - -c
     - |
       set -e
       apt-get update
       apt-get install dnsutils -y
-      dig @"$ZFA_SERVER_IP" "$TLD" axfr | grep "Transfer failed"
+      dig @"$_ZFA_SERVER_IP" "$_TLD" axfr | grep "Transfer failed"


### PR DESCRIPTION
We shouldn't have stripped the leading underscore in 84811d56. GCB requires user-defined substitutions to begin with an underscore.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3212)
<!-- Reviewable:end -->
