### PR TITLE
Add prod target to Cloud Deploy pipeline

### DIFF
--- a/release/cloudbuild-clouddeploy.yaml
+++ b/release/cloudbuild-clouddeploy.yaml
@@ -40,7 +40,7 @@ steps:
   - -c
   - |
     set -e
-    for env in crash sandbox; do
+    for env in crash sandbox production; do
       config_file="release/clouddeploy/${env}-config.yaml"
       if [ -f "$config_file" ]; then
         echo "Extracting checks from $config_file..."
@@ -100,7 +100,7 @@ steps:
   - -c
   - |
     set -e
-    for env in crash sandbox; do
+    for env in crash sandbox production; do
       target_file="release/clouddeploy/${env}-target.yaml"
       if [ -f "$target_file" ]; then
         echo "Applying target $target_file..."

--- a/release/cloudbuild-release.yaml
+++ b/release/cloudbuild-release.yaml
@@ -287,6 +287,7 @@ steps:
         awk 'NR==1,/^---$/ {if ($0 != "---") print}' ./jetty/kubernetes/nomulus-${env}-epp-server.yaml | \
           sed s/name:\ epp-server/name:\ epp-server-partial-phase/g | \
           sed s/service:\ epp-server/deployment:\ epp-server-partial-phase/g | \
+          sed s/value:\ epp-server/value:\ epp-server-partial-phase/g | \
           sed "/^spec:$/a\  replicas: ${stage}" \
           > ./jetty/kubernetes/nomulus-${env}-epp-server-partial-phase-${stage}.yaml
       done

--- a/release/clouddeploy/README.md
+++ b/release/clouddeploy/README.md
@@ -7,10 +7,10 @@ This directory contains the Google Cloud Deploy configuration files for the Nomu
 ### `delivery-pipeline.yaml`
 Defines the `DeliveryPipeline` resource named `deploy-nomulus` and its associated `Automation` resource (`deploy-nomulus/auto-advance-canary`). It sets up the serial pipeline for rolling out changes to different targets and automatically advancing canary rollouts.
 
-### Target Configurations (e.g., `production-target.yaml`)
+### Target Configurations (e.g., `crash-target.yaml`)
 Files matching this format define the `Target` resources for Cloud Deploy. They specify the GKE cluster and other environment-specific settings for deployment.
 
-### Environment Configurations (e.g., `production-config.yaml`)
+### Environment Configurations (e.g., `crash-config.yaml`)
 Configuration files containing environment-specific parameters and SLA-based alert policy checks (such as EPP and RDAP success metrics) used for automated analysis and target population.
 
 ### `skaffold.yaml`

--- a/release/clouddeploy/README.md
+++ b/release/clouddeploy/README.md
@@ -7,10 +7,10 @@ This directory contains the Google Cloud Deploy configuration files for the Nomu
 ### `delivery-pipeline.yaml`
 Defines the `DeliveryPipeline` resource named `deploy-nomulus` and its associated `Automation` resource (`deploy-nomulus/auto-advance-canary`). It sets up the serial pipeline for rolling out changes to different targets and automatically advancing canary rollouts.
 
-### Target Configurations (e.g., `crash-target.yaml`)
+### Target Configurations (e.g., `production-target.yaml`)
 Files matching this format define the `Target` resources for Cloud Deploy. They specify the GKE cluster and other environment-specific settings for deployment.
 
-### Environment Configurations (e.g., `crash-config.yaml`)
+### Environment Configurations (e.g., `production-config.yaml`)
 Configuration files containing environment-specific parameters and SLA-based alert policy checks (such as EPP and RDAP success metrics) used for automated analysis and target population.
 
 ### `skaffold.yaml`

--- a/release/clouddeploy/delivery-pipeline.yaml
+++ b/release/clouddeploy/delivery-pipeline.yaml
@@ -136,6 +136,78 @@ serialPipeline:
               googleCloud:
                 alertPolicyChecks:
                     sandboxStableDeploymentAlertPolicyChecks
+  - targetId: production
+    strategy:
+      canary:
+        customCanaryDeployment:
+          phaseConfigs:
+          - phaseId: "canary-1"
+            profiles: ["production-partial-phase-1"]
+            percentage: 10
+            predeploy:
+              tasks:
+              - type: container
+                image: gcr.io/google.com/cloudsdktool/google-cloud-cli:stable
+                env:
+                  TARGET_ID: ${{ target.id }}
+                  TAG_NAME: ${{ deploy_params['tag_name'] }}
+                  PROJECT_ID: ${{ deploy_params['project_id'] }}
+                command: ["/bin/bash"]
+                args:
+                - "-c"
+                - |
+                  gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/cloudbuild-schema-verify-${TARGET_ID}.yaml .
+                  gcloud builds submit --no-source --config=cloudbuild-schema-verify-${TARGET_ID}.yaml
+            analysis:
+              # 10 minutes.
+              duration: 600s
+              googleCloud:
+                alertPolicyChecks:
+                    productionPartialDeploymentAlertPolicyChecks
+          - phaseId: "canary-5"
+            profiles: ["production-partial-phase-5"]
+            percentage: 50
+            analysis:
+              # 10 minutes.
+              duration: 600s
+              googleCloud:
+                alertPolicyChecks:
+                    productionPartialDeploymentAlertPolicyChecks
+          - phaseId: "stable"
+            profiles: ["production"]
+            percentage: 100
+            postdeploy:
+              tasks:
+              - type: container
+                image: gcr.io/google.com/cloudsdktool/google-cloud-cli:stable
+                env:
+                  DEPLOYED_IMAGE: ${{ deploy_params['deployed_image'] }}
+                  BASE_IMAGE: ${{ deploy_params['base_image'] }}
+                  TARGET_ID: ${{ target.id }}
+                command: ["/bin/bash"]
+                args:
+                - "-c"
+                - |
+                  gcloud container images add-tag $DEPLOYED_IMAGE \
+                    ${BASE_IMAGE}:live-cd-${TARGET_ID} --quiet
+              - type: container
+                image: gcr.io/google.com/cloudsdktool/google-cloud-cli:stable
+                env:
+                  TARGET_ID: ${{ target.id }}
+                  TAG_NAME: ${{ deploy_params['tag_name'] }}
+                  PROJECT_ID: ${{ deploy_params['project_id'] }}
+                command: ["/bin/bash"]
+                args:
+                - "-c"
+                - |
+                  gcloud storage cp gs://${PROJECT_ID}-deploy/${TAG_NAME}/cloudbuild-schema-deploy-${TARGET_ID}.yaml .
+                  gcloud builds submit --no-source --config=cloudbuild-schema-deploy-${TARGET_ID}.yaml
+            analysis:
+              # 10 minutes.
+              duration: 600s
+              googleCloud:
+                alertPolicyChecks:
+                    productionStableDeploymentAlertPolicyChecks
 ---
 apiVersion: deploy.cloud.google.com/v1
 kind: Automation
@@ -148,6 +220,7 @@ selector:
   targets:
   - id: crash
   - id: sandbox
+  - id: production
 rules:
 - advanceRolloutRule:
     id: advance-canary-phases

--- a/release/clouddeploy/production-target.yaml
+++ b/release/clouddeploy/production-target.yaml
@@ -1,0 +1,30 @@
+apiVersion: deploy.cloud.google.com/v1
+kind: Target
+metadata:
+  name: production
+requireApproval: true
+executionConfigs:
+- usages:
+  - PREDEPLOY
+  - RENDER
+  - ANALYSIS
+  - POSTDEPLOY
+  executionTimeout: 3600s
+  defaultPool:
+    # Placeholder: Replace with artifact bucket name.
+    artifactStorage: artifactStorage
+    # Placeholder: Replace with project number.
+    serviceAccount: serviceAccount
+- usages:
+  - DEPLOY
+  executionTimeout: 3600s
+  privatePool:
+    # Placeholder: Replace with worker pool name.
+    workerPool: workerPool
+    # Placeholder: Replace with artifact bucket name.
+    artifactStorage: artifactStorage
+    # Placeholder: Replace with project number.
+    serviceAccount: serviceAccount
+gke:
+  # Placeholder: Replace with project ID, location, and cluster name.
+  cluster: cluster

--- a/release/clouddeploy/skaffold.yaml
+++ b/release/clouddeploy/skaffold.yaml
@@ -64,3 +64,33 @@ profiles:
     - ../../jetty/kubernetes/nomulus-sandbox-epp-server-partial-phase-5.yaml
   deploy:
     kubectl: { }
+- name: production
+  manifests:
+    rawYaml:
+    - ../../jetty/kubernetes/nomulus-production-backend.yaml
+    - ../../jetty/kubernetes/nomulus-production-console.yaml
+    - ../../jetty/kubernetes/nomulus-production-frontend.yaml
+    - ../../jetty/kubernetes/nomulus-production-pubapi.yaml
+    - ../../jetty/kubernetes/nomulus-production-epp-server.yaml
+  deploy:
+    kubectl: { }
+- name: production-partial-phase-1
+  manifests:
+    rawYaml:
+    - ../../jetty/kubernetes/nomulus-production-backend-partial-phase-1.yaml
+    - ../../jetty/kubernetes/nomulus-production-console-partial-phase-1.yaml
+    - ../../jetty/kubernetes/nomulus-production-frontend-partial-phase-1.yaml
+    - ../../jetty/kubernetes/nomulus-production-pubapi-partial-phase-1.yaml
+    - ../../jetty/kubernetes/nomulus-production-epp-server-partial-phase-1.yaml
+  deploy:
+    kubectl: { }
+- name: production-partial-phase-5
+  manifests:
+    rawYaml:
+    - ../../jetty/kubernetes/nomulus-production-backend-partial-phase-5.yaml
+    - ../../jetty/kubernetes/nomulus-production-console-partial-phase-5.yaml
+    - ../../jetty/kubernetes/nomulus-production-frontend-partial-phase-5.yaml
+    - ../../jetty/kubernetes/nomulus-production-pubapi-partial-phase-5.yaml
+    - ../../jetty/kubernetes/nomulus-production-epp-server-partial-phase-5.yaml
+  deploy:
+    kubectl: { }


### PR DESCRIPTION
I've already ran `$ gcloud builds submit --config release/cloudbuild-clouddeploy.yaml   --substitutions _INTERNAL_REPO_URL=https://team.googlesource.com/domain-registry-eng/nomulus-internal`

This also changes the value for container names in epp-server-partial-phase, this would be helpful to differentiate metrics.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3216)
<!-- Reviewable:end -->
