### PR TITLE
Fix typo in sync-and-tag YAML file

### DIFF
--- a/release/cloudbuild-sync-and-tag.yaml
+++ b/release/cloudbuild-sync-and-tag.yaml
@@ -25,7 +25,7 @@ steps:
   - --recursive
   - gs://$PROJECT_ID-deploy/${TAG_NAME}
   - gs://$PROJECT_ID-deploy/live
-- # Tag nomulus
+# Tag nomulus
 - name: 'gcr.io/$PROJECT_ID/builder:latest'
   args:
   - gcloud
@@ -34,7 +34,7 @@ steps:
   - add-tag
   - gcr.io/$PROJECT_ID/nomulus:${TAG_NAME}
   - gcr.io/$PROJECT_ID/nomulus:live
-- # Tag proxy
+# Tag proxy
 - name: 'gcr.io/$PROJECT_ID/builder:latest'
   args:
   - gcloud
@@ -43,7 +43,7 @@ steps:
   - add-tag
   - gcr.io/$PROJECT_ID/proxy:${TAG_NAME}
   - gcr.io/$PROJECT_ID/proxy:live
-- # Tag nomulus tool
+# Tag nomulus tool
 - name: 'gcr.io/$PROJECT_ID/builder:latest'
   args:
   - gcloud


### PR DESCRIPTION
This hasn't been a problem since i think the remote runners ignore empty or null lists (?) but just in case, we should remove this. Dashes signify the start of a list, and we just want comments.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/nomulus/3226)
<!-- Reviewable:end -->
